### PR TITLE
PhaseII verified: Prove `Either`'s spec

### DIFF
--- a/ostd/src/lib.rs
+++ b/ostd/src/lib.rs
@@ -49,8 +49,8 @@ pub mod sync;
 pub mod task;
 pub mod timer;
 pub mod trap;
-pub mod user;
-pub mod util; */
+pub mod user;*/
+pub mod util;
 
 /*use core::sync::atomic::{AtomicBool, Ordering};
 

--- a/ostd/src/util/either.rs
+++ b/ostd/src/util/either.rs
@@ -3,6 +3,9 @@
 ///
 /// [`Left`]: Self::Left
 /// [`Right`]: Self::Right
+use vstd::prelude::*;
+
+#[verus_verify]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Either<L, R> {
     /// Contains the left value
@@ -12,6 +15,7 @@ pub enum Either<L, R> {
 }
 
 impl<L, R> Either<L, R> {
+    #[verus_verify(dual_spec)]
     /// Converts to the left value, if any.
     pub fn left(self) -> Option<L> {
         match self {
@@ -20,6 +24,7 @@ impl<L, R> Either<L, R> {
         }
     }
 
+    #[verus_verify(dual_spec)]
     /// Converts to the right value, if any.
     pub fn right(self) -> Option<R> {
         match self {
@@ -28,11 +33,13 @@ impl<L, R> Either<L, R> {
         }
     }
 
+    #[verus_verify(dual_spec)]
     /// Returns true if the left value is present.
     pub fn is_left(&self) -> bool {
         matches!(self, Self::Left(_))
     }
 
+    #[verus_verify(dual_spec)]
     /// Returns true if the right value is present.
     pub fn is_right(&self) -> bool {
         matches!(self, Self::Right(_))

--- a/ostd/src/util/mod.rs
+++ b/ostd/src/util/mod.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 //! Utility types and methods.
 mod either;
-mod macros;
-pub(crate) mod marker;
-pub(crate) mod ops;
-pub(crate) mod range_alloc;
+//mod macros;
+//pub(crate) mod marker;
+//pub(crate) mod ops;
+//pub(crate) mod range_alloc;
 
 pub use either::Either;


### PR DESCRIPTION
This is basically a test of the [attribute syntax](https://github.com/verus-lang/verus/pull/1356). It turns out it is quite elegant for simple functions, we achieve a proof-code-ratio of 1:10!