### PR TITLE
verify `current_meta`

### DIFF
--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -579,6 +579,38 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
     }
 }
 
+#[verus_spec(
+    with Tracked(owner): Tracked<&'b mut CursorOwner<M>>
+)]
+fn borrow_current_meta_from_owner<'b, M: AnyFrameMeta + Repr<MetaSlotSmall>>(
+    current: ReprPtr<MetaSlot, MetadataAsLink<M>>,
+) -> (res: &'b mut M)
+    requires
+        old(owner).inv(),
+        0 <= old(owner).index < old(owner).length(),
+        old(owner).list_own.perms.contains_key(old(owner).index),
+        old(owner).list_own.perms[old(owner).index].is_init(),
+        old(owner).list_own.perms[old(owner).index].wf(
+            &old(owner).list_own.perms[old(owner).index].inner_perms,
+        ),
+        current.ptr == old(owner).list_own.perms[old(owner).index].points_to.pptr(),
+    ensures
+        final(owner).index == old(owner).index,
+        final(owner).list_own.list == old(owner).list_own.list,
+        final(owner).list_own.list_id == old(owner).list_own.list_id,
+        final(owner).list_own.perms.dom() === old(owner).list_own.perms.dom(),
+        final(owner).list_own.perms[final(owner).index].points_to.pptr()
+            == old(owner).list_own.perms[old(owner).index].points_to.pptr(),
+{
+    let current_md = MetadataAsLink::cast_to_metadata(current);
+    let tracked current_perm = vstd_extra::map_extra::tracked_borrow_mut_points_to(
+        &mut owner.list_own.perms,
+        owner.index,
+    );
+    let link_md = current_md.borrow_mut(Tracked(current_perm));
+    &mut link_md.metadata.meta
+}
+
 impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
     /// Moves the cursor to the next frame towards the back.
     ///
@@ -697,37 +729,64 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
     /// The cursor must be well-formed with respect to the tracked `CursorOwner`.
     /// ## Postconditions
     /// If the cursor is on an element, returns `Some(&mut meta)` borrowing the
-    /// current link's metadata. The cursor state and owner are otherwise
-    /// unchanged.
+    /// current link's metadata. The cursor state and list shape are otherwise
+    /// unchanged; the current metadata permission remains borrowed while the
+    /// returned reference is live.
     /// ## Safety
     /// The `&mut self` guarantees exclusive access to the cursor; the tracked
-    /// `CursorOwner` guarantees the perm for the current link is live. Together
-    /// they justify the mutable borrow of `link.meta`. The body is
-    /// `external_body` because the map-indexed perm extraction needed to call
-    /// `ReprPtr::borrow_mut` runs into a Verus modelling gap — see
-    /// `vstd_extra::map_extra::tracked_borrow_mut_points_to`. The ownership
-    /// invariants in the requires/ensures are what we rely on.
+    /// `CursorOwner` guarantees the perm for the current link is live.
     #[verus_spec(
-        with Tracked(owner): Tracked<&mut CursorOwner<M>>
+        with Tracked(owner): Tracked<&'b mut CursorOwner<M>>
     )]
-    #[verifier::external_body]
-    pub fn current_meta(&mut self) -> (res: Option<&mut M>)
+    pub fn current_meta<'b>(&'b mut self) -> (res: Option<&'b mut M>)
         requires
             old(self).wf(*old(owner)),
             old(owner).inv(),
         ensures
-            final(self).wf(*final(owner)),
-            final(owner).inv(),
-            *final(owner) == *old(owner),
+            final(owner).index == old(owner).index,
+            final(owner).list_own.list == old(owner).list_own.list,
+            final(owner).list_own.list_id == old(owner).list_own.list_id,
+            final(owner).list_own.perms.dom() === old(owner).list_own.perms.dom(),
             *final(self) == *old(self),
             res.is_some() == (0 <= final(owner).index < final(owner).length()),
     {
-        self.current.map(|current| {
-            // SAFETY: `&mut self` + the tracked owner ensure exclusive access
-            // to the current link's metadata.
-            let link_mut = unsafe { &mut *(current.ptr.addr() as *mut Link<M>) };
-            &mut link_mut.meta
-        })
+        match self.current {
+            Some(current) => {
+                proof {
+                    assert(self.wf(*owner));
+                    assert(owner.inv());
+                    assert(0 <= owner.index <= owner.length());
+                    if !(0 <= owner.index < owner.length()) {
+                        assert(owner.index == owner.length());
+                        assert(self.current.is_none());
+                        assert(false);
+                    }
+                    assert(owner.list_own.inv());
+                    assert(owner.list_own.inv_at(owner.index));
+                    assert(owner.list_own.perms.contains_key(owner.index));
+                    assert(owner.list_own.perms[owner.index].is_init());
+                    assert(owner.list_own.perms[owner.index].wf(
+                        &owner.list_own.perms[owner.index].inner_perms,
+                    ));
+                    assert(current == self.current.unwrap());
+                    assert(current.ptr == owner.list_own.perms[owner.index].points_to.pptr());
+                }
+                #[verus_spec(with Tracked(owner))]
+                let meta = borrow_current_meta_from_owner(current);
+                Some(meta)
+            },
+            None => {
+                proof {
+                    assert(self.wf(*owner));
+                    assert(owner.inv());
+                    if 0 <= owner.index < owner.length() {
+                        assert(self.current.is_some());
+                        assert(false);
+                    }
+                }
+                None
+            },
+        }
     }
 
     /// Takes the current pointing frame out of the linked list.

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -750,6 +750,11 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
             *final(self) == *old(self),
             res.is_some() == (0 <= final(owner).index < final(owner).length()),
     {
+        // Verus does not support option.map very well.
+        // self.current.map(|current| {
+        //     let link_mut = unsafe { &mut *(current.ptr.addr() as *mut Link<M>) };
+        //     &mut link_mut.meta
+        // })
         match self.current {
             Some(current) => {
                 proof {

--- a/vstd_extra/src/cast_ptr.rs
+++ b/vstd_extra/src/cast_ptr.rs
@@ -189,10 +189,10 @@ impl<R, T: Repr<R>> ReprPtr<R, T> {
     /// Borrows the pointed-to `T` mutably for the lifetime of `perm`.
     ///
     /// While the returned borrow is live, `perm` is exclusively held and
-    /// cannot be used. Mutations made through `*v` are not tracked by the
-    /// Verus model: the postcondition only promises the final `perm` is still
-    /// initialised and well-formed. Callers must preserve any invariants
-    /// beyond that themselves.
+    /// cannot be used. The returned borrow is tied to the tracked permission:
+    /// at the return point, the permission's value matches `*v`. Callers must
+    /// preserve any invariants beyond the final initialised/well-formed state
+    /// themselves.
     #[verifier::external_body]
     pub exec fn borrow_mut<'a>(self, Tracked(perm): Tracked<&'a mut PointsTo<R, T>>) -> (v:
         &'a mut T)
@@ -205,6 +205,7 @@ impl<R, T: Repr<R>> ReprPtr<R, T> {
             final(perm).pptr() == old(perm).pptr(),
             final(perm).is_init(),
             final(perm).wf(&final(perm).inner_perms),
+            final(perm).value() == *final(v),
     {
         // SAFETY: `Repr<R> for T` asserts layout compatibility between R and
         // T. The tracked `perm` guards against concurrent access.


### PR DESCRIPTION
Add an explicit assertion on `ReprPtr::borrow_mut` so that we know the owner will sync with the runtime value, this makes `current_meta` verify.