### PR TITLE
Ignore `Token::try_from`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "verus_builtin"
-version = "0.0.0-2025-12-07-0054"
+version = "0.0.0-2025-12-14-0054"
 
 [[package]]
 name = "verus_builtin_macros"
@@ -213,7 +213,7 @@ dependencies = [
 
 [[package]]
 name = "vstd"
-version = "0.0.0-2025-12-07-0054"
+version = "0.0.0-2025-12-14-0054"
 dependencies = [
  "verus_builtin",
  "verus_builtin_macros",

--- a/lock-protocol-rcu/src/mm/vm_space.rs
+++ b/lock-protocol-rcu/src/mm/vm_space.rs
@@ -68,6 +68,7 @@ impl Token {
     }
 }
 
+/*
 impl TryFrom<usize> for Token {
     type Error = ();
 
@@ -81,7 +82,7 @@ impl TryFrom<usize> for Token {
             Err(())
         }
     }
-}
+}*/
 
 impl vstd::std_specs::convert::FromSpecImpl<Token> for usize {
     open spec fn obeys_from_spec() -> bool {
@@ -136,6 +137,7 @@ impl Status {
     }
 }
 
+/*
 impl TryFrom<usize> for Status {
     type Error = ();
 
@@ -148,6 +150,7 @@ impl TryFrom<usize> for Status {
         }
     }
 }
+*/
 
 impl vstd::std_specs::convert::FromSpecImpl<Status> for usize {
     open spec fn obeys_from_spec() -> bool {


### PR DESCRIPTION
`Lock-protocol-rcu` does not compile because Verus now includes `TryFromSpec` in `std_specs`, ignoring it now. 