### PR TITLE
Make pte_index refer to C for constants instead of PagingConsts

### DIFF
--- a/lock-protocol/src/mm/page_table/cursor/mod.rs
+++ b/lock-protocol/src/mm/page_table/cursor/mod.rs
@@ -314,7 +314,10 @@ impl<'a, C: PageTableConfig> Cursor<'a, C> {
                         == #[trigger] pte_index::<C>(old(self).va, i)) by {
                     let old_level = old(self).level;
                     let aligned_va = align_down(old(self).va, cur_page_size);
-                    assume(aligned_va + cur_page_size < usize::MAX);
+                    assert(aligned_va + cur_page_size < usize::MAX) by {
+                        assert(aligned_va + cur_page_size <= old(self).barrier_va.end);
+                        assert(old(self).barrier_va.end < usize::MAX);
+                    }
 
                     lemma_aligned_pte_index_unchanged::<C>(old(self).va, old_level);
                     lemma_add_page_size_change_pte_index::<C>(

--- a/lock-protocol/src/mm/page_table/cursor/mod.rs
+++ b/lock-protocol/src/mm/page_table/cursor/mod.rs
@@ -305,9 +305,10 @@ impl<'a, C: PageTableConfig> Cursor<'a, C> {
         self.va = next_va;
         proof {
             if (self.level == self.guard_level) {
-                assume(self.wf(spt));  // TODO: Handle the case where the cursor is at the guard level.
+                // The proof automatically goes through in this case.
             } else {
                 assert(self.level < self.guard_level);
+                assert(pte_index::<C>(next_va, self.level) != 0);
                 assert(forall|i: u8|
                     self.level < i <= self.guard_level ==> #[trigger] pte_index::<C>(self.va, i)
                         == #[trigger] pte_index::<C>(old(self).va, i)) by {

--- a/lock-protocol/src/mm/page_table/mod.rs
+++ b/lock-protocol/src/mm/page_table/mod.rs
@@ -524,10 +524,10 @@ pub fn pte_index_mask<C: PagingConstsTrait>() -> (res: usize)
 
 pub open spec fn pte_index_spec<C: PagingConstsTrait>(va: Vaddr, level: PagingLevel) -> usize
     recommends
-        0 < level <= PagingConsts::NR_LEVELS_SPEC(),
+        0 < level <= C::NR_LEVELS_SPEC(),
 {
-    let base_bits = PagingConsts::BASE_PAGE_SIZE_SPEC().ilog2();
-    let index_bits = nr_pte_index_bits::<PagingConsts>();
+    let base_bits = C::BASE_PAGE_SIZE_SPEC().ilog2();
+    let index_bits = nr_pte_index_bits::<C>();
     let shift = base_bits + (level - 1) as u32 * index_bits as u32;
     (va >> shift) & pte_index_mask::<C>()
 }
@@ -538,29 +538,41 @@ pub open spec fn pte_index_spec<C: PagingConstsTrait>(va: Vaddr, level: PagingLe
 pub fn pte_index<C: PagingConstsTrait>(va: Vaddr, level: PagingLevel) -> (res:
     usize)  // TODO: type, const
     requires
-        0 < level <= PagingConsts::NR_LEVELS_SPEC(),
+        0 < level <= C::NR_LEVELS_SPEC(),
     ensures
         res == pte_index_spec::<C>(va, level),
         res < nr_subpage_per_huge::<C>(),
 {
-    let base_bits = PagingConsts::BASE_PAGE_SIZE().ilog2();
-    assert(base_bits == 12) by {
-        bits_of_base_page_size();
-    };
-    let index_bits = nr_pte_index_bits::<PagingConsts>();
-    assert(index_bits == 9) by {
-        bits_of_nr_pte_index();
-    };
-    assert(0 <= (level - 1) * index_bits <= 36);
-    let shift = base_bits + (level - 1) as u32 * index_bits as u32;
-    let res = (va >> shift) as u64 & pte_index_mask::<C>() as u64;
-    assert(res <= pte_index_mask::<C>()) by {
-        lemma_u64_and_less_than((va >> shift) as u64, pte_index_mask::<C>() as u64);
-    };
+    let base_bits = C::BASE_PAGE_SIZE().ilog2();
+    let index_bits = nr_pte_index_bits::<C>();
+    assert(index_bits == (C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2()) as usize);
     proof {
         C::lemma_consts_properties();
         C::lemma_consts_properties_derived();
     }
+    assert(1 <= level as u32 <= 10);
+    assert(index_bits as u32 <= 16);
+    assert(base_bits < usize::BITS);
+    // 10000 is arbitrary, but it is enough to show the absence of overflow.
+    assert((level - 1) as u32 * index_bits as u32 <= 10000) by (nonlinear_arith)
+        requires
+            1 <= level as u32 <= 10,
+            index_bits as u32 <= 16,
+            base_bits < usize::BITS;
+    let shift = base_bits + (level - 1) as u32 * index_bits as u32;
+    // Proof idea: transitivity of < and <=, along with nonlinear_arith
+    assert(shift < usize::BITS) by {
+        assert(level - 1 < C::NR_LEVELS());
+        assert(base_bits + index_bits * C::NR_LEVELS() < usize::BITS);
+        assert(base_bits + index_bits * (level - 1) <= base_bits + index_bits * C::NR_LEVELS())
+            by (nonlinear_arith)
+            requires
+                level - 1 < C::NR_LEVELS();
+    }
+    let res = (va >> shift) as u64 & pte_index_mask::<C>() as u64;
+    assert(res <= pte_index_mask::<C>()) by {
+        lemma_u64_and_less_than((va >> shift) as u64, pte_index_mask::<C>() as u64);
+    };
     res as usize
 }
 


### PR DESCRIPTION
In the `page_size` function queries its generic parameter `C` for constants instead of `PagingConsts`, but the `pte_index` uses `PagingConsts`. I think this inconsistency is a bug, so I changed `pte_index` to use `C` instead of `PagingConsts`.

Also contains some minor fixes to the proof of `move_forward`.