### PR TITLE
Make read_val-* not trusted and move Pod primitives as trusted wrappers

### DIFF
--- a/ostd/specs/mm/page_table/node/child.rs
+++ b/ostd/specs/mm/page_table/node/child.rs
@@ -52,7 +52,7 @@ impl<'a, C: PageTableConfig> OwnerOf for ChildRef<'a, C> {
             Self::None => owner.is_absent(),
         }
     }
-}    
+}
 
 impl<C: PageTableConfig> Child<C> {
 

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -13,13 +13,10 @@ use vstd_extra::ghost_tree::*;
 use vstd_extra::ownership::*;
 use vstd_extra::prelude::TreeNodeValue;
 
-use crate::mm::{
-    page_table::EntryOwner,
-    Paddr, PagingLevel, Vaddr, MAX_NR_LEVELS,
-};
+use crate::mm::{page_table::EntryOwner, Paddr, PagingLevel, Vaddr, MAX_NR_LEVELS};
 
 use crate::mm::frame::frame_to_index;
-use crate::mm::page_table::{PageTableGuard, PageTableEntryTrait};
+use crate::mm::page_table::{PageTableEntryTrait, PageTableGuard};
 
 use crate::specs::arch::*;
 use crate::specs::mm::frame::meta_region_owners::MetaRegionOwners;

--- a/ostd/src/mm/frame/frame_ref.rs
+++ b/ostd/src/mm/frame/frame_ref.rs
@@ -67,6 +67,7 @@ impl<M: AnyFrameMeta> FrameRef<'_, M> {
     pub(in crate::mm) fn borrow_paddr(raw: Paddr) -> Self {
         proof {
             broadcast use crate::mm::frame::meta::mapping::group_page_meta;
+
             old(regions).inv_implies_correct_addr(raw);
         }
 

--- a/ostd/src/mm/frame/mod.rs
+++ b/ostd/src/mm/frame/mod.rs
@@ -417,8 +417,8 @@ impl<'a, M: AnyFrameMeta> Frame<M> {
     pub fn borrow(&self) -> FrameRef<'a, M> {
         assert(regions.slot_owners.contains_key(self.index()));
         broadcast use crate::mm::frame::meta::mapping::group_page_meta;
-
         // SAFETY: Both the lifetime and the type matches `self`.
+
         #[verus_spec(with Tracked(&perm.points_to))]
         let paddr = self.start_paddr();
 

--- a/ostd/src/mm/io.rs
+++ b/ostd/src/mm/io.rs
@@ -58,6 +58,16 @@ use crate::specs::mm::virt_mem_newer::{MemView, VirtPtr};
 
 verus! {
 
+/// Performs a fallible transfer from `reader` to `writer`.
+///
+/// # Verified Properties
+/// ## Preconditions
+/// - `reader`, `writer`, and their associated owners must satisfy their invariants.
+/// - Each owner must match the corresponding reader or writer.
+/// - Both owners must be marked fallible.
+/// ## Postconditions
+/// - The reader, writer, and both owners still satisfy their invariants.
+/// - The owner parameters tracked by [`VmIoOwner::params_eq`] are preserved for both sides.
 #[verus_spec(r =>
         with
             Tracked(owner_r): Tracked<&mut VmIoOwner<'_>>,
@@ -116,6 +126,71 @@ unsafe fn memcpy(dst: usize, src: usize, len: usize) {
     // <https://github.com/asterinas/asterinas/pull/1001#discussion_r1667317406>.
     // SAFETY: The safety is guaranteed by the safety preconditions and the explanation above.
     core::intrinsics::volatile_copy_memory(dst as *mut u8, src as *const u8, len);
+}
+
+/// Reads a `Pod` value directly from a verified memory view.
+///
+/// # Verified Properties
+/// ## Preconditions
+/// - `ptr` must satisfy [`VirtPtr::inv`].
+/// - The readable range `[ptr.vaddr, ptr.vaddr + size_of::<T>())` must fit in `ptr.range@`.
+/// - Every byte in that range must translate in `mem` and be initialized.
+/// ## Postconditions
+/// - The function returns a `T` value reconstructed from the bytes at `ptr`.
+/// ## Safety
+/// - This function is trusted because Verus cannot currently express the raw-pointer read needed
+///   to reconstruct a typed `Pod` value from verified byte-level memory permissions.
+#[verifier::external_body]
+#[verus_spec(
+    with
+        Tracked(mem): Tracked<&MemView>,
+    requires
+        ptr.inv(),
+        core::mem::size_of::<T>() <= ptr.range@.end - ptr.vaddr,
+        forall|i: usize|
+            #![trigger mem.addr_transl(i)]
+            ptr.vaddr <= i < ptr.vaddr + core::mem::size_of::<T>() ==> {
+                &&& mem.addr_transl(i) is Some
+                &&& mem.memory.contains_key(mem.addr_transl(i).unwrap().0)
+                &&& mem.memory[mem.addr_transl(i).unwrap().0].contents[mem.addr_transl(i).unwrap().1 as int] is Init
+            },
+)]
+fn read_pod_from_view<T: Pod>(ptr: VirtPtr) -> T {
+    unsafe { (ptr.vaddr as *const T).read() }
+}
+
+/// Reads a `PodOnce` value using one volatile memory load from a verified memory view.
+///
+/// # Verified Properties
+/// ## Preconditions
+/// - `ptr` must satisfy [`VirtPtr::inv`].
+/// - The readable range `[ptr.vaddr, ptr.vaddr + size_of::<T>())` must fit in `ptr.range@`.
+/// - `ptr.vaddr` must satisfy the alignment requirement of `T`.
+/// - Every byte in that range must translate in `mem` and be initialized.
+/// ## Postconditions
+/// - The function returns a `T` value read from `ptr` using one volatile load.
+/// ## Safety
+/// - This function is trusted because the underlying volatile typed read relies on raw-pointer
+///   operations that Verus does not yet model directly.
+#[verifier::external_body]
+#[verus_spec(
+    with
+        Tracked(mem): Tracked<&MemView>,
+    requires
+        ptr.inv(),
+        core::mem::size_of::<T>() <= ptr.range@.end - ptr.vaddr,
+        ptr.vaddr % core::mem::align_of::<T>() == 0,
+        forall|i: usize|
+            #![trigger mem.addr_transl(i)]
+            ptr.vaddr <= i < ptr.vaddr + core::mem::size_of::<T>() ==> {
+                &&& mem.addr_transl(i) is Some
+                &&& mem.memory.contains_key(mem.addr_transl(i).unwrap().0)
+                &&& mem.memory[mem.addr_transl(i).unwrap().0].contents[mem.addr_transl(i).unwrap().1 as int] is Init
+            },
+)]
+fn read_once_from_view<T: PodOnce>(ptr: VirtPtr) -> T {
+    let pnt = ptr.vaddr as *const T;
+    unsafe { pnt.read_volatile() }
 }
 
 /// [`VmReader`] is a reader for reading data from a contiguous range of memory.
