### PR TITLE
RW:Test attribute syntax

### DIFF
--- a/lock-protocol/src/exec/rw/mem_content/meta_slot/mod.rs
+++ b/lock-protocol/src/exec/rw/mem_content/meta_slot/mod.rs
@@ -86,7 +86,7 @@ impl MetaSlot {
             *res =~= perm.get_pt(),
             res.wf(),
     )]
-    pub fn get_inner_pt(&self) -> (res: &PageTablePageMeta) {
+    pub fn get_inner_pt(&self) -> &PageTablePageMeta {
         unimplemented!()
     }
 }

--- a/lock-protocol/src/exec/rw/mem_content/meta_slot/mod.rs
+++ b/lock-protocol/src/exec/rw/mem_content/meta_slot/mod.rs
@@ -74,8 +74,10 @@ pub struct MetaSlot {
 }
 
 impl MetaSlot {
-    #[verifier::external_body]
-    pub fn get_inner_pt(&self, Tracked(perm): Tracked<&MetaSlotPerm>) -> (res: &PageTablePageMeta)
+    #[verus_verify(external_body)]
+    #[verus_spec( res =>
+        with
+            Tracked(perm): Tracked<&MetaSlotPerm>
         requires
             perm.is_pt(),
             perm.wf(),
@@ -83,7 +85,8 @@ impl MetaSlot {
         ensures
             *res =~= perm.get_pt(),
             res.wf(),
-    {
+    )]
+    pub fn get_inner_pt(&self) -> (res: &PageTablePageMeta) {
         unimplemented!()
     }
 }

--- a/lock-protocol/src/exec/rw/node/mod.rs
+++ b/lock-protocol/src/exec/rw/node/mod.rs
@@ -31,15 +31,17 @@ impl PageTableNode {
         self.perm@.get_pt()
     }
 
+    #[verus_spec]
     pub fn meta(&self) -> (res: &PageTablePageMeta)
         requires
             self.wf(),
         ensures
             *res =~= self.meta_spec(),
     {
-        let tracked perm = self.perm.borrow();
+        proof_decl!{let tracked perm = self.perm.borrow();}
         let meta_slot: &MetaSlot = ptr_ref(self.ptr, (Tracked(&perm.ptr_perm)));
-        &meta_slot.get_inner_pt(Tracked(perm))
+        proof_with!{Tracked(perm)}
+        meta_slot.get_inner_pt()
     }
 
     pub uninterp spec fn from_raw_spec(paddr: Paddr) -> Self;
@@ -102,9 +104,7 @@ impl PageTableNode {
         ensures
             res == self.level_spec(),
     {
-        let tracked perm = self.perm.borrow();
-        let meta_slot: &MetaSlot = ptr_ref(self.ptr, (Tracked(&perm.ptr_perm)));
-        meta_slot.get_inner_pt(Tracked(&perm)).level
+        self.meta().level
     }
 
     pub fn lock_write(self, m: Tracked<LockProtocolModel>) -> (res: (


### PR DESCRIPTION
This PR makes the first attempt to use [attribute-based spec syntax](https://github.com/verus-lang/verus/discussions/1716). The major benefit of including this is that the ghost parameters are encapsulated in the spec, so it is no longer necessary to modify the function signature. Additionally, proof code is now enclosed within `proof!` or `proof_decl!`, which I believe helps distinguish it from executable code.