### PR TITLE
Migrate OSTD changes

### DIFF
--- a/lock-protocol/src/mm/page_table/cursor/locking.rs
+++ b/lock-protocol/src/mm/page_table/cursor/locking.rs
@@ -2,7 +2,7 @@ use vstd::prelude::verus;
 
 use crate::mm::{
     meta::AnyFrameMeta, MapTrackingStatus, PageTable, PageTableEntryTrait, PageTableLockTrait,
-    PageTableMode, PagingConstsTrait, Vaddr,
+    PageTableConfig, PagingConstsTrait, Vaddr,
 };
 use std::ops::Range;
 
@@ -11,28 +11,16 @@ use super::Cursor;
 verus! {
 
 #[verifier::external_body]
-pub fn lock_range<
-    'a,
-    M: PageTableMode,
-    // E: PageTableEntryTrait = PageTableEntry,
-    E: PageTableEntryTrait,
-    // C: PagingConstsTrait = PagingConsts,
-    C: PagingConstsTrait,
-    PTL: PageTableLockTrait<E, C>,
->(pt: &PageTable<M, E, C>, va: &Range<Vaddr>, new_pt_is_tracked: MapTrackingStatus) -> Cursor<
-    'a,
-    M,
-    E,
-    C,
-    PTL,
-> {
+pub fn lock_range<'a, C: PageTableConfig, PTL: PageTableLockTrait<C>>(
+    pt: &PageTable<C>,
+    va: &Range<Vaddr>,
+) -> Cursor<'a, C, PTL> {
     // Placeholder implementation
     unimplemented!()
 }
 
-pub fn dfs_mark_astray<E: PageTableEntryTrait, C: PagingConstsTrait, PTL: PageTableLockTrait<E, C>>(
-    mut sub_tree: PTL,
-) -> (res: PTL)
+pub fn dfs_mark_astray<C: PageTableConfig, PTL: PageTableLockTrait<C>>(mut sub_tree: PTL) -> (res:
+    PTL)
     ensures
         res == sub_tree,
 {

--- a/lock-protocol/src/mm/page_table/cursor/spec_helpers.rs
+++ b/lock-protocol/src/mm/page_table/cursor/spec_helpers.rs
@@ -25,8 +25,8 @@ use crate::{
 };
 
 use super::{
-    pte_index, KernelMode, PageTable, PageTableEntryTrait, PageTableError, PageTableMode,
-    PagingConsts, PagingConstsTrait, PagingLevel, UserMode,
+    pte_index, PageTable, PageTableEntryTrait, PageTableError, PagingConsts, PagingConstsTrait,
+    PagingLevel,
 };
 
 use crate::spec::simple_page_table;


### PR DESCRIPTION
This commit migrates https://github.com/asterinas/asterinas/commit/2c917ba3835be39669f3f3b7173eeeb8c3d5922f to VOSTD/lock-protocol, which unifies page table template parameters.