### PR TITLE
fix: replace std with core

### DIFF
--- a/aster_common/src/mm/frame/frame_ref.rs
+++ b/aster_common/src/mm/frame/frame_ref.rs
@@ -1,8 +1,7 @@
 use vstd::prelude::*;
 
-use std::ops::Deref;
-
 use core::mem::ManuallyDrop;
+use core::ops::Deref;
 
 use super::*;
 

--- a/aster_common/src/mm/frame/meta.rs
+++ b/aster_common/src/mm/frame/meta.rs
@@ -11,7 +11,7 @@ use vstd_extra::ownership::*;
 
 use super::*;
 use core::ops::Deref;
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 verus! {
 

--- a/aster_common/src/mm/frame/meta_owners.rs
+++ b/aster_common/src/mm/frame/meta_owners.rs
@@ -12,7 +12,7 @@ use vstd_extra::ownership::*;
 
 use super::*;
 
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 verus! {
 

--- a/aster_common/src/mm/frame/mod.rs
+++ b/aster_common/src/mm/frame/mod.rs
@@ -24,7 +24,7 @@ use vstd::simple_pptr::{self, PPtr};
 use vstd_extra::cast_ptr;
 use vstd_extra::ownership::*;
 
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use super::*;
 

--- a/aster_common/src/mm/io.rs
+++ b/aster_common/src/mm/io.rs
@@ -2,7 +2,7 @@ use vstd::prelude::*;
 
 use vstd::simple_pptr::*;
 
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 verus! {
 

--- a/aster_common/src/mm/mod.rs
+++ b/aster_common/src/mm/mod.rs
@@ -26,7 +26,7 @@ use vstd_extra::extern_const;
 
 use super::*;
 
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 verus! {
 

--- a/aster_common/src/mm/page_table/node/entry.rs
+++ b/aster_common/src/mm/page_table/node/entry.rs
@@ -4,8 +4,8 @@ use vstd::simple_pptr::{self, PPtr};
 
 use vstd_extra::ownership::*;
 
-use std::marker::PhantomData;
-use std::ops::Deref;
+use core::marker::PhantomData;
+use core::ops::Deref;
 
 use super::*;
 

--- a/aster_common/src/mm/page_table/node/entry_view.rs
+++ b/aster_common/src/mm/page_table/node/entry_view.rs
@@ -1,6 +1,6 @@
 use vstd::prelude::*;
 
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use super::*;
 

--- a/aster_common/src/mm/page_table/node/mod.rs
+++ b/aster_common/src/mm/page_table/node/mod.rs
@@ -17,7 +17,7 @@ use vstd::cell::PCell;
 use vstd_extra::cast_ptr::*;
 use vstd_extra::ownership::*;
 
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use super::*;
 

--- a/aster_common/src/mm/page_table/owners.rs
+++ b/aster_common/src/mm/page_table/owners.rs
@@ -10,7 +10,7 @@ use vstd_extra::prelude::TreeNodeValue;
 
 use super::*;
 
-use std::ops::Deref;
+use core::ops::Deref;
 
 verus! {
 

--- a/aster_common/src/mm/page_table/view.rs
+++ b/aster_common/src/mm/page_table/view.rs
@@ -2,7 +2,7 @@ use vstd::prelude::*;
 
 use vstd_extra::ownership::*;
 
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use super::*;
 

--- a/aster_common/src/mm/vm_space.rs
+++ b/aster_common/src/mm/vm_space.rs
@@ -6,9 +6,8 @@ use crate::*;
 use crate::page_table::*;
 use crate::frame::{UFrame, Frame, AnyFrameMeta};
 
+use core::marker::PhantomData;
 use core::ops::Range;
-
-use std::marker::PhantomData;
 
 verus! {
 

--- a/specs/ostd/src/meta_specs.rs
+++ b/specs/ostd/src/meta_specs.rs
@@ -8,7 +8,7 @@ use vstd_extra::ownership::*;
 use aster_common::prelude::frame::*;
 use aster_common::prelude::*;
 
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 verus! {
 

--- a/vstd_extra/src/external/nonnull.rs
+++ b/vstd_extra/src/external/nonnull.rs
@@ -1,5 +1,5 @@
-use std::marker::PointeeSized;
-use std::ptr::NonNull;
+use core::marker::PointeeSized;
+use core::ptr::NonNull;
 use vstd::prelude::*;
 use vstd::raw_ptr::*;
 

--- a/vstd_extra/src/ownership.rs
+++ b/vstd_extra/src/ownership.rs
@@ -2,8 +2,8 @@ use vstd::atomic::*;
 use vstd::cell;
 use vstd::prelude::*;
 
-use std::marker::PhantomData;
-use std::ops::Range;
+use core::marker::PhantomData;
+use core::ops::Range;
 
 verus! {
 


### PR DESCRIPTION
No `core::sync::Arc;` so there is only 1 `std::` in `vstd_extra/src/external/smart_ptr.rs`