### PR TITLE
Refactor `sync::rcu::non_null::NonNullPtr`

### DIFF
--- a/ostd/src/sync/rcu/non_null/mod.rs
+++ b/ostd/src/sync/rcu/non_null/mod.rs
@@ -33,6 +33,9 @@ pub unsafe trait NonNullPtr: Sized + 'static {
     // TODO: Support `Target: ?Sized`.
     type Target;
 
+    /// The verification-only permission type that represents the ownership of the smart pointer.
+    type Permission: RawPtrPerm<SmartPtr = Self, Target = Self::Target> + Inv;
+
     // VERUS LIMITATION: Cannot use associated type with lifetime yet.
     /*/// A type that behaves just like a shared reference to the `NonNullPtr`.
     type Ref<'a>
@@ -41,7 +44,7 @@ pub unsafe trait NonNullPtr: Sized + 'static {
     // Verus LIMITATION: Cannot use `const` associated type yet.
     /// The power of two of the pointer alignment.
     // const ALIGN_BITS: u32;
-    fn ALIGN_BITS() -> u32;
+    const ALIGN_BITS: u32;
 
     /// Converts to a raw pointer.
     ///
@@ -53,12 +56,11 @@ pub unsafe trait NonNullPtr: Sized + 'static {
     /// `1 << Self::ALIGN_BITS`.
     /// VERUS LIMITATION: the #[verus_spec] attribute does not support `with` in trait yet.
     /// SOUNDNESS: Considering also returning the Dealloc permission to ensure no memory leak.
-    fn into_raw(self) -> ((ret,perm): (NonNull<Self::Target>, Tracked<SmartPtrPointsTo<Self::Target>>))
+    fn into_raw(self) -> ((ret,perm): (NonNull<Self::Target>, Tracked<Self::Permission>))
         ensures
             ptr_mut_from_nonnull(ret) == self.ptr_mut_spec(),
             ptr_mut_from_nonnull(ret) == perm@.ptr(),
             perm@.inv(),
-            Self::match_points_to_type(perm@),
     ;
 
     /// Converts back from a raw pointer.
@@ -79,10 +81,9 @@ pub unsafe trait NonNullPtr: Sized + 'static {
     /// SOUNDNESS: Considering consuming the Dealloc permission to ensure no double free.
     unsafe fn from_raw(
         ptr: NonNull<Self::Target>,
-        perm: Tracked<SmartPtrPointsTo<Self::Target>>,
+        perm: Tracked<Self::Permission>,
     ) -> (ret: Self)
         requires
-            Self::match_points_to_type(perm@),
             ptr_mut_from_nonnull(ptr) == perm@.ptr(),
             perm@.inv(),
         ensures
@@ -100,7 +101,6 @@ pub unsafe trait NonNullPtr: Sized + 'static {
     // VERUS LIMITATION: Cannot use associated type with lifetime yet, will implement it as a free function for each type.
     /*/// Converts a shared reference to a raw pointer.
     fn ref_as_raw(ptr_ref: Self::Ref<'_>) -> NonNull<Self::Target>;*/
-    spec fn match_points_to_type(perm: SmartPtrPointsTo<Self::Target>) -> bool;
 
     // A uninterpreted spec function that returns the inner raw pointer.
     spec fn ptr_mut_spec(self) -> *mut Self::Target;
@@ -169,36 +169,36 @@ impl<'a, T> BoxRef<'a, T> {
     }
 }
 
-#[verus_verify]
 unsafe impl<T: 'static> NonNullPtr for Box<T> {
     type Target = T;
+
+    type Permission = BoxPointsTo<T>;
 
     /*type Ref<'a>
         = BoxRef<'a, T>
     where
         Self: 'a;*/
-    //const ALIGN_BITS: u32 = core::mem::align_of::<T>().trailing_zeros();
     #[verifier::external_body]
-    fn ALIGN_BITS() -> u32 {
-        core::mem::align_of::<T>().trailing_zeros()
-    }
+    const ALIGN_BITS: u32 = core::mem::align_of::<T>().trailing_zeros();
 
