### PR TITLE
Retire `===`

### DIFF
--- a/ostd/src/mm/frame/meta.rs
+++ b/ostd/src/mm/frame/meta.rs
@@ -723,7 +723,7 @@ impl MetaSlot {
         with Tracked(meta_perm): Tracked<&mut vstd::cell::pcell_maybe_uninit::PointsTo<MetaSlotStorage>>,
             Tracked(vtable_perm): Tracked<&mut vstd::simple_pptr::PointsTo<usize>>
         requires
-            self.storage.id() === old(meta_perm).id(),
+            self.storage.id() == old(meta_perm).id(),
             self.vtable_ptr == old(vtable_perm).pptr(),
             old(vtable_perm).is_uninit(),
         ensures

--- a/vstd_extra/src/array_ptr.rs
+++ b/vstd_extra/src/array_ptr.rs
@@ -507,7 +507,7 @@ impl<V, const N: usize> PointsToArray<V, N> {
 impl<V, const N: usize> Clone for ArrayPtr<V, N> {
     fn clone(&self) -> (res: Self)
         ensures
-            res === *self,
+            res == *self,
     {
         Self { ..*self }
     }

--- a/vstd_extra/src/cast_ptr.rs
+++ b/vstd_extra/src/cast_ptr.rs
@@ -181,7 +181,7 @@ impl<R, T: Repr<R>> ReprPtr<R, T> {
             perm.is_init(),
             perm.wf(&perm.inner_perms),
         ensures
-            *v === perm.value(),
+            *v == perm.value(),
     {
         T::from_borrowed(self.ptr.borrow(Tracked(&perm.points_to)), Tracked(&perm.inner_perms))
     }

--- a/vstd_extra/src/map_extra.rs
+++ b/vstd_extra/src/map_extra.rs
@@ -290,10 +290,10 @@ pub axiom fn tracked_borrow_mut<K, V>(tracked m: &mut Map<K, V>, key: K) -> (tra
     requires
         old(m).dom().contains(key),
     ensures
-        *v === old(m).index(key),
-        final(m).dom() === old(m).dom(),
-        forall|k: K| k != key ==> #[trigger] final(m).index(k) === old(m).index(k),
-        final(m).index(key) === *final(v),
+        *v == old(m).index(key),
+        final(m).dom() == old(m).dom(),
+        forall|k: K| k != key ==> #[trigger] final(m).index(k) == old(m).index(k),
+        final(m).index(key) == *final(v),
 ;
 
 /// Same as [`tracked_borrow_mut`] for `PointsTo<R, T>` values, with the
@@ -306,18 +306,18 @@ pub axiom fn tracked_borrow_mut_points_to<K, R, T: crate::cast_ptr::Repr<R>>(
     requires
         old(m).dom().contains(key),
     ensures
-        *v === old(m).index(key),
-        // Open-spec equalities that don't fall out of `*v === old_v` because
+        *v == old(m).index(key),
+        // Open-spec equalities that don't fall out of `*v == old_v` because
         // the inner `simple_pptr::PointsTo<R>` is external_body.
-        v.pptr() === old(m).index(key).pptr(),
-        v.addr() === old(m).index(key).addr(),
+        v.pptr() == old(m).index(key).pptr(),
+        v.addr() == old(m).index(key).addr(),
         v.is_init() == old(m).index(key).is_init(),
         v.wf(&v.inner_perms) == old(m).index(key).wf(&old(m).index(key).inner_perms),
-        v.inner_perms === old(m).index(key).inner_perms,
-        final(m).dom() === old(m).dom(),
-        forall|k: K| k != key ==> #[trigger] final(m).index(k) === old(m).index(k),
-        final(m).index(key) === *final(v),
-        final(m).index(key).pptr() === final(v).pptr(),
+        v.inner_perms == old(m).index(key).inner_perms,
+        final(m).dom() == old(m).dom(),
+        forall|k: K| k != key ==> #[trigger] final(m).index(k) == old(m).index(k),
+        final(m).index(key) == *final(v),
+        final(m).index(key).pptr() == final(v).pptr(),
         final(m).index(key).is_init() == final(v).is_init(),
         final(m).index(key).wf(&final(v).inner_perms) == final(v).wf(&final(v).inner_perms),
 ;

--- a/vstd_extra/src/seq_extra.rs
+++ b/vstd_extra/src/seq_extra.rs
@@ -142,7 +142,7 @@ pub broadcast proof fn lemma_forall_seq_push<T>(s: Seq<T>, f: spec_fn(int, T) ->
 {
     if forall_seq(s.push(v), f) {
         assert forall|i| 0 <= i < s.len() implies f(i, s[i]) by {
-            assert(s[i] === s.push(v)[i]);
+            assert(s[i] == s.push(v)[i]);
         }
         assert(s.push(v)[s.len() as int] == v);
     }
@@ -155,7 +155,7 @@ pub broadcast proof fn lemma_seq_all_push<T>(s: Seq<T>, f: spec_fn(T) -> bool, v
 {
     if s.push(v).all(f) {
         assert forall|i| 0 <= i < s.len() implies f(s[i]) by {
-            assert(s[i] === s.push(v)[i]);
+            assert(s[i] == s.push(v)[i]);
         }
         assert(s.push(v)[s.len() as int] == v);
     }

--- a/vstd_extra/src/sub_ptr.rs
+++ b/vstd_extra/src/sub_ptr.rs
@@ -127,7 +127,7 @@ impl<R, T: SubRepr<R>> ReprPtr<R, T> {
             perm.is_init(),
             perm.wf(),
         ensures
-            *v === perm.value(),
+            *v == perm.value(),
     {
         T::from_borrowed(self.ptr.borrow(Tracked(&perm.points_to)))
     }


### PR DESCRIPTION
`===` is no longer required because Verus now has better type inference.