### PR TITLE
Specify (not verify) `ArcRef::deref_target`

### DIFF
--- a/ostd/src/sync/rcu/non_null/mod.rs
+++ b/ostd/src/sync/rcu/non_null/mod.rs
@@ -295,17 +295,20 @@ impl<T> Deref for ArcRef<'_, T> {
     }
 }
 
-/* 
+#[verus_verify]
 impl<'a, T> ArcRef<'a, T> {
     /// Dereferences `self` to get a reference to `T` with the lifetime `'a`.
+    /// VERUS LIMITATION: The code includes a cast from `&T` to `*const T`, which is not specified yet in Verus.
+    /// This is also a nontrivial use case that extends the lifetime of the reference.
+    #[verus_verify(external_body)]
+    #[verus_spec(ret => ensures *ret == *(self.deref_as_arc_spec()))]
     pub fn deref_target(&self) -> &'a T {
         // SAFETY: The reference is created through `NonNullPtr::raw_as_ref`, hence
         // the original owned pointer and target must outlive the lifetime parameter `'a`,
         // and during `'a` no mutable references to the pointer will exist.
         unsafe { &*(self.deref().deref() as *const T) }
     }
-}*/
-
+}
 
 unsafe impl<T: 'static> NonNullPtr for Arc<T> {
     type Target = T;


### PR DESCRIPTION
This one is hard and beyond the ability of Verus.
```
impl<'a, T> ArcRef<'a, T> {
    /// Dereferences `self` to get a reference to `T` with the lifetime `'a`.
    pub fn deref_target(&self) -> &'a T {
        // SAFETY: The reference is created through `NonNullPtr::raw_as_ref`, hence
        // the original owned pointer and target must outlive the lifetime parameter `'a`,
        // and during `'a` no mutable references to the pointer will exist.
        unsafe { &*(self.deref().deref() as *const T) }
    }
}
```
- First, there is a cast from a reference to a raw pointer, which is not supported yet in Verus, and it may involve a complex aliasing model about provenance, only formalized in Stacked/Tree borrows and not officially decided.
- Second, this code includes an extension of the lifetime, whose soundness is determined by the programmer in the original Rust code. The usual way to verify this is to use a ghost permission with a lifetime checked by Verus; however, in the permission model here, we only use permissions for raw pointers, and `ArcRef` uses `ManuallyDrop <Arc>` instead of a raw pointer, so there is no such permission. What we need is a permission that guarantees the lifetime of an `Arc`(or `ManuallyDrop<Arc>` ?) to enable borrowing like `<'a, T>:(ptr:&ManuallyDrop<Arc<T>>, perm: Tracked(&‘a PointsTo<T>)) -> &'a T`. However, this requires a strict and deliberate modeling of the behavior of the std API `Arc`. I do not intend to model this unless the Verus team has resolved the first problem.