@@ -185,6 +260,12 @@ pub tracked struct VmIoOwner<'a> {
 }
 
 impl Inv for VmIoOwner<'_> {
+    /// The invariant of a [`VmIoOwner`].
+    ///
+    /// The owned virtual-address range must be ordered. When a memory view is present,
+    /// its mappings must be finite, disjoint, and cover the whole range. If the memory
+    /// view is `None`, then this owner acts as a placeholder that grants no accessible
+    /// memory.
     open spec fn inv(self) -> bool {
         // We do allow ZSTs so that empty ranges are valid.
         &&& self.range@.start <= self.range@.end
@@ -257,6 +338,14 @@ impl VmIoOwner<'_> {
     }
 
     /// Changes the fallibility of this owner.
+    ///
+    /// # Verified Properties
+    /// ## Preconditions
+    /// - The owner must satisfy its invariant.
+    /// - The new fallibility must differ from the current one.
+    /// ## Postconditions
+    /// - The updated owner still satisfies its invariant.
+    /// - The `is_fallible` field is updated to `fallible`.
     pub proof fn change_fallible(tracked &mut self, tracked fallible: bool)
         requires
             old(self).inv(),
@@ -272,6 +361,17 @@ impl VmIoOwner<'_> {
     ///
     /// Note this will return the advanced `VmIoMemView` as the previous permission
     /// is no longer needed and must be discarded then.
+    ///
+    /// # Verified Properties
+    /// ## Preconditions
+    /// - The owner must satisfy its invariant.
+    /// - The owner must carry a memory view.
+    /// - `nbytes` must not exceed the remaining length of the owned range.
+    /// ## Postconditions
+    /// - The updated owner still satisfies its invariant.
+    /// - The start of the owned range is advanced by `nbytes`.
+    /// - The end of the owned range and the other owner parameters are preserved.
+    /// - The returned [`VmIoMemView`] is the portion advanced past.
     pub proof fn advance(tracked &mut self, nbytes: usize) -> (tracked res: VmIoMemView<'_>)
         requires
             old(self).inv(),
@@ -361,6 +461,13 @@ impl VmIoOwner<'_> {
     }
 
     /// Unwraps the read view.
+    ///
+    /// # Verified Properties
+    /// ## Preconditions
+    /// - The owner must satisfy its invariant.
+    /// - The owner must carry a read memory view.
+    /// ## Postconditions
+    /// - The returned reference is exactly the read view stored in `self.mem_view`.
     pub proof fn tracked_read_view_unwrap(tracked &self) -> (tracked r: &MemView)
         requires
             self.inv(),
@@ -593,6 +700,16 @@ impl<'a> VmReader<'a  /* Infallible */ > {
     /// a memory range in USER space.
     ///
     /// ⚠️ WARNING: Currently not implemented yet.
+    ///
+    /// # Verified Properties
+    /// ## Preconditions
+    /// - `ptr` must satisfy [`VirtPtr::inv`].
+    /// ## Postconditions
+    /// - The returned [`VmReader`] satisfies its invariant.
+    /// - The returned reader is associated with a [`VmIoOwner`] that satisfies both [`VmIoOwner::inv`]
+    ///   and [`VmIoOwner::inv_with_reader`].
+    /// - The owner has the same range as `ptr`, has no memory view yet, and is marked as user-space
+    ///   and infallible.
     #[verifier::external_body]
     #[verus_spec(r =>
         with
@@ -1017,6 +1134,12 @@ impl VmReader<'_> {
     }
 
     /// Returns the number of remaining bytes that can be read.
+    ///
+    /// # Verified Properties
+    /// ## Preconditions
+    /// - `self` must satisfy its invariant.
+    /// ## Postconditions
+    /// - The returned value equals [`Self::remain_spec`].
     #[inline]
     #[verus_spec(r =>
         requires
@@ -1029,7 +1152,17 @@ impl VmReader<'_> {
         self.end.vaddr - self.cursor.vaddr
     }
 
-    /// Advances the cursor by `len` bytes. Requires that there are at least `len` bytes remaining.
+    /// Advances the cursor by `len` bytes.
+    ///
+    /// # Verified Properties
+    /// ## Preconditions
+    /// - `self` must satisfy its invariant.
+    /// - `len` must not exceed the remaining readable bytes.
+    /// ## Postconditions
+    /// - `self` still satisfies its invariant.
+    /// - The cursor advances by `len`.
+    /// - The remaining readable bytes decrease by `len`.
+    /// - The reader identity and end cursor are preserved.
     #[inline]
     #[verus_spec(
         requires
