### PR TITLE
Replace `Some_0` with `0`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -39,4 +39,12 @@
         "miri",
         "verus_keep_ghost"
     ],
+    "verus-analyzer.check.overrideCommand": [
+        "cargo",
+        "dv",
+        "verify",
+        "--targets",
+        "ostd",
+    ],
+    "verus-analyzer.checkOnSave": false,
 }

--- a/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
+++ b/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
@@ -46,8 +46,8 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> Repr<MetaSlotStorage> for Link<M> {
                 &&& M::wf(link.slot, perm.storage)
                 &&& (link.next is Some) == (perm.next_ptr is Some)
                 &&& (link.prev is Some) == (perm.prev_ptr is Some)
-                &&& link.next is Some ==> link.next->Some_0 == perm.next_ptr->Some_0.addr()
-                &&& link.prev is Some ==> link.prev->Some_0 == perm.prev_ptr->Some_0.addr()
+                &&& link.next is Some ==> link.next->0 == perm.next_ptr->0.addr()
+                &&& link.prev is Some ==> link.prev->0 == perm.prev_ptr->0.addr()
             },
             _ => false,
         }

--- a/ostd/specs/mm/virt_mem_newer.rs
+++ b/ostd/specs/mm/virt_mem_newer.rs
@@ -117,7 +117,7 @@ impl MemView {
     ///
     /// Equivalent to resolving via [`Self::addr_transl`] and reading from [`Self::memory`].
     pub open spec fn read(self, va: usize) -> raw_ptr::MemContents<u8> {
-        let (pa, off) = self.addr_transl(va)->Some_0;
+        let (pa, off) = self.addr_transl(va)->0;
         self.memory[pa].contents[off as int]
     }
 
@@ -125,7 +125,7 @@ impl MemView {
     ///
     /// Returns a new [`MemView`] with one byte updated, preserving all mappings.
     pub open spec fn write(self, va: usize, x: u8) -> Self {
-        let (pa, off) = self.addr_transl(va)->Some_0;
+        let (pa, off) = self.addr_transl(va)->0;
         MemView {
             memory: self.memory.insert(pa, FrameContents {
                 contents: self.memory[pa].contents.update(off as int, raw_ptr::MemContents::Init(x)),
@@ -137,8 +137,8 @@ impl MemView {
 
     /// Whether two virtual addresses denote equal byte contents in this view.
     pub open spec fn eq_at(self, va1: usize, va2: usize) -> bool {
-        let (pa1, off1) = self.addr_transl(va1)->Some_0;
-        let (pa2, off2) = self.addr_transl(va2)->Some_0;
+        let (pa1, off1) = self.addr_transl(va1)->0;
+        let (pa2, off2) = self.addr_transl(va2)->0;
         self.memory[pa1].contents[off1 as int] == self.memory[pa2].contents[off2 as int]
     }
 

--- a/ostd/src/sync/mutex.rs
+++ b/ostd/src/sync/mutex.rs
@@ -34,7 +34,7 @@ closed spec fn wf(self) -> bool {
     invariant on lock with (val) is (v: bool, g: Option<PointsTo<T>>) {
         let active_guard = g is None;
         &&& v <==> active_guard
-        &&& g is Some ==> g->Some_0.id() == val.id()
+        &&& g is Some ==> g->0.id() == val.id()
     }
 }
 }
@@ -118,7 +118,7 @@ impl<T  /* : ?Sized */ > Mutex<T> {
         with
             -> locked_state: Tracked<Option<PointsTo<T>>>,
         ensures
-            ret ==> locked_state@ is Some && locked_state@->Some_0.id() == self.cell_id(),
+            ret ==> locked_state@ is Some && locked_state@->0.id() == self.cell_id(),
             !ret ==> locked_state@ is None,
     )]
     fn acquire_lock(&self) -> bool {

--- a/ostd/src/sync/once.rs
+++ b/ostd/src/sync/once.rs
@@ -86,7 +86,7 @@ pub closed spec fn wf(&self) -> bool {
                 &&& v == INITED
                 &&& points_to.id() == cell.id()
                 &&& points_to.value() is Some
-                &&& f@.inv(points_to.value()->Some_0)
+                &&& f@.inv(points_to.value()->0)
             }
         }
     }

--- a/ostd/src/sync/rwlock.rs
+++ b/ostd/src/sync/rwlock.rs
@@ -254,12 +254,12 @@ closed spec fn wf(self) -> bool {
         &&& g.read_retract_token.id() == v_id@.read_retract_token_id
         &&& g.upread_retract_token is Some ==>
             {
-                let token = g.upread_retract_token->Some_0;
+                let token = g.upread_retract_token->0;
                 &&& token.wf()
                 &&& token.id() == v_id@.upread_retract_token_id
             }
         &&& g.upreader_guard_token is Some ==> {
-            let token = g.upreader_guard_token->Some_0;
+            let token = g.upreader_guard_token->0;
             wf_upgradeable_guard_token(v_id@.core_token_id, v_id@.frac_id, val.id(), token)
         }
         &&& match g.read_guard_token {

--- a/ostd/src/sync/rwmutex.rs
+++ b/ostd/src/sync/rwmutex.rs
@@ -197,12 +197,12 @@ closed spec fn wf(self) -> bool {
         &&& g.read_retract_token.wf()
         &&& g.read_retract_token.id() == v_id@.read_retract_token_id
         &&& g.upread_retract_token is Some ==> {
-            let token = g.upread_retract_token->Some_0;
+            let token = g.upread_retract_token->0;
             &&& token.wf()
             &&& token.id() == v_id@.upread_retract_token_id
         }
         &&& g.upreader_guard_token is Some ==> {
-            let token = g.upreader_guard_token->Some_0;
+            let token = g.upreader_guard_token->0;
             wf_upgradeable_guard_token(v_id@.core_token_id, v_id@.frac_id, val.id(), token)
         }
         &&& match g.read_guard_token {

--- a/vstd_extra/src/external/nonzero.rs
+++ b/vstd_extra/src/external/nonzero.rs
@@ -141,7 +141,7 @@ impl OrdSpecImpl for NonZeroUsize {
     }
 
     open spec fn cmp_spec(&self, other: &Self) -> Ordering {
-        vstd::std_specs::cmp::PartialOrdSpec::partial_cmp_spec(self, other)->Some_0
+        vstd::std_specs::cmp::PartialOrdSpec::partial_cmp_spec(self, other)->0
     }
 }
 

--- a/vstd_extra/src/ghost_tree.rs
+++ b/vstd_extra/src/ghost_tree.rs
@@ -403,7 +403,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             &&& f(self.value, path)
             &&& forall|i: int|
                 0 <= i < self.children.len() ==> (#[trigger] self.children[i]) is Some
-                    ==> self.children[i]->Some_0.tree_predicate_map(path.push_tail(i as usize), f)
+                    ==> self.children[i]->0.tree_predicate_map(path.push_tail(i as usize), f)
         } else {
             &&& f(self.value, path)
         }
@@ -422,7 +422,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             self.children[i] is Some,
             self.tree_predicate_map(path, f),
         ensures
-            self.children[i]->Some_0.tree_predicate_map(path.push_tail(i as usize), f),
+            self.children[i]->0.tree_predicate_map(path.push_tail(i as usize), f),
     {
     }
 
@@ -450,13 +450,13 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
     {
         if self.level < L - 1 {
             assert forall|i: int|
-                #![trigger self.children[i]->Some_0]
+                #![trigger self.children[i]->0]
                 0 <= i < self.children.len()
-                    && self.children[i] is Some implies self.children[i]->Some_0.tree_predicate_map(
+                    && self.children[i] is Some implies self.children[i]->0.tree_predicate_map(
                 path.push_tail(i as usize),
                 g,
             ) by {
-                self.children[i]->Some_0.map_implies(path.push_tail(i as usize), f, g);
+                self.children[i]->0.map_implies(path.push_tail(i as usize), f, g);
             }
         }
     }
@@ -515,13 +515,13 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
     {
         if self.level < L - 1 {
             assert forall|i: int|
-                #![trigger self.children[i]->Some_0]
+                #![trigger self.children[i]->0]
                 0 <= i < self.children.len()
-                    && self.children[i] is Some implies self.children[i]->Some_0.tree_predicate_map(
+                    && self.children[i] is Some implies self.children[i]->0.tree_predicate_map(
                 path.push_tail(i as usize),
                 g,
             ) by {
-                self.children[i]->Some_0.map_implies_and(path.push_tail(i as usize), f1, f2, g);
+                self.children[i]->0.map_implies_and(path.push_tail(i as usize), f1, f2, g);
             }
         }
     }
@@ -716,9 +716,9 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             ) is None,
             self.level < L - 1 && self.children[key as int] is Some ==> #[trigger] self.child(
                 key,
-            ) is Some && self.child(key)->Some_0.level == self.level + 1 && self.child(
+            ) is Some && self.child(key)->0.level == self.level + 1 && self.child(
                 key,
-            )->Some_0.inv(),
+            )->0.inv(),
     {
     }
 
@@ -729,8 +729,8 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             self.child(key) is Some,
         ensures
             self.level < L - 1,
-            self.child(key)->Some_0.level == self.level + 1,
-            self.child(key)->Some_0.inv(),
+            self.child(key)->0.level == self.level + 1,
+            self.child(key)->0.inv(),
     {
         self.child_property(key);
         self.child_property_cases(key);
@@ -790,7 +790,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             forall|i: int|
                 0 <= i < N ==> #[trigger] self.children[i] is Some ==> value.rel_children(
                     i,
-                    Some(self.children[i]->Some_0.value),
+                    Some(self.children[i]->0.value),
                 ),
             forall|i: int|
                 0 <= i < N ==> #[trigger] self.children[i] is None ==> value.rel_children(i, None),
@@ -811,7 +811,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
                 None => n.value.rel_children(i, None),
             } by {
                 if n.children[i] is Some {
-                    let child = n.children[i]->Some_0;
+                    let child = n.children[i]->0;
                 }
             }
         }
@@ -894,7 +894,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             self.child(path.index(0)) is Some ==> #[trigger] self.recursive_insert(path, node)
                 == self.insert(
                 path.index(0),
-                self.child(path.index(0))->Some_0.recursive_insert(path.pop_head().1, node),
+                self.child(path.index(0))->0.recursive_insert(path.pop_head().1, node),
             ),
             self.child(path.index(0)) is None ==> #[trigger] self.recursive_insert(path, node)
                 == self.insert(
@@ -932,7 +932,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             let (hd, tl) = path.pop_head();
             path.pop_head_preserves_inv();
             if self.child(hd) is Some {
-                let c = self.child(hd)->Some_0;
+                let c = self.child(hd)->0;
                 self.child_some_properties(hd);
                 assert(self.insert(hd, c.recursive_insert(tl, node)).level == self.level);
             } else {
@@ -969,7 +969,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             let (hd, tl) = path.pop_head();
             path.pop_head_preserves_inv();
             if self.child(hd) is Some {
-                let c = self.child(hd)->Some_0;
+                let c = self.child(hd)->0;
                 self.child_some_properties(hd);
                 c.lemma_recursive_insert_preserves_value(tl, node);
                 let updated_child = c.recursive_insert(tl, node);
@@ -991,7 +991,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             node.level == self.level + path.len() as nat,
             self.recursive_seek(path.pop_tail().1) is Some ==> self.recursive_seek(
                 path.pop_tail().1,
-            )->Some_0.value.rel_children(path.pop_tail().0 as int, Some(node.value)),
+            )->0.value.rel_children(path.pop_tail().0 as int, Some(node.value)),
             self.recursive_seek(path.pop_tail().1) is None ==> T::default(
                 (node.level - 1) as nat,
             ).rel_children(path.pop_tail().0 as int, Some(node.value)),
@@ -1012,7 +1012,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             let (hd, tl) = path.pop_head();
             path.pop_head_preserves_inv();
             if self.child(hd) is Some {
-                let c = self.child(hd)->Some_0;
+                let c = self.child(hd)->0;
                 self.child_some_properties(hd);
                 assert(path.pop_tail().1.pop_head().1 == path.pop_head().1.pop_tail().1);
                 c.lemma_recursive_insert_preserves_inv(tl, node);
@@ -1153,14 +1153,14 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
     pub proof fn lemma_recursive_seek_trace_next(self, path: TreePath<N>, idx: usize)
         requires
             self.recursive_seek(path) is Some,
-            self.recursive_seek(path)->Some_0.children[idx as int] is Some,
+            self.recursive_seek(path)->0.children[idx as int] is Some,
             self.inv(),
             path.inv(),
             path.len() < L - self.level,
             0 <= idx < N,
         ensures
             self.recursive_trace(path.push_tail(idx)).len() == path.len() + 2,
-            self.recursive_seek(path)->Some_0.children[idx as int]->Some_0.value
+            self.recursive_seek(path)->0.children[idx as int]->0.value
                 == self.recursive_trace(path.push_tail(idx))[path.len() as int + 1],
         decreases path.len(),
     {
@@ -1169,7 +1169,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
         if path.len() == 0 {
             assert(self.recursive_trace(path2) =~= seq![
                 self.value,
-                self.children[idx as int]->Some_0.value,
+                self.children[idx as int]->0.value,
             ]) by { reveal_with_fuel(Node::recursive_trace, 2) }
         } else {
             let (hd1, tl1) = path.pop_head();
@@ -1234,7 +1234,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             let (hd, tl) = path.pop_head();
             path.pop_head_preserves_inv();
             if self.child(hd) is Some {
-                let c = self.child(hd)->Some_0;
+                let c = self.child(hd)->0;
                 assert(self.recursive_visit(path) =~= seq![c].add(c.recursive_visit(tl)));
                 c.lemma_recursive_visited_node_inv(tl);
             }
@@ -1261,7 +1261,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             let (hd, tl) = path.pop_head();
             path.pop_head_preserves_inv();
             if self.child(hd) is Some {
-                let c = self.child(hd)->Some_0;
+                let c = self.child(hd)->0;
                 assert(self.recursive_visit(path) =~= seq![c].add(c.recursive_visit(tl)));
                 c.lemma_recursive_visited_node_levels(tl);
             }
@@ -1276,7 +1276,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             !path.is_empty(),
             self.recursive_visit(path).len() > 0,
         ensures
-            self.recursive_visit(path).index(0) == self.child(path.index(0))->Some_0,
+            self.recursive_visit(path).index(0) == self.child(path.index(0))->0,
     {
         if path.len() == 0 {
         } else if path.len() == 1 {
@@ -1297,8 +1297,8 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             self.recursive_visit(path).len() > 0,
         ensures
             #[trigger] self.recursive_visit(path) == seq![
-                self.child(path.pop_head().0)->Some_0,
-            ].add(self.child(path.pop_head().0)->Some_0.recursive_visit(path.pop_head().1)),
+                self.child(path.pop_head().0)->0,
+            ].add(self.child(path.pop_head().0)->0.recursive_visit(path.pop_head().1)),
     {
         if path.len() == 1 {
             let (hd, tl) = path.pop_head();
@@ -1307,7 +1307,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             let c = self.child(hd);
             if c is None {
             } else {
-                let c = c->Some_0;
+                let c = c->0;
             }
         } else {
             let (hd, tl) = path.pop_head();
@@ -1317,7 +1317,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             let c = self.child(hd);
             if c is None {
             } else {
-                let c = c->Some_0;
+                let c = c->0;
                 self.lemma_recursive_visit_head(path);
             }
         }
@@ -1331,7 +1331,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             path.len() == 1,
         ensures
             self.child(path.index(0)) is Some ==> #[trigger] self.recursive_visit(path) =~= seq![
-                self.child(path.index(0))->Some_0,
+                self.child(path.index(0))->0,
             ],
             self.child(path.index(0)) is None ==> #[trigger] self.recursive_visit(path) =~= seq![],
     {
@@ -1394,10 +1394,10 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             self.inv(),
             self.child(key) is Some,
         ensures
-            #[trigger] self.on_subtree(self.child(key)->Some_0),
+            #[trigger] self.on_subtree(self.child(key)->0),
     {
         let path = TreePath::<N>::new(seq![key]);
-        let c = self.child(key)->Some_0;
+        let c = self.child(key)->0;
         assert(path.inv());
     }
 
@@ -1437,7 +1437,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             if self.child(hd) is None {
                 self
             } else {
-                let child = self.child(hd)->Some_0;
+                let child = self.child(hd)->0;
                 let updated_child = child.recursive_remove(tl);
                 self.insert(hd, updated_child)
             }
@@ -1460,7 +1460,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             let (hd, tl) = path.pop_head();
             path.pop_head_preserves_inv();
             if self.child(hd) is Some {
-                let c = self.child(hd)->Some_0;
+                let c = self.child(hd)->0;
                 self.child_some_properties(hd);
                 c.lemma_recursive_remove_preserves_level(tl);
             }
@@ -1483,7 +1483,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             let (hd, tl) = path.pop_head();
             path.pop_head_preserves_inv();
             if self.child(hd) is Some {
-                let c = self.child(hd)->Some_0;
+                let c = self.child(hd)->0;
                 self.child_some_properties(hd);
                 c.lemma_recursive_remove_preserves_value(tl);
             }
@@ -1498,9 +1498,9 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             path.len() > 0 ==> self.recursive_seek(path.pop_tail().1) is Some
                 ==> self.recursive_seek(
                 path.pop_tail().1,
-            )->Some_0.children[path.pop_tail().0 as int] is None || self.recursive_seek(
+            )->0.children[path.pop_tail().0 as int] is None || self.recursive_seek(
                 path.pop_tail().1,
-            )->Some_0.value.rel_children(path.pop_tail().0 as int, None),
+            )->0.value.rel_children(path.pop_tail().0 as int, None),
         ensures
             #[trigger] self.recursive_remove(path).inv(),
         decreases path.len(),
@@ -1514,7 +1514,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             let (hd, tl) = path.pop_head();
             path.pop_head_preserves_inv();
             if self.child(hd) is Some {
-                let c = self.child(hd)->Some_0;
+                let c = self.child(hd)->0;
                 self.child_some_properties(hd);
                 assert(path.pop_tail().1.pop_head().1 == path.pop_head().1.pop_tail().1);
                 c.lemma_recursive_remove_preserves_inv(tl);
@@ -1706,14 +1706,14 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
     pub proof fn lemma_seek_trace_next(self, path: TreePath<N>, idx: usize)
         requires
             self.seek(path) is Some,
-            self.seek(path)->Some_0.children[idx as int] is Some,
+            self.seek(path)->0.children[idx as int] is Some,
             self.inv(),
             path.inv(),
             path.len() < L,
             0 <= idx < N,
         ensures
             self.trace(path.push_tail(idx)).len() == path.len() + 2,
-            self.seek(path)->Some_0.children[idx as int]->Some_0.value == self.trace(
+            self.seek(path)->0.children[idx as int]->0.value == self.trace(
                 path.push_tail(idx),
             )[path.len() as int + 1],
     {
@@ -1729,7 +1729,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
             node.level == path.len() as nat,
             self.seek(path.pop_tail().1) is Some ==> self.seek(
                 path.pop_tail().1,
-            )->Some_0.value.rel_children(path.index(path.len() - 1) as int, Some(node.value)),
+            )->0.value.rel_children(path.index(path.len() - 1) as int, Some(node.value)),
             self.seek(path.pop_tail().1) is None ==> T::default(
                 (path.len() - 1) as nat,
             ).rel_children(path.index(path.len() - 1) as int, Some(node.value)),
@@ -1748,9 +1748,9 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
             path.len() < L,
             path.len() > 0 ==> self.seek(path.pop_tail().1) is Some ==> self.seek(
                 path.pop_tail().1,
-            )->Some_0.children[path.pop_tail().0 as int] is None || self.seek(
+            )->0.children[path.pop_tail().0 as int] is None || self.seek(
                 path.pop_tail().1,
-            )->Some_0.value.rel_children(path.index(path.len() - 1) as int, None),
+            )->0.value.rel_children(path.index(path.len() - 1) as int, None),
         ensures
             #[trigger] self.remove(path).inv(),
     {

--- a/vstd_extra/src/resource/ghost_resource/tokens.rs
+++ b/vstd_extra/src/resource/ghost_resource/tokens.rs
@@ -24,8 +24,8 @@ impl<T, const TOTAL: u64> CountGhostResource<T, TOTAL> {
         &&& TOTAL > 0
         &&& 0 <= self.frac() <= TOTAL
         &&& self.r is Some ==> {
-            &&& self.id == self.r->Some_0.id()
-            &&& self.view() == self.r->Some_0@
+            &&& self.id == self.r->0.id()
+            &&& self.view() == self.r->0@
         }
     }
 
@@ -52,7 +52,7 @@ impl<T, const TOTAL: u64> CountGhostResource<T, TOTAL> {
 
     /// Returns the `CountGhost<T,TOTAL>` stored in this `CountGhostResource`.
     pub closed spec fn storage(self) -> CountGhost<T, TOTAL> {
-        self.r->Some_0
+        self.r->0
     }
 
     /// Returns the value of type `T` stored in this `CountGhostResource`.
@@ -241,7 +241,7 @@ impl<T, const TOTAL: u64> CountResource<T, TOTAL> {
 
     /// Returns the `Count<T,TOTAL>` stored in this `CountResource`.
     pub closed spec fn storage(self) -> Count<T, TOTAL> {
-        self.r->Some_0
+        self.r->0
     }
 
     /// Type invariant.

--- a/vstd_extra/src/resource/storage_protocol/excl.rs
+++ b/vstd_extra/src/resource/storage_protocol/excl.rs
@@ -173,7 +173,7 @@ impl<T> Exclusive<T> {
             Self::type_inv_inner(final(r).value()),
             final(r).value()->Exclusive_0 is None,
             final(r).loc() == old(r).loc(),
-            res == old(r).value()->Exclusive_0->Some_0,
+            res == old(r).value()->Exclusive_0->0,
     {
         let tracked mut tmp = StorageResource::<(), T, ExclusiveSP<T>>::alloc(
             ExclusiveSP::Unit,
@@ -212,7 +212,7 @@ impl<T> Exclusive<T> {
             Self::type_inv_inner(final(r).value()),
             final(r).value()->Exclusive_0 is Some,
             final(r).loc() == old(r).loc(),
-            final(r).value()->Exclusive_0->Some_0 == value,
+            final(r).value()->Exclusive_0->0 == value,
     {
         let ghost g = value;
         let tracked mut tmp = StorageResource::<(), T, ExclusiveSP<T>>::alloc(


### PR DESCRIPTION
During the development of the `enum` type inference of verus-analyzer, I realized that we never need a `Some` variant name when accessing the field in spec mode, because `None` has no fields. This PR replaces all `->Some_0` with `->0`, which is much simpler and conceptually cleaner than `unwrap`.