### PR TITLE
Breaking: Update verus crate names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,6 @@ version = 4
 name = "aster_common"
 version = "0.1.0"
 dependencies = [
- "builtin_macros",
  "vstd",
  "vstd_extra",
 ]
@@ -16,22 +15,6 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "builtin"
-version = "0.1.0"
-
-[[package]]
-name = "builtin_macros"
-version = "0.1.0"
-dependencies = [
- "prettyplease_verus",
- "proc-macro2",
- "quote",
- "syn",
- "syn_verus",
- "synstructure",
-]
 
 [[package]]
 name = "fvt1-mem-region-init"
@@ -68,8 +51,6 @@ dependencies = [
 name = "fvt3-page-acquisition-safety"
 version = "0.1.0"
 dependencies = [
- "builtin",
- "builtin_macros",
  "num-derive",
  "num-traits",
  "vstd",
@@ -79,8 +60,6 @@ dependencies = [
 name = "fvt4-into-from-raw"
 version = "0.1.0"
 dependencies = [
- "builtin",
- "builtin_macros",
  "num-derive",
  "num-traits",
  "vstd",
@@ -144,14 +123,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease_verus"
-version = "0.2.29"
-dependencies = [
- "proc-macro2",
- "syn_verus",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,29 +141,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "state_machines_macros"
-version = "0.1.0"
-dependencies = [
- "indexmap",
- "proc-macro2",
- "quote",
- "syn_verus",
-]
-
-[[package]]
 name = "syn"
 version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn_verus"
-version = "2.0.96"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -223,19 +175,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "verus_builtin"
+version = "0.1.0"
+
+[[package]]
+name = "verus_builtin_macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+ "verus_prettyplease",
+ "verus_syn",
+]
+
+[[package]]
+name = "verus_prettyplease"
+version = "0.2.29+verus"
+dependencies = [
+ "proc-macro2",
+ "verus_syn",
+]
+
+[[package]]
+name = "verus_state_machines_macros"
+version = "0.1.0"
+dependencies = [
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "verus_syn",
+]
+
+[[package]]
+name = "verus_syn"
+version = "2.0.96+verus"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "vstd"
 version = "0.1.0"
 dependencies = [
- "builtin",
- "builtin_macros",
- "state_machines_macros",
+ "verus_builtin",
+ "verus_builtin_macros",
+ "verus_state_machines_macros",
 ]
 
 [[package]]
 name = "vstd_extra"
 version = "0.1.0"
 dependencies = [
- "builtin",
- "builtin_macros",
  "vstd",
 ]

--- a/aster_common/Cargo.toml
+++ b/aster_common/Cargo.toml
@@ -7,5 +7,4 @@ edition = "2021"
 
 [dependencies]
 vstd = { path = "../tools/verus/source/vstd" }
-builtin_macros = { path = "../tools/verus/source/builtin_macros" }
 vstd_extra = { path = "../vstd_extra" }

--- a/aster_common/src/cpu/set/atomic/spec.rs
+++ b/aster_common/src/cpu/set/atomic/spec.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 
-use state_machines_macros::tokenized_state_machine;
+use verus_state_machines_macros::tokenized_state_machine;
 use vstd::prelude::*;
 
 verus! {

--- a/fvt13-vmspace-unmap-safety/src/spin/spec.rs
+++ b/fvt13-vmspace-unmap-safety/src/spin/spec.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use state_machines_macros::tokenized_state_machine;
+use verus_state_machines_macros::tokenized_state_machine;
 use vstd::prelude::*;
 
 verus! {

--- a/fvt3-page-acquisition-safety/Cargo.toml
+++ b/fvt3-page-acquisition-safety/Cargo.toml
@@ -10,8 +10,6 @@ rustc = []
 
 [dependencies]
 vstd ={ path = "../tools/verus/source/vstd" }
-builtin ={ path = "../tools/verus/source/builtin" }
-builtin_macros ={ path = "../tools/verus/source/builtin_macros" }
 num-derive = { version = "*", default-features = false }
 num-traits = { version = "*", default-features = false }
 

--- a/fvt4-into-from-raw/Cargo.toml
+++ b/fvt4-into-from-raw/Cargo.toml
@@ -10,8 +10,6 @@ rustc = []
 
 [dependencies]
 vstd ={ path = "../tools/verus/source/vstd" }
-builtin ={ path = "../tools/verus/source/builtin" }
-builtin_macros ={ path = "../tools/verus/source/builtin_macros" }
 num-derive = { version = "*", default-features = false }
 num-traits = { version = "*", default-features = false }
 

--- a/lock-protocol/src/exec/rcu/node/spinlock/mod.rs
+++ b/lock-protocol/src/exec/rcu/node/spinlock/mod.rs
@@ -1,5 +1,5 @@
 use core::marker::PhantomData;
-use state_machines_macros::tokenized_state_machine;
+use verus_state_machines_macros::tokenized_state_machine;
 use vstd::prelude::*;
 use vstd::atomic_ghost::*;
 use vstd::invariant::InvariantPredicate;

--- a/lock-protocol/src/exec/rw/node/rwlock/mod.rs
+++ b/lock-protocol/src/exec/rw/node/rwlock/mod.rs
@@ -1,6 +1,6 @@
 // Copied from vstd
 use core::marker::PhantomData;
-use state_machines_macros::tokenized_state_machine;
+use verus_state_machines_macros::tokenized_state_machine;
 use vstd::prelude::*;
 use vstd::atomic_ghost::*;
 use vstd::invariant::InvariantPredicate;

--- a/lock-protocol/src/spec/rcu/atomic.rs
+++ b/lock-protocol/src/spec/rcu/atomic.rs
@@ -1,4 +1,4 @@
-use state_machines_macros::state_machine;
+use verus_state_machines_macros::state_machine;
 use vstd::prelude::*;
 use vstd::map::*;
 

--- a/lock-protocol/src/spec/rcu/tree.rs
+++ b/lock-protocol/src/spec/rcu/tree.rs
@@ -1,4 +1,4 @@
-use state_machines_macros::tokenized_state_machine;
+use verus_state_machines_macros::tokenized_state_machine;
 use vstd::prelude::*;
 use vstd::multiset::*;
 

--- a/lock-protocol/src/spec/rcu/tree_refines_atomic.rs
+++ b/lock-protocol/src/spec/rcu/tree_refines_atomic.rs
@@ -1,8 +1,8 @@
 use vstd::prelude::*;
 use vstd::map::*;
 
-use state_machines_macros::case_on_init;
-use state_machines_macros::case_on_next;
+use verus_state_machines_macros::case_on_init;
+use verus_state_machines_macros::case_on_next;
 
 use crate::spec::{common::*, utils::*};
 

--- a/lock-protocol/src/spec/rw/atomic.rs
+++ b/lock-protocol/src/spec/rw/atomic.rs
@@ -1,4 +1,4 @@
-use state_machines_macros::state_machine;
+use verus_state_machines_macros::state_machine;
 use vstd::prelude::*;
 use vstd::map::*;
 

--- a/lock-protocol/src/spec/rw/tree.rs
+++ b/lock-protocol/src/spec/rw/tree.rs
@@ -1,4 +1,4 @@
-use state_machines_macros::tokenized_state_machine;
+use verus_state_machines_macros::tokenized_state_machine;
 use vstd::prelude::*;
 
 use crate::spec::{common::*, utils::*};

--- a/lock-protocol/src/spec/rw/tree_refines_atomic.rs
+++ b/lock-protocol/src/spec/rw/tree_refines_atomic.rs
@@ -1,8 +1,8 @@
 use vstd::prelude::*;
 use vstd::map::*;
 
-use state_machines_macros::case_on_init;
-use state_machines_macros::case_on_next;
+use verus_state_machines_macros::case_on_init;
+use verus_state_machines_macros::case_on_next;
 
 use crate::spec::{common::*, utils::*};
 

--- a/lock-protocol/src/spec/sub_pt/state_machine.rs
+++ b/lock-protocol/src/spec/sub_pt/state_machine.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use state_machines_macros::*;
+use verus_state_machines_macros::*;
 use vstd::prelude::*;
 
 use crate::mm::allocator::pa_is_valid_kernel_address;

--- a/lock-protocol/src/test/struct_test.rs
+++ b/lock-protocol/src/test/struct_test.rs
@@ -1,7 +1,4 @@
 #[allow(unused_imports)]
-use builtin::*;
-use builtin_macros::*;
-
 use vstd::prelude::*;
 
 verus! {

--- a/lock-protocol/src/test/token_usage/common.rs
+++ b/lock-protocol/src/test/token_usage/common.rs
@@ -1,6 +1,3 @@
-use builtin::*;
-use builtin_macros::*;
-
 use super::super::super::spec::{common::*, utils::*};
 
 verus! {

--- a/lock-protocol/src/test/token_usage/exec_nid.rs
+++ b/lock-protocol/src/test/token_usage/exec_nid.rs
@@ -1,5 +1,3 @@
-use builtin::*;
-use builtin_macros::*;
 use vstd::prelude::*;
 
 use super::super::super::spec::{utils::*, common::*};

--- a/lock-protocol/src/test/token_usage/mod.rs
+++ b/lock-protocol/src/test/token_usage/mod.rs
@@ -4,9 +4,7 @@ mod spin_lock;
 
 use std::collections::HashMap;
 
-use builtin::*;
-use builtin_macros::*;
-use state_machines_macros::tokenized_state_machine;
+use verus_state_machines_macros::tokenized_state_machine;
 use vstd::prelude::*;
 use vstd::hash_map::*;
 use vstd::tokens::*;

--- a/lock-protocol/src/test/token_usage/spin_lock.rs
+++ b/lock-protocol/src/test/token_usage/spin_lock.rs
@@ -1,6 +1,4 @@
-use builtin::*;
-use builtin_macros::*;
-use state_machines_macros::tokenized_state_machine;
+use verus_verus_state_machines_macros::tokenized_state_machine;
 use vstd::{
     atomic_ghost::AtomicBool,
     atomic_with_ghost,

--- a/lock-protocol/src/test/tsm_test.rs
+++ b/lock-protocol/src/test/tsm_test.rs
@@ -1,5 +1,5 @@
 use vstd::prelude::*;
-use state_machines_macros::*;
+use verus_state_machines_macros::*;
 
 verus! {
 

--- a/vstd_extra/Cargo.toml
+++ b/vstd_extra/Cargo.toml
@@ -7,5 +7,3 @@ edition = "2021"
 
 [dependencies]
 vstd = { path = "../tools/verus/source/vstd" }
-builtin = { path = "../tools/verus/source/builtin" }
-builtin_macros = { path = "../tools/verus/source/builtin_macros" }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -491,8 +491,6 @@ lazy_static! {
     static ref SYSTEM_CRATES: HashSet<&'static str> = {
         let mut set = HashSet::new();
         set.insert("vstd");
-        set.insert("builtin");
-        set.insert("builtin_macros");
         set
     };
 }
@@ -773,18 +771,7 @@ fn exec_doc(args: &DocArgs) -> Result<(), DynError> {
             ))
             .arg("--extern")
             .arg(format!(
-                "builtin={}/target-verus/debug/libbuiltin.rlib",
-                verus_root.display()
-            ))
-            .arg("--extern")
-            .arg(format!(
-                "builtin_macros={}/target-verus/debug/libbuiltin_macros.{}",
-                verus_root.display(),
-                dll_ext
-            ))
-            .arg("--extern")
-            .arg(format!(
-                "state_machines_macros={}/target-verus/debug/libstate_machines_macros.{}",
+                "verus_state_machines_macros={}/target-verus/debug/lib_verus_state_machines_macros.{}",
                 verus_root.display(),
                 dll_ext
             ))


### PR DESCRIPTION
[The latest Verus](https://github.com/verus-lang/verus/pull/1815) renamed `bulitin`, `builtin_macros`, and `state_machines_macros` with a `verus_` prefix, and our Verus fork follows this update. This PR modifies the usages of these crates accordingly. Users should run `cargo xtask update` asap.