### PR TITLE
Fix `verus-update-test` workflow

### DIFF
--- a/.github/workflows/verus-update-test.yml
+++ b/.github/workflows/verus-update-test.yml
@@ -50,6 +50,8 @@ jobs:
           git config --global user.email "ci@asterinas.verus"
           cargo clean
           cargo dv bootstrap --restart
+          # Discard any uncommitted changes in tools/verus before upgrade
+          git -C tools/verus reset --hard HEAD
           cargo dv bootstrap --upgrade --test_branch
           make 2>&1 | tee verus_phaseII.log
           if grep -q "error:" verus_phaseII.log; then


### PR DESCRIPTION
[In some cases](https://github.com/asterinas/vostd/actions/runs/19280849500), running `cargo dv bootstrap` modifies the `Cargo.lock` file, which prevents switching to the test branch and causes the workflow to abort. This PR fixes the issue by discarding any uncommitted changes.