### PR TITLE
Fix new mut ref

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ $(VERIFICATION_TARGETS):
 all: verify
 
 verify:
-	cargo dv verify --targets $(VERIFICATION_TARGETS) -- -V new-mut-ref
+	cargo dv verify --targets $(VERIFICATION_TARGETS)
 
 fmt:
 	cargo dv fmt

--- a/ostd/src/sync/rcu/non_null/either.rs
+++ b/ostd/src/sync/rcu/non_null/either.rs
@@ -11,6 +11,23 @@ use crate::util::Either;
 verus! {
 
 broadcast use {group_nonull_axioms, group_raw_ptr_axioms, group_nonzero_axioms};
+
+proof fn lemma_aligned_addr_clears_tag_bit(addr: usize, tag: usize, align_bits: u32, ptr_align_bits: u32)
+    requires
+        addr % (1usize << ptr_align_bits) == 0,
+        tag == 1usize << align_bits,
+        align_bits < ptr_align_bits < usize::BITS,
+    ensures
+        addr & tag == 0,
+{
+    assert(addr & tag == 0) by (bit_vector)
+    requires
+        addr % (1usize << ptr_align_bits) == 0,
+        tag == 1usize << align_bits,
+        align_bits < ptr_align_bits < usize::BITS,
+    ;
+}
+
 // If both `L` and `R` have at least one alignment bit (i.e., their alignments are at least 2), we
 // can use the alignment bit to indicate whether a pointer is `L` or `R`, so it's possible to
 // implement `NonNullPtr` for `Either<L, R>`.
@@ -130,12 +147,7 @@ unsafe impl<L: NonNullPtr, R: NonNullPtr> NonNullPtr for Either<L, R> {
                         ;
                         vstd::arithmetic::div_mod::lemma_mod_multiples_basic(q as int * scale as int, tag as int);
                     }
-                    assert(addr & tag == 0) by (bit_vector)
-                    requires
-                        addr % (1usize << r_align_bits) == 0,
-                        tag == 1usize << align_bits,
-                        align_bits + 1 <= r_align_bits < usize::BITS,
-                    ;
+                    lemma_aligned_addr_clears_tag_bit(addr, tag, align_bits, r_align_bits);
                     assert(tagged_addr & !tag == addr) by (bit_vector)
                     requires
                         tagged_addr == addr | tag,

--- a/ostd/src/sync/rwlock.rs
+++ b/ostd/src/sync/rwlock.rs
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 use vstd::atomic_ghost::*;
 use vstd::cell::{self, pcell::*, CellId};
-use vstd::pcm::Loc;
 use vstd::prelude::*;
-use vstd::tokens::frac::{self, Empty, Frac, FracGhost};
+use vstd::resource::Loc;
 use vstd_extra::resource::ghost_resource::{csum::*, excl::*, tokens::*};
 use vstd_extra::sum::*;
 use vstd_extra::{prelude::*, resource};

--- a/ostd/src/sync/rwmutex.rs
+++ b/ostd/src/sync/rwmutex.rs
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 use vstd::atomic_ghost::*;
 use vstd::cell::{self, pcell::*, CellId};
-use vstd::pcm::Loc;
 use vstd::prelude::*;
-use vstd::tokens::frac::{Empty, Frac};
+use vstd::resource::Loc;
 use vstd_extra::auxiliary::pcell_borrow_mut;
 use vstd_extra::resource::ghost_resource::{csum::*, excl::*, tokens::*};
 use vstd_extra::sum::*;

--- a/vstd_extra/src/external/range.rs
+++ b/vstd_extra/src/external/range.rs
@@ -7,7 +7,11 @@ verus! {
 /// matching `ExactSizeIterator::len` for `Range<A: Step>` where `Step::steps_between`
 /// returns `None` on `end < start`, collapsed to 0.
 pub open spec fn range_usize_len_spec(r: &Range<usize>) -> usize {
-    if r.start < r.end { (r.end - r.start) as usize } else { 0usize }
+    if r.start < r.end {
+        (r.end - r.start) as usize
+    } else {
+        0usize
+    }
 }
 
 /// Exec-mode `len` for a `Range<usize>`: use in place of `r.len()` which is an
@@ -18,7 +22,11 @@ pub fn range_usize_len(r: &Range<usize>) -> (ret: usize)
     ensures
         ret == range_usize_len_spec(r),
 {
-    if r.start < r.end { r.end - r.start } else { 0 }
+    if r.start < r.end {
+        r.end - r.start
+    } else {
+        0
+    }
 }
 
 /// Whether a `Range<usize>` is empty. Malformed ranges (`start > end`) are empty.

--- a/vstd_extra/src/resource/ghost_resource/csum.rs
+++ b/vstd_extra/src/resource/ghost_resource/csum.rs
@@ -2,9 +2,9 @@ use std::f32::consts::E;
 
 use vstd::modes::tracked_swap;
 //！ Sum types for ghost resources.
-use vstd::resource::Loc;
 use vstd::prelude::*;
 use vstd::resource::storage_protocol::*;
+use vstd::resource::Loc;
 
 use crate::resource::storage_protocol::csum::*;
 use crate::sum::*;

--- a/vstd_extra/src/resource/ghost_resource/csum.rs
+++ b/vstd_extra/src/resource/ghost_resource/csum.rs
@@ -2,9 +2,9 @@ use std::f32::consts::E;
 
 use vstd::modes::tracked_swap;
 //！ Sum types for ghost resources.
-use vstd::pcm::Loc;
+use vstd::resource::Loc;
 use vstd::prelude::*;
-use vstd::storage_protocol::*;
+use vstd::resource::storage_protocol::*;
 
 use crate::resource::storage_protocol::csum::*;
 use crate::sum::*;

--- a/vstd_extra/src/resource/ghost_resource/excl.rs
+++ b/vstd_extra/src/resource/ghost_resource/excl.rs
@@ -1,9 +1,9 @@
 //！ Exclusive ghost resource.
 use vstd::modes::tracked_swap;
-use vstd::resource::Loc;
-use vstd::resource::pcm::Resource;
 use vstd::prelude::*;
+use vstd::resource::pcm::Resource;
 use vstd::resource::storage_protocol::StorageResource;
+use vstd::resource::Loc;
 
 use super::super::pcm::excl::*;
 use super::super::storage_protocol::excl::*;

--- a/vstd_extra/src/resource/ghost_resource/excl.rs
+++ b/vstd_extra/src/resource/ghost_resource/excl.rs
@@ -1,8 +1,9 @@
 //！ Exclusive ghost resource.
 use vstd::modes::tracked_swap;
-use vstd::pcm::*;
+use vstd::resource::Loc;
+use vstd::resource::pcm::Resource;
 use vstd::prelude::*;
-use vstd::storage_protocol::StorageResource;
+use vstd::resource::storage_protocol::StorageResource;
 
 use super::super::pcm::excl::*;
 use super::super::storage_protocol::excl::*;

--- a/vstd_extra/src/resource/ghost_resource/frac.rs
+++ b/vstd_extra/src/resource/ghost_resource/frac.rs
@@ -1,8 +1,8 @@
 //! Real-based fractional ghost resource.
 use vstd::map::*;
-use vstd::resource::Loc;
 use vstd::prelude::*;
 use vstd::resource::storage_protocol::*;
+use vstd::resource::Loc;
 
 use crate::resource::storage_protocol::frac::*;
 

--- a/vstd_extra/src/resource/ghost_resource/frac.rs
+++ b/vstd_extra/src/resource/ghost_resource/frac.rs
@@ -1,8 +1,8 @@
 //! Real-based fractional ghost resource.
 use vstd::map::*;
-use vstd::pcm::Loc;
+use vstd::resource::Loc;
 use vstd::prelude::*;
-use vstd::storage_protocol::*;
+use vstd::resource::storage_protocol::*;
 
 use crate::resource::storage_protocol::frac::*;
 

--- a/vstd_extra/src/resource/ghost_resource/tokens.rs
+++ b/vstd_extra/src/resource/ghost_resource/tokens.rs
@@ -5,10 +5,10 @@ use crate::sum::*;
 use vstd::map::*;
 use vstd::modes::tracked_swap;
 use vstd::prelude::*;
-use vstd::resource::Loc;
 use vstd::resource::algebra::ResourceAlgebra;
-use vstd::resource::pcm::{PCM, Resource};
+use vstd::resource::pcm::{Resource, PCM};
 use vstd::resource::storage_protocol::{Protocol, StorageResource};
+use vstd::resource::Loc;
 
 verus! {
 

--- a/vstd_extra/src/resource/ghost_resource/tokens.rs
+++ b/vstd_extra/src/resource/ghost_resource/tokens.rs
@@ -2,11 +2,539 @@ use std::borrow::Borrow;
 
 //！ A wrapper around `vstd::tokens::FracGhost` that stores and dispatches fractional access.
 use crate::sum::*;
-use vstd::pcm::Loc;
+use vstd::map::*;
+use vstd::modes::tracked_swap;
 use vstd::prelude::*;
-use vstd::tokens::frac::{Empty, Frac, FracGhost};
+use vstd::resource::Loc;
+use vstd::resource::algebra::ResourceAlgebra;
+use vstd::resource::pcm::{PCM, Resource};
+use vstd::resource::storage_protocol::{Protocol, StorageResource};
 
 verus! {
+
+broadcast use {vstd::map::group_map_axioms, vstd::set::group_set_axioms};
+
+// Integer-based fractional ghost tokens kept for code that predates
+// vstd::resource::frac's real-valued fractions.
+ghost enum FractionalCarrier<T, const TOTAL: u64> {
+    Value { v: T, n: int },
+    Empty,
+    Invalid,
+}
+
+impl<T, const TOTAL: u64> FractionalCarrier<T, TOTAL> {
+    spec fn new(v: T) -> Self {
+        FractionalCarrier::Value { v, n: TOTAL as int }
+    }
+}
+
+impl<T, const TOTAL: u64> ResourceAlgebra for FractionalCarrier<T, TOTAL> {
+    closed spec fn valid(self) -> bool {
+        match self {
+            FractionalCarrier::Invalid => false,
+            FractionalCarrier::Empty => true,
+            FractionalCarrier::Value { v: _, n } => 0 < n <= TOTAL,
+        }
+    }
+
+    closed spec fn op(a: Self, b: Self) -> Self {
+        match a {
+            FractionalCarrier::Invalid => FractionalCarrier::Invalid,
+            FractionalCarrier::Empty => b,
+            FractionalCarrier::Value { v: sv, n: sn } => match b {
+                FractionalCarrier::Invalid => FractionalCarrier::Invalid,
+                FractionalCarrier::Empty => a,
+                FractionalCarrier::Value { v: ov, n: on } => {
+                    if sv != ov {
+                        FractionalCarrier::Invalid
+                    } else if sn <= 0 || on <= 0 {
+                        FractionalCarrier::Invalid
+                    } else {
+                        FractionalCarrier::Value { v: sv, n: sn + on }
+                    }
+                },
+            },
+        }
+    }
+
+    proof fn valid_op(a: Self, b: Self) {
+    }
+
+    proof fn commutative(a: Self, b: Self) {
+    }
+
+    proof fn associative(a: Self, b: Self, c: Self) {
+    }
+}
+
+impl<T, const TOTAL: u64> PCM for FractionalCarrier<T, TOTAL> {
+    closed spec fn unit() -> Self {
+        FractionalCarrier::Empty
+    }
+
+    proof fn op_unit(self) {
+    }
+
+    proof fn unit_valid() {
+    }
+}
+
+pub tracked struct FracGhost<T, const TOTAL: u64 = 2> {
+    r: Resource<FractionalCarrier<T, TOTAL>>,
+}
+
+impl<T, const TOTAL: u64> FracGhost<T, TOTAL> {
+    #[verifier::type_invariant]
+    spec fn inv(self) -> bool {
+        self.r.value() is Value
+    }
+
+    pub closed spec fn id(self) -> Loc {
+        self.r.loc()
+    }
+
+    pub closed spec fn view(self) -> T {
+        self.r.value()->v
+    }
+
+    pub closed spec fn frac(self) -> int {
+        self.r.value()->n
+    }
+
+    pub open spec fn valid(self, id: Loc, frac: int) -> bool {
+        &&& self.id() == id
+        &&& self.frac() == frac
+    }
+
+    pub proof fn new(v: T) -> (tracked result: Self)
+        requires
+            TOTAL > 0,
+        ensures
+            result.frac() == TOTAL as int,
+            result@ == v,
+    {
+        let f = FractionalCarrier::<T, TOTAL>::new(v);
+        let tracked r = Resource::alloc(f);
+        Self { r }
+    }
+
+    pub proof fn agree(tracked self: &Self, tracked other: &Self)
+        requires
+            self.id() == other.id(),
+        ensures
+            self@ == other@,
+    {
+        use_type_invariant(self);
+        use_type_invariant(other);
+        let tracked joined = self.r.join_shared(&other.r);
+        joined.validate()
+    }
+
+    pub proof fn take(tracked &mut self) -> (tracked result: Self)
+        ensures
+            result == *old(self),
+    {
+        self.bounded();
+        let tracked mut mself = Self::dummy();
+        tracked_swap(self, &mut mself);
+        mself
+    }
+
+    pub proof fn split(tracked &mut self, n: int) -> (tracked result: Self)
+        requires
+            0 < n < old(self).frac(),
+        ensures
+            result.id() == final(self).id(),
+            final(self).id() == old(self).id(),
+            final(self)@ == old(self)@,
+            result@ == old(self)@,
+            final(self).frac() + result.frac() == old(self).frac(),
+            result.frac() == n,
+    {
+        self.bounded();
+        let tracked mut mself = Self::dummy();
+        tracked_swap(self, &mut mself);
+        use_type_invariant(&mself);
+        let tracked (r1, r2) = mself.r.split(
+            FractionalCarrier::Value { v: mself.r.value()->v, n: mself.r.value()->n - n },
+            FractionalCarrier::Value { v: mself.r.value()->v, n },
+        );
+        self.r = r1;
+        Self { r: r2 }
+    }
+
+    pub proof fn combine(tracked &mut self, tracked other: Self)
+        requires
+            old(self).id() == other.id(),
+        ensures
+            final(self).id() == old(self).id(),
+            final(self)@ == old(self)@,
+            final(self)@ == other@,
+            final(self).frac() == old(self).frac() + other.frac(),
+    {
+        self.bounded();
+        let tracked mut mself = Self::dummy();
+        tracked_swap(self, &mut mself);
+        use_type_invariant(&mself);
+        use_type_invariant(&other);
+        let tracked mut r = mself.r;
+        r.validate_2(&other.r);
+        *self = Self { r: r.join(other.r) };
+    }
+
+    pub proof fn update(tracked &mut self, v: T)
+        requires
+            old(self).frac() == TOTAL,
+        ensures
+            final(self).id() == old(self).id(),
+            final(self)@ == v,
+            final(self).frac() == old(self).frac(),
+    {
+        self.bounded();
+        let tracked mut mself = Self::dummy();
+        tracked_swap(self, &mut mself);
+        use_type_invariant(&mself);
+        let tracked r = mself.r;
+        let f = FractionalCarrier::<T, TOTAL>::Value { v, n: TOTAL as int };
+        *self = Self { r: r.update(f) };
+    }
+
+    pub proof fn update_with(tracked &mut self, tracked other: &mut Self, v: T)
+        requires
+            old(self).id() == old(other).id(),
+            old(self).frac() + old(other).frac() == TOTAL,
+        ensures
+            final(self).id() == old(self).id(),
+            final(other).id() == old(other).id(),
+            final(self).frac() == old(self).frac(),
+            final(other).frac() == old(other).frac(),
+            old(self)@ == old(other)@,
+            final(self)@ == v,
+            final(other)@ == v,
+    {
+        let ghost other_frac = other.frac();
+        other.bounded();
+        let tracked mut xother = Self::dummy();
+        tracked_swap(other, &mut xother);
+        self.bounded();
+        self.combine(xother);
+        self.update(v);
+        let tracked mut xother = self.split(other_frac);
+        tracked_swap(other, &mut xother);
+    }
+
+    pub proof fn bounded(tracked &self)
+        ensures
+            0 < self.frac() <= TOTAL,
+    {
+        use_type_invariant(self);
+        self.r.validate()
+    }
+
+    pub proof fn dummy() -> (tracked result: Self)
+        requires
+            TOTAL > 0,
+    {
+        Self::new(arbitrary())
+    }
+}
+
+ghost enum FractionalCarrierOpt<T, const TOTAL: u64> {
+    Value { v: Option<T>, n: int },
+    Empty,
+    Invalid,
+}
+
+impl<T, const TOTAL: u64> Protocol<(), T> for FractionalCarrierOpt<T, TOTAL> {
+    closed spec fn op(self, other: Self) -> Self {
+        match self {
+            FractionalCarrierOpt::Invalid => FractionalCarrierOpt::Invalid,
+            FractionalCarrierOpt::Empty => other,
+            FractionalCarrierOpt::Value { v: sv, n: sn } => match other {
+                FractionalCarrierOpt::Invalid => FractionalCarrierOpt::Invalid,
+                FractionalCarrierOpt::Empty => self,
+                FractionalCarrierOpt::Value { v: ov, n: on } => {
+                    if sv != ov {
+                        FractionalCarrierOpt::Invalid
+                    } else if sn <= 0 || on <= 0 {
+                        FractionalCarrierOpt::Invalid
+                    } else {
+                        FractionalCarrierOpt::Value { v: sv, n: sn + on }
+                    }
+                },
+            },
+        }
+    }
+
+    closed spec fn rel(self, s: Map<(), T>) -> bool {
+        match self {
+            FractionalCarrierOpt::Value { v, n } => {
+                (match v {
+                    Some(v0) => s.dom().contains(()) && s[()] == v0,
+                    None => s =~= map![],
+                }) && n == TOTAL && n != 0
+            },
+            FractionalCarrierOpt::Empty => false,
+            FractionalCarrierOpt::Invalid => false,
+        }
+    }
+
+    closed spec fn unit() -> Self {
+        FractionalCarrierOpt::Empty
+    }
+
+    proof fn commutative(a: Self, b: Self) {
+    }
+
+    proof fn associative(a: Self, b: Self, c: Self) {
+    }
+
+    proof fn op_unit(a: Self) {
+    }
+}
+
+pub tracked struct Frac<T, const TOTAL: u64 = 2> {
+    r: StorageResource<(), T, FractionalCarrierOpt<T, TOTAL>>,
+}
+
+pub tracked struct Empty<T, const TOTAL: u64 = 2> {
+    r: StorageResource<(), T, FractionalCarrierOpt<T, TOTAL>>,
+}
+
+impl<T, const TOTAL: u64> Frac<T, TOTAL> {
+    #[verifier::type_invariant]
+    spec fn inv(self) -> bool {
+        self.r.value() matches FractionalCarrierOpt::Value { v: Some(_), .. }
+    }
+
+    pub closed spec fn id(self) -> Loc {
+        self.r.loc()
+    }
+
+    pub closed spec fn resource(self) -> T {
+        self.r.value()->v.unwrap()
+    }
+
+    pub closed spec fn frac(self) -> int {
+        self.r.value()->n
+    }
+
+    pub open spec fn valid(self, id: Loc, frac: int) -> bool {
+        &&& self.id() == id
+        &&& self.frac() == frac
+    }
+
+    pub proof fn new(tracked v: T) -> (tracked result: Self)
+        requires
+            TOTAL > 0,
+        ensures
+            result.frac() == TOTAL as int,
+            result.resource() == v,
+    {
+        let f = FractionalCarrierOpt::<T, TOTAL>::Value { v: Some(v), n: TOTAL as int };
+        let tracked mut m = Map::<(), T>::tracked_empty();
+        m.tracked_insert((), v);
+        let tracked r = StorageResource::alloc(f, m);
+        Self { r }
+    }
+
+    pub proof fn agree(tracked self: &Self, tracked other: &Self)
+        requires
+            self.id() == other.id(),
+        ensures
+            self.resource() == other.resource(),
+    {
+        use_type_invariant(self);
+        use_type_invariant(other);
+        let tracked joined = self.r.join_shared(&other.r);
+        joined.validate();
+    }
+
+    pub proof fn split(tracked &mut self, n: int) -> (tracked result: Self)
+        requires
+            0 < n < old(self).frac(),
+        ensures
+            result.id() == final(self).id(),
+            final(self).id() == old(self).id(),
+            final(self).resource() == old(self).resource(),
+            result.resource() == old(self).resource(),
+            final(self).frac() + result.frac() == old(self).frac(),
+            result.frac() == n,
+    {
+        use_type_invariant(&*self);
+        Self::split_helper(&mut self.r, n)
+    }
+
+    proof fn split_helper(
+        tracked r: &mut StorageResource<(), T, FractionalCarrierOpt<T, TOTAL>>,
+        n: int,
+    ) -> (tracked result: Self)
+        requires
+            0 < n < old(r).value()->n,
+            old(r).value() matches FractionalCarrierOpt::Value { v: Some(_), .. },
+        ensures
+            result.id() == final(r).loc(),
+            final(r).loc() == old(r).loc(),
+            final(r).value()->v.unwrap() == old(r).value()->v.unwrap(),
+            result.resource() == old(r).value()->v.unwrap(),
+            final(r).value()->n + result.frac() == old(r).value()->n,
+            result.frac() == n,
+            final(r).value() matches FractionalCarrierOpt::Value { v: Some(_), .. },
+    {
+        r.validate();
+        let tracked mut r1 = StorageResource::alloc(
+            FractionalCarrierOpt::Value { v: None, n: TOTAL as int },
+            Map::tracked_empty(),
+        );
+        tracked_swap(r, &mut r1);
+        let tracked (r1, r2) = r1.split(
+            FractionalCarrierOpt::Value { v: r1.value()->v, n: r1.value()->n - n },
+            FractionalCarrierOpt::Value { v: r1.value()->v, n },
+        );
+        *r = r1;
+        Self { r: r2 }
+    }
+
+    pub proof fn combine(tracked &mut self, tracked other: Self)
+        requires
+            old(self).id() == other.id(),
+        ensures
+            final(self).id() == old(self).id(),
+            final(self).resource() == old(self).resource(),
+            final(self).resource() == other.resource(),
+            final(self).frac() == old(self).frac() + other.frac(),
+    {
+        use_type_invariant(&*self);
+        Self::combine_helper(&mut self.r, other)
+    }
+
+    proof fn combine_helper(
+        tracked r: &mut StorageResource<(), T, FractionalCarrierOpt<T, TOTAL>>,
+        tracked other: Self,
+    )
+        requires
+            old(r).loc() == other.id(),
+            old(r).value() matches FractionalCarrierOpt::Value { v: Some(_), .. },
+        ensures
+            final(r).loc() == old(r).loc(),
+            final(r).value()->v.unwrap() == old(r).value()->v.unwrap(),
+            final(r).value()->v.unwrap() == other.resource(),
+            final(r).value()->n == old(r).value()->n + other.frac(),
+            final(r).value() matches FractionalCarrierOpt::Value { v: Some(_), .. },
+    {
+        r.validate();
+        use_type_invariant(&other);
+        let tracked mut r1 = StorageResource::alloc(
+            FractionalCarrierOpt::Value { v: None, n: TOTAL as int },
+            Map::tracked_empty(),
+        );
+        tracked_swap(r, &mut r1);
+        r1.validate_with_shared(&other.r);
+        *r = StorageResource::join(r1, other.r);
+    }
+
+    pub proof fn bounded(tracked &self)
+        ensures
+            0 < self.frac() <= TOTAL,
+    {
+        use_type_invariant(self);
+        let (x, _) = self.r.validate();
+    }
+
+    pub proof fn borrow(tracked &self) -> (tracked ret: &T)
+        ensures
+            ret == self.resource(),
+    {
+        use_type_invariant(self);
+        StorageResource::guard(&self.r, map![() => self.resource()]).tracked_borrow(())
+    }
+
+    pub proof fn take_resource(tracked self) -> (tracked pair: (T, Empty<T, TOTAL>))
+        requires
+            self.frac() == TOTAL,
+        ensures
+            pair.0 == self.resource(),
+            pair.1.id() == self.id(),
+    {
+        use_type_invariant(&self);
+        self.r.validate();
+        let p1 = self.r.value();
+        let p2 = FractionalCarrierOpt::Value { v: None, n: TOTAL as int };
+        let b2 = map![() => self.resource()];
+        assert forall|q: FractionalCarrierOpt<T, TOTAL>, t1: Map<(), T>|
+            #![all_triggers]
+            FractionalCarrierOpt::rel(FractionalCarrierOpt::op(p1, q), t1) implies exists|
+            t2: Map<(), T>,
+        |
+            #![all_triggers]
+            FractionalCarrierOpt::rel(FractionalCarrierOpt::op(p2, q), t2) && t2.dom().disjoint(
+                b2.dom(),
+            ) && t1 =~= t2.union_prefer_right(b2) by {
+            let t2 = map![];
+            assert(FractionalCarrierOpt::rel(FractionalCarrierOpt::op(p2, q), t2));
+            assert(t2.dom().disjoint(b2.dom()));
+            assert(t1 =~= t2.union_prefer_right(b2));
+        }
+        let tracked Self { r } = self;
+        let tracked (new_r, mut m) = r.withdraw(p2, b2);
+        let tracked emp = Empty { r: new_r };
+        let tracked resource = m.tracked_remove(());
+        (resource, emp)
+    }
+}
+
+impl<T, const TOTAL: u64> Empty<T, TOTAL> {
+    #[verifier::type_invariant]
+    spec fn inv(self) -> bool {
+        &&& self.r.value() matches FractionalCarrierOpt::Value { v: None, n }
+        &&& n == TOTAL
+    }
+
+    pub closed spec fn id(self) -> Loc {
+        self.r.loc()
+    }
+
+    pub proof fn new(tracked v: T) -> (tracked result: Self)
+        requires
+            TOTAL > 0,
+    {
+        let f = FractionalCarrierOpt::<T, TOTAL>::Value { v: None, n: TOTAL as int };
+        let tracked mut m = Map::<(), T>::tracked_empty();
+        let tracked r = StorageResource::alloc(f, m);
+        Self { r }
+    }
+
+    pub proof fn put_resource(tracked self, tracked resource: T) -> (tracked frac: Frac<T, TOTAL>)
+        ensures
+            frac.id() == self.id(),
+            frac.resource() == resource,
+            frac.frac() == TOTAL,
+    {
+        use_type_invariant(&self);
+        self.r.validate();
+        let p1 = self.r.value();
+        let b1 = map![() => resource];
+        let p2 = FractionalCarrierOpt::Value { v: Some(resource), n: TOTAL as int };
+        assert forall|q: FractionalCarrierOpt<T, TOTAL>, t1: Map<(), T>|
+            #![all_triggers]
+            FractionalCarrierOpt::rel(FractionalCarrierOpt::op(p1, q), t1) implies exists|
+            t2: Map<(), T>,
+        |
+            #![all_triggers]
+            FractionalCarrierOpt::rel(FractionalCarrierOpt::op(p2, q), t2) && t1.dom().disjoint(
+                b1.dom(),
+            ) && t1.union_prefer_right(b1) =~= t2 by {
+            let t2 = map![() => resource];
+            assert(FractionalCarrierOpt::rel(FractionalCarrierOpt::op(p2, q), t2)
+                && t1.dom().disjoint(b1.dom()) && t1.union_prefer_right(b1) =~= t2);
+        }
+        let tracked mut m = Map::tracked_empty();
+        m.tracked_insert((), resource);
+        let tracked Self { r } = self;
+        let tracked new_r = r.deposit(m, p2);
+        Frac { r: new_r }
+    }
+}
 
 /// A struct that stores and dispatches `FracGhost<T>`.
 /// Unlike `FracGhost`, it provides an `empty` state.

--- a/vstd_extra/src/resource/pcm/agree.rs
+++ b/vstd_extra/src/resource/pcm/agree.rs
@@ -2,9 +2,9 @@
 //!
 //! For Iris definition, see:
 //! <https://gitlab.mpi-sws.org/iris/iris/-/blob/master/iris/algebra/agree.v>
+use vstd::prelude::*;
 use vstd::resource::algebra::ResourceAlgebra;
 use vstd::resource::pcm::PCM;
-use vstd::prelude::*;
 
 verus! {
 

--- a/vstd_extra/src/resource/pcm/agree.rs
+++ b/vstd_extra/src/resource/pcm/agree.rs
@@ -2,7 +2,8 @@
 //!
 //! For Iris definition, see:
 //! <https://gitlab.mpi-sws.org/iris/iris/-/blob/master/iris/algebra/agree.v>
-use vstd::pcm::PCM;
+use vstd::resource::algebra::ResourceAlgebra;
+use vstd::resource::pcm::PCM;
 use vstd::prelude::*;
 
 verus! {
@@ -19,14 +20,14 @@ pub ghost enum AgreeR<A> {
     AgreeInvalid,
 }
 
-impl<A: PartialEq> PCM for AgreeR<A> {
+impl<A: PartialEq> ResourceAlgebra for AgreeR<A> {
     open spec fn valid(self) -> bool {
         self !is AgreeInvalid
     }
 
     /// Composition: two agreeing values must be equal.
-    open spec fn op(self, other: Self) -> Self {
-        match (self, other) {
+    open spec fn op(a: Self, b: Self) -> Self {
+        match (a, b) {
             (AgreeR::Unit, x) => x,
             (x, AgreeR::Unit) => x,
             (AgreeR::Agree(a), AgreeR::Agree(b)) => {
@@ -40,11 +41,7 @@ impl<A: PartialEq> PCM for AgreeR<A> {
         }
     }
 
-    open spec fn unit() -> Self {
-        AgreeR::Unit
-    }
-
-    proof fn closed_under_incl(a: Self, b: Self) {
+    proof fn valid_op(a: Self, b: Self) {
     }
 
     proof fn commutative(a: Self, b: Self) {
@@ -52,8 +49,14 @@ impl<A: PartialEq> PCM for AgreeR<A> {
 
     proof fn associative(a: Self, b: Self, c: Self) {
     }
+}
 
-    proof fn op_unit(a: Self) {
+impl<A: PartialEq> PCM for AgreeR<A> {
+    open spec fn unit() -> Self {
+        AgreeR::Unit
+    }
+
+    proof fn op_unit(self) {
     }
 
     proof fn unit_valid() {

--- a/vstd_extra/src/resource/pcm/csum.rs
+++ b/vstd_extra/src/resource/pcm/csum.rs
@@ -2,7 +2,8 @@
 //!
 //! For Iris definition, see:
 //! <https://gitlab.mpi-sws.org/iris/iris/-/blob/master/iris/algebra/csum.v>
-use vstd::pcm::PCM;
+use vstd::resource::algebra::ResourceAlgebra;
+use vstd::resource::pcm::PCM;
 use vstd::prelude::*;
 
 verus! {
@@ -18,7 +19,7 @@ pub ghost enum CsumR<A, B> {
     CsumInvalid,
 }
 
-impl<A: PCM, B: PCM> PCM for CsumR<A, B> {
+impl<A: PCM, B: PCM> ResourceAlgebra for CsumR<A, B> {
     open spec fn valid(self) -> bool {
         match self {
             CsumR::Unit => true,
@@ -28,8 +29,8 @@ impl<A: PCM, B: PCM> PCM for CsumR<A, B> {
         }
     }
 
-    open spec fn op(self, other: Self) -> Self {
-        match (self, other) {
+    open spec fn op(a: Self, b: Self) -> Self {
+        match (a, b) {
             (CsumR::Unit, x) => x,
             (x, CsumR::Unit) => x,
             (CsumR::Cinl(a1), CsumR::Cinl(a2)) => CsumR::Cinl(A::op(a1, a2)),
@@ -38,18 +39,14 @@ impl<A: PCM, B: PCM> PCM for CsumR<A, B> {
         }
     }
 
-    open spec fn unit() -> Self {
-        CsumR::Unit
-    }
-
-    proof fn closed_under_incl(a: Self, b: Self) {
+    proof fn valid_op(a: Self, b: Self) {
         if Self::op(a, b).valid() {
             match (a, b) {
                 (CsumR::Cinl(a1), CsumR::Cinl(a2)) => {
-                    A::closed_under_incl(a1, a2);
+                    A::valid_op(a1, a2);
                 },
                 (CsumR::Cinr(b1), CsumR::Cinr(b2)) => {
-                    B::closed_under_incl(b1, b2);
+                    B::valid_op(b1, b2);
                 },
                 _ => {},
             }
@@ -79,8 +76,14 @@ impl<A: PCM, B: PCM> PCM for CsumR<A, B> {
             _ => {},
         }
     }
+}
 
-    proof fn op_unit(a: Self) {
+impl<A: PCM, B: PCM> PCM for CsumR<A, B> {
+    open spec fn unit() -> Self {
+        CsumR::Unit
+    }
+
+    proof fn op_unit(self) {
     }
 
     proof fn unit_valid() {

--- a/vstd_extra/src/resource/pcm/csum.rs
+++ b/vstd_extra/src/resource/pcm/csum.rs
@@ -2,9 +2,9 @@
 //!
 //! For Iris definition, see:
 //! <https://gitlab.mpi-sws.org/iris/iris/-/blob/master/iris/algebra/csum.v>
+use vstd::prelude::*;
 use vstd::resource::algebra::ResourceAlgebra;
 use vstd::resource::pcm::PCM;
-use vstd::prelude::*;
 
 verus! {
 

--- a/vstd_extra/src/resource/pcm/excl.rs
+++ b/vstd_extra/src/resource/pcm/excl.rs
@@ -2,9 +2,9 @@
 //!
 //! For Iris definition, see:
 //! <https://gitlab.mpi-sws.org/iris/iris/-/blob/master/iris/algebra/excl.v>
+use vstd::prelude::*;
 use vstd::resource::algebra::ResourceAlgebra;
 use vstd::resource::pcm::PCM;
-use vstd::prelude::*;
 
 verus! {
 

--- a/vstd_extra/src/resource/pcm/excl.rs
+++ b/vstd_extra/src/resource/pcm/excl.rs
@@ -2,7 +2,8 @@
 //!
 //! For Iris definition, see:
 //! <https://gitlab.mpi-sws.org/iris/iris/-/blob/master/iris/algebra/excl.v>
-use vstd::pcm::PCM;
+use vstd::resource::algebra::ResourceAlgebra;
+use vstd::resource::pcm::PCM;
 use vstd::prelude::*;
 
 verus! {
@@ -19,25 +20,21 @@ pub ghost enum ExclR<A> {
     ExclInvalid,
 }
 
-impl<A> PCM for ExclR<A> {
+impl<A> ResourceAlgebra for ExclR<A> {
     open spec fn valid(self) -> bool {
         self !is ExclInvalid
     }
 
     // Composition of two non-unit elements is always invalid.
-    open spec fn op(self, other: Self) -> Self {
-        match (self, other) {
+    open spec fn op(a: Self, b: Self) -> Self {
+        match (a, b) {
             (ExclR::Unit, x) => x,
             (x, ExclR::Unit) => x,
             _ => ExclR::ExclInvalid,
         }
     }
 
-    open spec fn unit() -> Self {
-        ExclR::Unit
-    }
-
-    proof fn closed_under_incl(a: Self, b: Self) {
+    proof fn valid_op(a: Self, b: Self) {
     }
 
     proof fn commutative(a: Self, b: Self) {
@@ -45,8 +42,14 @@ impl<A> PCM for ExclR<A> {
 
     proof fn associative(a: Self, b: Self, c: Self) {
     }
+}
 
-    proof fn op_unit(a: Self) {
+impl<A> PCM for ExclR<A> {
+    open spec fn unit() -> Self {
+        ExclR::Unit
+    }
+
+    proof fn op_unit(self) {
     }
 
     proof fn unit_valid() {

--- a/vstd_extra/src/resource/pcm/frac.rs
+++ b/vstd_extra/src/resource/pcm/frac.rs
@@ -8,7 +8,8 @@
 //! For Iris definition, see:
 //! <https://gitlab.mpi-sws.org/iris/iris/-/blob/master/iris/algebra/frac.v>
 use vstd::arithmetic::*;
-use vstd::pcm::PCM;
+use vstd::resource::algebra::ResourceAlgebra;
+use vstd::resource::pcm::PCM;
 use vstd::prelude::*;
 
 verus! {
@@ -21,7 +22,7 @@ pub ghost enum FracR<T> {
     Invalid,
 }
 
-impl<T: PartialEq> PCM for FracR<T> {
+impl<T: PartialEq> ResourceAlgebra for FracR<T> {
     open spec fn valid(self) -> bool {
         match self {
             FracR::Unit => true,
@@ -31,8 +32,8 @@ impl<T: PartialEq> PCM for FracR<T> {
     }
 
     /// Two Frac combine iff they agree on the value and the sum of fractions does not exceed 1.0. This follows the original Iris design.
-    open spec fn op(self, other: Self) -> Self {
-        match (self, other) {
+    open spec fn op(a: Self, b: Self) -> Self {
+        match (a, b) {
             (FracR::Unit, x) => x,
             (x, FracR::Unit) => x,
             (FracR::Frac(q1, a1), FracR::Frac(q2, a2)) => {
@@ -46,11 +47,7 @@ impl<T: PartialEq> PCM for FracR<T> {
         }
     }
 
-    open spec fn unit() -> Self {
-        FracR::Unit
-    }
-
-    proof fn closed_under_incl(a: Self, b: Self) {
+    proof fn valid_op(a: Self, b: Self) {
     }
 
     proof fn commutative(a: Self, b: Self) {
@@ -58,8 +55,14 @@ impl<T: PartialEq> PCM for FracR<T> {
 
     proof fn associative(a: Self, b: Self, c: Self) {
     }
+}
 
-    proof fn op_unit(a: Self) {
+impl<T: PartialEq> PCM for FracR<T> {
+    open spec fn unit() -> Self {
+        FracR::Unit
+    }
+
+    proof fn op_unit(self) {
     }
 
     proof fn unit_valid() {

--- a/vstd_extra/src/resource/pcm/frac.rs
+++ b/vstd_extra/src/resource/pcm/frac.rs
@@ -8,9 +8,9 @@
 //! For Iris definition, see:
 //! <https://gitlab.mpi-sws.org/iris/iris/-/blob/master/iris/algebra/frac.v>
 use vstd::arithmetic::*;
+use vstd::prelude::*;
 use vstd::resource::algebra::ResourceAlgebra;
 use vstd::resource::pcm::PCM;
-use vstd::prelude::*;
 
 verus! {
 

--- a/vstd_extra/src/resource/storage_protocol/csum.rs
+++ b/vstd_extra/src/resource/storage_protocol/csum.rs
@@ -3,11 +3,11 @@ use core::panic;
 
 use crate::sum::*;
 use vstd::math::add;
-use vstd::resource::Loc;
 use vstd::pervasive::arbitrary;
 use vstd::prelude::*;
 use vstd::prelude::*;
 use vstd::resource::storage_protocol::*;
+use vstd::resource::Loc;
 
 verus! {
 

--- a/vstd_extra/src/resource/storage_protocol/csum.rs
+++ b/vstd_extra/src/resource/storage_protocol/csum.rs
@@ -3,11 +3,11 @@ use core::panic;
 
 use crate::sum::*;
 use vstd::math::add;
-use vstd::pcm::Loc;
+use vstd::resource::Loc;
 use vstd::pervasive::arbitrary;
 use vstd::prelude::*;
 use vstd::prelude::*;
-use vstd::storage_protocol::*;
+use vstd::resource::storage_protocol::*;
 
 verus! {
 

--- a/vstd_extra/src/resource/storage_protocol/excl.rs
+++ b/vstd_extra/src/resource/storage_protocol/excl.rs
@@ -1,7 +1,7 @@
 //! Exclusive storage protocol resource algebra.
-use vstd::pcm::Loc;
+use vstd::resource::Loc;
 use vstd::prelude::*;
-use vstd::storage_protocol::*;
+use vstd::resource::storage_protocol::*;
 
 verus! {
 

--- a/vstd_extra/src/resource/storage_protocol/excl.rs
+++ b/vstd_extra/src/resource/storage_protocol/excl.rs
@@ -1,7 +1,7 @@
 //! Exclusive storage protocol resource algebra.
-use vstd::resource::Loc;
 use vstd::prelude::*;
 use vstd::resource::storage_protocol::*;
+use vstd::resource::Loc;
 
 verus! {
 

--- a/vstd_extra/src/resource/storage_protocol/frac.rs
+++ b/vstd_extra/src/resource/storage_protocol/frac.rs
@@ -1,8 +1,8 @@
 //! Real-based fractional permissions storage protocol.
 use vstd::map::*;
-use vstd::pcm::Loc;
+use vstd::resource::Loc;
 use vstd::prelude::*;
-use vstd::storage_protocol::*;
+use vstd::resource::storage_protocol::*;
 
 verus! {
 

--- a/vstd_extra/src/resource/storage_protocol/frac.rs
+++ b/vstd_extra/src/resource/storage_protocol/frac.rs
@@ -1,8 +1,8 @@
 //! Real-based fractional permissions storage protocol.
 use vstd::map::*;
-use vstd::resource::Loc;
 use vstd::prelude::*;
 use vstd::resource::storage_protocol::*;
+use vstd::resource::Loc;
 
 verus! {
 

--- a/vstd_extra/src/resource/storage_protocol/hybrid_product.rs
+++ b/vstd_extra/src/resource/storage_protocol/hybrid_product.rs
@@ -1,8 +1,8 @@
 //! Product of a PCM and a storage-protocol resource algebra.
 use core::marker::PhantomData;
-use vstd::pcm::PCM;
+use vstd::resource::pcm::PCM;
 use vstd::prelude::*;
-use vstd::storage_protocol::*;
+use vstd::resource::storage_protocol::*;
 
 verus! {
 
@@ -17,7 +17,7 @@ pub ghost struct HybridProduct<P: PCM, S: Protocol<K, V>, K, V> {
 impl<P, S, K, V> Protocol<K, V> for HybridProduct<P, S, K, V> where P: PCM, S: Protocol<K, V> {
     open spec fn op(self, other: Self) -> Self {
         HybridProduct {
-            pcm: self.pcm.op(other.pcm),
+            pcm: P::op(self.pcm, other.pcm),
             protocol: self.protocol.op(other.protocol),
             _phantom: PhantomData,
         }

--- a/vstd_extra/src/resource/storage_protocol/hybrid_product.rs
+++ b/vstd_extra/src/resource/storage_protocol/hybrid_product.rs
@@ -1,7 +1,7 @@
 //! Product of a PCM and a storage-protocol resource algebra.
 use core::marker::PhantomData;
-use vstd::resource::pcm::PCM;
 use vstd::prelude::*;
+use vstd::resource::pcm::PCM;
 use vstd::resource::storage_protocol::*;
 
 verus! {


### PR DESCRIPTION
Since Verus have enabled the `new-mut-ref` by default in https://github.com/verus-lang/verus/pull/2393, we do not need to add `-V new-mut-ref` now.

And the token methods in VSTD are updated largely, the KVerus ports the old token code  back in the vstd_extra.
Maybe @rikosellic could have a better method?