### PR TITLE
Provide fallback to powershell if pwsh is not present when bootstrapping

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -56,7 +56,7 @@ fn get_powershell_command() -> io::Result<Command> {
 
     Err(io::Error::new(
         io::ErrorKind::NotFound,
-        "No working PowerShell version found"
+        "No working PowerShell version found",
     ))
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -51,6 +51,12 @@ fn get_powershell_command() -> io::Result<Command> {
         .status();
 
     if matches!(check_ps, Ok(status) if status.success()) {
+        eprintln!("Warning: Using powershell.exe(Windows PowerShell 5.x).");
+        eprintln!(
+            "If you encounter errors related to `Get‑ExecutionPolicy` or \
+            failure loading the `Microsoft.PowerShell.Security` module, please \
+            try using `pwsh` (PowerShell 7 or later) instead."
+        );
         return Ok(Command::new("powershell"));
     }
 


### PR DESCRIPTION
When bootstrapping using `cargo xtask bootstrap` on Windows without a separately installed `pwsh`, the bootstrapping process will fail because of "program not found".

This PR introduces a function `get_powershell_command` that chooses the appropriate PowerShell command on Windows. It defaults to `pwsh` and falls back to `powershell` if `pwsh` is not present.

The bootstrapping process had been tested with both shells.