### PR TITLE
Align with latest vstd API

### DIFF
--- a/lock-protocol/src/spec/utils.rs
+++ b/lock-protocol/src/spec/utils.rs
@@ -1235,25 +1235,24 @@ impl NodeHelper {
 
             // Show that the child traces are disjoint
             assert(pairwise_disjoint(child_subtree_trace_set));
-            // Show that the arbitrary union of the child_subtree_trace_set is equal to the child_trace_set
-            assert(child_trace_set =~= arbitrary_union(child_subtree_trace_set)) by {
+            // Show that the flatten of the child_subtree_trace_set is equal to the child_trace_set
+            assert(child_trace_set =~= child_subtree_trace_set.flatten()) by {
                 assert forall|child_trace: Seq<nat>| #[trigger]
-                    child_trace_set.contains(child_trace) == arbitrary_union(
-                        child_subtree_trace_set,
-                    ).contains(child_trace) by {
+                    child_trace_set.contains(child_trace)
+                        == child_subtree_trace_set.flatten().contains(child_trace) by {
                     if child_trace_set.contains(child_trace) {
                         assert(trace.is_prefix_of(child_trace));
                         let trace_child = child_trace.subrange(0, (trace.len() + 1) as int);
                         let offset = child_trace[trace.len() as int];
                         assert(trace_child =~= trace.push(offset));
                         assert(offset_set.contains(offset));
-                        // Definition of arbitrary union
+                        // Definition of flatten
                         assert(child_traces.contains(trace_child));
                         assert(child_subtree_trace_set.contains(
                             Self::get_subtree_traces(trace_child),
                         ));
                     }
-                    if arbitrary_union(child_subtree_trace_set).contains(child_trace) {
+                    if child_subtree_trace_set.flatten().contains(child_trace) {
                         let child_subtree_trace = choose|t: Set<Seq<nat>>|
                             child_subtree_trace_set.contains(t) && t.contains(child_trace);
                         let trace_child = choose|t: Seq<nat>| #[trigger]
@@ -1267,7 +1266,7 @@ impl NodeHelper {
             }
 
             assert(child_trace_set.len() == 512 * Self::tree_size_spec(2 - trace.len())) by {
-                lemma_arbitrary_union_cardinality_under_disjointness_same_length(
+                lemma_flatten_cardinality_under_disjointness_same_length(
                     child_subtree_trace_set,
                     Self::tree_size_spec(2 - trace.len()),
                 );

--- a/lock-protocol/src/spec/utils.rs
+++ b/lock-protocol/src/spec/utils.rs
@@ -27,6 +27,7 @@ pub broadcast group group_node_helper_lemmas {
 impl NodeHelper {
     /// depth starts from 0(root) to 3 (leaf),
     /// level starts from 4(root) to 1 (leaf).
+    #[verifier::inline]
     pub open spec fn level_to_dep(level: nat) -> nat
         recommends
             1 <= level <= 4,
@@ -34,6 +35,7 @@ impl NodeHelper {
         (4 - level) as nat
     }
 
+    #[verifier::inline]
     pub open spec fn dep_to_level(dep: nat) -> nat
         recommends
             0 <= dep < 4,
@@ -148,10 +150,12 @@ impl NodeHelper {
         Self::tree_size_spec(3)
     }
 
+    // Do not inline this function, it serves as a trigger.
     pub open spec fn valid_nid(nid: NodeId) -> bool {
         0 <= nid < Self::total_size()
     }
 
+    #[verifier::inline]
     pub open spec fn root_id() -> NodeId {
         0
     }

--- a/lock-protocol/src/spec/utils.rs
+++ b/lock-protocol/src/spec/utils.rs
@@ -81,6 +81,7 @@ impl NodeHelper {
     }
 
     /// Returns the size of the tree with nodes at most `max_dep` depth.
+    #[verifier::memoize]
     pub closed spec fn tree_size_spec(max_dep: int) -> nat
         recommends
             0 <= max_dep < 4,
@@ -138,7 +139,6 @@ impl NodeHelper {
             Self::tree_size_relation_spec(2),
             Self::tree_size_relation_spec(3),
     {
-        Self::lemma_tree_size_spec_table();
         assert(Self::tree_size_relation_spec(0)) by (compute_only);
         assert(Self::tree_size_relation_spec(1)) by (compute_only);
         assert(Self::tree_size_relation_spec(2)) by (compute_only);
@@ -555,7 +555,7 @@ impl NodeHelper {
         } else {
             assert(Self::tree_size_spec(cur_level - 1) * 512 + 1 == Self::tree_size_spec(
                 cur_level as int,
-            )) by { Self::lemma_tree_size_spec_table() };
+            ));
 
             let sz = Self::tree_size_spec(cur_level - 1);
             // Prove offset < 512
@@ -656,7 +656,6 @@ impl NodeHelper {
 
     {
         if trace.len() == 0 {
-            assert(Self::tree_size_spec(cur_level) > 0) by { Self::lemma_tree_size_spec_table() };
         } else {
             let new_trace = trace.subrange(1, trace.len() as int);
             assert(new_trace.len() == trace.len() - 1);
@@ -668,7 +667,7 @@ impl NodeHelper {
             }) by {
                 assert(Self::tree_size_spec(cur_level - 1) * 512 + 1 == Self::tree_size_spec(
                     cur_level,
-                )) by { Self::lemma_tree_size_spec_table() };
+                ));
                 assert(Self::tree_size_spec(cur_level) - 1 - trace[0] * Self::tree_size_spec(
                     cur_level - 1,
                 ) == (512 - trace[0]) * Self::tree_size_spec(cur_level - 1)) by {
@@ -689,9 +688,6 @@ impl NodeHelper {
                         Self::tree_size_spec(cur_level - 1) as int,
                     )
                 };
-                assert(Self::tree_size_spec(cur_level - 1) > 0) by {
-                    Self::lemma_tree_size_spec_table()
-                };
             };
 
             let new_level = cur_level - 1;
@@ -709,7 +705,7 @@ impl NodeHelper {
             assert(new_rt + sz <= cur_rt + Self::tree_size_spec(cur_level)) by {
                 // tree_size_spec(cur_level) = 512*sz + 1
                 assert(Self::tree_size_spec(cur_level) == Self::tree_size_spec(cur_level - 1) * 512
-                    + 1) by { Self::lemma_tree_size_spec_table() };
+                    + 1);
 
                 // need: trace[0]*sz + sz <= 512*sz
                 assert(trace[0] < 512);
@@ -759,7 +755,6 @@ impl NodeHelper {
             Self::valid_nid(Self::trace_to_nid(trace)),
             trace =~= Self::nid_to_trace(Self::trace_to_nid(trace)),
     {
-        Self::lemma_tree_size_spec_table();
         Self::lemma_trace_to_nid_rec_sound(trace, 0, 3)
     }
 
@@ -891,7 +886,6 @@ impl NodeHelper {
         ensures
             Self::sub_tree_size(nid) >= 1,
     {
-        Self::lemma_tree_size_spec_table();
         Self::lemma_nid_to_trace_sound(nid);
     }
 
@@ -937,7 +931,6 @@ impl NodeHelper {
         let dep_ch = Self::nid_to_dep(ch);
         let sz_pa = Self::sub_tree_size(pa);
         let sz_ch = Self::sub_tree_size(ch);
-        Self::lemma_tree_size_spec_table();  // Apply tree size lemma to both nodes.
         // Verify trace properties.
         let trace_pa = Self::nid_to_trace(pa);
         let trace_ch = Self::nid_to_trace(ch);
@@ -1161,7 +1154,6 @@ impl NodeHelper {
     {
         let subtree_trace_set = Self::get_subtree_traces(trace);
         assert(subtree_trace_set.contains(trace));
-        Self::lemma_tree_size_spec_table();
         Self::lemma_valid_trace_set_cardinality();
         if trace.len() == 3 {
             assert(forall|subtree_trace| #[trigger]

--- a/vstd_extra/src/function_properties.rs
+++ b/vstd_extra/src/function_properties.rs
@@ -24,7 +24,7 @@ pub open spec fn left_inverse_on<A, B>(
     domain: Set<A>,
     codomain: Set<B>,
 ) -> bool {
-    forall|x: A| #[trigger] domain.contains(x) ==> codomain.contains(f(x)) && g(f(x)) == x
+    domain.all(|x: A| codomain.contains(f(x)) && g(f(x)) == x)
 }
 
 /// `g` is a right inverse of `f` on `codomain` if `f(g(y)) == y` for all `y` in `codomain`,
@@ -35,7 +35,7 @@ pub open spec fn right_inverse_on<A, B>(
     domain: Set<A>,
     codomain: Set<B>,
 ) -> bool {
-    forall|y: B| #[trigger] codomain.contains(y) ==> domain.contains(g(y)) && f(g(y)) == y
+    codomain.all(|y: B| domain.contains(g(y)) && f(g(y)) == y)
 }
 
 /// `g` is a two-sided inverse of `f` if it is both a left and right inverse.

--- a/vstd_extra/src/seq_extra.rs
+++ b/vstd_extra/src/seq_extra.rs
@@ -4,25 +4,9 @@ use vstd::seq::*;
 verus! {
 
 #[verifier::external_body]
-pub proof fn seq_tracked_empty<T>() -> (tracked res: Seq<T>)
-    ensures
-        res == Seq::<T>::empty(),
-{
-    unimplemented!();
-}
-
-#[verifier::external_body]
 pub proof fn seq_tracked_new<T>(len: nat, f: impl Fn(int) -> T) -> (tracked res: Seq<T>)
     ensures
         res == Seq::<T>::new(len, f),
-{
-    unimplemented!();
-}
-
-#[verifier::external_body]
-pub proof fn seq_tracked_push<T>(s: Seq<T>, x: T) -> (tracked res: Seq<T>)
-    ensures
-        res == s.push(x),
 {
     unimplemented!();
 }

--- a/vstd_extra/src/set_extra.rs
+++ b/vstd_extra/src/set_extra.rs
@@ -6,7 +6,7 @@ verus! {
 /// is empty.
 pub proof fn lemma_filter_all_false<T>(s: Set<T>, f: spec_fn(T) -> bool)
     requires
-        forall|x: T| #[trigger] s.contains(x) ==> !f(x),
+        s.all(|x: T| !f(x)),
     ensures
         s.filter(f).is_empty(),
 {
@@ -14,7 +14,7 @@ pub proof fn lemma_filter_all_false<T>(s: Set<T>, f: spec_fn(T) -> bool)
 
 pub proof fn lemma_filter_all_true<T>(s: Set<T>, f: spec_fn(T) -> bool)
     requires
-        forall|x: T| #[trigger] s.contains(x) ==> f(x),
+        s.all(f),
     ensures
         s.filter(f) =~= s,
 {
@@ -209,7 +209,7 @@ pub proof fn lemma_flatten_cardinality_under_disjointness_same_length<A>(parts: 
     requires
         parts.finite(),
         pairwise_disjoint(parts),
-        forall|p: Set<A>| #[trigger] parts.contains(p) ==> p.finite() && p.len() == c,
+        parts.all(|p: Set<A>| p.finite() && p.len() == c),
     ensures
         parts.flatten().len() == parts.len() * c,
         parts.flatten().finite(),


### PR DESCRIPTION
This pull request uses the latest vstd APIs.
- Use `Set::flatten` instead of `arbitrary_union`
- Remove `seq_tracked_empty`, `seq_tracked_push`