### PR TITLE
Disable re-exporting `array_ptr` in `vstd_extra::prelude`

### DIFF
--- a/ostd/src/mm/pod.rs
+++ b/ostd/src/mm/pod.rs
@@ -1,8 +1,5 @@
 use vstd::prelude::*;
-use vstd_extra::{
-    array_ptr::{self, PointsToArray},
-    prelude::ArrayPtr,
-};
+use vstd_extra::array_ptr::{self, ArrayPtr, PointsToArray};
 
 use core::mem::MaybeUninit;
 

--- a/vstd_extra/src/lib.rs
+++ b/vstd_extra/src/lib.rs
@@ -17,8 +17,8 @@ pub mod external;
 pub mod function_properties;
 pub mod ghost_tree;
 pub mod ownership;
-pub mod undroppable;
 pub mod resource;
+pub mod undroppable;
 
 #[macro_use]
 pub mod ptr_extra;

--- a/vstd_extra/src/prelude.rs
+++ b/vstd_extra/src/prelude.rs
@@ -1,6 +1,6 @@
 pub use super::arithmetic::*;
 
-pub use super::array_ptr::*;
+// pub use super::array_ptr::*;
 
 pub use super::auxiliary::*;
 

--- a/vstd_extra/src/undroppable.rs
+++ b/vstd_extra/src/undroppable.rs
@@ -30,7 +30,7 @@ impl<T: Undroppable> NeverDrop<T> {
             t.constructor_requires(*old(s)),
         ensures
             t.constructor_ensures(*old(s), *s),
-            res.0@ == t
+            res.0@ == t,
     {
         proof {
             t.constructor_spec(s);


### PR DESCRIPTION
The original design re-exports `array_ptr::PointsTo` in `vstd_extra::prelude`, which may easily result in conflict names.