### PR TITLE
Refactor `SubPageTableStateMachine` to use ancestors rather than decendants

### DIFF
--- a/lock-protocol/src/exec/mod.rs
+++ b/lock-protocol/src/exec/mod.rs
@@ -386,6 +386,7 @@ struct_with_invariants!{
         pub perms: HashMap<usize, (PPtr<MockPageTablePage>, Tracked<PointsTo<MockPageTablePage>>)>,
         // State machine.
         pub frames: Tracked<sub_page_table::SubPageTableStateMachine::frames>,
+        pub i_ptes: Tracked<sub_page_table::SubPageTableStateMachine::i_ptes>,
         pub ptes: Tracked<sub_page_table::SubPageTableStateMachine::ptes>,
         pub instance: Tracked<sub_page_table::SubPageTableStateMachine::Instance>,
     }


### PR DESCRIPTION
Using descendants, you need to modify 2 KV pairs on allocation. While using ancestors you can just modify 1.