### PR TITLE
Fix breaking change about `cell::PointsTo` in fvt1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,11 +170,11 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "verus_builtin"
-version = "0.0.0-2025-08-12-1837"
+version = "0.0.0-2025-12-07-0054"
 
 [[package]]
 name = "verus_builtin_macros"
-version = "0.0.0-2025-11-30-0053"
+version = "0.0.0-2025-12-07-0054"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -213,7 +213,7 @@ dependencies = [
 
 [[package]]
 name = "vstd"
-version = "0.0.0-2025-11-30-0053"
+version = "0.0.0-2025-12-07-0054"
 dependencies = [
  "verus_builtin",
  "verus_builtin_macros",

--- a/aster_common/src/page/meta/page_meta.rs
+++ b/aster_common/src/page/meta/page_meta.rs
@@ -178,9 +178,7 @@ impl PageTablePageMeta {
         res: PageTablePageMetaModel,
     ) -> bool {
         &&& res.lock@.value == 1
-        &&& res.inner.opt_value() == Some(
-            { PageTablePageMetaInner { level, nr_children: 0, is_tracked } },
-        )
+        &&& res.inner.value() == PageTablePageMetaInner { level, nr_children: 0, is_tracked } 
     }
 
     pub fn new_locked(level: PagingLevel, is_tracked: MapTrackingStatus) -> (res: (


### PR DESCRIPTION
This is caused by the removal of the already deprecated `cell::PointsTo::opt_value` method in the [latest Verus update](https://github.com/verus-lang/verus/commit/aa6d3c8269eaf5abbc3509d5baf0cef7e38f469d).