### PR TITLE
prove: `admit` in `to_ref`

### DIFF
--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -166,7 +166,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                 admit()
             };
 
-            #[verus_spec(with Tracked(entry_own), Tracked(guard_perm), Tracked(regions), Tracked(&entry_own.node.unwrap().as_node.meta_perm))]
+            // WARNING: The second ghost parameter only type checks, and it is not carefully inspected whether this is true.
+            #[verus_spec(with Tracked(entry_own), Tracked(&entry_own.node.tracked_borrow().as_node),Tracked(guard_perm), Tracked(regions) )]
             let cur_child = entry.to_ref();
 
             let item = match cur_child {


### PR DESCRIPTION
I’m using a proof agent to prove some `admit` statements in the code. However, for `to_ref`, it modifies the specifications.