### PR TITLE
Verify Cursor::move_forward

### DIFF
--- a/lock-protocol/src/mm/mod.rs
+++ b/lock-protocol/src/mm/mod.rs
@@ -66,8 +66,9 @@ pub proof fn lemma_page_size_spec_properties<C: PagingConstsTrait>(level: Paging
         ),
         // Sometimes the order of the operators to multiplication are reversed
         page_size_spec::<C>(level) as nat == pow2(
-            (C::BASE_PAGE_SIZE().ilog2() + (level - 1) * (C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2())) as nat,
-        )
+            (C::BASE_PAGE_SIZE().ilog2() + (level - 1) * (C::BASE_PAGE_SIZE().ilog2()
+                - C::PTE_SIZE().ilog2())) as nat,
+        ),
 {
     C::lemma_consts_properties();
     C::lemma_consts_properties_derived();
@@ -102,7 +103,8 @@ pub proof fn lemma_page_size_spec_properties<C: PagingConstsTrait>(level: Paging
         (C::BASE_PAGE_SIZE().ilog2() + (C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2()) * (
         level - 1)) as nat,
     );
-    assert((C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2()) * (level - 1) == (level - 1) * (C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2())) by (nonlinear_arith);
+    assert((C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2()) * (level - 1) == (level - 1) * (
+    C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2())) by (nonlinear_arith);
 }
 
 pub proof fn lemma_page_size_increases<C: PagingConstsTrait>(i: PagingLevel, j: PagingLevel)
@@ -115,17 +117,14 @@ pub proof fn lemma_page_size_increases<C: PagingConstsTrait>(i: PagingLevel, j: 
     lemma_page_size_spec_properties::<C>(i);
     lemma_page_size_spec_properties::<C>(j);
     C::lemma_consts_properties();
-    assert(
-        (C::BASE_PAGE_SIZE().ilog2() + (C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2()) * (
-        i - 1)) as nat <=
-        (C::BASE_PAGE_SIZE().ilog2() + (C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2()) * (
-        j - 1)) as nat
-    );
+    assert((C::BASE_PAGE_SIZE().ilog2() + (C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2()) * (i
+        - 1)) as nat <= (C::BASE_PAGE_SIZE().ilog2() + (C::BASE_PAGE_SIZE().ilog2()
+        - C::PTE_SIZE().ilog2()) * (j - 1)) as nat);
     lemma_pow2_increases(
-        (C::BASE_PAGE_SIZE().ilog2() + (C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2()) * (
-        i - 1)) as nat,
-        (C::BASE_PAGE_SIZE().ilog2() + (C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2()) * (
-        j - 1)) as nat,
+        (C::BASE_PAGE_SIZE().ilog2() + (C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2()) * (i
+            - 1)) as nat,
+        (C::BASE_PAGE_SIZE().ilog2() + (C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2()) * (j
+            - 1)) as nat,
     );
 }
 
@@ -232,7 +231,9 @@ proof fn lemma_page_size_adjacent_levels<C: PagingConstsTrait>(level: PagingLeve
     requires
         1 < level <= C::NR_LEVELS(),
     ensures
-        page_size_spec::<C>(level) as nat == nr_subpage_per_huge::<C>() as nat * (page_size_spec::<C>((level - 1) as PagingLevel) as nat),
+        page_size_spec::<C>(level) as nat == nr_subpage_per_huge::<C>() as nat * (page_size_spec::<
+            C,
+        >((level - 1) as PagingLevel) as nat),
 {
     C::lemma_consts_properties();
     C::lemma_consts_properties_derived();
@@ -249,26 +250,23 @@ proof fn lemma_page_size_adjacent_levels<C: PagingConstsTrait>(level: PagingLeve
         ); {}
         pow2(
             (C::BASE_PAGE_SIZE().ilog2() + (C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2()) * (
-            level - 2)) as nat +
-            (C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2()) as nat,
+            level - 2)) as nat + (C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2()) as nat,
         ); {
             lemma_pow2_adds(
-                (C::BASE_PAGE_SIZE().ilog2() + (C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2()) * (
-                level - 2)) as nat,
+                (C::BASE_PAGE_SIZE().ilog2() + (C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2())
+                    * (level - 2)) as nat,
                 (C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2()) as nat,
             );
         }
