### PR TITLE
Add a parallel option to verify

### DIFF
--- a/.github/workflows/xtask-verify.yml
+++ b/.github/workflows/xtask-verify.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Run verification
         run: |
-          make 2>&1 | tee verus.log
+          VOSTD_VERIFY_PARALLEL=1 make 2>&1 | tee verus.log
           if grep -q "error:" verus.log; then
             echo "::error title=Verification Failed::Verification errors found in the code"
             echo "Verification errors:"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 .DEFAULT_GOAL := all
-.PHONY: lock-protocol
+.PHONY: lock-protocol all compile verify verify-parallel clean fmt
 
-# List of verification targets
 VERIFICATION_TARGETS := \
 	fvt1-mem-region-init \
 	fvt3-page-acquisition-safety \
@@ -13,7 +12,6 @@ VERIFICATION_TARGETS := \
 	fvt13-vmspace-unmap-safety \
 	lock-protocol
 
-# Compile-only targets
 COMPILE_TARGETS := vstd_extra aster_common
 
 # Pattern rule for individual FVT targets
@@ -29,14 +27,13 @@ fmt:
 all: compile verify
 
 compile:
-	@for target in $(COMPILE_TARGETS); do \
-		cargo xtask compile --targets $$target; \
-	done
+	cargo xtask compile --targets $(COMPILE_TARGETS)
 
 verify:
-	@for target in $(VERIFICATION_TARGETS); do \
-		cargo xtask verify --targets $$target; \
-	done
+	cargo xtask verify --targets $(VERIFICATION_TARGETS) $(if $(VOSTD_VERIFY_PARALLEL),--parallel)
+
+verify-parallel:
+	VOSTD_VERIFY_PARALLEL=1 $(MAKE) verify
 
 clean:
 	cargo clean


### PR DESCRIPTION
- Add a `--parallel` option to `cargo xtask verify` to enable concurrent verification of different targets. It does not work with `--count-line`.
- `make` will enable the parallel verification if the environment variable `VOSTD_VERIFY_PARALLEL` is set to true, which is used in CI\CD.
- Otherwise, `make` is serial as before.