### PR TITLE
Use verus cache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,13 @@ jobs:
           path: tools/verus
           key: ${{ runner.os }}-verus-${{ env.VERUS_COMMIT }}
 
+      - name: Cache verusfmt
+        id: cache-verusfmt
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/verusfmt
+          key: ${{ runner.os }}-verusfmt-${{ env.VERUS_COMMIT }}
+
       - name: Bootstrap Verus (if needed)
         run: |
           if [ "${{ steps.cache-verus.outputs.cache-hit }}" = "true" ]; then
@@ -54,6 +61,12 @@ jobs:
             rm -rf tools/verus
             cargo dv bootstrap
           fi
+
+          if ! command -v verusfmt >/dev/null 2>&1; then
+            echo "verusfmt not found, installing via cargo dv bootstrap..."
+            cargo dv bootstrap
+          fi
+          verusfmt --version
 
       - name: Run verification
         run: |

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -46,6 +46,13 @@ jobs:
           path: tools/verus
           key: ${{ runner.os }}-verus-${{ env.VERUS_COMMIT }}
 
+      - name: Cache verusfmt
+        id: cache-verusfmt
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/verusfmt
+          key: ${{ runner.os }}-verusfmt-${{ env.VERUS_COMMIT }}
+
       - name: Bootstrap Verus (if needed)
         run: |
           if [ "${{ steps.cache-verus.outputs.cache-hit }}" = "true" ]; then
@@ -55,6 +62,12 @@ jobs:
             rm -rf tools/verus
             cargo dv bootstrap
           fi
+
+          if ! command -v verusfmt >/dev/null 2>&1; then
+            echo "verusfmt not found, installing via cargo dv bootstrap..."
+            cargo dv bootstrap
+          fi
+          verusfmt --version
 
       - name: Run verification
         run: make


### PR DESCRIPTION
Add `tools/verus` in CI cache. `cargo dv bootstrap` will be skipped if `tools/verus` matches `asterinas/verus`. It reduces CI time from 8 minutes to 4 minutes if cache hit.