### PR TITLE
Use `NonZeroSize` in `sync::rcu::non_null::either`

### DIFF
--- a/ostd/src/sync/rcu/non_null/either.rs
+++ b/ostd/src/sync/rcu/non_null/either.rs
@@ -139,14 +139,14 @@ unsafe impl<L: NonNullPtr, R: NonNullPtr> NonNullPtr for Either<L, R> {
                 .map_addr(|addr| addr | (1 << Self::ALIGN_BITS))
                 .cast(), */
                 let (right, Tracked(perm)) = right.into_raw();
-                let right_raw = right.map_addr_v(|addr: NonZeroUsize| -> (ret: NonZeroUsize) 
+                let right_tagged = right.map_addr_v(|addr: NonZeroUsize| -> (ret: NonZeroUsize) 
                     ensures ret@ == addr@ | (1usize << Self::ALIGN_BITS)
                     {unsafe { NonZeroUsize::new_unchecked(addr.get() | (1usize << Self::ALIGN_BITS)) }});
                 proof! {
                     let addr = right.addr_spec()@;
-                    let tagged_addr = right_raw.addr_spec()@;
+                    let tagged_addr = right_tagged.addr_spec()@;
                     right.lemma_addr_is_nonnull();
-                    right_raw.lemma_addr_view_eq_view_ptr_mut();
+                    right_tagged.lemma_addr_view_eq_view_ptr_mut();
                     assert(tagged_addr & tag == tag) by (bit_vector)
                     requires
                         tagged_addr == addr | tag,
@@ -203,7 +203,7 @@ unsafe impl<L: NonNullPtr, R: NonNullPtr> NonNullPtr for Either<L, R> {
                     }
                 }
                 (
-                    right_raw.cast(),
+                    right_tagged.cast(),
                     Tracked(EitherPointsTo { perm: Sum::Right(perm) }),
                 )
             },
@@ -342,24 +342,23 @@ const fn min(a: u32, b: u32) -> u32 {
 /// non-null pointer.
 #[verus_spec(ret =>
     requires
-        (ptr.view_ptr_mut()@.addr & bits) < ptr.view_ptr_mut()@.addr,
-        (ptr.view_ptr_mut()@.addr & !bits) != 0,
+        (ptr.view_ptr_mut().addr() & bits) < ptr.view_ptr_mut().addr(),
+        (ptr.view_ptr_mut().addr() & !bits) != 0,
     ensures
-        ret.0 == (ptr.view_ptr_mut()@.addr & bits),
-        ret.1.view_ptr_mut() == ptr.view_ptr_mut().with_addr((ptr.view_ptr_mut()@.addr & !bits) as usize),
+        ret.0 == (ptr.view_ptr_mut().addr() & bits),
+        ret.1.view_ptr_mut() == ptr.view_ptr_mut().with_addr((ptr.view_ptr_mut().addr() & !bits) as usize),
 )]
 unsafe fn remove_bits<T>(ptr: NonNull<T>, bits: usize) -> (usize, NonNull<T>) {
     // use core::num::NonZeroUsize;
-    // let removed_bits = ptr.addr().get() & bits;
-    // let result_ptr = ptr.map_addr(|addr|
+    use vstd_extra::external::nonzero::NonZeroUsize;
+    let removed_bits = ptr.addr_v().get() & bits;
     // // SAFETY: The safety is upheld by the caller.
-    // unsafe { NonZeroUsize::new_unchecked(addr.get() & !bits) });
-    // FIXME: Fix when Verus supports `NonZeroUsize`.
-    let raw = ptr.as_ptr();
-    let removed_bits = (raw as usize) & bits;
-    let raw_addr = raw.map_addr(|addr|->(ret:usize) ensures ret == addr & !bits { addr & !bits });
-    let result_ptr = unsafe { NonNull::new_unchecked(raw_addr) };
-
+    let result_ptr = ptr.map_addr_v(|addr| -> (ret: NonZeroUsize) 
+        ensures ret@ == addr@ & !bits
+        {unsafe { NonZeroUsize::new_unchecked(addr.get() & !bits) }});
+    proof!{
+        result_ptr.lemma_addr_view_eq_view_ptr_mut();
+    }
     (removed_bits, result_ptr)
 }
 

