### PR TITLE
`raw_ptr` in rw

### DIFF
--- a/lock-protocol/src/exec/rw/mem_content/meta_slot/mod.rs
+++ b/lock-protocol/src/exec/rw/mem_content/meta_slot/mod.rs
@@ -3,7 +3,7 @@ pub mod mapping;
 use builtin::*;
 use builtin_macros::*;
 use vstd::prelude::*;
-use vstd::simple_pptr::{PPtr, PointsTo};
+use vstd::raw_ptr::{PointsTo};
 
 use crate::spec::{common::*, utils::*};
 use super::super::{common::*, types::*};
@@ -86,9 +86,8 @@ pub tracked struct MetaSlotPerm {
 }
 
 impl MetaSlotPerm {
-    pub open spec fn relate(&self, ptr: PPtr<MetaSlot>) -> bool {
-        &&& self.inner.pptr() == ptr
-        &&& self.inner.addr() == ptr.addr()
+    pub open spec fn relate(&self, ptr: *const MetaSlot) -> bool {
+        &&& self.inner.ptr() == ptr
     }
 
     pub open spec fn wf(&self, meta_slot_array: &MetaSlotArray) -> bool {
@@ -111,7 +110,7 @@ impl MetaSlotPerm {
     }
 
     pub open spec fn meta_vaddr(&self) -> Vaddr {
-        self.inner.addr()
+        self.inner.ptr() as usize
     }
 
     pub open spec fn value(&self) -> MetaSlot {
@@ -121,7 +120,7 @@ impl MetaSlotPerm {
 
 struct_with_invariants! {
     pub struct MetaSlotArray {
-        pub vec: Vec<PPtr<MetaSlot>>,
+        pub vec: Vec<* const MetaSlot>,
     }
 
     pub open spec fn wf(&self) -> bool {

--- a/lock-protocol/src/exec/rw/node/mod.rs
+++ b/lock-protocol/src/exec/rw/node/mod.rs
@@ -5,7 +5,7 @@ pub mod rwlock;
 use builtin::*;
 use builtin_macros::*;
 use vstd::prelude::*;
-use vstd::simple_pptr::{PPtr, PointsTo};
+use vstd::raw_ptr::{PointsTo, ptr_ref};
 
 use vstd_extra::array_ptr::*;
 
@@ -19,7 +19,7 @@ use entry::Entry;
 verus! {
 
 pub struct PageTableNode {
-    pub ptr: PPtr<MetaSlot>,
+    pub ptr: *const MetaSlot,
     pub perm: Tracked<MetaSlotPerm>,
     pub nid: Ghost<NodeId>,
     pub inst: Tracked<SpecInstance>,
@@ -38,7 +38,7 @@ impl PageTableNode {
             *res =~= self.meta_spec(),
     {
         let tracked perm: &PointsTo<MetaSlot> = &self.perm.borrow().inner;
-        let meta_slot: &MetaSlot = self.ptr.borrow(Tracked(perm));
+        let meta_slot: &MetaSlot = ptr_ref(self.ptr, (Tracked(perm)));
         assert(meta_slot.is_pt());
         &meta_slot.get_inner_pt()
     }
@@ -112,7 +112,7 @@ impl PageTableNode {
             res == self.level_spec(),
     {
         let tracked perm: &PointsTo<MetaSlot> = &self.perm.borrow().inner;
-        let meta_slot: &MetaSlot = self.ptr.borrow(Tracked(perm));
+        let meta_slot: &MetaSlot = ptr_ref(self.ptr, Tracked(perm));
         assert(meta_slot.is_pt());
         meta_slot.get_inner_pt().level
     }

--- a/lock-protocol/src/mm/page_table/cursor/mod.rs
+++ b/lock-protocol/src/mm/page_table/cursor/mod.rs
@@ -74,7 +74,7 @@ pub struct Cursor<'a, C: PageTableConfig, PTL: PageTableLockTrait<C>> {
 }
 
 /// The maximum value of `PagingConstsTrait::NR_LEVELS`.
-const MAX_NR_LEVELS: usize = 4;
+pub const MAX_NR_LEVELS: usize = 4;
 
 // #[derive(Clone, Debug)] // TODO: Implement Debug and Clone for PageTableItem
 pub enum PageTableItem {


### PR DESCRIPTION
This PR modifies two definitions to align with `aster-3-rw`:
- Use `array` instead of `Vec` in `Cursor::path`
- Use `* const MetaSlot` instead of `PPtr<MetaSlot>`