### PR TITLE
Use `parse_flags` instead of `bit_mapping`

### DIFF
--- a/fvt5-lifecycle-safety/src/page/meta/impls.rs
+++ b/fvt5-lifecycle-safety/src/page/meta/impls.rs
@@ -1,5 +1,13 @@
 extern crate vstd_extra;
-use aster_common::{x86_64::*, mm::*, page::{meta::*,model::PageUsePermission}, page_prop::*, page_table::*, task::*, vm_space::*};
+use aster_common::{
+    x86_64::*,
+    mm::*,
+    page::{meta::*, model::PageUsePermission},
+    page_prop::*,
+    page_table::*,
+    task::*,
+    vm_space::*,
+};
 use std::fs::read;
 
 use vstd::prelude::*;
@@ -9,12 +17,12 @@ use crate::common::*;
 use super::*;
 use super::model::*;
 
-/* 
+/*
 verus! {
 /// # Write of the `MetaSlotInner` to the `MetaSlot`.
-/// 
-/// Verus (and also safe Rust) does not support writing value to 
-/// the union type. So we use a more verbose way to define the 
+///
+/// Verus (and also safe Rust) does not support writing value to
+/// the union type. So we use a more verbose way to define the
 /// new object of the `MetaSlotInner`.
 
 impl MetaSlotInner {
@@ -39,10 +47,10 @@ verus!{
 impl MetaSlot {
 
 /// Simulate the initial state of the `MetaSlot`.
-/// 
+///
 /// This function is purely logical and not used for the implementation.
 /// It is defined for verify the invariants of the `MetaSlot`.
-/// 
+///
 #[rustc_allow_incoherent_impl]
 pub fn init() -> (res: (Self, Tracked<MetaSlotModel>))
     ensures
@@ -81,7 +89,7 @@ pub fn init() -> (res: (Self, Tracked<MetaSlotModel>))
 
 /// implements `self.usage.compare_exchange(0, u)`
 #[rustc_allow_incoherent_impl]
-pub fn claim(&self, usage: PageUsage, Tracked(model): Tracked<MetaSlotModel>) 
+pub fn claim(&self, usage: PageUsage, Tracked(model): Tracked<MetaSlotModel>)
     -> (res: (bool, Tracked<MetaSlotModel>))
     requires
         self.inv_relate(model),
@@ -186,7 +194,7 @@ pub fn dec(&self, mut model: Tracked<MetaSlotModel>) -> (res: (u32, Tracked<Meta
 
 /// implements `(ptr as *mut M).write(M::default())` for `from_unused()`
 #[rustc_allow_incoherent_impl]
-pub fn put_inner(&self, inner: MetaSlotInner, mut model: Tracked<MetaSlotModel>) 
+pub fn put_inner(&self, inner: MetaSlotInner, mut model: Tracked<MetaSlotModel>)
     -> (res: Tracked<MetaSlotModel>)
     requires
         self.inv_relate(model@),
@@ -209,7 +217,7 @@ pub fn put_inner(&self, inner: MetaSlotInner, mut model: Tracked<MetaSlotModel>)
 }
 
 /// seal the `inner` for `from_unused()`
-/// 
+///
 /// This function is purely logical and not used for the implementation.
 #[rustc_allow_incoherent_impl]
 pub fn seal(&self, mut model: Tracked<MetaSlotModel>) -> (res: Tracked<MetaSlotModel>)
@@ -230,7 +238,7 @@ pub fn seal(&self, mut model: Tracked<MetaSlotModel>) -> (res: Tracked<MetaSlotM
 }
 
 /// complete M::on_drop() for `drop_as_last()`
-/// 
+///
 /// This function is purely logical and not used for the implementation.
 #[rustc_allow_incoherent_impl]
 pub fn clear_inner(&self, mut model: Tracked<MetaSlotModel>) -> (res: Tracked<MetaSlotModel>)

--- a/lock-protocol/src/exec/rw/pte/page_prop.rs
+++ b/lock-protocol/src/exec/rw/pte/page_prop.rs
@@ -322,6 +322,17 @@ impl PageFlags {
     {
         Self { bits: 0b00010000 }
     }
+
+    #[verifier::external_body]
+    pub proof fn lemma_consts_properties()
+        ensures
+            Self::R().value().ilog2() == 0,
+            Self::W().value().ilog2() == 1,
+            Self::X().value().ilog2() == 2,
+            Self::ACCESSED().value().ilog2() == 3,
+            Self::DIRTY().value().ilog2() == 4,
+    {
+    }
 }
 
 }
@@ -428,6 +439,15 @@ impl PrivilegedPageFlags {
         ensures res == Self::SHARED_spec()
     {
         Self { bits: 0b10000000 }
+    }
+
+    #[verifier::external_body]
+    pub proof fn lemma_consts_properties()
+        ensures
+            Self::USER().value().ilog2() == 0,
+            Self::GLOBAL().value().ilog2() == 1,
+            Self::SHARED().value().ilog2() == 7,
+    {
     }
 
 }

--- a/lock-protocol/src/exec/rw/pte/page_table_flags.rs
+++ b/lock-protocol/src/exec/rw/pte/page_table_flags.rs
@@ -1,4 +1,9 @@
+use vstd::arithmetic::power2::{lemma2_to64, lemma2_to64_rest};
 use vstd::prelude::*;
+use vstd::arithmetic::{
+    power2::pow2,
+    logarithm::{log, lemma_log_pow},
+};
 
 verus! {
 
@@ -145,6 +150,22 @@ impl PageTableFlags {
         ensures res == Self::NO_EXECUTE_spec()
     {
         1usize << 63
+    }
+
+    #[verifier::external_body]
+    pub proof fn lemma_consts_properties()
+        ensures
+            Self::PRESENT().ilog2() == 0,
+            Self::WRITABLE().ilog2() == 1,
+            Self::USER().ilog2() == 2,
+            Self::WRITE_THROUGH().ilog2() == 3,
+            Self::NO_CACHE().ilog2() == 4,
+            Self::ACCESSED().ilog2() == 5,
+            Self::DIRTY().ilog2() == 6,
+            Self::HUGE().ilog2() == 7,
+            Self::GLOBAL().ilog2() == 8,
+            Self::NO_EXECUTE().ilog2() == 63,
+    {
     }
 
 }

--- a/vstd_extra/src/array_ptr.rs
+++ b/vstd_extra/src/array_ptr.rs
@@ -51,8 +51,7 @@ pub uninterp spec fn mem_contents_wrap<V, const N: usize>(
     data: raw_ptr::MemContents<[V; N]>,
 ) -> (res: [raw_ptr::MemContents<V>; N]);
 
-#[verifier::external_body]
-pub proof fn axiom_mem_contents_unwrap_init_correctness<V, const N: usize>(
+pub axiom fn axiom_mem_contents_unwrap_init_correctness<V, const N: usize>(
     arr: [raw_ptr::MemContents<V>; N],
     res: raw_ptr::MemContents<[V; N]>,
 )
@@ -62,12 +61,9 @@ pub proof fn axiom_mem_contents_unwrap_init_correctness<V, const N: usize>(
     ensures
         res.is_init(),
         forall|index: int| 0 <= index < N ==> #[trigger] res.value()[index] == arr[index].value(),
-{
-    unimplemented!();
-}
+;
 
-#[verifier::external_body]
-pub proof fn axiom_mem_contents_unwrap_uninit_correctness<V, const N: usize>(
+pub axiom fn axiom_mem_contents_unwrap_uninit_correctness<V, const N: usize>(
     arr: [raw_ptr::MemContents<V>; N],
     res: raw_ptr::MemContents<[V; N]>,
 )
@@ -76,12 +72,9 @@ pub proof fn axiom_mem_contents_unwrap_uninit_correctness<V, const N: usize>(
         is_mem_contents_all_uninit(arr),
     ensures
         res.is_uninit(),
-{
-    unimplemented!();
-}
+;
 
-#[verifier::external_body]
-pub proof fn axiom_mem_contents_wrap_correctness<V, const N: usize>(
+pub axiom fn axiom_mem_contents_wrap_correctness<V, const N: usize>(
     data: raw_ptr::MemContents<[V; N]>,
     res: [raw_ptr::MemContents<V>; N],
 )
@@ -91,9 +84,7 @@ pub proof fn axiom_mem_contents_wrap_correctness<V, const N: usize>(
         data.is_uninit() ==> is_mem_contents_all_uninit(res),
         data.is_init() ==> is_mem_contents_all_init(res) && forall|index: int|
             0 <= index < N ==> #[trigger] res[index].value() == data.value()[index],
-{
-    unimplemented!();
-}
+;
 
 impl<V, const N: usize> PointsToArrayData<V, N> {
     #[verifier::external_body]


### PR DESCRIPTION
This PR tries to replace `bit_mapping`, which uses suspicious iterators and axiomatized specifications, with `parse_flags`, which is consistent with the actual production code and enables verification using the `bit-vector` module of Z3.