### PR TITLE
Add `NonZeroUsize` support

### DIFF
--- a/ostd/src/sync/rcu/non_null/either.rs
+++ b/ostd/src/sync/rcu/non_null/either.rs
@@ -3,14 +3,14 @@ use core::{marker::PhantomData, ptr::NonNull};
 
 use vstd::{bits, prelude::*};
 use vstd::raw_ptr::group_raw_ptr_axioms;
-use vstd_extra::{prelude::*, sum::Sum};
+use vstd_extra::{prelude::*, sum::Sum, external::nonzero::*};
 
 use super::NonNullPtr;
 use crate::util::Either;
 
 verus! {
 
-broadcast use {group_nonull_axioms, group_raw_ptr_axioms};
+broadcast use {group_nonull_axioms, group_raw_ptr_axioms, group_nonzero_axioms};
 
 pub tracked struct EitherPointsTo<L: PtrPointsToTrait, R: PtrPointsToTrait> {
     pub perm: Sum<L, R>,

--- a/vstd_extra/src/external/mod.rs
+++ b/vstd_extra/src/external/mod.rs
@@ -11,7 +11,6 @@ pub mod smart_ptr;
 
 pub use ilog2::*;
 pub use nonnull::*;
-pub use nonzero::*;
 pub use ptr::*;
 pub use smart_ptr::*;
 

--- a/vstd_extra/src/external/nonnull.rs
+++ b/vstd_extra/src/external/nonnull.rs
@@ -1,10 +1,10 @@
+use super::nonzero::NonZeroUsize;
 use core::marker::PointeeSized;
 use core::num::NonZero;
 use core::ptr::NonNull;
 use vstd::prelude::*;
 use vstd::raw_ptr::*;
 use vstd::std_specs::cmp::*;
-use super::nonzero::NonZeroUsize;
 
 verus! {
 
@@ -34,10 +34,10 @@ pub trait NonNullAdditionalFns<T: PointeeSized> {
 
     /// A wrapper of `NonNull::addr` in `std`, here we use our own `NonZeroUsize`
     fn addr(self) -> (ret: NonZeroUsize)
-    ensures
-        ret == self.addr_spec(),
-        ret.view() == self.view_ptr_mut()@.addr,
-    ;   
+        ensures
+            ret == self.addr_spec(),
+            ret.view() == self.view_ptr_mut()@.addr,
+    ;
 }
 
 impl<T: PointeeSized> NonNullAdditionalFns<T> for NonNull<T> {
@@ -48,16 +48,14 @@ impl<T: PointeeSized> NonNullAdditionalFns<T> for NonNull<T> {
     uninterp spec fn dangling_spec() -> NonNull<T>;
 
     axiom fn lemma_addr_is_nonnull(self);
-    
-    open spec fn addr_spec(self) -> NonZeroUsize
-    {
+
+    open spec fn addr_spec(self) -> NonZeroUsize {
         NonZeroUsize::nonzero_usize_from_usize(self.view_ptr_mut()@.addr)
     }
 
     #[verifier::external_body]
     #[verifier::when_used_as_spec(nonnull_addr_spec_wrapper)]
-    fn addr(self) -> (ret: NonZeroUsize)
-    {
+    fn addr(self) -> (ret: NonZeroUsize) {
         unimplemented!()
     }
 }
@@ -144,37 +142,38 @@ pub assume_specification<T>[ NonNull::dangling ]() -> (ret: NonNull<T>)
 ;
 
 #[inline(always)]
-pub open spec fn nonnull_with_addr_spec_wrapper<T: PointeeSized>(ptr: NonNull<T>, addr: NonZeroUsize) -> NonNull<T> {
+pub open spec fn nonnull_with_addr_spec_wrapper<T: PointeeSized>(
+    ptr: NonNull<T>,
+    addr: NonZeroUsize,
+) -> NonNull<T> {
     ptr.with_addr_spec(addr)
 }
 
 // To prevent circular dependency
-pub trait NonNullAdditionalFnsMore<T>: NonNullAdditionalFns<T> 
-where T: PointeeSized
-{
+pub trait NonNullAdditionalFnsMore<T>: NonNullAdditionalFns<T> where T: PointeeSized {
     spec fn with_addr_spec(self, addr: NonZeroUsize) -> NonNull<T>;
 
     fn with_addr(self, addr: NonZeroUsize) -> (ret: NonNull<T>)
-    ensures
-        ret.view_ptr_mut()@.metadata == self.view_ptr_mut()@.metadata,
-        ret.view_ptr_mut()@.provenance == self.view_ptr_mut()@.provenance,
-        ret.view_ptr_mut()@.addr == addr.view(),
+        ensures
+            ret.view_ptr_mut()@.metadata == self.view_ptr_mut()@.metadata,
+            ret.view_ptr_mut()@.provenance == self.view_ptr_mut()@.provenance,
+            ret.view_ptr_mut()@.addr == addr.view(),
     ;
-    
+
     /// A wrapper of `NonNull::map_addr` in `std`, here we use our own `NonZeroUsize`
     fn map_addr<F: FnOnce(NonZeroUsize) -> NonZeroUsize>(self, f: F) -> (ret: NonNull<T>)
-    requires
-        f.requires((self.addr_spec(),)),
-    ensures
-        ret.view_ptr_mut()@.metadata == self.view_ptr_mut()@.metadata,
-        ret.view_ptr_mut()@.provenance == self.view_ptr_mut()@.provenance,
-        f.ensures((self.addr_spec(),), ret.addr_spec()),;
+        requires
+            f.requires((self.addr_spec(),)),
+        ensures
+            ret.view_ptr_mut()@.metadata == self.view_ptr_mut()@.metadata,
+            ret.view_ptr_mut()@.provenance == self.view_ptr_mut()@.provenance,
+            f.ensures((self.addr_spec(),), ret.addr_spec()),
+    ;
 }
 
 impl<T: PointeeSized> NonNullAdditionalFnsMore<T> for NonNull<T> {
     #[verifier::external_body]
-    fn map_addr<F: FnOnce(NonZeroUsize) -> NonZeroUsize>(self, f: F) -> (ret: NonNull<T>)
-    {
+    fn map_addr<F: FnOnce(NonZeroUsize) -> NonZeroUsize>(self, f: F) -> (ret: NonNull<T>) {
         unimplemented!()
     }
 
@@ -182,8 +181,7 @@ impl<T: PointeeSized> NonNullAdditionalFnsMore<T> for NonNull<T> {
 
     #[verifier::external_body]
     #[verifier::when_used_as_spec(nonnull_with_addr_spec_wrapper)]
-    fn with_addr(self, addr: NonZeroUsize) -> (ret: NonNull<T>)
-    {
+    fn with_addr(self, addr: NonZeroUsize) -> (ret: NonNull<T>) {
         unimplemented!()
     }
 }
@@ -193,4 +191,5 @@ pub broadcast group group_nonull_axioms {
     axiom_cast_spec_eq,
     axiom_view_ptr_mut_eq,
 }
+
 } // verus!

--- a/vstd_extra/src/external/nonnull.rs
+++ b/vstd_extra/src/external/nonnull.rs
@@ -1,4 +1,3 @@
-use crate::external::nonzero::*;
 use core::marker::PointeeSized;
 use core::num::NonZero;
 use core::ptr::NonNull;

--- a/vstd_extra/src/external/nonnull.rs
+++ b/vstd_extra/src/external/nonnull.rs
@@ -3,6 +3,8 @@ use core::num::NonZero;
 use core::ptr::NonNull;
 use vstd::prelude::*;
 use vstd::raw_ptr::*;
+use vstd::std_specs::cmp::*;
+use super::nonzero::NonZeroUsize;
 
 verus! {
 
@@ -27,6 +29,15 @@ pub trait NonNullAdditionalFns<T: PointeeSized> {
         ensures
             self.view_ptr_mut()@.addr != 0,
     ;
+
+    spec fn addr_spec(self) -> NonZeroUsize;
+
+    /// A wrapper of `NonNull::addr` in `std`, here we use our own `NonZeroUsize`
+    fn addr(self) -> (ret: NonZeroUsize)
+    ensures
+        ret == self.addr_spec(),
+        ret.view() == self.view_ptr_mut()@.addr,
+    ;   
 }
 
 impl<T: PointeeSized> NonNullAdditionalFns<T> for NonNull<T> {
@@ -37,6 +48,23 @@ impl<T: PointeeSized> NonNullAdditionalFns<T> for NonNull<T> {
     uninterp spec fn dangling_spec() -> NonNull<T>;
 
     axiom fn lemma_addr_is_nonnull(self);
+    
+    open spec fn addr_spec(self) -> NonZeroUsize
+    {
+        NonZeroUsize::nonzero_usize_from_usize(self.view_ptr_mut()@.addr)
+    }
+
+    #[verifier::external_body]
+    #[verifier::when_used_as_spec(nonnull_addr_spec_wrapper)]
+    fn addr(self) -> (ret: NonZeroUsize)
+    {
+        unimplemented!()
+    }
+}
+
+#[inline(always)]
+pub open spec fn nonnull_addr_spec_wrapper<T: PointeeSized>(ptr: NonNull<T>) -> NonZeroUsize {
+    ptr.addr_spec()
 }
 
 #[inline(always)]
@@ -102,15 +130,6 @@ pub assume_specification<T: PointeeSized, U>[ NonNull::<T>::cast::<U> ](ptr: Non
         ptr.cast_spec::<U>(),
 ;
 
-/// FIXME: Better specification that captures the effect of the mapping function `f` on the pointer's address, instead of just saying the metadata and provenance are unchanged.
-pub assume_specification<T: PointeeSized, F: FnOnce(NonZero<usize>) -> NonZero<usize>>[ NonNull::<
-    T,
->::map_addr ](ptr: NonNull<T>, f: F) -> (ret: NonNull<T>)
-    ensures
-        ret.view_ptr_mut()@.metadata == ptr.view_ptr_mut()@.metadata,
-        ret.view_ptr_mut()@.provenance == ptr.view_ptr_mut()@.provenance,
-;
-
 // Specification for NonNull::dangling(), uninterpreted because the ptr only has to satisfy the alignment requirement.
 // See https://doc.rust-lang.org/stable/std/ptr/struct.NonNull.html#method.dangling.
 pub uninterp spec fn nonnull_dangling_spec<T>() -> NonNull<T>;
@@ -124,10 +143,54 @@ pub assume_specification<T>[ NonNull::dangling ]() -> (ret: NonNull<T>)
         nonnull_dangling_spec::<T>(),
 ;
 
+#[inline(always)]
+pub open spec fn nonnull_with_addr_spec_wrapper<T: PointeeSized>(ptr: NonNull<T>, addr: NonZeroUsize) -> NonNull<T> {
+    ptr.with_addr_spec(addr)
+}
+
+// To prevent circular dependency
+pub trait NonNullAdditionalFnsMore<T>: NonNullAdditionalFns<T> 
+where T: PointeeSized
+{
+    spec fn with_addr_spec(self, addr: NonZeroUsize) -> NonNull<T>;
+
+    fn with_addr(self, addr: NonZeroUsize) -> (ret: NonNull<T>)
+    ensures
+        ret.view_ptr_mut()@.metadata == self.view_ptr_mut()@.metadata,
+        ret.view_ptr_mut()@.provenance == self.view_ptr_mut()@.provenance,
+        ret.view_ptr_mut()@.addr == addr.view(),
+    ;
+    
+    /// A wrapper of `NonNull::map_addr` in `std`, here we use our own `NonZeroUsize`
+    fn map_addr<F: FnOnce(NonZeroUsize) -> NonZeroUsize>(self, f: F) -> (ret: NonNull<T>)
+    requires
+        f.requires((self.addr_spec(),)),
+    ensures
+        ret.view_ptr_mut()@.metadata == self.view_ptr_mut()@.metadata,
+        ret.view_ptr_mut()@.provenance == self.view_ptr_mut()@.provenance,
+        f.ensures((self.addr_spec(),), ret.addr_spec()),;
+}
+
+impl<T: PointeeSized> NonNullAdditionalFnsMore<T> for NonNull<T> {
+    #[verifier::external_body]
+    fn map_addr<F: FnOnce(NonZeroUsize) -> NonZeroUsize>(self, f: F) -> (ret: NonNull<T>)
+    {
+        unimplemented!()
+    }
+
+    uninterp spec fn with_addr_spec(self, addr: NonZeroUsize) -> NonNull<T>;
+
+    #[verifier::external_body]
+    #[verifier::when_used_as_spec(nonnull_with_addr_spec_wrapper)]
+    fn with_addr(self, addr: NonZeroUsize) -> (ret: NonNull<T>)
+    {
+        unimplemented!()
+    }
+}
+
 pub broadcast group group_nonull_axioms {
     axiom_nonnull_from_ptr_mut_spec_eq,
     axiom_cast_spec_eq,
     axiom_view_ptr_mut_eq,
 }
-
 } // verus!

--- a/vstd_extra/src/external/nonzero.rs
+++ b/vstd_extra/src/external/nonzero.rs
@@ -1,7 +1,112 @@
+//! Specifications for `core::num::NonZero<T>` for the concrete element types
+//! we use (`usize`, `u8`).
+//!
+//! ## Why wrappers instead of `assume_specification`
+//!
+//! `core::num::NonZero::<T>::{new, get}` are generic over
+//! `T: ZeroablePrimitive`, where `ZeroablePrimitive` is a sealed external
+//! trait (its `Sealed` super-trait is private to `core`). That combination
+//! makes both standard escape hatches unusable:
+//!   * `assume_specification` requires a *byte-for-byte* signature match with
+//!     the original generic function, so it cannot be specialized.
+//!   * `#[verifier::external_trait_specification]` for `ZeroablePrimitive`
+//!     fails because the proxy trait cannot reproduce the private `Sealed`
+//!     super-trait bound.
+//!
+//! Either path forces Verus into `--no-lifetime`, which is infectious across
+//! crate boundaries (any downstream `--import`er would also need it).
+//!
+//! Instead, we wrap the std `NonZero<T>` in our own `#[verifier::external_body]`
+//! newtypes (one per element type) and expose `new`/`get` as `external_body`
+//! exec functions whose Verus signatures only mention the wrapper. The std
+//! `NonZero<T>` therefore never appears in any spec or wrapper signature,
+//! which lets verification run with full lifetime checking enabled.
+
 use core::num::NonZero;
 use vstd::prelude::*;
 
 verus! {
 
+// ---- NonZeroUsize ----
+
+#[verifier::external_body]
+pub struct NonZeroUsize {
+    inner: NonZero<usize>,
+}
+
+pub uninterp spec fn spec_nonzero_usize_view(nz: NonZeroUsize) -> usize;
+
+#[verifier::external_body]
+pub fn nonzero_usize_new(v: usize) -> (r: Option<NonZeroUsize>)
+    ensures
+        r.is_some() <==> v != 0,
+        r.is_some() ==> spec_nonzero_usize_view(r.unwrap()) == v,
+{
+    NonZero::<usize>::new(v).map(|inner| NonZeroUsize { inner })
+}
+
+#[verifier::external_body]
+pub fn nonzero_usize_get(nz: NonZeroUsize) -> (r: usize)
+    ensures
+        r == spec_nonzero_usize_view(nz),
+        r != 0,
+{
+    nz.inner.get()
+}
+
+// ---- NonZeroU8 ----
+
+#[verifier::external_body]
+pub struct NonZeroU8 {
+    inner: NonZero<u8>,
+}
+
+pub uninterp spec fn spec_nonzero_u8_view(nz: NonZeroU8) -> u8;
+
+#[verifier::external_body]
+pub fn nonzero_u8_new(v: u8) -> (r: Option<NonZeroU8>)
+    ensures
+        r.is_some() <==> v != 0,
+        r.is_some() ==> spec_nonzero_u8_view(r.unwrap()) == v,
+{
+    NonZero::<u8>::new(v).map(|inner| NonZeroU8 { inner })
+}
+
+#[verifier::external_body]
+pub fn nonzero_u8_get(nz: NonZeroU8) -> (r: u8)
+    ensures
+        r == spec_nonzero_u8_view(nz),
+        r != 0,
+{
+    nz.inner.get()
+}
 
 } // verus!
+
+// Outside `verus!`, expose interop with the underlying std type for callers
+// that need to bridge with non-Verus exec code. These are plain Rust impls
+// (not part of the verifier surface), so they don't reintroduce the
+// `ZeroablePrimitive` bound into Verus.
+impl NonZeroUsize {
+    #[inline]
+    pub fn into_inner(self) -> NonZero<usize> {
+        self.inner
+    }
+
+    #[inline]
+    pub fn from_inner(inner: NonZero<usize>) -> Self {
+        Self { inner }
+    }
+}
+
+impl NonZeroU8 {
+    #[inline]
+    pub fn into_inner(self) -> NonZero<u8> {
+        self.inner
+    }
+
+    #[inline]
+    pub fn from_inner(inner: NonZero<u8>) -> Self {
+        Self { inner }
+    }
+}

--- a/vstd_extra/src/external/nonzero.rs
+++ b/vstd_extra/src/external/nonzero.rs
@@ -21,11 +21,10 @@
 //! wrapper. The std `NonZero<usize>` therefore never appears in any spec or
 //! wrapper signature, which lets verification run with full lifetime checking
 //! enabled.
-
+use core::cmp::Ordering;
 use core::num::NonZero;
 use vstd::prelude::*;
 use vstd::std_specs::cmp::*;
-use core::cmp::Ordering;
 
 verus! {
 
@@ -45,7 +44,7 @@ impl NonZeroUsize {
     pub uninterp spec fn nonzero_usize_from_usize(n: usize) -> Self;
 
     pub broadcast axiom fn axiom_nonzero_usize_from_usize_view_eq(n: usize)
-        requires 
+        requires
             n != 0,
         ensures
             (#[trigger] Self::nonzero_usize_from_usize(n)).view() == n,
@@ -55,14 +54,14 @@ impl NonZeroUsize {
         ensures
             Self::nonzero_usize_from_usize(#[trigger] self.view()) == self,
     ;
-    
+
     #[verifier::external_body]
     pub const fn new(n: usize) -> (ret: Option<Self>)
-    ensures
-        match ret {
-            Some(nz) => nz.view() == n,
-            None => n == 0,
-        },
+        ensures
+            match ret {
+                Some(nz) => nz.view() == n,
+                None => n == 0,
+            },
     {
         if let Some(inner) = core::num::NonZeroUsize::new(n) {
             Some(NonZeroUsize { inner })
@@ -74,16 +73,16 @@ impl NonZeroUsize {
     #[verifier::external_body]
     #[verifier::when_used_as_spec(nonzero_usize_from_usize)]
     pub const unsafe fn new_unchecked(n: usize) -> (ret: Self)
-    ensures
-        ret.view() == n,
+        ensures
+            ret.view() == n,
     {
         NonZeroUsize { inner: core::num::NonZeroUsize::new_unchecked(n) }
     }
 
     #[verifier::external_body]
     pub const fn get(&self) -> (ret: usize)
-    ensures
-        ret == self.view(),
+        ensures
+            ret == self.view(),
     {
         self.inner.get()
     }
@@ -97,14 +96,16 @@ impl NonZeroUsize {
 impl Clone for NonZeroUsize {
     #[verifier::external_body]
     fn clone(&self) -> (ret: Self)
-    ensures
-        ret.view() == self.view(),
+        ensures
+            ret.view() == self.view(),
     {
         NonZeroUsize { inner: self.inner }
     }
 }
 
-impl Copy for NonZeroUsize {}
+impl Copy for NonZeroUsize {
+
+}
 
 impl PartialEqSpecImpl for NonZeroUsize {
     open spec fn obeys_eq_spec() -> bool {
@@ -114,7 +115,6 @@ impl PartialEqSpecImpl for NonZeroUsize {
     open spec fn eq_spec(&self, other: &Self) -> bool {
         self.view() == other.view()
     }
-
 }
 
 impl PartialOrdSpecImpl for NonZeroUsize {
@@ -148,4 +148,4 @@ pub broadcast group group_nonzero_axioms {
     NonZeroUsize::axiom_view_nonzero_usize_from_usize_eq,
 }
 
-}
+} // verus!

--- a/vstd_extra/src/external/nonzero.rs
+++ b/vstd_extra/src/external/nonzero.rs
@@ -1,5 +1,4 @@
-//! Specifications for `core::num::NonZero<T>` for the concrete element types
-//! we use (`usize`, `u8`).
+//! Specifications for `core::num::NonZero<usize>` using a wrapper type `NonZeroUsize`.
 //!
 //! ## Why wrappers instead of `assume_specification`
 //!
@@ -16,97 +15,137 @@
 //! Either path forces Verus into `--no-lifetime`, which is infectious across
 //! crate boundaries (any downstream `--import`er would also need it).
 //!
-//! Instead, we wrap the std `NonZero<T>` in our own `#[verifier::external_body]`
-//! newtypes (one per element type) and expose `new`/`get` as `external_body`
-//! exec functions whose Verus signatures only mention the wrapper. The std
-//! `NonZero<T>` therefore never appears in any spec or wrapper signature,
-//! which lets verification run with full lifetime checking enabled.
+//! Instead, we wrap the std `NonZero<usize>` in our own
+//! `#[verifier::external_body]` newtype and expose `new`/`get` as
+//! `external_body` exec functions whose Verus signatures only mention the
+//! wrapper. The std `NonZero<usize>` therefore never appears in any spec or
+//! wrapper signature, which lets verification run with full lifetime checking
+//! enabled.
 
 use core::num::NonZero;
 use vstd::prelude::*;
+use vstd::std_specs::cmp::*;
+use core::cmp::Ordering;
 
 verus! {
 
-// ---- NonZeroUsize ----
-
 #[verifier::external_body]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NonZeroUsize {
-    inner: NonZero<usize>,
+    pub inner: NonZero<usize>,
 }
 
-pub uninterp spec fn spec_nonzero_usize_view(nz: NonZeroUsize) -> usize;
+impl View for NonZeroUsize {
+    type V = usize;
 
-#[verifier::external_body]
-pub fn nonzero_usize_new(v: usize) -> (r: Option<NonZeroUsize>)
-    ensures
-        r.is_some() <==> v != 0,
-        r.is_some() ==> spec_nonzero_usize_view(r.unwrap()) == v,
-{
-    NonZero::<usize>::new(v).map(|inner| NonZeroUsize { inner })
+    uninterp spec fn view(&self) -> Self::V;
 }
 
-#[verifier::external_body]
-pub fn nonzero_usize_get(nz: NonZeroUsize) -> (r: usize)
-    ensures
-        r == spec_nonzero_usize_view(nz),
-        r != 0,
-{
-    nz.inner.get()
-}
-
-// ---- NonZeroU8 ----
-
-#[verifier::external_body]
-pub struct NonZeroU8 {
-    inner: NonZero<u8>,
-}
-
-pub uninterp spec fn spec_nonzero_u8_view(nz: NonZeroU8) -> u8;
-
-#[verifier::external_body]
-pub fn nonzero_u8_new(v: u8) -> (r: Option<NonZeroU8>)
-    ensures
-        r.is_some() <==> v != 0,
-        r.is_some() ==> spec_nonzero_u8_view(r.unwrap()) == v,
-{
-    NonZero::<u8>::new(v).map(|inner| NonZeroU8 { inner })
-}
-
-#[verifier::external_body]
-pub fn nonzero_u8_get(nz: NonZeroU8) -> (r: u8)
-    ensures
-        r == spec_nonzero_u8_view(nz),
-        r != 0,
-{
-    nz.inner.get()
-}
-
-} // verus!
-
-// Outside `verus!`, expose interop with the underlying std type for callers
-// that need to bridge with non-Verus exec code. These are plain Rust impls
-// (not part of the verifier surface), so they don't reintroduce the
-// `ZeroablePrimitive` bound into Verus.
 impl NonZeroUsize {
-    #[inline]
-    pub fn into_inner(self) -> NonZero<usize> {
-        self.inner
+    pub uninterp spec fn nonzero_usize_from_usize(n: usize) -> Self;
+
+    pub broadcast axiom fn axiom_nonzero_usize_from_usize_view_eq(n: usize)
+        requires 
+            n != 0,
+        ensures
+            (#[trigger] Self::nonzero_usize_from_usize(n)).view() == n,
+    ;
+
+    pub broadcast axiom fn axiom_view_nonzero_usize_from_usize_eq(self)
+        ensures
+            Self::nonzero_usize_from_usize(#[trigger] self.view()) == self,
+    ;
+    
+    #[verifier::external_body]
+    pub const fn new(n: usize) -> (ret: Option<Self>)
+    ensures
+        match ret {
+            Some(nz) => nz.view() == n,
+            None => n == 0,
+        },
+    {
+        if let Some(inner) = core::num::NonZeroUsize::new(n) {
+            Some(NonZeroUsize { inner })
+        } else {
+            None
+        }
     }
 
-    #[inline]
-    pub fn from_inner(inner: NonZero<usize>) -> Self {
-        Self { inner }
+    #[verifier::external_body]
+    #[verifier::when_used_as_spec(nonzero_usize_from_usize)]
+    pub const unsafe fn new_unchecked(n: usize) -> (ret: Self)
+    ensures
+        ret.view() == n,
+    {
+        NonZeroUsize { inner: core::num::NonZeroUsize::new_unchecked(n) }
+    }
+
+    #[verifier::external_body]
+    pub const fn get(&self) -> (ret: usize)
+    ensures
+        ret == self.view(),
+    {
+        self.inner.get()
+    }
+
+    axiom fn lemma_nonzero_neq_zero(self)
+        ensures
+            self.view() != 0,
+    ;
+}
+
+impl Clone for NonZeroUsize {
+    #[verifier::external_body]
+    fn clone(&self) -> (ret: Self)
+    ensures
+        ret.view() == self.view(),
+    {
+        NonZeroUsize { inner: self.inner }
     }
 }
 
-impl NonZeroU8 {
-    #[inline]
-    pub fn into_inner(self) -> NonZero<u8> {
-        self.inner
+impl Copy for NonZeroUsize {}
+
+impl PartialEqSpecImpl for NonZeroUsize {
+    open spec fn obeys_eq_spec() -> bool {
+        true
     }
 
-    #[inline]
-    pub fn from_inner(inner: NonZero<u8>) -> Self {
-        Self { inner }
+    open spec fn eq_spec(&self, other: &Self) -> bool {
+        self.view() == other.view()
     }
+
+}
+
+impl PartialOrdSpecImpl for NonZeroUsize {
+    open spec fn obeys_partial_cmp_spec() -> bool {
+        true
+    }
+
+    open spec fn partial_cmp_spec(&self, other: &Self) -> Option<Ordering> {
+        if self.view() < other.view() {
+            Some(Ordering::Less)
+        } else if self.view() > other.view() {
+            Some(Ordering::Greater)
+        } else {
+            Some(Ordering::Equal)
+        }
+    }
+}
+
+impl OrdSpecImpl for NonZeroUsize {
+    open spec fn obeys_cmp_spec() -> bool {
+        true
+    }
+
+    open spec fn cmp_spec(&self, other: &Self) -> Ordering {
+        vstd::std_specs::cmp::PartialOrdSpec::partial_cmp_spec(self, other)->Some_0
+    }
+}
+
+pub broadcast group group_nonzero_axioms {
+    NonZeroUsize::axiom_nonzero_usize_from_usize_view_eq,
+    NonZeroUsize::axiom_view_nonzero_usize_from_usize_eq,
+}
+
 }


### PR DESCRIPTION
This PR supports `NonZeroUsize` by wrapping `std::num::NonZero<usize>`. The reason it cannot be directly supported with `#[external_type_specification]` is that there is a sealed trait.