### PR TITLE
Remove use of `builtin` and `builtin_macros`

### DIFF
--- a/aster_common/src/cpu/set/atomic/exec.rs
+++ b/aster_common/src/cpu/set/atomic/exec.rs
@@ -1,5 +1,3 @@
-use builtin::*;
-use builtin_macros::*;
 use vstd::{prelude::*, atomic_ghost::AtomicBool, atomic_with_ghost};
 use super::spec::AtomicCpuSetSpec;
 use super::super::CpuSet;

--- a/aster_common/src/cpu/set/atomic/spec.rs
+++ b/aster_common/src/cpu/set/atomic/spec.rs
@@ -1,7 +1,5 @@
 #![allow(non_snake_case)]
 
-use builtin::*;
-use builtin_macros::*;
 use state_machines_macros::tokenized_state_machine;
 use vstd::prelude::*;
 

--- a/fvt13-vmspace-unmap-safety/src/spin/exec.rs
+++ b/fvt13-vmspace-unmap-safety/src/spin/exec.rs
@@ -1,6 +1,4 @@
 #[allow(unused_imports)]
-use builtin::*;
-use builtin_macros::*;
 use vstd::{
     atomic_ghost::AtomicBool,
     atomic_with_ghost,

--- a/fvt13-vmspace-unmap-safety/src/spin/spec.rs
+++ b/fvt13-vmspace-unmap-safety/src/spin/spec.rs
@@ -1,6 +1,4 @@
 #[allow(unused_imports)]
-use builtin::*;
-use builtin_macros::*;
 use state_machines_macros::tokenized_state_machine;
 use vstd::prelude::*;
 

--- a/fvt13-vmspace-unmap-safety/src/tlb/mod.rs
+++ b/fvt13-vmspace-unmap-safety/src/tlb/mod.rs
@@ -2,8 +2,6 @@ mod cpu_local_queue;
 // pub mod local_queue;
 // pub mod model;
 
-use builtin::*;
-use builtin_macros::*;
 use vstd::prelude::*;
 use aster_common::x86_64::mm::{PAGE_SIZE, MAX_NR_PAGES};
 use aster_common::cpu::PinCurrentCpu;

--- a/lock-protocol/src/exec/rcu/common.rs
+++ b/lock-protocol/src/exec/rcu/common.rs
@@ -1,7 +1,5 @@
 use std::ops::Range;
 
-use builtin::*;
-use builtin_macros::*;
 use vstd::prelude::*;
 use vstd::vstd::arithmetic::power2::*;
 use vstd::arithmetic::div_mod::*;

--- a/lock-protocol/src/exec/rcu/configs.rs
+++ b/lock-protocol/src/exec/rcu/configs.rs
@@ -1,5 +1,3 @@
-use builtin::*;
-use builtin_macros::*;
 use vstd::prelude::*;
 
 verus! {

--- a/lock-protocol/src/exec/rcu/cursor/locking.rs
+++ b/lock-protocol/src/exec/rcu/cursor/locking.rs
@@ -1,8 +1,7 @@
 use core::mem::ManuallyDrop;
 use core::ops::Deref;
 use std::ops::Range;
-use builtin::*;
-use builtin_macros::*;
+
 use vstd::prelude::*;
 
 use vstd_extra::manually_drop::*;

--- a/lock-protocol/src/exec/rcu/cursor/mod.rs
+++ b/lock-protocol/src/exec/rcu/cursor/mod.rs
@@ -1,8 +1,7 @@
 pub mod locking;
 
 use std::ops::Range;
-use builtin::*;
-use builtin_macros::*;
+
 use vstd::prelude::*;
 
 use crate::spec::{common::*, utils::*, rcu::*};

--- a/lock-protocol/src/exec/rcu/frame/meta/mapping.rs
+++ b/lock-protocol/src/exec/rcu/frame/meta/mapping.rs
@@ -1,8 +1,6 @@
 use core::ops::Range;
 use core::mem::size_of;
 
-use builtin::*;
-use builtin_macros::*;
 use vstd::prelude::*;
 
 use super::super::super::common::*;

--- a/lock-protocol/src/exec/rcu/frame/meta/mod.rs
+++ b/lock-protocol/src/exec/rcu/frame/meta/mod.rs
@@ -1,7 +1,5 @@
 pub mod mapping;
 
-use builtin::*;
-use builtin_macros::*;
 use vstd::prelude::*;
 use vstd::raw_ptr::{PointsTo};
 

--- a/lock-protocol/src/exec/rcu/node/child.rs
+++ b/lock-protocol/src/exec/rcu/node/child.rs
@@ -1,7 +1,6 @@
 use core::mem::ManuallyDrop;
 use core::ops::Deref;
-use builtin::*;
-use builtin_macros::*;
+
 use vstd::prelude::*;
 use vstd::vpanic;
 

--- a/lock-protocol/src/exec/rcu/node/entry.rs
+++ b/lock-protocol/src/exec/rcu/node/entry.rs
@@ -1,6 +1,5 @@
 use core::ops::Deref;
-use builtin::*;
-use builtin_macros::*;
+
 use vstd::prelude::*;
 
 use crate::spec::{common::*, utils::*};

--- a/lock-protocol/src/exec/rcu/node/mod.rs
+++ b/lock-protocol/src/exec/rcu/node/mod.rs
@@ -6,8 +6,7 @@ pub mod stray;
 use core::mem::ManuallyDrop;
 use core::ops::Deref;
 use core::marker::PhantomData;
-use builtin::*;
-use builtin_macros::*;
+
 use vstd::prelude::*;
 use vstd::raw_ptr::{PointsTo, ptr_ref};
 use vstd::cell::{PCell, PointsTo as CellPointsTo};

--- a/lock-protocol/src/exec/rcu/node/stray.rs
+++ b/lock-protocol/src/exec/rcu/node/stray.rs
@@ -1,5 +1,3 @@
-use builtin::*;
-use builtin_macros::*;
 use vstd::prelude::*;
 
 use crate::spec::{common::*, utils::*, rcu::*};

--- a/lock-protocol/src/exec/rcu/page_table.rs
+++ b/lock-protocol/src/exec/rcu/page_table.rs
@@ -1,5 +1,3 @@
-use builtin::*;
-use builtin_macros::*;
 use vstd::prelude::*;
 use vstd::tokens::*;
 use vstd::atomic_ghost::*;

--- a/lock-protocol/src/exec/rcu/trust_rcu.rs
+++ b/lock-protocol/src/exec/rcu/trust_rcu.rs
@@ -1,5 +1,3 @@
-use builtin::*;
-use builtin_macros::*;
 use vstd::prelude::*;
 
 use crate::spec::{common::*, utils::*, rcu::*};

--- a/lock-protocol/src/exec/rcu/types.rs
+++ b/lock-protocol/src/exec/rcu/types.rs
@@ -1,6 +1,4 @@
-use builtin::*;
-use builtin_macros::*;
-
+use vstd::prelude::*;
 use crate::spec::rcu::*;
 
 verus! {

--- a/lock-protocol/src/exec/rw/common.rs
+++ b/lock-protocol/src/exec/rw/common.rs
@@ -1,7 +1,5 @@
 use std::ops::Range;
 
-use builtin::*;
-use builtin_macros::*;
 use vstd::prelude::*;
 use vstd::vstd::arithmetic::power2::*;
 use vstd::arithmetic::div_mod::*;

--- a/lock-protocol/src/exec/rw/configs.rs
+++ b/lock-protocol/src/exec/rw/configs.rs
@@ -1,5 +1,3 @@
-use builtin::*;
-use builtin_macros::*;
 use vstd::prelude::*;
 
 verus! {

--- a/lock-protocol/src/exec/rw/cursor.rs
+++ b/lock-protocol/src/exec/rw/cursor.rs
@@ -2,8 +2,6 @@ use std::mem::ManuallyDrop;
 use core::ops::Deref;
 use std::ops::Range;
 
-use builtin::*;
-use builtin_macros::*;
 use vstd::invariant;
 use vstd::prelude::*;
 use vstd::atomic_with_ghost;

--- a/lock-protocol/src/exec/rw/frame/allocator.rs
+++ b/lock-protocol/src/exec/rw/frame/allocator.rs
@@ -1,5 +1,3 @@
-use builtin::*;
-use builtin_macros::*;
 use vstd::prelude::*;
 
 use crate::spec::{common::*, utils::*, tree::*};

--- a/lock-protocol/src/exec/rw/frame/common.rs
+++ b/lock-protocol/src/exec/rw/frame/common.rs
@@ -1,5 +1,3 @@
-use builtin::*;
-use builtin_macros::*;
 use vstd::prelude::*;
 
 verus! {

--- a/lock-protocol/src/exec/rw/frame/mod.rs
+++ b/lock-protocol/src/exec/rw/frame/mod.rs
@@ -1,7 +1,5 @@
 // mod common;
 // mod allocator;
-use builtin::*;
-use builtin_macros::*;
 use vstd::prelude::*;
 use vstd::rwlock::*;
 use vstd::vstd::arithmetic::power2::*;

--- a/lock-protocol/src/exec/rw/mem_content/meta_slot/mapping.rs
+++ b/lock-protocol/src/exec/rw/mem_content/meta_slot/mapping.rs
@@ -1,8 +1,6 @@
 use core::ops::Range;
 use core::mem::size_of;
 
-use builtin::*;
-use builtin_macros::*;
 use vstd::prelude::*;
 
 use super::super::super::common::*;

--- a/lock-protocol/src/exec/rw/mem_content/meta_slot/mod.rs
+++ b/lock-protocol/src/exec/rw/mem_content/meta_slot/mod.rs
@@ -1,7 +1,5 @@
 pub mod mapping;
 
-use builtin::*;
-use builtin_macros::*;
 use vstd::prelude::*;
 use vstd::{
     raw_ptr::{PointsTo},

--- a/lock-protocol/src/exec/rw/mem_content/mod.rs
+++ b/lock-protocol/src/exec/rw/mem_content/mod.rs
@@ -1,7 +1,5 @@
 pub mod meta_slot;
 
-use builtin::*;
-use builtin_macros::*;
 use vstd::prelude::*;
 
 pub use meta_slot::*;

--- a/lock-protocol/src/exec/rw/node/child.rs
+++ b/lock-protocol/src/exec/rw/node/child.rs
@@ -1,6 +1,5 @@
 use core::mem::ManuallyDrop;
-use builtin::*;
-use builtin_macros::*;
+
 use vstd::prelude::*;
 use vstd::vpanic;
 

--- a/lock-protocol/src/exec/rw/node/entry.rs
+++ b/lock-protocol/src/exec/rw/node/entry.rs
@@ -1,5 +1,3 @@
-use builtin::*;
-use builtin_macros::*;
 use vstd::prelude::*;
 
 use crate::spec::{common::*, utils::*};

--- a/lock-protocol/src/exec/rw/node/mod.rs
+++ b/lock-protocol/src/exec/rw/node/mod.rs
@@ -2,8 +2,6 @@ pub mod child;
 pub mod entry;
 pub mod rwlock;
 
-use builtin::*;
-use builtin_macros::*;
 use vstd::prelude::*;
 use vstd::raw_ptr::{PointsTo, ptr_ref};
 

--- a/lock-protocol/src/exec/rw/page_table.rs
+++ b/lock-protocol/src/exec/rw/page_table.rs
@@ -1,6 +1,5 @@
 use core::fmt::Debug;
-use builtin::*;
-use builtin_macros::*;
+
 use vstd::prelude::*;
 use vstd::tokens::*;
 use vstd::atomic_ghost::*;

--- a/lock-protocol/src/exec/rw/types.rs
+++ b/lock-protocol/src/exec/rw/types.rs
@@ -1,6 +1,4 @@
-use builtin::*;
-use builtin_macros::*;
-
+use vstd::prelude::*;
 use crate::spec::rw::*;
 
 verus! {

--- a/lock-protocol/src/spec/common.rs
+++ b/lock-protocol/src/spec/common.rs
@@ -1,7 +1,5 @@
 use std::{io::Write, path, result};
 
-use builtin::*;
-use builtin_macros::*;
 use vstd::{prelude::*, seq::*};
 use vstd_extra::{ghost_tree::Node, seq_extra::*};
 

--- a/lock-protocol/src/spec/rcu/tree.rs
+++ b/lock-protocol/src/spec/rcu/tree.rs
@@ -1,5 +1,3 @@
-use builtin::*;
-use builtin_macros::*;
 use state_machines_macros::tokenized_state_machine;
 use vstd::prelude::*;
 

--- a/lock-protocol/src/spec/rcu/types.rs
+++ b/lock-protocol/src/spec/rcu/types.rs
@@ -1,5 +1,3 @@
-use builtin::*;
-use builtin_macros::*;
 use vstd::{prelude::*, seq::*};
 
 use crate::spec::{common::*, utils::*};

--- a/lock-protocol/src/spec/rw/atomic.rs
+++ b/lock-protocol/src/spec/rw/atomic.rs
@@ -1,5 +1,3 @@
-use builtin::*;
-use builtin_macros::*;
 use state_machines_macros::state_machine;
 use vstd::prelude::*;
 use vstd::map::*;

--- a/lock-protocol/src/spec/rw/tree.rs
+++ b/lock-protocol/src/spec/rw/tree.rs
@@ -1,5 +1,3 @@
-use builtin::*;
-use builtin_macros::*;
 use state_machines_macros::tokenized_state_machine;
 use vstd::prelude::*;
 

--- a/lock-protocol/src/spec/rw/tree_refines_atomic.rs
+++ b/lock-protocol/src/spec/rw/tree_refines_atomic.rs
@@ -1,8 +1,5 @@
-use builtin::*;
-use builtin_macros::*;
-use vstd::*;
+use vstd::prelude::*;
 use vstd::map::*;
-// use vstd::
 
 use state_machines_macros::case_on_init;
 use state_machines_macros::case_on_next;

--- a/lock-protocol/src/spec/rw/types.rs
+++ b/lock-protocol/src/spec/rw/types.rs
@@ -1,5 +1,3 @@
-use builtin::*;
-use builtin_macros::*;
 use vstd::{prelude::*, seq::*};
 
 use crate::spec::{common::*, utils::*};

--- a/lock-protocol/src/spec/rw/wf_tree_path.rs
+++ b/lock-protocol/src/spec/rw/wf_tree_path.rs
@@ -1,7 +1,5 @@
 use std::{io::Write, path, result};
 
-use builtin::*;
-use builtin_macros::*;
 use vstd::{prelude::*, seq::*};
 use vstd_extra::{ghost_tree::Node, seq_extra::*};
 

--- a/lock-protocol/src/spec/utils.rs
+++ b/lock-protocol/src/spec/utils.rs
@@ -1,7 +1,5 @@
 use std::intrinsics::offset;
 
-use builtin::*;
-use builtin_macros::*;
 use vstd::bytes;
 use vstd::prelude::*;
 use vstd::arithmetic::power::*;


### PR DESCRIPTION
Remove use of `builtin` and `builtin_macros` to prepare for [the crate name update](https://verus-lang.zulipchat.com/#narrow/channel/402809-announcements/topic/Changes.20to.20Verus-related.20crate.20names/with/530673885).