### PR TITLE
Migrate to `cell::pcell::PCell` in sync

### DIFF
--- a/vstd_extra/src/auxiliary.rs
+++ b/vstd_extra/src/auxiliary.rs
@@ -5,7 +5,7 @@ verus! {
 // Produces an arbitrary PointsTo permission for type T, this is sound because one can not use
 // such a permission to access memory.
 #[verifier(external_body)]
-pub proof fn arbitrary_cell_pointsto<T>() -> (tracked res: vstd::cell::PointsTo<T>) {
+pub proof fn arbitrary_cell_pointsto<T>() -> (tracked res: vstd::cell::pcell::PointsTo<T>) {
     unimplemented!();
 }
 


### PR DESCRIPTION
Use the new always-initialized `PCell`.