### PR TITLE
Delete potential unsound axioms in ghost tree

### DIFF
--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -2807,7 +2807,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             owner.level,
         );
         let tracked subtree = OwnerSubtree::new_val_tracked(absent_entry_owner,
-            (owner.continuations.tracked_borrow(owner.level - 1).tree_level + 1) as nat);
+            (owner.continuations[owner.level - 1].tree_level + 1) as nat);
 
         assert(subtree.value.meta_slot_paddr() is None);
         proof {

--- a/vstd_extra/src/ghost_tree.rs
+++ b/vstd_extra/src/ghost_tree.rs
@@ -592,7 +592,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
         Node { value: val, level: lv, children: Seq::new(N as nat, |i| Some(Self::new(lv + 1))) }
     }
 
-    pub axiom fn new_val_tracked(tracked val: T, tracked lv: nat) -> (tracked res: Self)
+    pub axiom fn new_val_tracked(tracked val: T, lv: nat) -> (tracked res: Self)
         requires
             0 <= lv < L,
             N > 0,


### PR DESCRIPTION
Fix several axioms in `ghost_tree`.
- Remove axioms that `L, N` are positive. Add them in the type invariant.
- Change the mode of the seq len parameter from `tracked` to `ghost` in `new_val_tracked`.