--- a/ostd/src/sync/rcu/non_null/either.rs
+++ b/ostd/src/sync/rcu/non_null/either.rs
@@ -139,12 +139,14 @@ unsafe impl<L: NonNullPtr, R: NonNullPtr> NonNullPtr for Either<L, R> {
                 .map_addr(|addr| addr | (1 << Self::ALIGN_BITS))
                 .cast(), */
                 let (right, Tracked(perm)) = right.into_raw();
-                let right_raw = right.as_ptr().map_addr(|addr| -> (ret: usize) 
-                    ensures ret == addr | (1usize << Self::ALIGN_BITS)
-                    {addr | (1usize << Self::ALIGN_BITS)});
+                let right_raw = right.map_addr_v(|addr: NonZeroUsize| -> (ret: NonZeroUsize) 
+                    ensures ret@ == addr@ | (1usize << Self::ALIGN_BITS)
+                    {unsafe { NonZeroUsize::new_unchecked(addr.get() | (1usize << Self::ALIGN_BITS)) }});
                 proof! {
-                    let addr = right.as_ptr().addr();
-                    let tagged_addr = right_raw.addr();
+                    let addr = right.addr_spec()@;
+                    let tagged_addr = right_raw.addr_spec()@;
+                    right.lemma_addr_is_nonnull();
+                    right_raw.lemma_addr_view_eq_view_ptr_mut();
                     assert(tagged_addr & tag == tag) by (bit_vector)
                     requires
                         tagged_addr == addr | tag,
@@ -201,7 +203,7 @@ unsafe impl<L: NonNullPtr, R: NonNullPtr> NonNullPtr for Either<L, R> {
                     }
                 }
                 (
-                    unsafe { NonNull::new_unchecked(right_raw) }.cast(),
+                    right_raw.cast(),
                     Tracked(EitherPointsTo { perm: Sum::Right(perm) }),
                 )
             },