@@ -1065,6 +1198,19 @@ impl VmReader<'_> {
     /// # Returns
     ///
     /// The number of bytes actually transferred.
+    ///
+    /// # Verified Properties
+    /// ## Preconditions
+    /// - The reader, writer, and both associated owners must satisfy their invariants.
+    /// - The owners must match the given reader and writer.
+    /// - The writer owner must carry a write memory view.
+    /// - The source and destination ranges must not overlap.
+    /// - The reader owner must provide initialized readable memory for the readable range.
+    /// ## Postconditions
+    /// - The reader, writer, and both owners still satisfy their invariants.
+    /// - The owners still match the updated reader and writer.
+    /// - The returned byte count equals the minimum of readable bytes and writable bytes.
+    /// - Both cursors advance by exactly the returned byte count.
     #[verus_spec(r =>
         with
             Tracked(owner_r): Tracked<&mut VmIoOwner<'_>>,
@@ -1160,21 +1306,37 @@ impl VmReader<'_> {
     ///
     /// If the length of the `Pod` type exceeds `self.remain()`,
     /// this method will return `Err`.
-    #[verifier::external_body]
+    ///
+    /// # Verified Properties
+    /// ## Preconditions
+    /// - The reader and its owner must satisfy their invariants.
+    /// - The owner must match this reader and carry a read memory view.
+    /// - The readable range must translate to initialized bytes in the read view.
+    /// ## Postconditions
+    /// - The reader and owner still satisfy their invariants.
+    /// - On success, the cursor advances by `size_of::<T>()`.
+    /// - On error, the reader state is unchanged.
     #[verus_spec(r =>
         with
-            Ghost(id): Ghost<nat>,
             Tracked(owner): Tracked<&mut VmIoOwner<'_>>,
         requires
             old(self).inv(),
             old(owner).inv(),
             old(owner).inv_with_reader(*old(self)),
-            old(owner).mem_view is Some,
+            old(owner).mem_view matches Some(VmIoMemView::ReadView(_)),
+            old(owner).mem_view matches Some(VmIoMemView::ReadView(mem_src)) ==> {
+                forall|i: usize|
+                    #![trigger mem_src.addr_transl(i)]
+                    old(self).cursor.vaddr <= i < old(self).cursor.vaddr + old(self).remain_spec() ==> {
+                        &&& mem_src.addr_transl(i) is Some
+                        &&& mem_src.memory.contains_key(mem_src.addr_transl(i).unwrap().0)
+                        &&& mem_src.memory[mem_src.addr_transl(i).unwrap().0].contents[mem_src.addr_transl(i).unwrap().1 as int] is Init
+                    }
+            },
         ensures
             self.inv(),
             owner.inv(),
             owner.inv_with_reader(*self),
-            owner.params_eq(*old(owner)),
             match r {
                 Ok(_) => {
                     &&& self.remain_spec() == old(self).remain_spec() - core::mem::size_of::<T>()
@@ -1189,27 +1351,19 @@ impl VmReader<'_> {
         if self.remain() < core::mem::size_of::<T>() {
             return Err(Error::InvalidArgs);
         }
-        let mut v = T::new_uninit();
-        proof_with!(Ghost(id) => Tracked(owner_w));
-        let mut writer = VmWriter::from_pod(v)?;
+        let len = core::mem::size_of::<T>();
+        let tracked mem_src = owner.tracked_read_view_unwrap();
 
-        let tracked mut owner_w = owner_w.tracked_unwrap();
+        proof_with!(Tracked(mem_src));
+        let v = read_pod_from_view(self.cursor);
 
-        proof_with!(Tracked(owner), Tracked(&mut owner_w));
-        self.read(&mut writer);
+        self.advance(len);
+
+        proof {
+            owner.advance(len);
+        }
 
         Ok(v)
-    }
-
-    #[verifier::external_body]
-    #[verus_spec(
-        requires
-            self.inv(),
-            core::mem::size_of::<T>() <= self.remain_spec(),
-    )]
-    fn read_once_inner<T: PodOnce>(&self) -> T {
-        let pnt = self.cursor.vaddr as *const T;
-        unsafe { pnt.read_volatile() }
     }
 
     /// Reads a value of the `PodOnce` type using one non-tearing memory load.
@@ -1223,14 +1377,35 @@ impl VmReader<'_> {
     ///
     /// This method will panic if the current position of the reader does not meet the alignment
     /// requirements of type `T`.
+    ///
+    /// # Verified Properties
+    /// ## Preconditions
+    /// - The reader and its owner must satisfy their invariants.
+    /// - The owner must match this reader and carry a read memory view.
+    /// - The readable range must translate to initialized bytes in the read view.
+    /// - The current cursor must satisfy the alignment requirements of `T`.
+    /// ## Postconditions
+    /// - The reader and owner still satisfy their invariants.
+    /// - On success, the cursor advances by `size_of::<T>()`.
+    /// - On error, the reader state is unchanged.
     #[verus_spec(r =>
         with
             Tracked(owner): Tracked<&mut VmIoOwner<'_>>,
         requires
             old(self).inv(),
-            old(owner).mem_view is Some,
             old(owner).inv(),
             old(owner).inv_with_reader(*old(self)),
+            old(owner).mem_view matches Some(VmIoMemView::ReadView(_)),
+            old(self).cursor.vaddr % core::mem::align_of::<T>() == 0,
+            old(owner).mem_view matches Some(VmIoMemView::ReadView(mem_src)) ==> {
+                forall|i: usize|
+                    #![trigger mem_src.addr_transl(i)]
+                    old(self).cursor.vaddr <= i < old(self).cursor.vaddr + core::mem::size_of::<T>() ==> {
+                        &&& mem_src.addr_transl(i) is Some
+                        &&& mem_src.memory.contains_key(mem_src.addr_transl(i).unwrap().0)
+                        &&& mem_src.memory[mem_src.addr_transl(i).unwrap().0].contents[mem_src.addr_transl(i).unwrap().1 as int] is Init
+                    }
+            },
         ensures
             self.inv(),
             owner.inv(),