-        pow2(
-            (C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2()) as nat,
-        ) * pow2(
+        pow2((C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2()) as nat) * pow2(
             (C::BASE_PAGE_SIZE().ilog2() + (C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2()) * (
-            level - 2)) as nat
+            level - 2)) as nat,
         ); {
             lemma_page_size_spec_properties::<C>(prev_level);
         }
-        pow2(
-            (C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2()) as nat,
-        ) * (page_size_spec::<C>(prev_level) as nat); {}
+        pow2((C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2()) as nat) * (page_size_spec::<C>(
+            prev_level,
+        ) as nat); {}
         nr_subpage_per_huge::<C>() as nat * (page_size_spec::<C>(prev_level) as nat);
     }
 }
@@ -280,7 +278,10 @@ proof fn lemma_page_size_geometric<C: PagingConstsTrait>(i: PagingLevel, j: Pagi
     requires
         1 <= i <= j <= C::NR_LEVELS(),
     ensures
-        page_size::<C>(j) as nat == page_size::<C>(i) as nat * pow(nr_subpage_per_huge::<C>() as int, (j - i) as nat) as nat,
+        page_size::<C>(j) as nat == page_size::<C>(i) as nat * pow(
+            nr_subpage_per_huge::<C>() as int,
+            (j - i) as nat,
+        ) as nat,
     decreases j - i,
 {
     if (i == j) {

--- a/lock-protocol/src/mm/mod.rs
+++ b/lock-protocol/src/mm/mod.rs
@@ -63,6 +63,10 @@ pub proof fn lemma_page_size_spec_properties<C: PagingConstsTrait>(level: Paging
             (C::BASE_PAGE_SIZE().ilog2() + (C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2()) * (
             level - 1)) as nat,
         ),
+        // Sometimes the order of the operators to multiplication are reversed
+        page_size_spec::<C>(level) as nat == pow2(
+            (C::BASE_PAGE_SIZE().ilog2() + (level - 1) * (C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2())) as nat,
+        )
 {
     C::lemma_consts_properties();
     C::lemma_consts_properties_derived();
@@ -97,6 +101,7 @@ pub proof fn lemma_page_size_spec_properties<C: PagingConstsTrait>(level: Paging
         (C::BASE_PAGE_SIZE().ilog2() + (C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2()) * (
         level - 1)) as nat,
     );
+    assert((C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2()) * (level - 1) == (level - 1) * (C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2())) by (nonlinear_arith);
 }
 
 /// The page size

--- a/lock-protocol/src/mm/mod.rs
+++ b/lock-protocol/src/mm/mod.rs
@@ -59,6 +59,10 @@ pub proof fn lemma_page_size_spec_properties<C: PagingConstsTrait>(level: Paging
     ensures
         page_size_spec::<C>(level) > 0,
         is_power_2(page_size_spec::<C>(level) as int),
+        page_size_spec::<C>(level) as nat == pow2(
+            (C::BASE_PAGE_SIZE().ilog2() + (C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2()) * (
+            level - 1)) as nat,
+        ),
 {
     C::lemma_consts_properties();
     C::lemma_consts_properties_derived();

--- a/lock-protocol/src/mm/page_table/cursor/mod.rs
+++ b/lock-protocol/src/mm/page_table/cursor/mod.rs
@@ -716,6 +716,7 @@ impl<'a, C: PageTableConfig> CursorMut<'a, C> {
     ///
     /// This function will panic if the end range covers a part of a huge page
     /// and the next page is that huge page.
+    #[verifier::spinoff_prover]
     pub unsafe fn take_next(
         &mut self,
         len: usize,

--- a/lock-protocol/src/mm/page_table/cursor/mod.rs
+++ b/lock-protocol/src/mm/page_table/cursor/mod.rs
@@ -12,8 +12,10 @@ use std::{
 
 use vstd::{
     arithmetic::{div_mod::*, power::*, power2::*},
-    calc, invariant, layout::is_power_2, pervasive::VecAdditionalExecFns,
-    prelude::*, raw_ptr::MemContents, seq::Seq,
+    calc, invariant,
+    pervasive::VecAdditionalExecFns,
+    prelude::*,
+    raw_ptr::MemContents,
 };
 use vstd::bits::*;
 use vstd::tokens::SetToken;
@@ -29,10 +31,7 @@ use crate::{
         node::PageTableNode,
         nr_subpage_per_huge,
         page_prop::PageProperty,
-        page_size,
-        page_size_spec,
-        lemma_page_size_spec_properties,
-        lemma_page_size_increases,
+        page_size, page_size_spec, lemma_page_size_spec_properties, lemma_page_size_increases,
         lemma_page_size_geometric,
         vm_space::Token,
         Frame, Paddr, PageTableGuard, Vaddr, MAX_USERSPACE_VADDR, PAGE_SIZE,
@@ -43,9 +42,9 @@ use crate::{
 
 use super::{
     lemma_aligned_pte_index_unchanged, lemma_addr_aligned_propagate,
-    lemma_carry_ends_at_nonzero_result_bits, lemma_pte_index_alternative_spec,
-    pte_index, pte_index_mask, PageTable, PageTableConfig, PageTableEntryTrait,
-    PageTableError, PagingConsts, PagingConstsTrait, PagingLevel,
+    lemma_carry_ends_at_nonzero_result_bits, lemma_pte_index_alternative_spec, pte_index,
+    pte_index_mask, PageTable, PageTableConfig, PageTableEntryTrait, PageTableError, PagingConsts,
+    PagingConstsTrait, PagingLevel,
 };
 
 use crate::spec::sub_pt::{SubPageTable, index_pte_paddr};
@@ -331,7 +330,6 @@ impl<'a, C: PageTableConfig> Cursor<'a, C> {
                 }
                 assert(self.va == next_va == aligned_va + old_page_size);
 
-                
                 assert forall|i: u8| self.level < i <= self.guard_level implies pte_index::<C>(
                     self.va,
                     i,
@@ -343,14 +341,20 @@ impl<'a, C: PageTableConfig> Cursor<'a, C> {
                         lemma_page_size_spec_properties::<C>((self.level + 1) as u8);
                     }
                     // Ratio of page_size::<C>(i) / next_pg_size
-                    let ratio = pow(nr_subpage_per_huge::<C>() as int, (i - (self.level + 1)) as nat) as nat;
+                    let ratio = pow(
+                        nr_subpage_per_huge::<C>() as int,
+                        (i - (self.level + 1)) as nat,
+                    ) as nat;
                     assert(page_size::<C>(i) as nat == next_pg_size * ratio) by {
                         lemma_page_size_geometric::<C>((self.level + 1) as u8, i);
                     }
                     assert(ratio > 0) by {
                         C::lemma_consts_properties();
                         assert(nr_subpage_per_huge::<C>() > 0);
-                        lemma_pow_positive(nr_subpage_per_huge::<C>() as int, (i - (self.level + 1)) as nat);
+                        lemma_pow_positive(
+                            nr_subpage_per_huge::<C>() as int,
+                            (i - (self.level + 1)) as nat,
+                        );
                     }
 
                     calc! {
@@ -361,20 +365,32 @@ impl<'a, C: PageTableConfig> Cursor<'a, C> {
                         pte_index::<C>(next_va, i) as nat; {
                             lemma_pte_index_alternative_spec::<C>(next_va, i);
                         }
-                        next_va as nat / page_size_spec::<C>(i) as nat % nr_subpage_per_huge::<C>() as nat; {
+                        next_va as nat / page_size_spec::<C>(i) as nat % nr_subpage_per_huge::<
+                            C,
+                        >() as nat; {
                             // Already proven: page_size(i) == next_pg_size * ratio
                         }
-                        next_va as nat / (next_pg_size * ratio) % nr_subpage_per_huge::<C>() as nat; {
-                            lemma_div_denominator(next_va as int, next_pg_size as int, ratio as int);
+                        next_va as nat / (next_pg_size * ratio) % nr_subpage_per_huge::<
+                            C,
+                        >() as nat; {
+                            lemma_div_denominator(
+                                next_va as int,
+                                next_pg_size as int,
+                                ratio as int,
+                            );
                         }
                         next_va as nat / next_pg_size / ratio % nr_subpage_per_huge::<C>() as nat; {
                             assert(next_va == aligned_va + old_page_size);
                             // These are the arguments to lemma_carry_ends_at_nonzero_result_bits
-                            let p = (C::BASE_PAGE_SIZE().ilog2() + (C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2()) * self.level) as nat;
+                            let p = (C::BASE_PAGE_SIZE().ilog2() + (C::BASE_PAGE_SIZE().ilog2()
+                                - C::PTE_SIZE().ilog2()) * self.level) as nat;
                             assert(pow2(p) == next_pg_size) by {
-                                lemma_page_size_spec_properties::<C>((self.level + 1) as PagingLevel);
+                                lemma_page_size_spec_properties::<C>(
+                                    (self.level + 1) as PagingLevel,
+                                );
                             }
-                            let q = (C::BASE_PAGE_SIZE().ilog2() + (C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2()) * (self.level - 1)) as nat;
+                            let q = (C::BASE_PAGE_SIZE().ilog2() + (C::BASE_PAGE_SIZE().ilog2()
+                                - C::PTE_SIZE().ilog2()) * (self.level - 1)) as nat;
                             assert(pow2(q) == page_size::<C>(self.level) as nat) by {
                                 lemma_page_size_spec_properties::<C>(self.level);
                             }
@@ -383,8 +399,10 @@ impl<'a, C: PageTableConfig> Cursor<'a, C> {
                             // q <= p
                             assert(q <= p) by (nonlinear_arith)
                                 requires
-                                    p == (C::BASE_PAGE_SIZE().ilog2() + (C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2()) * self.level) as nat,
-                                    q == (C::BASE_PAGE_SIZE().ilog2() + (C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2()) * (self.level - 1)) as nat,
+                                    p == (C::BASE_PAGE_SIZE().ilog2() + (C::BASE_PAGE_SIZE().ilog2()
+                                        - C::PTE_SIZE().ilog2()) * self.level) as nat,
+                                    q == (C::BASE_PAGE_SIZE().ilog2() + (C::BASE_PAGE_SIZE().ilog2()
+                                        - C::PTE_SIZE().ilog2()) * (self.level - 1)) as nat,
                                     C::BASE_PAGE_SIZE().ilog2() - C::PTE_SIZE().ilog2() >= 0,
                             ;
                             // old_page_size is not too large
@@ -400,17 +418,32 @@ impl<'a, C: PageTableConfig> Cursor<'a, C> {
                                 assert(pte_index::<C>(next_va, self.level) != 0);
                             }
                             // Now we are finally ready to apply the main lemma
-                            lemma_carry_ends_at_nonzero_result_bits(next_va as nat, aligned_va as nat, p, q);
+                            lemma_carry_ends_at_nonzero_result_bits(
+                                next_va as nat,
+                                aligned_va as nat,
+                                p,
+                                q,
+                            );
                             // Let's restate the result of the lemma here.
                             assert(next_va as nat / pow2(p) == aligned_va as nat / pow2(p));
                         }
-                        aligned_va as nat / next_pg_size / ratio % nr_subpage_per_huge::<C>() as nat; {
-                            lemma_div_denominator(aligned_va as int, next_pg_size as int, ratio as int);
+                        aligned_va as nat / next_pg_size / ratio % nr_subpage_per_huge::<
+                            C,
+                        >() as nat; {
+                            lemma_div_denominator(
+                                aligned_va as int,
+                                next_pg_size as int,
+                                ratio as int,
+                            );
                         }
-                        aligned_va as nat / (next_pg_size * ratio) % nr_subpage_per_huge::<C>() as nat; {
+                        aligned_va as nat / (next_pg_size * ratio) % nr_subpage_per_huge::<
+                            C,
+                        >() as nat; {
                             // Already proven: page_size(i) == next_pg_size * ratio
                         }
-                        aligned_va as nat / page_size_spec::<C>(i) as nat % nr_subpage_per_huge::<C>() as nat; {
+                        aligned_va as nat / page_size_spec::<C>(i) as nat % nr_subpage_per_huge::<
+                            C,
+                        >() as nat; {
                             lemma_pte_index_alternative_spec::<C>(aligned_va, i);
                         }
                         pte_index::<C>(aligned_va, i) as nat; {

--- a/lock-protocol/src/mm/page_table/mod.rs
+++ b/lock-protocol/src/mm/page_table/mod.rs
@@ -593,16 +593,19 @@ pub fn pte_index<C: PagingConstsTrait>(va: Vaddr, level: PagingLevel) -> (res:
 }
 
 // PTE index increment recursively
+//
+// Returns the level `cur_level` PTE index of the virtual address formed by
+// adding the page size of `add_level` to `va`.
 pub open spec fn pte_index_add_with_carry<C: PagingConstsTrait>(
     va: Vaddr,
     add_level: PagingLevel,
     cur_level: PagingLevel,
 ) -> usize
-    recommends
-        1 <= add_level <= cur_level <= C::NR_LEVELS_SPEC(),
     decreases cur_level,
 {
-    if cur_level <= add_level {
+    if cur_level < add_level {
+        pte_index_spec::<C>(va, cur_level)
+    } else if cur_level == add_level {
         if pte_index_spec::<C>(va, cur_level) == pte_index_mask::<C>() {
             0  // Overflow
 

--- a/lock-protocol/src/mm/page_table/mod.rs
+++ b/lock-protocol/src/mm/page_table/mod.rs
@@ -831,40 +831,6 @@ proof fn lemma_carry_ends_at_nonzero_result_bits(x: nat, y: nat, p: nat, q: nat)
     assert(a - c == 0);
 }
 
-proof fn lemma_sub_mod_div_same(a: usize, b: usize)
-    requires
-        a >= 0,
-        b > 0,
-    ensures
-        0 <= a / b == ((a - (a % b)) as usize) / b <= a,
-{
-    // int versions of a and b
-    let ai = a as int;
-    let bi = b as int;
-    // First, prove the two inequalities
-    assert(a / b == ai / bi);
-    lemma_div_pos_is_pos(ai, bi);
-    lemma_div_nonincreasing(ai, bi);
-    assert(0 <= a / b <= a);
-    // Then, tackle the equality in the middle
-    // First, prove a - (a % b) does fit in usize
-    assert(ai - (ai % bi) >= 0) by {
-        lemma_mod_decreases(ai as nat, bi as nat);
-    }
-    assert(0 <= ai - (ai % bi) <= ai <= usize::MAX);
-    assert(((a - (a % b)) as usize) == ai - (ai % bi));
-    // Now we can do all the reasoning with the int versions, without worrying about overflow
-    let di = ai / bi;
-    let mi = ai % bi;
-    assert(ai == bi * di + mi) by {
-        lemma_fundamental_div_mod(ai, bi);
-    }
-    assert(ai - (ai % bi) == bi * di);
-    assert(bi * di == di * bi) by (nonlinear_arith);
-    lemma_div_multiples_vanish(di, bi);
-    assert(ai / bi == di == (ai - (ai % bi)) / bi);
-}
-
 proof fn lemma_usize_shr_is_div(x: usize, shift: int)
     requires
         0 <= shift < usize::BITS,

--- a/lock-protocol/src/mm/page_table/mod.rs
+++ b/lock-protocol/src/mm/page_table/mod.rs
@@ -731,7 +731,7 @@ proof fn lemma_addr_aligned_propagate<C: PagingConstsTrait>(va: Vaddr, level: Pa
 // A number x can be represented the sum of its three parts
 proof fn lemma_nat_as_parts(x: nat, p: nat, q: nat)
     requires
-        0 < q < p,
+        0 <= q <= p,
     ensures
         x == pow2(p) * (x / pow2(p)) + pow2(q) * (x % pow2(p) / pow2(q)) + (x % pow2(q)),
         0 <= x % pow2(q) < pow2(q),
@@ -741,7 +741,7 @@ proof fn lemma_nat_as_parts(x: nat, p: nat, q: nat)
         let m = pow2(q);
         let d = pow2((p - q) as nat);
         assert(m * d == pow2(p)) by {
-            assert(p - q > 0);
+            assert(p - q >= 0);
             assert(pow2(p) == pow2(q + (p - q) as nat));
             lemma_pow2_adds(q as nat, (p - q) as nat);
         }
@@ -794,7 +794,7 @@ proof fn lemma_carry_ends_at_nonzero_result_bits(x: nat, y: nat, p: nat, q: nat)
     // This proof is going to rely heavily on nonlinear arithmetics
     by (nonlinear_arith)
     requires
-        0 < q < p,
+        0 <= q <= p,
         y < x <= y + pow2(q),
         // The condition on the result
         x % pow2(q) == 0,


### PR DESCRIPTION
Verified `Cursor::move_forward`.

Added two alternative `spec fn` for `pte_index` that doesn't use bit arithmetics and some properties for the `page_size` function.

Fixed a typo in `lemma_aligned_pte_index_unchanged`.