--- a/ostd/src/sync/rcu/non_null/either.rs
+++ b/ostd/src/sync/rcu/non_null/either.rs
@@ -145,8 +145,6 @@ unsafe impl<L: NonNullPtr, R: NonNullPtr> NonNullPtr for Either<L, R> {
                 proof! {
                     let addr = right.addr_spec()@;
                     let tagged_addr = right_tagged.addr_spec()@;
-                    right.lemma_addr_is_nonnull();
-                    right_tagged.lemma_addr_view_eq_view_ptr_mut();
                     assert(tagged_addr & tag == tag) by (bit_vector)
                     requires
                         tagged_addr == addr | tag,
@@ -223,7 +221,6 @@ unsafe impl<L: NonNullPtr, R: NonNullPtr> NonNullPtr for Either<L, R> {
         }
         proof! {
             let ghost ptr_addr = ptr.view_ptr_mut()@.addr;
-            ptr.lemma_addr_is_nonnull();
             assert(tag > 0) by (bit_vector)
             requires
                 tag == 1usize << align_bits,
@@ -352,13 +349,11 @@ unsafe fn remove_bits<T>(ptr: NonNull<T>, bits: usize) -> (usize, NonNull<T>) {
     // use core::num::NonZeroUsize;
     use vstd_extra::external::nonzero::NonZeroUsize;
     let removed_bits = ptr.addr_v().get() & bits;
-    // // SAFETY: The safety is upheld by the caller.
-    let result_ptr = ptr.map_addr_v(|addr| -> (ret: NonZeroUsize) 
+    let result_ptr = ptr
+        .map_addr_v(|addr| -> (ret: NonZeroUsize) 
         ensures ret@ == addr@ & !bits
+        // SAFETY: The safety is upheld by the caller.
         {unsafe { NonZeroUsize::new_unchecked(addr.get() & !bits) }});
-    proof!{
-        result_ptr.lemma_addr_view_eq_view_ptr_mut();
-    }
     (removed_bits, result_ptr)
 }
 

--- a/vstd_extra/src/external/nonnull.rs
+++ b/vstd_extra/src/external/nonnull.rs
@@ -158,12 +158,17 @@ pub open spec fn nonnull_with_addr_spec_wrapper<T: PointeeSized>(
 // To prevent circular dependency
 pub trait NonNullAdditionalFnsMore<T>: NonNullAdditionalFns<T> where T: PointeeSized {
     spec fn with_addr_spec(self, addr: NonZeroUsize) -> NonNull<T>;
+    
+    proof fn lemma_with_addr_properties(self, addr: NonZeroUsize)
+        ensures
+            self.with_addr_spec(addr).view_ptr_mut()@.metadata == self.view_ptr_mut()@.metadata,
+            self.with_addr_spec(addr).view_ptr_mut()@.provenance == self.view_ptr_mut()@.provenance,
+            self.with_addr_spec(addr).view_ptr_mut()@.addr == addr.view(),
+    ;
 
     fn with_addr_v(self, addr: NonZeroUsize) -> (ret: NonNull<T>)
-        ensures
-            ret.view_ptr_mut()@.metadata == self.view_ptr_mut()@.metadata,
-            ret.view_ptr_mut()@.provenance == self.view_ptr_mut()@.provenance,
-            ret.view_ptr_mut()@.addr == addr.view(),
+        returns
+            self.with_addr_spec(addr),
     ;
 
     /// A wrapper of `NonNull::map_addr` in `std`, here we use our own `NonZeroUsize`
@@ -184,6 +189,8 @@ impl<T: PointeeSized> NonNullAdditionalFnsMore<T> for NonNull<T> {
     }
 
     uninterp spec fn with_addr_spec(self, addr: NonZeroUsize) -> NonNull<T>;
+
+    axiom fn lemma_with_addr_properties(self, addr: NonZeroUsize);
 
     #[verifier::external_body]
     #[verifier::when_used_as_spec(nonnull_with_addr_spec_wrapper)]

--- a/vstd_extra/src/external/nonnull.rs
+++ b/vstd_extra/src/external/nonnull.rs
@@ -25,16 +25,16 @@ pub trait NonNullAdditionalFns<T: PointeeSized> {
     spec fn dangling_spec() -> NonNull<T>;
 
     /// Type invariant: the address of the pointer is non-null.
-    proof fn lemma_addr_is_nonnull(self)
+    broadcast proof fn lemma_addr_is_nonnull(self)
         ensures
-            self.view_ptr_mut()@.addr != 0,
+            (#[trigger] self.view_ptr_mut())@.addr != 0,
     ;
 
     spec fn addr_spec(self) -> NonZeroUsize;
 
-    proof fn lemma_addr_view_eq_view_ptr_mut(self)
+    broadcast proof fn lemma_addr_view_eq_view_ptr_mut(self)
         ensures
-            self.addr_spec().view() == self.view_ptr_mut()@.addr,
+            (#[trigger] self.addr_spec()).view() == self.view_ptr_mut()@.addr,
     ;
 
     /// A wrapper of `NonNull::addr` in `std`, here we use our own `NonZeroUsize`
@@ -203,6 +203,8 @@ pub broadcast group group_nonull_axioms {
     axiom_nonnull_from_ptr_mut_spec_eq,
     axiom_cast_spec_eq,
     axiom_view_ptr_mut_eq,
+    NonNullAdditionalFns::lemma_addr_view_eq_view_ptr_mut,
+    NonNullAdditionalFns::lemma_addr_is_nonnull,
 }
 
 } // verus!

--- a/vstd_extra/src/external/nonnull.rs
+++ b/vstd_extra/src/external/nonnull.rs
@@ -158,7 +158,7 @@ pub open spec fn nonnull_with_addr_spec_wrapper<T: PointeeSized>(
 // To prevent circular dependency
 pub trait NonNullAdditionalFnsMore<T>: NonNullAdditionalFns<T> where T: PointeeSized {
     spec fn with_addr_spec(self, addr: NonZeroUsize) -> NonNull<T>;
-    
+
     proof fn lemma_with_addr_properties(self, addr: NonZeroUsize)
         ensures
             self.with_addr_spec(addr).view_ptr_mut()@.metadata == self.view_ptr_mut()@.metadata,

--- a/vstd_extra/src/external/nonnull.rs
+++ b/vstd_extra/src/external/nonnull.rs
@@ -32,11 +32,15 @@ pub trait NonNullAdditionalFns<T: PointeeSized> {
 
     spec fn addr_spec(self) -> NonZeroUsize;
 
-    /// A wrapper of `NonNull::addr` in `std`, here we use our own `NonZeroUsize`
-    fn addr(self) -> (ret: NonZeroUsize)
+    proof fn lemma_addr_view_eq_view_ptr_mut(self)
         ensures
-            ret == self.addr_spec(),
-            ret.view() == self.view_ptr_mut()@.addr,
+            self.addr_spec().view() == self.view_ptr_mut()@.addr,
+    ;
+
+    /// A wrapper of `NonNull::addr` in `std`, here we use our own `NonZeroUsize`
+    fn addr_v(self) -> NonZeroUsize
+        returns
+            self.addr_spec(),
     ;
 }
 
@@ -53,9 +57,11 @@ impl<T: PointeeSized> NonNullAdditionalFns<T> for NonNull<T> {
         NonZeroUsize::nonzero_usize_from_usize(self.view_ptr_mut()@.addr)
     }
 
+    axiom fn lemma_addr_view_eq_view_ptr_mut(self);
+
     #[verifier::external_body]
     #[verifier::when_used_as_spec(nonnull_addr_spec_wrapper)]
-    fn addr(self) -> (ret: NonZeroUsize) {
+    fn addr_v(self) -> NonZeroUsize {
         unimplemented!()
     }
 }
@@ -153,7 +159,7 @@ pub open spec fn nonnull_with_addr_spec_wrapper<T: PointeeSized>(
 pub trait NonNullAdditionalFnsMore<T>: NonNullAdditionalFns<T> where T: PointeeSized {
     spec fn with_addr_spec(self, addr: NonZeroUsize) -> NonNull<T>;
 
-    fn with_addr(self, addr: NonZeroUsize) -> (ret: NonNull<T>)
+    fn with_addr_v(self, addr: NonZeroUsize) -> (ret: NonNull<T>)
         ensures
             ret.view_ptr_mut()@.metadata == self.view_ptr_mut()@.metadata,
             ret.view_ptr_mut()@.provenance == self.view_ptr_mut()@.provenance,
@@ -161,7 +167,7 @@ pub trait NonNullAdditionalFnsMore<T>: NonNullAdditionalFns<T> where T: PointeeS
     ;
 
     /// A wrapper of `NonNull::map_addr` in `std`, here we use our own `NonZeroUsize`
-    fn map_addr<F: FnOnce(NonZeroUsize) -> NonZeroUsize>(self, f: F) -> (ret: NonNull<T>)
+    fn map_addr_v<F: FnOnce(NonZeroUsize) -> NonZeroUsize>(self, f: F) -> (ret: NonNull<T>)
         requires
             f.requires((self.addr_spec(),)),
         ensures
@@ -173,7 +179,7 @@ pub trait NonNullAdditionalFnsMore<T>: NonNullAdditionalFns<T> where T: PointeeS
 
 impl<T: PointeeSized> NonNullAdditionalFnsMore<T> for NonNull<T> {
     #[verifier::external_body]
-    fn map_addr<F: FnOnce(NonZeroUsize) -> NonZeroUsize>(self, f: F) -> (ret: NonNull<T>) {
+    fn map_addr_v<F: FnOnce(NonZeroUsize) -> NonZeroUsize>(self, f: F) -> (ret: NonNull<T>) {
         unimplemented!()
     }
 
@@ -181,7 +187,7 @@ impl<T: PointeeSized> NonNullAdditionalFnsMore<T> for NonNull<T> {
 
     #[verifier::external_body]
     #[verifier::when_used_as_spec(nonnull_with_addr_spec_wrapper)]
-    fn with_addr(self, addr: NonZeroUsize) -> (ret: NonNull<T>) {
+    fn with_addr_v(self, addr: NonZeroUsize) -> (ret: NonNull<T>) {
         unimplemented!()
     }
 }

--- a/vstd_extra/src/external/nonzero.rs
+++ b/vstd_extra/src/external/nonzero.rs
@@ -86,9 +86,9 @@ impl NonZeroUsize {
         self.inner.get()
     }
 
-    axiom fn lemma_nonzero_neq_zero(self)
+    broadcast axiom fn lemma_nonzero_neq_zero(self)
         ensures
-            self.view() != 0,
+            #[trigger] self.view() != 0,
     ;
 }
 
@@ -143,6 +143,7 @@ impl OrdSpecImpl for NonZeroUsize {
 }
 
 pub broadcast group group_nonzero_axioms {
+    NonZeroUsize::lemma_nonzero_neq_zero,
     NonZeroUsize::axiom_nonzero_usize_from_usize_view_eq,
     NonZeroUsize::axiom_view_nonzero_usize_from_usize_eq,
 }

--- a/vstd_extra/src/external/nonzero.rs
+++ b/vstd_extra/src/external/nonzero.rs
@@ -22,7 +22,6 @@
 //! wrapper signature, which lets verification run with full lifetime checking
 //! enabled.
 use core::cmp::Ordering;
-use core::num::NonZero;
 use vstd::prelude::*;
 use vstd::std_specs::cmp::*;
 
@@ -31,7 +30,7 @@ verus! {
 #[verifier::external_body]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NonZeroUsize {
-    pub inner: NonZero<usize>,
+    pub inner: core::num::NonZero<usize>,
 }
 
 impl View for NonZeroUsize {


### PR DESCRIPTION
Replace the `NonNull --> *mut T --> <*mut T>::map_addr --> NonNull` trace with the direct `NonNull::map_addr_v`, which is closer to the source code.