### PR TITLE
fix: demo verification error

### DIFF
--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -21,7 +21,9 @@ default = ["verify", "alloc"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-vstd = { workspace = true, optional = true }
-verus_builtin = { workspace = true, optional = true }
-verus_builtin_macros = { workspace = true, optional = true }
+vstd = { workspace = true }
+verus_builtin = { workspace = true }
+verus_builtin_macros = { workspace = true }
+
+vstd_extra = { path = "../vstd_extra" }
 aster_common = { path = "../aster_common" }

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -4,6 +4,7 @@ use vstd::prelude::*;
 use vstd_extra::update_field;
 use vstd::simple_pptr::*;
 use aster_common::prelude::*;
+use vstd_extra::ownership::*;
 
 mod common {
     use super::*;
@@ -96,8 +97,8 @@ impl Data {
         ensures
             self.a_to_b_spec(i, self.model(old(own)), self.model(own))
     {
-        update_field!(self.cell => a -= i, own.perm.borrow_mut());
-        update_field!(self.cell => b += i, own.perm.borrow_mut());
+    update_field!(self.cell => a -= i; own.perm.borrow_mut());
+    update_field!(self.cell => b += i; own.perm.borrow_mut());
     }
 }
 }


### PR DESCRIPTION
Still some errors like:
```
error[E0599]: no method named `borrow_mut` found for mutable reference `&mut vstd::simple_pptr::PointsTo<common::DataCell>` in the current scope
   --> /home/yuwei/ruzykaller/kverus/database/verified/code/demo/src/lib.rs:100:5
    |
100 |     update_field!(self.cell => a -= i; own.perm.borrow_mut());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------^^^^^^^^^^^^^^
    |                                        |
    |                                        method `borrow_mut` is available on `&mut vstd::prelude::Tracked<vstd::simple_pptr::PointsTo<common::DataCell>>`
    |
    = help: items from traits can only be used if the trait is in scope
    = note: this error originates in the macro `update_field` (in Nightly builds, run with -Z macro-backtrace for more info)
help: trait `BorrowMut` which provides `borrow_mut` is implemented but not in scope; perhaps you want to import it
    |
3   + use core::borrow::BorrowMut;
    |
help: there is a method `borrow` with a similar name
   --> /home/yuwei/ruzykaller/kverus/database/verified/code/vstd_extra/src/ptr_extra.rs:76:71
    |
76  -                 tracked_exec(#[verifier::tracked_block_wrapped] $perm.borrow_mut()));
76  +                 tracked_exec(#[verifier::tracked_block_wrapped] $perm.borrow()));
    |

error[E0599]: no method named `borrow_mut` found for mutable reference `&mut vstd::simple_pptr::PointsTo<common::DataCell>` in the current scope
   --> /home/yuwei/ruzykaller/kverus/database/verified/code/demo/src/lib.rs:100:5
    |
100 |     update_field!(self.cell => a -= i; own.perm.borrow_mut());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------^^^^^^^^^^^^^^
    |                                        |
    |                                        method `borrow_mut` is available on `&mut vstd::prelude::Tracked<vstd::simple_pptr::PointsTo<common::DataCell>>`
    |
    = help: items from traits can only be used if the trait is in scope
    = note: this error originates in the macro `update_field` (in Nightly builds, run with -Z macro-backtrace for more info)
help: trait `BorrowMut` which provides `borrow_mut` is implemented but not in scope; perhaps you want to import it
    |
3   + use core::borrow::BorrowMut;
    |
help: there is a method `borrow` with a similar name
   --> /home/yuwei/ruzykaller/kverus/database/verified/code/vstd_extra/src/ptr_extra.rs:80:71
    |
80  -                 tracked_exec(#[verifier::tracked_block_wrapped] $perm.borrow_mut()), __tmp);
80  +                 tracked_exec(#[verifier::tracked_block_wrapped] $perm.borrow()), __tmp);
    |

error[E0599]: no method named `borrow_mut` found for mutable reference `&mut vstd::simple_pptr::PointsTo<common::DataCell>` in the current scope
   --> /home/yuwei/ruzykaller/kverus/database/verified/code/demo/src/lib.rs:101:5
    |
101 |     update_field!(self.cell => b += i; own.perm.borrow_mut());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------^^^^^^^^^^^^^^
    |                                        |
    |                                        method `borrow_mut` is available on `&mut vstd::prelude::Tracked<vstd::simple_pptr::PointsTo<common::DataCell>>`
    |
    = help: items from traits can only be used if the trait is in scope
    = note: this error originates in the macro `update_field` (in Nightly builds, run with -Z macro-backtrace for more info)
help: trait `BorrowMut` which provides `borrow_mut` is implemented but not in scope; perhaps you want to import it
    |
3   + use core::borrow::BorrowMut;
    |
help: there is a method `borrow` with a similar name
   --> /home/yuwei/ruzykaller/kverus/database/verified/code/vstd_extra/src/ptr_extra.rs:63:71
    |
63  -                 tracked_exec(#[verifier::tracked_block_wrapped] $perm.borrow_mut()));
63  +                 tracked_exec(#[verifier::tracked_block_wrapped] $perm.borrow()));
    |

error[E0599]: no method named `borrow_mut` found for mutable reference `&mut vstd::simple_pptr::PointsTo<common::DataCell>` in the current scope
   --> /home/yuwei/ruzykaller/kverus/database/verified/code/demo/src/lib.rs:101:5
    |
101 |     update_field!(self.cell => b += i; own.perm.borrow_mut());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^--------^^^^^^^^^^^^^^
    |                                        |
    |                                        method `borrow_mut` is available on `&mut vstd::prelude::Tracked<vstd::simple_pptr::PointsTo<common::DataCell>>`
    |
    = help: items from traits can only be used if the trait is in scope
    = note: this error originates in the macro `update_field` (in Nightly builds, run with -Z macro-backtrace for more info)
help: trait `BorrowMut` which provides `borrow_mut` is implemented but not in scope; perhaps you want to import it
    |
3   + use core::borrow::BorrowMut;
    |
help: there is a method `borrow` with a similar name
   --> /home/yuwei/ruzykaller/kverus/database/verified/code/vstd_extra/src/ptr_extra.rs:67:71
    |
67  -                 tracked_exec(#[verifier::tracked_block_wrapped] $perm.borrow_mut()), __tmp);
67  +                 tracked_exec(#[verifier::tracked_block_wrapped] $perm.borrow()), __tmp);
    |

error: aborting due to 4 previous errors
```