### PR TITLE
ManuallyDrop deref workaround

### DIFF
--- a/aster_common/src/page/meta/meta_slot.rs
+++ b/aster_common/src/page/meta/meta_slot.rs
@@ -56,7 +56,7 @@ impl MetaSlotInner {
 
     pub open spec fn borrow_pt_spec(& self) -> & PageTablePageMeta
     {
-        &get_union_field::<MetaSlotInner, ManuallyDrop<PageTablePageMeta>>(*self, "_pt").deref()
+        &manually_drop_unwrap(get_union_field::<MetaSlotInner, ManuallyDrop<PageTablePageMeta>>(*self, "_pt"))
     }
 
     #[verifier::external_body]
@@ -72,7 +72,7 @@ impl MetaSlotInner {
 
     pub open spec fn borrow_frame_spec(&self) -> & FrameMeta
     {
-        &get_union_field::<MetaSlotInner, ManuallyDrop<FrameMeta>>(*self, "_frame").deref()
+        &manually_drop_unwrap(get_union_field::<MetaSlotInner, ManuallyDrop<FrameMeta>>(*self, "_frame"))
     }
 
     #[verifier::external_body]
@@ -94,7 +94,7 @@ impl MetaSlot {
             inner_perm.is_init(),
             is_variant(inner_perm.value(), "_pt"),
     {
-        &get_union_field::<MetaSlotInner, ManuallyDrop<PageTablePageMeta>>(inner_perm.value(), "_pt").deref()
+        &manually_drop_unwrap(get_union_field::<MetaSlotInner, ManuallyDrop<PageTablePageMeta>>(inner_perm.value(), "_pt"))
     }
 
     pub fn borrow_pt<'a>(&'a self,
@@ -118,7 +118,7 @@ impl MetaSlot {
             inner_perm.is_init(),
             is_variant(inner_perm.value(), "_frame"),
     {
-        &get_union_field::<MetaSlotInner, ManuallyDrop<FrameMeta>>(inner_perm.value(), "_frame").deref()
+        &manually_drop_unwrap(get_union_field::<MetaSlotInner, ManuallyDrop<FrameMeta>>(inner_perm.value(), "_frame"))
     }
 
     pub fn borrow_frame<'a>(&'a self,

--- a/fvt5-lifecycle-safety/src/page/mod.rs
+++ b/fvt5-lifecycle-safety/src/page/mod.rs
@@ -401,7 +401,9 @@ impl DynPage {
             res.0.paddr() == paddr,
             res.1@.invariants(),
     {
+        broadcast use vstd_extra::manually_drop::ex_manually_drop_value_axiom;
         //Ghost operations
+
         proof {
             s.lemma_get_page_index_eq_page_to_index_spec(paddr);
         }


### PR DESCRIPTION
This PR changes the definition of `ManuallyDrop::deref` by explicitly using `ex_manually_drop_deref_spec` instead of the `*` operator as a temporary workaround for #38.