### PR TITLE
Fix missing `deref` specifications

### DIFF
--- a/ostd/src/sync/rwlock.rs
+++ b/ostd/src/sync/rwlock.rs
@@ -1074,7 +1074,10 @@ impl<'a, T  /*: ?Sized*/ , G: SpinGuardian> RwLockUpgradeableGuard<'a, T, G> {
 impl<T  /*: ?Sized*/ , G: SpinGuardian> Deref for RwLockUpgradeableGuard<'_, T, G> {
     type Target = T;
 
-    fn deref(&self) -> &T {
+    fn deref(&self) -> &T
+        returns
+            self.view(),
+    {
         proof!{
             use_type_invariant(self);
         }


### PR DESCRIPTION
This PR complements #358 as doing `rwlock_guard.inner_field` calls `deref` implicitly which would require us to have a `view` available there. So I added `returns self.view()` in case that anyone uses it in the future.