### PR TITLE
Retire `pcell_borrow_mut`

### DIFF
--- a/ostd/src/sync/mutex.rs
+++ b/ostd/src/sync/mutex.rs
@@ -252,7 +252,7 @@ impl<T/* : ?Sized */> DerefMut for MutexGuard<'_, T> {
             use_type_invariant(&*self);
         }
         //unsafe { &mut *self.mutex.val.get() }
-        pcell_borrow_mut(&self.mutex.val, &mut self.v_perm)
+        self.mutex.val.borrow_mut(Tracked(&mut *self.v_perm))
     }
 } 
 

--- a/ostd/src/sync/rwlock.rs
+++ b/ostd/src/sync/rwlock.rs
@@ -897,7 +897,7 @@ impl<T  /*: ?Sized*/ , G: SpinGuardian> DerefMut for RwLockWriteGuard<'_, T, G> 
             use_type_invariant(&*self);
         }
         //unsafe { &mut *self.inner.val.get() }
-        pcell_borrow_mut(&self.inner.val, &mut self.v_perm)
+        self.inner.val.borrow_mut(Tracked(&mut *self.v_perm))
     }
 }
 

--- a/ostd/src/sync/rwmutex.rs
+++ b/ostd/src/sync/rwmutex.rs
@@ -3,7 +3,6 @@ use vstd::atomic_ghost::*;
 use vstd::cell::{self, pcell::*, CellId};
 use vstd::prelude::*;
 use vstd::resource::Loc;
-use vstd_extra::auxiliary::pcell_borrow_mut;
 use vstd_extra::resource::ghost_resource::{count::*, csum::*, excl::*, tokens::*};
 use vstd_extra::sum::*;
 
@@ -853,7 +852,7 @@ impl<T /*: ?Sized*/ > DerefMut for RwMutexWriteGuard<'_, T> {
             use_type_invariant(&*self);
         }
         //unsafe { &mut *self.inner.val.get() }
-        pcell_borrow_mut(&self.inner.val, &mut self.v_perm)
+        self.inner.val.borrow_mut(Tracked(&mut *self.v_perm))
     }
 }
 

--- a/ostd/src/sync/spin.rs
+++ b/ostd/src/sync/spin.rs
@@ -437,7 +437,7 @@ impl<T: /* ?Sized */, G: SpinGuardian> DerefMut for SpinLockGuard<'_, T, G> {
             use_type_invariant(&*self);
         }
         // unsafe { &mut *self.lock.inner.val.get() }
-        pcell_borrow_mut(&self.lock.inner.val, &mut self.v_perm)
+        self.lock.inner.val.borrow_mut(Tracked(&mut *self.v_perm))
     }
 }
 }

--- a/vstd_extra/src/auxiliary.rs
+++ b/vstd_extra/src/auxiliary.rs
@@ -16,20 +16,4 @@ pub axiom fn axiom_permission_u64_ext_eq(p1: PermissionU64, p2: PermissionU64)
         p1 == p2,
 ;
 
-/// A Verus version of `unsafe { &mut *cell.get() }` for `UnsafeCell<T>`.
-/// FIXME: Waiting for official support from Verus.
-#[verifier::external_body]
-pub exec fn pcell_borrow_mut<'a, T>(cell: &'a PCell<T>, perm: &'a mut Tracked<PointsTo<T>>) -> (res:
-    &'a mut T)
-    requires
-        cell.id() == perm.id(),
-    ensures
-        *final(res) == *final(perm).value(),
-        final(perm).id() == old(perm).id(),
-    no_unwind
-{
-    // SAFETY: the caller must ensure that `perm` is a valid permission for `cell`.
-    unimplemented!();
-}
-
 } // verus!


### PR DESCRIPTION
It is now covered by `vstd`.