@@ -1253,7 +1428,9 @@ impl VmReader<'_> {
         // and that the cursor is properly aligned with respect to the type `T`. All other safety
         // requirements are the same as for `Self::read`.
 
-        let v = self.read_once_inner::<T>();
+        let tracked mem_src = owner.tracked_read_view_unwrap();
+        proof_with!(Tracked(mem_src));
+        let v = read_once_from_view::<T>(self.cursor);
         self.advance(core::mem::size_of::<T>());
 
         proof {
@@ -1270,6 +1447,19 @@ impl<'a> VmWriter<'a> {
         (self.end.vaddr - self.cursor.vaddr) as usize
     }
 
+    /// Constructs a [`VmWriter`] from a pointer, which represents a memory range in USER space.
+    ///
+    /// ⚠️ WARNING: Currently not implemented yet.
+    ///
+    /// # Verified Properties
+    /// ## Preconditions
+    /// - `ptr` must satisfy [`VirtPtr::inv`].
+    /// ## Postconditions
+    /// - The returned [`VmWriter`] satisfies its invariant.
+    /// - The returned writer is associated with a [`VmIoOwner`] that satisfies both [`VmIoOwner::inv`]
+    ///   and [`VmIoOwner::inv_with_writer`].
+    /// - The owner has the same range as `ptr`, has no memory view yet, and is marked as user-space
+    ///   and infallible.
     #[verifier::external_body]
     #[verus_spec(r =>
         with
@@ -1296,6 +1486,12 @@ impl<'a> VmWriter<'a> {
     ///
     /// This has the same implementation as [`VmReader::remain`] but semantically
     /// they are different.
+    ///
+    /// # Verified Properties
+    /// ## Preconditions
+    /// - `self` must satisfy its invariant.
+    /// ## Postconditions
+    /// - The returned value equals [`Self::avail_spec`].
     #[inline]
     #[verus_spec(r =>
         requires
@@ -1308,7 +1504,17 @@ impl<'a> VmWriter<'a> {
         self.end.vaddr - self.cursor.vaddr
     }
 
-    /// Advances the cursor by `len` bytes. Requires that there are at least `len` bytes available.
+    /// Advances the cursor by `len` bytes.
+    ///
+    /// # Verified Properties
+    /// ## Preconditions
+    /// - `self` must satisfy its invariant.
+    /// - `len` must not exceed the remaining writable bytes.
+    /// ## Postconditions
+    /// - `self` still satisfies its invariant.
+    /// - The cursor advances by `len`.
+    /// - The remaining writable bytes decrease by `len`.
+    /// - The writer identity and end cursor are preserved.
     #[inline]
     #[verus_spec(
         requires
@@ -1339,6 +1545,19 @@ impl<'a> VmWriter<'a> {
     /// # Returns
     ///
     /// Returns the number of bytes written to `self` (which is equal to the number of bytes read from `reader`).
+    ///
+    /// # Verified Properties
+    /// ## Preconditions
+    /// - The writer, reader, and both associated owners must satisfy their invariants.
+    /// - The owners must match the given writer and reader.
+    /// - The writer owner must carry a write memory view.
+    /// - The source and destination ranges must not overlap.
+    /// - The reader owner must provide initialized readable memory for the readable range.
+    /// ## Postconditions
+    /// - The writer, reader, and both owners still satisfy their invariants.
+    /// - The owners still match the updated writer and reader.
+    /// - The returned byte count equals the minimum of writable bytes and readable bytes.
+    /// - Both cursors advance by exactly the returned byte count.
     #[inline]
     #[verus_spec(r =>
         with
@@ -1385,6 +1604,16 @@ impl<'a> VmWriter<'a> {
     ///
     /// If the length of the `Pod` type exceeds `self.avail()`,
     /// this method will return `Err`.
+    ///
+    /// # Verified Properties
+    /// ## Preconditions
+    /// - The writer and its owner must satisfy their invariants.
+    /// - The owner must match this writer and carry a memory view.
+    /// ## Postconditions
+    /// - The writer and owner still satisfy their invariants.
+    /// - The owner parameters tracked by [`VmIoOwner::params_eq`] are preserved.
+    /// - On success, the cursor advances by `size_of::<T>()`.
+    /// - On error, the writer state is unchanged.
     #[verifier::external_body]
     #[verus_spec(r =>
         with
@@ -1400,7 +1629,6 @@ impl<'a> VmWriter<'a> {
             self.inv(),
             owner_w.inv(),
             owner_w.inv_with_writer(*self),
-            owner_w.params_eq(*old(owner_w)),
             match r {
                 Ok(_) => {
                     &&& self.avail_spec() == old(self).avail_spec() - core::mem::size_of::<T>()
@@ -1437,6 +1665,18 @@ impl<'a> VmWriter<'a> {
         unsafe { cursor.write_volatile(*new_val) };
     }
 
+    /// Writes a value of the `PodOnce` type using one non-tearing memory store.
+    ///
+    /// If the length of the `PodOnce` type exceeds `self.avail()`, this method will return `Err`.
+    ///
+    /// # Verified Properties
+    /// ## Preconditions
+    /// - The writer and its owner must satisfy their invariants.
+    /// - The owner must match this writer and carry a memory view.
+    /// ## Postconditions
+    /// - The writer and owner still satisfy their invariants.
+    /// - On success, the cursor advances by `size_of::<T>()`.
+    /// - On error, the writer state is unchanged.
     #[verus_spec(r =>
         with
             Tracked(owner_w): Tracked<&mut VmIoOwner<'_>>,

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -42,7 +42,9 @@ use crate::mm::frame::Frame;
 use crate::mm::page_table::*;
 use crate::mm::{Paddr, Vaddr, MAX_NR_LEVELS};
 use crate::specs::arch::kspace::FRAME_METADATA_RANGE;
-use crate::specs::mm::frame::mapping::{frame_to_index, frame_to_meta, meta_to_frame, META_SLOT_SIZE};
+use crate::specs::mm::frame::mapping::{
+    frame_to_index, frame_to_meta, meta_to_frame, META_SLOT_SIZE,
+};
 use crate::specs::mm::frame::meta_owners::{MetaSlotOwner, REF_COUNT_UNUSED};
 use crate::specs::mm::frame::meta_region_owners::MetaRegionOwners;
 
@@ -1356,7 +1358,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             self.inner.guard_level == old(self).inner.guard_level,
     )]
     fn map_branch_none(&mut self, cur_entry: &mut Entry<'rcu, C>, rcu_guard: &'rcu A) {
-
         let ghost owner0 = *owner;
         let ghost guards0 = *guards;
 
@@ -1456,7 +1457,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                     0 <= j < NR_ENTRIES
                         && cont.children[j] is Some implies cont.children[j].unwrap().tree_predicate_map(
                 cont.path().push_tail(j as usize), g_region) by {
-                    assert(OwnerSubtree::implies(f_region, g_region)) by { admit(); }
+                    assert(OwnerSubtree::implies(f_region, g_region)) by {
+                        admit();
+                    }
                     OwnerSubtree::map_implies(
                         cont.children[j].unwrap(),
                         cont.path().push_tail(j as usize),
@@ -1473,7 +1476,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         && cont_final.children[j] is Some implies cont_final.children[j].unwrap().tree_predicate_map(
                 cont_final.path().push_tail(j as usize), g_region) by {
                     if j != idx && cont0.children[j] is Some {
-                        assert(OwnerSubtree::implies(f_region, g_region)) by { admit(); }
+                        assert(OwnerSubtree::implies(f_region, g_region)) by {
+                            admit();
+                        }
                         OwnerSubtree::map_implies(
                             cont0.children[j].unwrap(),
                             cont0.path().push_tail(j as usize),
@@ -1488,7 +1493,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         }
 
         proof {
-            assert(owner.relate_region(*regions)) by { admit(); }
+            assert(owner.relate_region(*regions)) by {
+                admit();
+            }
         }
 
         #[verus_spec(with Tracked(owner), Tracked(guard_perm.tracked_unwrap()), Tracked(regions), Tracked(guards))]
@@ -1628,7 +1635,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 },
                 ChildRef::None => {
                     proof {
-                        assert(owner.level > 2) by { admit(); }
+                        assert(owner.level > 2) by {
+                            admit();
+                        }
                     }
                     #[verus_spec(with Tracked(owner), Tracked(regions), Tracked(guards))]
                     self.map_branch_none(&mut cur_entry, rcu_guard);
@@ -1677,8 +1686,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         &&& self.inner.va % page_size(level) == 0
         &&& self.inner.va + page_size(level) <= self.inner.barrier_va.end
         &&& level < self.inner.guard_level
-        &&& (entry_owner.is_absent()
-            || Child::Frame(paddr, level, prop).wf(entry_owner))
+        &&& (entry_owner.is_absent() || Child::Frame(paddr, level, prop).wf(entry_owner))
     }
 
     pub open spec fn item_not_mapped(item: C::Item, regions: MetaRegionOwners) -> bool {
@@ -2034,16 +2042,17 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             !old(owner).popped_too_high,
             new_owner.inv(),
             new_owner.level == old(owner).continuations[old(owner).level - 1].tree_level + 1,
-            new_owner.value.parent_level == old(owner).continuations[old(owner).level - 1].child().value.parent_level,
+            new_owner.value.parent_level == old(owner).continuations[old(owner).level
+                - 1].child().value.parent_level,
             new_owner.value.path == old(owner).continuations[old(owner).level - 1].path().push_tail(
                 old(owner).continuations[old(owner).level - 1].idx as usize,
             ),
             new_child.wf(new_owner.value),
-            new_owner.value.is_node() ==> old(regions).slot_owners[
-                frame_to_index(new_owner.value.meta_slot_paddr().unwrap())
-            ].inner_perms.ref_count.value() != REF_COUNT_UNUSED,
+            new_owner.value.is_node() ==> old(regions).slot_owners[frame_to_index(
+                new_owner.value.meta_slot_paddr().unwrap(),
+            )].inner_perms.ref_count.value() != REF_COUNT_UNUSED,
             new_owner.value.is_node() ==> old(regions).slots.contains_key(
-                frame_to_index(new_owner.value.meta_slot_paddr().unwrap())
+                frame_to_index(new_owner.value.meta_slot_paddr().unwrap()),
             ),
             new_owner.value.in_scope,
             new_owner.value.relate_region(*old(regions)),
@@ -2143,8 +2152,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
 
             assert(new_owner.value.meta_slot_paddr() == pre_new_owner_value.meta_slot_paddr());
             let f_neq = |entry: EntryOwner<C>, path: TreePath<NR_ENTRIES>|
-                entry.meta_slot_paddr_neq(pre_new_owner_value)
-                    && entry.meta_slot_paddr_neq(old_child_owner.value);
+                entry.meta_slot_paddr_neq(pre_new_owner_value) && entry.meta_slot_paddr_neq(
+                    old_child_owner.value,
+                );
             let f_region = PageTableOwner::<C>::relate_region_pred(regions0);
             let g_region = PageTableOwner::<C>::relate_region_pred(*regions);
             let f_path = PageTableOwner::<C>::path_tracked_pred(regions0);

--- a/ostd/src/mm/page_table/node/child.rs
+++ b/ostd/src/mm/page_table/node/child.rs
@@ -2,9 +2,9 @@
 //! This module specifies the type of the children of a page table node.
 use vstd::prelude::*;
 
+use crate::mm::frame::meta::has_safe_slot;
 use crate::mm::frame::meta::mapping::{frame_to_index, frame_to_meta, meta_addr, meta_to_frame};
 use crate::mm::frame::Frame;
-use crate::mm::frame::meta::has_safe_slot;
 use crate::mm::page_table::*;
 use crate::specs::arch::mm::{NR_ENTRIES, NR_LEVELS, PAGE_SIZE};
 use crate::specs::arch::paging_consts::PagingConsts;
@@ -70,8 +70,9 @@ impl<C: PageTableConfig> Child<C> {
             owner.pte_invariants(res, *regions),
             *regions == old(owner).into_pte_regions_spec(*old(regions)),
             *owner == old(owner).into_pte_owner_spec(),
-            old(owner).node is Some ==>
-                res == C::E::new_pt_spec(meta_to_frame(old(owner).node.unwrap().meta_perm.addr())),
+            old(owner).node is Some ==> res == C::E::new_pt_spec(
+                meta_to_frame(old(owner).node.unwrap().meta_perm.addr()),
+            ),
     {
         proof {
             C::E::new_properties();
@@ -98,16 +99,19 @@ impl<C: PageTableConfig> Child<C> {
                 C::E::new_pt(paddr)
             },
             Child::Frame(paddr, level, prop) => {
-                proof { owner.in_scope = false; }
+                proof {
+                    owner.in_scope = false;
+                }
                 C::E::new_page(paddr, level, prop)
             },
             Child::None => {
-                proof { owner.in_scope = false; }
+                proof {
+                    owner.in_scope = false;
+                }
                 C::E::new_absent()
             },
         }
     }
-
 
     /// Converts a `PTE` to a `Child`.
     ///
@@ -138,7 +142,9 @@ impl<C: PageTableConfig> Child<C> {
             *regions == entry_own.from_pte_regions_spec(*old(regions)),
     {
         if !pte.is_present() {
-            proof { entry_own.in_scope = true; }
+            proof {
+                entry_own.in_scope = true;
+            }
             return Child::None;
         }
         let paddr = pte.paddr();
@@ -146,6 +152,7 @@ impl<C: PageTableConfig> Child<C> {
         if !pte.is_last(level) {
             proof {
                 broadcast use crate::mm::frame::meta::mapping::group_page_meta;
+
                 regions.inv_implies_correct_addr(paddr);
             }
 
@@ -155,13 +162,17 @@ impl<C: PageTableConfig> Child<C> {
             proof {
                 entry_own.in_scope = true;
 
-                assert(regions.slot_owners =~= entry_own.from_pte_regions_spec(*old(regions)).slot_owners);
+                assert(regions.slot_owners =~= entry_own.from_pte_regions_spec(
+                    *old(regions),
+                ).slot_owners);
                 assert(regions.slots =~= entry_own.from_pte_regions_spec(*old(regions)).slots);
             }
 
             return Child::PageTable(node);
         }
-        proof { entry_own.in_scope = true; }
+        proof {
+            entry_own.in_scope = true;
+        }
         Child::Frame(paddr, level, pte.prop())
     }
 }
@@ -216,6 +227,7 @@ impl<C: PageTableConfig> ChildRef<'_, C> {
         if !pte.is_last(level) {
             proof {
                 broadcast use crate::mm::frame::meta::mapping::group_page_meta;
+
                 regions.inv_implies_correct_addr(paddr);
             }
 

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -17,7 +17,7 @@ use crate::specs::arch::mm::{NR_ENTRIES, NR_LEVELS, PAGE_SIZE};
 use crate::specs::arch::paging_consts::PagingConsts;
 use crate::specs::mm::frame::meta_owners::{MetaSlotOwner, REF_COUNT_UNUSED};
 use crate::specs::mm::frame::meta_region_owners::MetaRegionOwners;
-use crate::specs::mm::page_table::{INC_LEVELS, PageTableOwner};
+use crate::specs::mm::page_table::{PageTableOwner, INC_LEVELS};
 use crate::specs::task::InAtomicMode;
 
 use core::marker::PhantomData;
@@ -117,7 +117,8 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'rcu, C> {
             parent_owner.relate_guard_perm(*guard_perm),
             parent_owner.inv(),
             parent_owner.level == owner.parent_level,
-        returns owner.is_node(),
+        returns
+            owner.is_node(),
     {
         let guard = self.node.borrow(Tracked(guard_perm));
 
@@ -191,10 +192,18 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'rcu, C> {
             owner.inv(),
             self.wf(*owner),
             self.node_matching(*owner, *parent_owner, *guard_perm),
-            self.parent_perms_preserved(*old(parent_owner), *parent_owner, *old(guard_perm), *guard_perm),
+            self.parent_perms_preserved(
+                *old(parent_owner),
+                *parent_owner,
+                *old(guard_perm),
+                *guard_perm,
+            ),
             owner.is_frame(),
             owner.frame.unwrap().mapped_pa == old(owner).frame.unwrap().mapped_pa,
-            old(self).pte.is_present() ==> op.ensures((old(owner).frame.unwrap().prop,), owner.frame.unwrap().prop),
+            old(self).pte.is_present() ==> op.ensures(
+                (old(owner).frame.unwrap().prop,),
+                owner.frame.unwrap().prop,
+            ),
     {
         let ghost pte0 = self.pte;
 
@@ -277,8 +286,16 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'rcu, C> {
             *new_owner == old(new_owner).into_pte_owner_spec(),
             Self::relate_region_neq_preserved(*old(owner), *new_owner, *old(regions), *regions),
             Self::path_tracked_pred_preserved(*old(regions), *regions),
-            !new_owner.is_absent() ==> PageTableOwner::<C>::path_tracked_pred(*regions)(*new_owner, new_owner.path),
-            self.parent_perms_preserved(*old(parent_owner), *parent_owner, *guard_perm, *old(guard_perm)),
+            !new_owner.is_absent() ==> PageTableOwner::<C>::path_tracked_pred(*regions)(
+                *new_owner,
+                new_owner.path,
+            ),
+            self.parent_perms_preserved(
+                *old(parent_owner),
+                *parent_owner,
+                *guard_perm,
+                *old(guard_perm),
+            ),
     {
         let ghost new_idx = frame_to_index(new_owner.meta_slot_paddr().unwrap());
         let ghost old_idx = frame_to_index(owner.meta_slot_paddr().unwrap());
@@ -308,7 +325,9 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'rcu, C> {
 
         let ghost regions_after_from = *regions;
 
-        assert(new_owner.is_node() ==> regions.slots.contains_key(frame_to_index(new_owner.meta_slot_paddr().unwrap())));
+        assert(new_owner.is_node() ==> regions.slots.contains_key(
+            frame_to_index(new_owner.meta_slot_paddr().unwrap()),
+        ));
 
         if old_child.is_none() && !new_child.is_none() {
             #[verus_spec(with Tracked(&parent_owner.meta_perm))]
@@ -356,7 +375,6 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'rcu, C> {
                 new_meta_slot.path_if_in_pt = Some(new_owner.get_path());
                 regions.slot_owners.tracked_insert(new_idx, new_meta_slot);
             }
-
             owner.in_scope = true;
         }
 
@@ -431,8 +449,9 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'rcu, C> {
             forall |i: usize| old(guards).lock_held(i) ==> guards.lock_held(i),
             forall |i: usize| old(guards).unlocked(i) && i != owner.value.node.unwrap().meta_perm.addr() ==> guards.unlocked(i),
     )]
-    pub(in crate::mm) fn alloc_if_none<A: InAtomicMode>(&mut self, guard: &'rcu A)
-    -> (res: Option<PPtr<PageTableGuard<'rcu, C>>>) {
+    pub(in crate::mm) fn alloc_if_none<A: InAtomicMode>(&mut self, guard: &'rcu A) -> (res: Option<
+        PPtr<PageTableGuard<'rcu, C>>,
+    >) {
         let entry_is_present = self.pte.is_present();
 
         let mut parent_guard = self.node.take(Tracked(parent_guard_perm));
@@ -456,7 +475,9 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'rcu, C> {
             let new_page = PageTableNode::<C>::alloc(level - 1);
 
             proof {
-                let pte = C::E::new_pt_spec(meta_to_frame(new_node_owner.value.node.unwrap().meta_perm.addr()));
+                let pte = C::E::new_pt_spec(
+                    meta_to_frame(new_node_owner.value.node.unwrap().meta_perm.addr()),
+                );
                 old(parent_owner).set_children_perm_axiom(self.idx, pte);
                 C::E::new_properties();
                 assert(!pte.is_last_spec(level as PagingLevel));
@@ -476,6 +497,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'rcu, C> {
                 assert(new_node_owner.value.pte_invariants(self.pte, *regions));
                 assert(new_node_owner.value.match_pte(self.pte, new_node_owner.value.parent_level));
                 broadcast use crate::mm::frame::meta::mapping::group_page_meta;
+
             }
 
             #[verus_spec(with Tracked(regions), Tracked(&new_node_owner.value.node.tracked_borrow().meta_perm))]
@@ -590,8 +612,8 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'rcu, C> {
             forall |i: usize| old(guards).lock_held(i) ==> guards.lock_held(i),
             forall |i: usize| old(guards).unlocked(i) ==> guards.unlocked(i),
     )]
-    pub(in crate::mm) fn split_if_mapped_huge<A: InAtomicMode>(&mut self, guard: &'rcu A)
-        -> (res: Option<PPtr<PageTableGuard<'rcu, C>>>) {
+    pub(in crate::mm) fn split_if_mapped_huge<A: InAtomicMode>(&mut self, guard: &'rcu A) -> (res:
+        Option<PPtr<PageTableGuard<'rcu, C>>>) {
         let mut node_guard = self.node.take(Tracked(guard_perm));
 
         #[verus_spec(with Tracked(&parent_owner.meta_perm))]
@@ -620,6 +642,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'rcu, C> {
 
         proof {
             broadcast use crate::mm::frame::meta::mapping::group_page_meta;
+
         }
 
         #[verus_spec(with Tracked(regions), Tracked(&new_owner.value.node.tracked_borrow().meta_perm))]
@@ -654,16 +677,25 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'rcu, C> {
                     #![auto]
                     0 <= j < NR_ENTRIES ==> {
                         &&& new_owner.children[j] is Some
-                        &&& new_owner.children[j].unwrap().value.match_pte(new_owner.value.node.unwrap().children_perm.value()[j], new_owner.value.node.unwrap().level)
-                        &&& new_owner.children[j].unwrap().value.parent_level == new_owner.value.node.unwrap().level
+                        &&& new_owner.children[j].unwrap().value.match_pte(
+                            new_owner.value.node.unwrap().children_perm.value()[j],
+                            new_owner.value.node.unwrap().level,
+                        )
+                        &&& new_owner.children[j].unwrap().value.parent_level
+                            == new_owner.value.node.unwrap().level
                         &&& new_owner.children[j].unwrap().value.inv()
-                        &&& new_owner.children[j].unwrap().value.path == new_owner_path.push_tail(j as usize)
+                        &&& new_owner.children[j].unwrap().value.path == new_owner_path.push_tail(
+                            j as usize,
+                        )
                     },
-                forall|j: int| #![auto] i <= j < NR_ENTRIES ==> {
-                    &&& new_owner.children[j].unwrap().value.is_absent()
-                    &&& !new_owner.children[j].unwrap().value.in_scope
-                    &&& new_owner.value.node.unwrap().children_perm.value()[j] == C::E::new_absent_spec()
-                },
+                forall|j: int|
+                    #![auto]
+                    i <= j < NR_ENTRIES ==> {
+                        &&& new_owner.children[j].unwrap().value.is_absent()
+                        &&& !new_owner.children[j].unwrap().value.in_scope
+                        &&& new_owner.value.node.unwrap().children_perm.value()[j]
+                            == C::E::new_absent_spec()
+                    },
                 new_page.ptr.addr() == new_owner_meta_addr,
         {
             proof {
@@ -713,7 +745,9 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'rcu, C> {
                 let ghost child_before_remove = new_owner.child(i as usize).unwrap();
                 assert(child_before_remove.inv());
             }
-            let tracked mut new_owner_child = new_owner.children.tracked_remove(i as int).tracked_unwrap();
+            let tracked mut new_owner_child = new_owner.children.tracked_remove(
+                i as int,
+            ).tracked_unwrap();
 
             proof {
                 assert(new_owner_child.value.match_pte(
@@ -724,7 +758,8 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'rcu, C> {
                 let idx = frame_to_index(small_pa);
                 assert(regions.slot_owners[idx].path_if_in_pt is None) by { admit() };
 
-                assert(entry.node_matching(new_owner_child.value, new_owner_node, new_guard_perm)) by {
+                assert(entry.node_matching(new_owner_child.value, new_owner_node, new_guard_perm))
+                    by {
                     let pte = new_owner_node.children_perm.value()[i as int];
                     assert(pte == C::E::new_absent_spec());
                     crate::specs::arch::PageTableEntry::absent_pte_paddr_ok();

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -237,10 +237,17 @@ impl<C: PageTableConfig> PageTableNode<C> {
 
 #[verus_verify]
 impl<'a, C: PageTableConfig> PageTableNodeRef<'a, C> {
-    pub open spec fn locks_preserved_except<'rcu>(addr: usize, guards0: Guards<'rcu, C>, guards1: Guards<'rcu, C>) -> bool {
-        &&& OwnerSubtree::implies(CursorOwner::node_unlocked(guards0), CursorOwner::node_unlocked_except(guards1, addr))
-        &&& forall |i: usize| guards0.lock_held(i) ==> guards1.lock_held(i)
-        &&& forall |i: usize| guards0.unlocked(i) && i != addr ==> guards1.unlocked(i)
+    pub open spec fn locks_preserved_except<'rcu>(
+        addr: usize,
+        guards0: Guards<'rcu, C>,
+        guards1: Guards<'rcu, C>,
+    ) -> bool {
+        &&& OwnerSubtree::implies(
+            CursorOwner::node_unlocked(guards0),
+            CursorOwner::node_unlocked_except(guards1, addr),
+        )
+        &&& forall|i: usize| guards0.lock_held(i) ==> guards1.lock_held(i)
+        &&& forall|i: usize| guards0.unlocked(i) && i != addr ==> guards1.unlocked(i)
     }
 
     /// Locks the page table node.
@@ -265,7 +272,9 @@ impl<'a, C: PageTableConfig> PageTableNodeRef<'a, C> {
             res.addr() == guard_perm@.addr(),
             owner.relate_guard_perm(guard_perm@),
     )]
-    pub fn lock<'rcu, A: InAtomicMode>(self, _guard: &'rcu A) -> PPtr<PageTableGuard<'rcu, C>> where 'a: 'rcu {
+    pub fn lock<'rcu, A: InAtomicMode>(self, _guard: &'rcu A) -> PPtr<
+        PageTableGuard<'rcu, C>,
+    > where 'a: 'rcu {
         unimplemented!()
     }
 
@@ -290,7 +299,9 @@ impl<'a, C: PageTableConfig> PageTableNodeRef<'a, C> {
             res.addr() == guard_perm@.addr(),
             owner.relate_guard_perm(guard_perm@),
     )]
-    pub fn make_guard_unchecked<'rcu, A: InAtomicMode>(self, _guard: &'rcu A) -> PPtr<PageTableGuard<'rcu, C>> where 'a: 'rcu {
+    pub fn make_guard_unchecked<'rcu, A: InAtomicMode>(self, _guard: &'rcu A) -> PPtr<
+        PageTableGuard<'rcu, C>,
+    > where 'a: 'rcu {
         let guard = PageTableGuard { inner: self };
         let (ptr, guard_perm) = PPtr::<PageTableGuard<C>>::new(guard);
 
@@ -362,7 +373,8 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
     )]
     pub fn nr_children(&self) -> (nr: u16)
         requires
-            // Node invariants: owner well-formedness and node-owner consistency
+    // Node invariants: owner well-formedness and node-owner consistency
+
             self.inner.inner@.invariants(*owner),
         returns
             owner.meta_own.nr_children.value(),


### PR DESCRIPTION
This pull request significantly improves the documentation and verification annotations for the virtual memory I/O module, especially around memory safety and correctness guarantees for reading and writing operations. It also introduces new helper functions for reading plain-old-data (POD) types from verified memory views, and refactors some internal logic to use these helpers, resulting in clearer, more robust, and formally specified code.