-    fn into_raw(self) -> (NonNull<Self::Target>, Tracked<SmartPtrPointsTo<Self::Target>>) {
+    fn into_raw(self) -> (NonNull<Self::Target>, Tracked<Self::Permission>) {
         //let ptr = Box::into_raw(self);
         let (ptr, Tracked(points_to), Tracked(dealloc)) = box_into_raw(self);
         proof_decl!{
-            let tracked perm = SmartPtrPointsTo::new_box_points_to(points_to, dealloc);
+            let tracked box_points_to = BoxPointsTo {
+                perm: PointsTowithDealloc::new(points_to, dealloc),
+            };
         }
         // [VERIFIED] SAFETY: The pointer representing a `Box` can never be NULL.
-        (unsafe { NonNull::new_unchecked(ptr) }, Tracked(perm))
+        (unsafe { NonNull::new_unchecked(ptr) }, Tracked(box_points_to))
     }
 
     unsafe fn from_raw(
         ptr: NonNull<Self::Target>,
-        Tracked(perm): Tracked<SmartPtrPointsTo<Self::Target>>,
+        Tracked(perm): Tracked<Self::Permission>,
     ) -> Self {
         proof_decl!{
-            let tracked perm = perm.get_box_points_to().tracked_get_points_to_with_dealloc();
+            let tracked perm = perm.tracked_get_points_to_with_dealloc();
         }
         let ptr = ptr.as_ptr();
 
@@ -217,10 +217,6 @@ unsafe impl<T: 'static> NonNullPtr for Box<T> {
         // SAFETY: The pointer representing a `Box` can never be NULL.
         unsafe { NonNull::new_unchecked(ptr_ref.inner) }
     }*/
-    open spec fn match_points_to_type(perm: SmartPtrPointsTo<Self::Target>) -> bool {
-        perm is Box
-    }
-
     open spec fn ptr_mut_spec(self) -> *mut Self::Target {
         box_pointer_spec(self)
     }
@@ -318,35 +314,29 @@ impl<'a, T> ArcRef<'a, T> {
 unsafe impl<T: 'static> NonNullPtr for Arc<T> {
     type Target = T;
 
+    type Permission = ArcPointsTo<T>;
+
     /*
     type Ref<'a>
         = ArcRef<'a, T>
     where
         Self: 'a;*/
-    //const ALIGN_BITS: u32 = core::mem::align_of::<T>().trailing_zeros();
+    
     #[verifier::external_body]
-    fn ALIGN_BITS() -> u32 {
-        core::mem::align_of::<T>().trailing_zeros()
-    }
+    const ALIGN_BITS: u32 = core::mem::align_of::<T>().trailing_zeros();
 
-    fn into_raw(self) -> (NonNull<Self::Target>, Tracked<SmartPtrPointsTo<Self::Target>>) {
+    fn into_raw(self) -> (NonNull<Self::Target>, Tracked<Self::Permission>) {
         // let ptr = Arc::into_raw(self).cast_mut();
-        let (ptr, Tracked(points_to)) = arc_into_raw(self);
+        let (ptr, Tracked(perm)) = arc_into_raw(self);
         let ptr = ptr as *mut T;
-        proof_decl!{
-            let tracked perm = SmartPtrPointsTo::Arc(points_to);
-        }
         // [VERIFIED] SAFETY: The pointer representing an `Arc` can never be NULL.
         (unsafe { NonNull::new_unchecked(ptr) }, Tracked(perm))
     }
 
     unsafe fn from_raw(
         ptr: NonNull<Self::Target>,
-        Tracked(perm): Tracked<SmartPtrPointsTo<Self::Target>>,
+        Tracked(perm): Tracked<Self::Permission>,
     ) -> Self {
-        proof_decl!{
-            let tracked perm = perm.get_arc_points_to();
-        }
         //let ptr = ptr.as_ptr().cast_const();
         let ptr = ptr.as_ptr() as *const T;
 
@@ -369,9 +359,6 @@ unsafe impl<T: 'static> NonNullPtr for Arc<T> {
     fn ref_as_raw(ptr_ref: Self::Ref<'_>) -> NonNull<Self::Target> {
         NonNullPtr::into_raw(ManuallyDrop::into_inner(ptr_ref.inner))
     }*/
-    open spec fn match_points_to_type(perm: SmartPtrPointsTo<Self::Target>) -> bool {
-        perm is Arc
-    }
 
     open spec fn ptr_mut_spec(self) -> *mut Self::Target {
         arc_pointer_spec(self) as *mut Self::Target
@@ -391,7 +378,7 @@ pub fn arc_ref_as_raw<T: 'static>(ptr_ref: ArcRef<'_, T>) -> ((ret,perm): (
 {
     // NonNullPtr::into_raw(ManuallyDrop::into_inner(ptr_ref.inner))
     let (ptr, Tracked(perm)) = NonNullPtr::into_raw(ManuallyDrop::into_inner(ptr_ref.inner));
-    (ptr, Tracked(perm.get_arc_points_to()))
+    (ptr, Tracked(perm))
 }
 
 pub unsafe fn arc_raw_as_ref<'a, T: 'static>(

--- a/ostd/src/sync/rcu/non_null/mod.rs
+++ b/ostd/src/sync/rcu/non_null/mod.rs
@@ -34,7 +34,7 @@ pub unsafe trait NonNullPtr: Sized + 'static {
     type Target;
 
     /// The verification-only permission type that represents the ownership of the smart pointer.
-    type Permission: RawPtrPerm<SmartPtr = Self, Target = Self::Target> + Inv;
+    type Permission: RawPtrPerm<Ptr = Self, Target = Self::Target> + Inv;
 
     // VERUS LIMITATION: Cannot use associated type with lifetime yet.
     /*/// A type that behaves just like a shared reference to the `NonNullPtr`.

--- a/vstd_extra/src/external/smart_ptr.rs
+++ b/vstd_extra/src/external/smart_ptr.rs
@@ -8,6 +8,47 @@ use vstd::raw_ptr::*;
 // A unified interface for the raw ptr permission returned by `into_raw` methods of smart pointers like `Box` and `Arc`.
 verus! {
 
+/// A verification-only trait that abstracts the permission that can be obtained from a raw pointer.
+pub trait RawPtrPerm {
+    /// The type of the smart pointer.
+    type SmartPtr;
+    
+    /// The type of the value that the smart pointer points to.
+    type Target;
+    
+    spec fn ptr(self) -> *mut Self::Target;
+
+    spec fn addr(self) -> usize;
+}
+
+impl<T> RawPtrPerm for BoxPointsTo<T> {
+    type SmartPtr = Box<T>;
+    type Target = T;
+
+    open spec fn ptr(self) -> *mut T {
+        self.perm.ptr()
+    }
+
+    open spec fn addr(self) -> usize {
+        self.ptr().addr()
+    }
+}
+
+impl<T> RawPtrPerm for ArcPointsTo<T> {
+    type SmartPtr = Arc<T>;
+    type Target = T;
+
+    open spec fn ptr(self) -> *mut T {
+        self.perm.ptr()
+    }
+
+    open spec fn addr(self) -> usize {
+        self.ptr().addr()
+    }
+}
+
+
+
 // The permission to access memory given by the `into_raw` methods of smart pointers like `Box` and `Arc`.
 /// For `Box<T>`, the `into_raw` method gives you the ownership of the memory
 pub tracked struct BoxPointsTo<T> {
@@ -19,11 +60,6 @@ pub tracked struct BoxPointsTo<T> {
 /// See <https://doc.rust-lang.org/src/alloc/sync.rs.html#1480>.
 pub tracked struct ArcPointsTo<T: 'static> {
     pub perm: &'static PointsTo<T>,
-}
-
-pub tracked enum SmartPtrPointsTo<T: 'static> {
-    Box(BoxPointsTo<T>),
-    Arc(ArcPointsTo<T>),
 }
 
 impl<T> BoxPointsTo<T> {
@@ -128,113 +164,6 @@ impl<T> Inv for ArcPointsTo<T> {
         &&& self.addr() != 0
         &&& self.addr() as int % vstd::layout::align_of::<T>() as int == 0
         &&& self.is_init()
-    }
-}
-
-impl<T> Inv for SmartPtrPointsTo<T> {
-    open spec fn inv(self) -> bool {
-        match self {
-            SmartPtrPointsTo::Box(b) => { b.inv() },
-            SmartPtrPointsTo::Arc(a) => { a.inv() },
-        }
-    }
-}
-
-impl<T> SmartPtrPointsTo<T> {
-    pub open spec fn ptr(self) -> *mut T {
-        match self {
-            SmartPtrPointsTo::Box(b) => b.ptr(),
-            SmartPtrPointsTo::Arc(a) => a.ptr(),
-        }
-    }
-
-    pub open spec fn addr(self) -> usize {
-        self.ptr().addr()
-    }
-
-    pub open spec fn is_init(self) -> bool {
-        match self {
-            SmartPtrPointsTo::Box(b) => b.is_init(),
-            SmartPtrPointsTo::Arc(a) => a.is_init(),
-        }
-    }
-
-    pub open spec fn is_uninit(self) -> bool {
-        match self {
-            SmartPtrPointsTo::Box(b) => b.is_uninit(),
-            SmartPtrPointsTo::Arc(a) => a.is_uninit(),
-        }
-    }
-
-    pub proof fn get_box_points_to(tracked self) -> (tracked ret: BoxPointsTo<T>)
-        requires
-            self is Box,
-        returns
-            self->Box_0,
-    {
-        match self {
-            SmartPtrPointsTo::Box(p) => p,
-            _ => proof_from_false(),
-        }
-    }
-
-    pub proof fn get_arc_points_to(tracked self) -> (tracked ret: ArcPointsTo<T>)
-        requires
-            self is Arc,
-        returns
-            self->Arc_0,
-    {
-        match self {
-            SmartPtrPointsTo::Arc(p) => p,
-            _ => proof_from_false(),
-        }
-    }
-
-    pub proof fn new_box_points_to(
-        tracked points_to: PointsTo<T>,
-        tracked dealloc: Option<Dealloc>,
-    ) -> (tracked ret: SmartPtrPointsTo<T>)
-        requires
-            points_to.is_init(),
-            match dealloc {
-                Some(dealloc) => {
-                    &&& vstd::layout::size_of::<T>() > 0
-                    &&& valid_layout(size_of::<T>(), dealloc.align() as usize)
-                    &&& points_to.ptr().addr() == dealloc.addr()
-                    &&& points_to.ptr()@.provenance == dealloc.provenance()
-                    &&& dealloc.size() == vstd::layout::size_of::<T>()
-                    &&& dealloc.align() == vstd::layout::align_of::<T>()
-                },
-                None => { vstd::layout::size_of::<T>() == 0 },
-            },
-        ensures
-            ret.inv(),
-            ret is Box,
-        returns
-            (SmartPtrPointsTo::Box(
-                BoxPointsTo { perm: PointsTowithDealloc { points_to, dealloc } },
-            )),
-    {
-        let tracked box_points_to = BoxPointsTo {
-            perm: PointsTowithDealloc::new(points_to, dealloc),
-        };
-        SmartPtrPointsTo::Box(box_points_to)
-    }
-
-    pub proof fn new_arc_points_to(tracked points_to: &'static PointsTo<T>) -> (tracked ret:
-        SmartPtrPointsTo<T>)
-        requires
-            points_to.is_init(),
-            points_to.ptr().addr() != 0,
-            points_to.ptr().addr() as int % vstd::layout::align_of::<T>() as int == 0,
-        ensures
-            ret.inv(),
-            ret is Arc,
-        returns
-            (SmartPtrPointsTo::Arc(ArcPointsTo { perm: points_to })),
-    {
-        let tracked arc_points_to = ArcPointsTo { perm: points_to };
-        SmartPtrPointsTo::Arc(arc_points_to)
     }
 }
 

--- a/vstd_extra/src/external/smart_ptr.rs
+++ b/vstd_extra/src/external/smart_ptr.rs
@@ -10,10 +10,10 @@ verus! {
 
 /// A verification-only trait that abstracts the permission that can be obtained from a raw pointer.
 pub trait RawPtrPerm {
-    /// The type of the smart pointer.
-    type SmartPtr;
+    /// The type of the pointer.
+    type Ptr;
     
-    /// The type of the value that the smart pointer points to.
+    /// The type of the value that the pointer points to.
     type Target;
     
     spec fn ptr(self) -> *mut Self::Target;
@@ -22,7 +22,8 @@ pub trait RawPtrPerm {
 }
 
 impl<T> RawPtrPerm for BoxPointsTo<T> {
-    type SmartPtr = Box<T>;
+    type Ptr = Box<T>;
+    
     type Target = T;
 
     open spec fn ptr(self) -> *mut T {
@@ -35,7 +36,8 @@ impl<T> RawPtrPerm for BoxPointsTo<T> {
 }
 
 impl<T> RawPtrPerm for ArcPointsTo<T> {
-    type SmartPtr = Arc<T>;
+    type Ptr = Arc<T>;
+    
     type Target = T;
 
     open spec fn ptr(self) -> *mut T {


### PR DESCRIPTION
This PR refactors the verification design of `sync::rcu::non_null::NonNullPtr`. I replace the awkward `SmartPtrPointsTo` with a `RawPtrPerm` trait and add an associated type for permission in `NonNullPtr`, giving a much cleaner design.