### PR TITLE
rustc 1.85.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.82.0"
+channel = "1.85.1"
 components = [ "rustc", "rust-std", "cargo", "rustfmt", "rustc-dev", "llvm-tools" ]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -216,7 +216,7 @@ struct BootstrapArgs {
     restart: bool,
 
     #[arg(long = "rust-version", help = "The rust version to use",
-        default_value = "1.82.0", action = ArgAction::Set)]
+        default_value = "1.85.1", action = ArgAction::Set)]
     rust_version: String,
 }
 
@@ -227,7 +227,7 @@ struct UpdateArgs {
     no_verus: bool,
 
     #[arg(long = "rust-version", help = "The rust version to use",
-        default_value = "1.82.0", action = ArgAction::Set)]
+        default_value = "1.85.1", action = ArgAction::Set)]
     rust_version: String,
 }
 


### PR DESCRIPTION
This PR updates the toolchain to 1.85.1 to keep up with the latest Verus.