### PR TITLE
Remove `NonNullPtr` impl for `Weak<T>`

### DIFF
--- a/ostd/src/sync/rcu/non_null/mod.rs
+++ b/ostd/src/sync/rcu/non_null/mod.rs
@@ -7,7 +7,6 @@ use alloc::{sync::Arc, boxed::Box};
 
 //mod either;
 
-use alloc::sync::Weak;
 use core::simd::ptr;
 use core::{marker::PhantomData, mem::ManuallyDrop, ops::Deref, ptr::NonNull};
 
@@ -401,64 +400,6 @@ pub unsafe fn arc_raw_as_ref<'a, T: 'static>(raw: NonNull<T>, perm: Tracked<ArcP
             }
         }
     }
-
-/* 
-/// A type that represents `&'a Weak<T>`.
-#[derive(Debug)]
-pub struct WeakRef<'a, T> {
-    inner: ManuallyDrop<Weak<T>>,
-    _marker: PhantomData<&'a Weak<T>>,
-}
-
-impl<T> Deref for WeakRef<'_, T> {
-    type Target = Weak<T>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-unsafe impl<T: 'static> NonNullPtr for Weak<T> {
-    type Target = T;
-
-    type Ref<'a>
-        = WeakRef<'a, T>
-    where
-        Self: 'a;
-
-    // The alignment of `Weak<T>` is 1 instead of `align_of::<T>()`.
-    // This is because `Weak::new()` uses a dangling pointer that is _not_ aligned.
-    const ALIGN_BITS: u32 = 0;
-
-    fn into_raw(self) -> NonNull<Self::Target> {
-        let ptr = Weak::into_raw(self).cast_mut();
-
-        // SAFETY: The pointer representing an `Weak` can never be NULL.
-        unsafe { NonNull::new_unchecked(ptr) }
-    }
-
-    unsafe fn from_raw(ptr: NonNull<Self::Target>) -> Self {
-        let ptr = ptr.as_ptr().cast_const();
-
-        // SAFETY: The safety is upheld by the caller.
-        unsafe { Weak::from_raw(ptr) }
-    }
-
-    unsafe fn raw_as_ref<'a>(raw: NonNull<Self::Target>) -> Self::Ref<'a> {
-        // SAFETY: The safety is upheld by the caller.
-        unsafe {
-            WeakRef {
-                inner: ManuallyDrop::new(Weak::from_raw(raw.as_ptr())),
-                _marker: PhantomData,
-            }
-        }
-    }
-
-    fn ref_as_raw(ptr_ref: Self::Ref<'_>) -> NonNull<Self::Target> {
-        NonNullPtr::into_raw(ManuallyDrop::into_inner(ptr_ref.inner))
-    }
-}
-*/
 }
 
 verus!{


### PR DESCRIPTION
During verification, we found there is a [UB](https://github.com/asterinas/asterinas/issues/2801) in the implmentation of `NonNullPtr` for `Weak<T>`, the related API has been removed now.