### PR TITLE
Rename tracked versions of spec functions

### DIFF
--- a/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
+++ b/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
@@ -523,14 +523,12 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorOwner<M> {
         CursorOwner::<M> { list_own: list_own, index: index }
     }
 
-    #[verifier::returns(proof)]
-    pub axiom fn tracked_cursor_mut_at_owner(list_own: LinkedListOwner<M>, index: int) -> Self
-        returns Self::cursor_mut_at_owner(list_own, index);
+    pub axiom fn tracked_cursor_mut_at_owner(list_own: LinkedListOwner<M>, index: int) -> (tracked res: Self)
+        ensures res == Self::cursor_mut_at_owner(list_own, index);
 
-    #[verifier::returns(proof)]
     pub axiom fn tracked_front_owner(
         list_own: LinkedListOwner<M>,
-    ) -> (res: Self)
+    ) -> (tracked res: Self)
         ensures
             res == Self::front_owner(list_own);
     pub open spec fn back_owner(
@@ -546,11 +544,10 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorOwner<M> {
         }
     }
 
-    #[verifier::returns(proof)]
     #[verifier::external_body]
     pub proof fn tracked_back_owner(
         list_own: LinkedListOwner<M>,
-    ) -> (res: Self)
+    ) -> (tracked res: Self)
         ensures
             res == Self::back_owner(list_own),
     {
@@ -573,11 +570,10 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorOwner<M> {
         }
     }
 
-    #[verifier::returns(proof)]
     #[verifier::external_body]
     pub proof fn tracked_ghost_owner(
         list_own: LinkedListOwner<M>,
-    ) -> (res: Self)
+    ) -> (tracked res: Self)
         ensures
             res == Self::ghost_owner(list_own),
     {

--- a/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
+++ b/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
@@ -510,13 +510,13 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorOwner<M> {
             final(cursor).list_own.perms[old(cursor).index] == perm,
             final(cursor).index == old(cursor).index + 1;
 
-    pub open spec fn front_owner_spec(
+    pub open spec fn front_owner(
         list_own: LinkedListOwner<M>,
     ) -> Self {
         CursorOwner::<M> { list_own: list_own, index: 0 }
     }
 
-    pub open spec fn cursor_mut_at_owner_spec(
+    pub open spec fn cursor_mut_at_owner(
         list_own: LinkedListOwner<M>,
         index: int,
     ) -> Self {
@@ -524,16 +524,16 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorOwner<M> {
     }
 
     #[verifier::returns(proof)]
-    pub axiom fn cursor_mut_at_owner(list_own: LinkedListOwner<M>, index: int) -> Self
-        returns Self::cursor_mut_at_owner_spec(list_own, index);
+    pub axiom fn tracked_cursor_mut_at_owner(list_own: LinkedListOwner<M>, index: int) -> Self
+        returns Self::cursor_mut_at_owner(list_own, index);
 
     #[verifier::returns(proof)]
-    pub axiom fn front_owner(
+    pub axiom fn tracked_front_owner(
         list_own: LinkedListOwner<M>,
     ) -> (res: Self)
         ensures
-            res == Self::front_owner_spec(list_own);
-    pub open spec fn back_owner_spec(
+            res == Self::front_owner(list_own);
+    pub open spec fn back_owner(
         list_own: LinkedListOwner<M>,
     ) -> Self {
         CursorOwner::<M> {
@@ -548,11 +548,11 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorOwner<M> {
 
     #[verifier::returns(proof)]
     #[verifier::external_body]
-    pub proof fn back_owner(
+    pub proof fn tracked_back_owner(
         list_own: LinkedListOwner<M>,
     ) -> (res: Self)
         ensures
-            res == Self::back_owner_spec(list_own),
+            res == Self::back_owner(list_own),
     {
         CursorOwner::<M> {
             list_own: list_own,
@@ -564,7 +564,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorOwner<M> {
         }
     }
 
-    pub open spec fn ghost_owner_spec(
+    pub open spec fn ghost_owner(
         list_own: LinkedListOwner<M>,
     ) -> Self {
         CursorOwner::<M> {
@@ -575,11 +575,11 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorOwner<M> {
 
     #[verifier::returns(proof)]
     #[verifier::external_body]
-    pub proof fn ghost_owner(
+    pub proof fn tracked_ghost_owner(
         list_own: LinkedListOwner<M>,
     ) -> (res: Self)
         ensures
-            res == Self::ghost_owner_spec(list_own),
+            res == Self::ghost_owner(list_own),
     {
         CursorOwner::<M> {
             list_own: list_own,

--- a/ostd/specs/mm/frame/unique.rs
+++ b/ostd/specs/mm/frame/unique.rs
@@ -92,7 +92,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrameOwner<M> {
         UniqueFrameOwner::<M> { meta_own: owner, meta_perm: perm, slot_index: index@ }
     }
 
-    pub open spec fn from_unused_owner_spec(
+    pub open spec fn from_unused_owner(
         old_regions: MetaRegionOwners,
         paddr: Paddr,
         metadata: M,
@@ -110,13 +110,13 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrameOwner<M> {
         &&& regions.inv()
     }
 
-    pub axiom fn from_unused_owner(
+    pub axiom fn tracked_from_unused_owner(
         tracked regions: &mut MetaRegionOwners,
         paddr: Paddr,
         meta_perm: PointsTo<MetaSlot, Metadata<M>>,
     ) -> (tracked res: Self)
     ensures
-        Self::from_unused_owner_spec(*old(regions), paddr, meta_perm.value().metadata, res, *final(regions));
+        Self::from_unused_owner(*old(regions), paddr, meta_perm.value().metadata, res, *final(regions));
     /* {
         let tracked perm = regions.slots.tracked_remove(frame_to_index(paddr));
         UniqueFrameOwner::<M> {

--- a/ostd/specs/mm/io.rs
+++ b/ostd/specs/mm/io.rs
@@ -281,7 +281,7 @@ impl VmIoOwner {
         let tracked res = match old_view {
             VmIoMemView::WriteView(view) => {
                 let ghost view_g = view;
-                let tracked (left, right) = view.split(old_start, nbytes);
+                let tracked (left, right) = view.tracked_split(old_start, nbytes);
                 MemView::lemma_split_preserves_transl(view_g, old_start, nbytes, left, right);
                 assert(right.mappings.finite());
                 assert(right.mappings_are_disjoint()) by {
@@ -297,7 +297,7 @@ impl VmIoOwner {
             },
             VmIoMemView::ReadView(view) => {
                 let ghost view_g = view;
-                let tracked (left, right) = view.split(old_start, nbytes);
+                let tracked (left, right) = view.tracked_split(old_start, nbytes);
                 MemView::lemma_split_preserves_transl(view_g, old_start, nbytes, left, right);
                 assert(right.mappings.finite());
                 assert(right.mappings_are_disjoint()) by {
@@ -400,7 +400,7 @@ impl VmIoOwner {
         let tracked left_view = match old_view {
             VmIoMemView::WriteView(view) => {
                 let ghost view_g = view;
-                let tracked (left, right) = view.split(old_start, nbytes);
+                let tracked (left, right) = view.tracked_split(old_start, nbytes);
                 MemView::lemma_split_preserves_transl(view_g, old_start, nbytes, left, right);
                 // Prove both halves preserve mappings invariants and translation.
                 assert(left.mappings.finite());
@@ -426,7 +426,7 @@ impl VmIoOwner {
             },
             VmIoMemView::ReadView(view) => {
                 let ghost view_g = view;
-                let tracked (left, right) = view.split(old_start, nbytes);
+                let tracked (left, right) = view.tracked_split(old_start, nbytes);
                 MemView::lemma_split_preserves_transl(view_g, old_start, nbytes, left, right);
                 assert(left.mappings.finite());
                 assert(left.mappings_are_disjoint()) by {

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -266,10 +266,10 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         }
     }
 
-    pub open spec fn push_level_owner_spec(self, guard: PageTableGuard<'rcu, C>) -> Self
+    pub open spec fn push_level_owner(self, guard: PageTableGuard<'rcu, C>) -> Self
     {
         let cont = self.continuations[self.level - 1];
-        let (child, cont) = cont.make_cont_spec(self.va.index[self.level - 2] as usize, guard);
+        let (child, cont) = cont.make_cont(self.va.index[self.level - 2] as usize, guard);
         let new_continuations = self.continuations.insert(self.level - 1, cont);
         let new_continuations = new_continuations.insert(self.level - 2, child);
 
@@ -287,9 +287,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.inv(),
             self.level > 1,
         ensures
-            self.push_level_owner_spec(guard).max_steps() < self.max_steps()
+            self.push_level_owner(guard).max_steps() < self.max_steps()
     {
-        let new_self = self.push_level_owner_spec(guard);
+        let new_self = self.push_level_owner(guard);
         let l = self.level as usize;
         let lm1 = (self.level - 1) as usize;
         // Continuations agree at indices [l-1, NR_LEVELS): only [l-2] changed.
@@ -329,8 +329,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.inv(),
             self.level > 1,
         ensures
-            self.push_level_owner_spec(guard).va == self.va,
-            self.push_level_owner_spec(guard).continuations[self.level - 2].idx == self.va.index[self.level - 2],
+            self.push_level_owner(guard).va == self.va,
+            self.push_level_owner(guard).continuations[self.level - 2].idx == self.va.index[self.level - 2],
     {
         assert(self.va.index.contains_key(self.level - 2));
     }
@@ -341,16 +341,16 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.level > 1,
             self.cur_entry_owner().is_node(),
         ensures
-            self.push_level_owner_spec(guard)@.mappings == self@.mappings,
+            self.push_level_owner(guard)@.mappings == self@.mappings,
     {
-        let new_owner = self.push_level_owner_spec(guard);
+        let new_owner = self.push_level_owner(guard);
         let old_cont = self.continuations[self.level - 1];
-        let (child_cont, modified_cont) = old_cont.make_cont_spec(self.va.index[self.level - 2] as usize, guard);
+        let (child_cont, modified_cont) = old_cont.make_cont(self.va.index[self.level - 2] as usize, guard);
 
         assert(old_cont.all_some());
         old_cont.view_mappings_take_child();
 
-        let taken = old_cont.take_child_spec().1;
+        let taken = old_cont.take_child().1;
 
         assert(modified_cont.children =~= taken.children) by {
             assert forall |j: int| 0 <= j < modified_cont.children.len()
@@ -469,7 +469,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     self.continuations[i].guard.inner.inner@.ptr.addr()
                         != guard.inner.inner@.ptr.addr(),
         ensures
-            self.push_level_owner_spec(guard).inv(),
+            self.push_level_owner(guard).inv(),
     {
         // locking-work: when self.level == self.guard_level, self.inv() does
         // not supply va.index[guard_level-1] == prefix.index[guard_level-1]
@@ -478,13 +478,13 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         // Derive it from in_locked_range() for all cases.
         self.in_locked_range_guard_index_eq_prefix();
 
-        let new_owner = self.push_level_owner_spec(guard);
+        let new_owner = self.push_level_owner(guard);
         let new_level = (self.level - 1) as u8;
 
         let old_cont = self.continuations[self.level - 1];
         old_cont.inv_children_unroll(old_cont.idx as int);
         let child_node = old_cont.children[old_cont.idx as int].unwrap();
-        let (child, modified_cont) = old_cont.make_cont_spec(self.va.index[self.level - 2] as usize, guard);
+        let (child, modified_cont) = old_cont.make_cont(self.va.index[self.level - 2] as usize, guard);
 
         old_cont.inv_children_rel_unroll(old_cont.idx as int);
         assert(child.entry_own == child_node.value);
@@ -825,19 +825,19 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             // The new guard must be locked in guards
             guards.lock_held(guard.inner.inner@.ptr.addr()),
         ensures
-            self.push_level_owner_spec(guard).inv(),
-            self.push_level_owner_spec(guard).children_not_locked(guards),
-            self.push_level_owner_spec(guard).nodes_locked(guards),
-            self.push_level_owner_spec(guard).metaregion_sound(regions),
+            self.push_level_owner(guard).inv(),
+            self.push_level_owner(guard).children_not_locked(guards),
+            self.push_level_owner(guard).nodes_locked(guards),
+            self.push_level_owner(guard).metaregion_sound(regions),
     {
         if self.level == self.guard_level {
             self.in_locked_range_guard_index_eq_prefix();
         }
         reveal(CursorContinuation::inv_children);
-        let new_owner = self.push_level_owner_spec(guard);
+        let new_owner = self.push_level_owner(guard);
         let old_cont = self.continuations[self.level - 1];
         old_cont.inv_children_unroll_all();
-        let (child_cont, modified_cont) = old_cont.make_cont_spec(self.va.index[self.level - 2] as usize, guard);
+        let (child_cont, modified_cont) = old_cont.make_cont(self.va.index[self.level - 2] as usize, guard);
 
         let cur_entry = self.cur_entry_owner();
         let cur_entry_addr = cur_entry.node.unwrap().meta_perm.addr();
@@ -1084,21 +1084,21 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
     }
 
     #[verifier::returns(proof)]
-    pub proof fn push_level_owner(tracked &mut self, guard: PageTableGuard<'rcu, C>)
+    pub proof fn tracked_push_level_owner(tracked &mut self, guard: PageTableGuard<'rcu, C>)
         requires
             old(self).inv(),
             old(self).level > 1,
         ensures
-            *final(self) == old(self).push_level_owner_spec(guard),
+            *final(self) == old(self).push_level_owner(guard),
     {
         assert(self.va.index.contains_key(self.level - 2));
 
         let ghost self0 = *self;
         let tracked mut cont = self.continuations.tracked_remove(self.level - 1);
         let ghost cont0 = cont;
-        let tracked child = cont.make_cont(self.va.index[self.level - 2] as usize, guard);
+        let tracked child = cont.tracked_make_cont(self.va.index[self.level - 2] as usize, guard);
 
-        assert((child, cont) == cont0.make_cont_spec(self.va.index[self.level - 2] as usize, guard));
+        assert((child, cont) == cont0.make_cont(self.va.index[self.level - 2] as usize, guard));
 
         self.continuations.tracked_insert(self.level - 1, cont);
         self.continuations.tracked_insert(self.level - 2, child);
@@ -1110,11 +1110,11 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         self.level = (self.level - 1) as u8;
     }
 
-    pub open spec fn pop_level_owner_spec(self) -> (Self, PageTableGuard<'rcu, C>)
+    pub open spec fn pop_level_owner(self) -> (Self, PageTableGuard<'rcu, C>)
     {
         let child = self.continuations[self.level - 1];
         let cont = self.continuations[self.level as int];
-        let (new_cont, guard) = cont.restore_spec(child);
+        let (new_cont, guard) = cont.restore(child);
         let new_continuations = self.continuations.insert(self.level as int, new_cont);
         let new_continuations = new_continuations.remove(self.level - 1);
         let new_level = (self.level + 1) as u8;
@@ -1133,15 +1133,15 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.level < NR_LEVELS,
             // [STEP 3] in_locked_range dropped
         ensures
-            self.pop_level_owner_spec().0.inv(),
+            self.pop_level_owner().0.inv(),
     {
         let child = self.continuations[self.level - 1];
         assert(child.inv());
         assert(child.all_some());
         let cont = self.continuations[self.level as int];
         assert(cont.inv());
-        let (new_cont, _) = cont.restore_spec(child);
-        let new_owner = self.pop_level_owner_spec().0;
+        let (new_cont, _) = cont.restore(child);
+        let new_owner = self.pop_level_owner().0;
 
         let child_node = OwnerSubtree {
             value: child.entry_own,
@@ -1321,15 +1321,15 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.nodes_locked(guards),
             self.metaregion_sound(regions),
         ensures
-            self.pop_level_owner_spec().0.inv(),
-            self.pop_level_owner_spec().0.only_current_locked(guards),
-            self.pop_level_owner_spec().0.nodes_locked(guards),
-            self.pop_level_owner_spec().0.metaregion_sound(regions),
+            self.pop_level_owner().0.inv(),
+            self.pop_level_owner().0.only_current_locked(guards),
+            self.pop_level_owner().0.nodes_locked(guards),
+            self.pop_level_owner().0.metaregion_sound(regions),
     {
-        let new_owner = self.pop_level_owner_spec().0;
+        let new_owner = self.pop_level_owner().0;
         let child = self.continuations[self.level - 1];
         let cont = self.continuations[self.level as int];
-        let (new_cont, _guard) = cont.restore_spec(child);
+        let (new_cont, _guard) = cont.restore(child);
         let child_node = OwnerSubtree {
             value: child.entry_own,
             level: child.tree_level,
@@ -1427,9 +1427,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             forall |i: int| #![auto] self.level - 1 <= i < NR_LEVELS ==> new_va.index[i] == self.va.index[i],
             forall |i: int| #![auto] self.guard_level - 1 <= i < NR_LEVELS ==> new_va.index[i] == self.prefix.index[i],
         ensures
-            self.set_va_spec(new_va).inv(),
+            self.set_va(new_va).inv(),
     {
-        let r = self.set_va_spec(new_va);
+        let r = self.set_va(new_va);
 
         assert(r.in_locked_range()) by {
             let gl = self.guard_level;
@@ -1503,19 +1503,19 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
     }
 
     #[verifier::returns(proof)]
-    pub proof fn pop_level_owner(tracked &mut self) -> (tracked guard: PageTableGuard<'rcu, C>)
+    pub proof fn tracked_pop_level_owner(tracked &mut self) -> (tracked guard: PageTableGuard<'rcu, C>)
         requires
             old(self).inv(),
             old(self).level < NR_LEVELS,
         ensures
-            *final(self) == old(self).pop_level_owner_spec().0,
-            guard == old(self).pop_level_owner_spec().1,
+            *final(self) == old(self).pop_level_owner().0,
+            guard == old(self).pop_level_owner().1,
     {
         let ghost self0 = *self;
         let tracked mut parent = self.continuations.tracked_remove(self.level as int);
         let tracked child = self.continuations.tracked_remove(self.level - 1);
 
-        let tracked guard = parent.restore(child);
+        let tracked guard = parent.tracked_restore(child);
 
         self.continuations.tracked_insert(self.level as int, parent);
 
@@ -1544,7 +1544,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             // `above_locked_range`.
             self.inc_index().zero_below_level()
         } else if self.level < NR_LEVELS {
-            self.pop_level_owner_spec().0.move_forward_owner_spec()
+            self.pop_level_owner().0.move_forward_owner_spec()
         } else {
             // self.level == NR_LEVELS && self.index() + 1 == NR_ENTRIES.
             // Advance to the next leading_bits-chunk via `next_index(NR_LEVELS)`.
@@ -1579,7 +1579,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 // Pop to parent. Parent is at guard_level + 1 with popped_too_high.
                 assert(self.level < NR_LEVELS);
                 self.pop_level_owner_preserves_inv();
-                let popped = self.pop_level_owner_spec().0;
+                let popped = self.pop_level_owner().0;
                 // popped.popped_too_high == true, so move_forward on popped
                 // does inc_index().zero_below_level(). VA increases.
                 // k == NR_ENTRIES - 1 here, so the parent idx advances.
@@ -1594,7 +1594,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         } else if self.level + 1 < self.guard_level {
             assert(self.level < NR_LEVELS);
             self.pop_level_owner_preserves_inv();
-            self.pop_level_owner_spec().0.move_forward_increases_va();
+            self.pop_level_owner().0.move_forward_increases_va();
         } else {
             assert(self.level < NR_LEVELS);
             assert(self.guard_level == self.level + 1);
@@ -1602,7 +1602,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             let k = self.prefix.index[self.guard_level - 1];
             assert(self.va.index[self.level as int] == k);
             self.pop_level_owner_preserves_inv();
-            let popped = self.pop_level_owner_spec().0;
+            let popped = self.pop_level_owner().0;
             assert(self.move_forward_owner_spec() == popped.move_forward_owner_spec());
             if k + 1 < NR_ENTRIES {
                 assert(popped.move_forward_owner_spec() == popped.inc_index().zero_below_level());
@@ -1628,7 +1628,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.inc_index().zero_preserves_all_but_va();
         } else if self.level < NR_LEVELS {
             self.pop_level_owner_preserves_inv();
-            self.pop_level_owner_spec().0.move_forward_not_popped_too_high();
+            self.pop_level_owner().0.move_forward_not_popped_too_high();
         }
     }
 
@@ -1669,7 +1669,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         } else if self.level < NR_LEVELS {
             // Case B1: pop again (popped2.popped_too_high also true) and recurse.
             self.pop_level_owner_preserves_inv();
-            let popped2 = self.pop_level_owner_spec().0;
+            let popped2 = self.pop_level_owner().0;
             let lp1 = (self.level + 1) as usize;
             popped2.max_steps_partial_eq(self, lp1);
             Self::max_steps_subtree_positive(lp1);
@@ -1688,7 +1688,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             // popped2.popped_too_high holds: popped2.level == self.level + 1
             // > self.guard_level (since self.popped_too_high gives
             // self.level >= self.guard_level), so popped2 satisfies the
-            // popped_too_high arm of pop_level_owner_spec.
+            // popped_too_high arm of pop_level_owner.
 
             // Recurse on popped2.
             popped2.move_forward_owner_popped_too_high_decreases();
@@ -1758,7 +1758,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         } else if self.level < NR_LEVELS {
             self.in_locked_range_level_le_guard_level();
             self.pop_level_owner_preserves_inv();
-            let popped = self.pop_level_owner_spec().0;
+            let popped = self.pop_level_owner().0;
             let lp1 = (self.level + 1) as usize;
             popped.max_steps_partial_eq(self, lp1);
             Self::max_steps_subtree_positive(lp1);
@@ -1917,7 +1917,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         } else if self.level < NR_LEVELS {
             self.in_locked_range_level_le_guard_level();
             self.pop_level_owner_preserves_inv();
-            let popped = self.pop_level_owner_spec().0;
+            let popped = self.pop_level_owner().0;
             if !popped.popped_too_high {
                 popped.move_forward_va_is_align_up();
             } else {
@@ -1970,12 +1970,12 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.level < NR_LEVELS,
             self.in_locked_range(),
         ensures
-            self.pop_level_owner_spec().0@.mappings == self@.mappings,
+            self.pop_level_owner().0@.mappings == self@.mappings,
     {
         let child = self.continuations[self.level - 1];
         let parent = self.continuations[self.level as int];
-        let (restored_parent, _) = parent.restore_spec(child);
-        let popped = self.pop_level_owner_spec().0;
+        let (restored_parent, _) = parent.restore(child);
+        let popped = self.pop_level_owner().0;
         let child_subtree = child.as_subtree();
 
         assert(child.inv());
@@ -2014,7 +2014,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         parent.as_subtree_restore(child);
 
         let r = restored_parent;
-        let p = parent.put_child_spec(child_subtree);
+        let p = parent.put_child(child_subtree);
         assert forall |j: int| 0 <= j < r.children.len()
             implies r.children[j] == p.children[j] by {
             if j == parent.idx as int {
@@ -2025,7 +2025,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         };
         assert(r.children =~= p.children);
         assert(restored_parent.view_mappings() =~=
-            parent.put_child_spec(child_subtree).view_mappings()) by {
+            parent.put_child(child_subtree).view_mappings()) by {
             assert(r.path() == p.path());
             assert forall |m: Mapping| r.view_mappings().contains(m)
                 implies p.view_mappings().contains(m) by {
@@ -2167,7 +2167,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 };
             };
         } else if self.level < NR_LEVELS {
-            let popped = self.pop_level_owner_spec().0;
+            let popped = self.pop_level_owner().0;
 
             self.pop_level_owner_preserves_inv();
             assert(popped.in_locked_range()) by {

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -1083,7 +1083,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         };
     }
 
-    #[verifier::returns(proof)]
     pub proof fn tracked_push_level_owner(tracked &mut self, guard: PageTableGuard<'rcu, C>)
         requires
             old(self).inv(),
@@ -1502,7 +1501,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         });
     }
 
-    #[verifier::returns(proof)]
     pub proof fn tracked_pop_level_owner(tracked &mut self) -> (tracked guard: PageTableGuard<'rcu, C>)
         requires
             old(self).inv(),

--- a/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
@@ -45,21 +45,21 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             self.inv(),
             self.all_some(),
         ensures
-            self.take_child_spec().1.view_mappings() == self.view_mappings() - self.view_mappings_take_child_spec()
+            self.take_child().1.view_mappings() == self.view_mappings() - self.view_mappings_take_child_spec()
     {
         self.inv_children_unroll_all();
-        let def = self.take_child_spec().1.view_mappings();
+        let def = self.take_child().1.view_mappings();
         let diff = self.view_mappings() - self.view_mappings_take_child_spec();
         assert forall |m: Mapping| diff.contains(m) implies def.contains(m) by {
             let i = choose|i: int| 0 <= i < self.children.len() && #[trigger] self.children[i] is Some &&
                 PageTableOwner(self.children[i].unwrap()).view_rec(self.path().push_tail(i as usize)).contains(m);
             assert(i != self.idx);
-            assert(self.take_child_spec().1.children[i] is Some);
+            assert(self.take_child().1.children[i] is Some);
         };
         assert forall |m: Mapping|
         #![trigger def.contains(m)]
         def.contains(m) implies diff.contains(m) by {
-            let left = self.take_child_spec().1;
+            let left = self.take_child().1;
             assert(left.view_mappings().contains(m));
             if self.view_mappings_take_child_spec().contains(m) {
                 assert(PageTableOwner(self.children[self.idx as int].unwrap())
@@ -92,19 +92,19 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             child.inv(),
             self.all_but_index_some(),
         ensures
-            self.put_child_spec(child).view_mappings() == self.view_mappings() + PageTableOwner(child).view_rec(self.path().push_tail(self.idx as usize))
+            self.put_child(child).view_mappings() == self.view_mappings() + PageTableOwner(child).view_rec(self.path().push_tail(self.idx as usize))
     {
-        let def = self.put_child_spec(child).view_mappings();
+        let def = self.put_child(child).view_mappings();
         let sum = self.view_mappings() + PageTableOwner(child).view_rec(self.path().push_tail(self.idx as usize));
         assert forall |m: Mapping| sum.contains(m) implies def.contains(m) by {
             if self.view_mappings().contains(m) {
                 let i = choose|i: int| 0 <= i < self.children.len() && #[trigger] self.children[i] is Some &&
                     PageTableOwner(self.children[i].unwrap()).view_rec(self.path().push_tail(i as usize)).contains(m);
                 assert(i != self.idx);
-                assert(self.put_child_spec(child).children[i] == self.children[i]);
+                assert(self.put_child(child).children[i] == self.children[i]);
             } else {
                 assert(PageTableOwner(child).view_rec(self.path().push_tail(self.idx as usize)).contains(m));
-                assert(self.put_child_spec(child).children[self.idx as int] == Some(child));
+                assert(self.put_child(child).children[self.idx as int] == Some(child));
             }
         };
     }
@@ -643,7 +643,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             c3.view_mappings_put_child(c2.as_subtree());
             c3.as_subtree_restore(c2);
 
-            let l4 = c3.restore_spec(c2).0;
+            let l4 = c3.restore(c2).0;
             assert(l4.all_some()) by {
                 assert forall |i: int| 0 <= i < NR_ENTRIES implies l4.children[i] is Some by {
                     if i == c3.idx as int {
@@ -693,7 +693,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             c2.view_mappings_put_child(c1.as_subtree());
             c2.as_subtree_restore(c1);
 
-            let l3 = c2.restore_spec(c1).0;
+            let l3 = c2.restore(c1).0;
             assert(l3.all_some()) by {
                 assert forall |i: int| 0 <= i < NR_ENTRIES implies l3.children[i] is Some by {
                     if i == c2.idx as int {
@@ -729,7 +729,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             c3.as_subtree_restore(l3);
             c3.view_mappings_put_child(l3.as_subtree());
 
-            let l4 = c3.restore_spec(l3).0;
+            let l4 = c3.restore(l3).0;
             assert(l4.all_some()) by {
                 assert forall |i: int| 0 <= i < NR_ENTRIES implies l4.children[i] is Some by {
                     if i == c3.idx as int {
@@ -779,7 +779,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             c0.as_subtree_inv();
             c1.view_mappings_put_child(c0.as_subtree());
             c1.as_subtree_restore(c0);
-            let l2 = c1.restore_spec(c0).0;
+            let l2 = c1.restore(c0).0;
             assert(l2.all_some()) by {
                 assert forall |i: int| 0 <= i < NR_ENTRIES implies l2.children[i] is Some by {
                     if i == c1.idx as int {
@@ -813,7 +813,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             l2.as_subtree_inv();
             c2.view_mappings_put_child(l2.as_subtree());
             c2.as_subtree_restore(l2);
-            let l3 = c2.restore_spec(l2).0;
+            let l3 = c2.restore(l2).0;
             assert(l3.all_some()) by {
                 assert forall |i: int| 0 <= i < NR_ENTRIES implies l3.children[i] is Some by {
                     if i == c2.idx as int {
@@ -846,7 +846,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             l3.as_subtree_inv();
             c3.view_mappings_put_child(l3.as_subtree());
             c3.as_subtree_restore(l3);
-            let l4 = c3.restore_spec(l3).0;
+            let l4 = c3.restore(l3).0;
             assert(l4.all_some()) by {
                 assert forall |i: int| 0 <= i < NR_ENTRIES implies l4.children[i] is Some by {
                     if i == c3.idx as int {

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -55,7 +55,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         self.children[self.idx as int].unwrap()
     }
 
-    pub open spec fn take_child_spec(self) -> (OwnerSubtree<C>, Self) {
+    pub open spec fn take_child(self) -> (OwnerSubtree<C>, Self) {
         let child = self.children[self.idx as int].unwrap();
         let cont = Self {
             children: self.children.remove(self.idx as int).insert(self.idx as int, None),
@@ -65,14 +65,14 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
     }
 
     #[verifier::returns(proof)]
-    pub proof fn take_child(tracked &mut self) -> (res: OwnerSubtree<C>)
+    pub proof fn tracked_take_child(tracked &mut self) -> (res: OwnerSubtree<C>)
         requires
             old(self).inv(),
             old(self).idx < old(self).children.len(),
             old(self).children[old(self).idx as int] is Some,
         ensures
-            res == old(self).take_child_spec().0,
-            *final(self) == old(self).take_child_spec().1,
+            res == old(self).take_child().0,
+            *final(self) == old(self).take_child().1,
             res.inv()
     {
         self.inv_children_unroll(self.idx as int);
@@ -81,7 +81,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         child
     }
 
-    pub open spec fn put_child_spec(self, child: OwnerSubtree<C>) -> Self {
+    pub open spec fn put_child(self, child: OwnerSubtree<C>) -> Self {
         Self {
             children: self.children.remove(self.idx as int).insert(self.idx as int, Some(child)),
             ..self
@@ -89,12 +89,12 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
     }
 
     #[verifier::returns(proof)]
-    pub proof fn put_child(tracked &mut self, tracked child: OwnerSubtree<C>)
+    pub proof fn tracked_put_child(tracked &mut self, tracked child: OwnerSubtree<C>)
         requires
             old(self).idx < old(self).children.len(),
             old(self).children[old(self).idx as int] is None,
         ensures
-            *final(self) == old(self).put_child_spec(child)
+            *final(self) == old(self).put_child(child)
     {
         let _ = self.children.tracked_remove(old(self).idx as int);
         self.children.tracked_insert(old(self).idx as int, Some(child));
@@ -105,14 +105,14 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             self.idx < self.children.len(),
             self.children[self.idx as int] is Some,
         ensures
-            self.take_child_spec().1.put_child_spec(self.take_child_spec().0) == self,
+            self.take_child().1.put_child(self.take_child().0) == self,
     {
-        let child = self.take_child_spec().0;
-        let cont = self.take_child_spec().1;
-        assert(cont.put_child_spec(child).children == self.children);
+        let child = self.take_child().0;
+        let cont = self.take_child().1;
+        assert(cont.put_child(child).children == self.children);
     }
 
-    pub open spec fn make_cont_spec(self, idx: usize, guard: PageTableGuard<'rcu, C>) -> (Self, Self) {
+    pub open spec fn make_cont(self, idx: usize, guard: PageTableGuard<'rcu, C>) -> (Self, Self) {
         let child = Self {
             entry_own: self.children[self.idx as int].unwrap().value,
             tree_level: (self.tree_level + 1) as nat,
@@ -129,16 +129,16 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
     }
 
     #[verifier::returns(proof)]
-    pub axiom fn make_cont(tracked &mut self, idx: usize, guard: PageTableGuard<'rcu, C>) -> (res: Self)
+    pub axiom fn tracked_make_cont(tracked &mut self, idx: usize, guard: PageTableGuard<'rcu, C>) -> (res: Self)
         requires
             old(self).all_some(),
             old(self).idx < NR_ENTRIES,
             idx < NR_ENTRIES,
         ensures
-            res == old(self).make_cont_spec(idx, guard).0,
-            *final(self) == old(self).make_cont_spec(idx, guard).1;
+            res == old(self).make_cont(idx, guard).0,
+            *final(self) == old(self).make_cont(idx, guard).1;
 
-    pub open spec fn restore_spec(self, child: Self) -> (Self, PageTableGuard<'rcu, C>) {
+    pub open spec fn restore(self, child: Self) -> (Self, PageTableGuard<'rcu, C>) {
         let child_node = OwnerSubtree {
             value: child.entry_own,
             level: child.tree_level,
@@ -148,12 +148,12 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
     }
 
     #[verifier::returns(proof)]
-    pub axiom fn restore(tracked &mut self, tracked child: Self) -> (tracked guard: PageTableGuard<'rcu, C>)
+    pub axiom fn tracked_restore(tracked &mut self, tracked child: Self) -> (tracked guard: PageTableGuard<'rcu, C>)
         ensures
-            *final(self) == old(self).restore_spec(child).0,
-            guard == old(self).restore_spec(child).1;
+            *final(self) == old(self).restore(child).0,
+            guard == old(self).restore(child).1;
 
-    pub open spec fn new_spec(owner_subtree: OwnerSubtree<C>, idx: usize, guard: PageTableGuard<'rcu, C>) -> Self {
+    pub open spec fn new(owner_subtree: OwnerSubtree<C>, idx: usize, guard: PageTableGuard<'rcu, C>) -> Self {
         Self {
             entry_own: owner_subtree.value,
             idx: idx,
@@ -164,10 +164,10 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         }
     }
 
-    pub axiom fn new(tracked owner_subtree: OwnerSubtree<C>, idx: usize, guard: PageTableGuard<'rcu, C>)
+    pub axiom fn tracked_new(tracked owner_subtree: OwnerSubtree<C>, idx: usize, guard: PageTableGuard<'rcu, C>)
     -> (tracked res: Self)
         ensures
-            res == Self::new_spec(owner_subtree, idx, guard);
+            res == Self::new(owner_subtree, idx, guard);
 
     pub open spec fn map_children(self, f: spec_fn(EntryOwner<C>, TreePath<NR_ENTRIES>) -> bool) -> bool {
         forall |i: int|
@@ -526,12 +526,12 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         ensures
             final(regions).slot_owners == old(regions).slot_owners,
             final(regions).slots == old(regions).slots,
-            res.value == EntryOwner::<C>::new_frame_spec(paddr, self.path().push_tail(self.idx as usize), self.level(), prop, is_tracked).set_in_scope(false),
+            res.value == EntryOwner::<C>::new_frame(paddr, self.path().push_tail(self.idx as usize), self.level(), prop, is_tracked).set_in_scope(false),
             res.inv(),
             res.level == self.tree_level + 1,
             res == OwnerSubtree::new_val(res.value, res.level as nat),
     {
-        let tracked mut owner = EntryOwner::<C>::new_frame(paddr, self.path().push_tail(self.idx as usize), self.level(), prop, is_tracked);
+        let tracked mut owner = EntryOwner::<C>::tracked_new_frame(paddr, self.path().push_tail(self.idx as usize), self.level(), prop, is_tracked);
         owner.in_scope = false;
         OwnerSubtree::new_val_tracked(owner, self.tree_level + 1)
     }
@@ -594,7 +594,7 @@ impl<'rcu, C: PageTableConfig> Inv for CursorOwner<'rcu, C> {
         // The cursor stays within the same canonical half of the address
         // space as its prefix — so `leading_bits` agrees throughout traversal.
         &&& self.va.leading_bits == self.prefix.leading_bits
-        // Established at construction (new_spec initializes both va and
+        // Established at construction (new initializes both va and
         // prefix with LEADING_BITS_spec()) and preserved by cursor ops.
         &&& self.prefix.leading_bits == C::LEADING_BITS_spec() as int
         // The cursor's VA shares upper indices with the prefix when the
@@ -896,18 +896,18 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
     pub open spec fn as_page_table_owner(self) -> PageTableOwner<C> {
         if self.level == 1 {
             let l1 = self.continuations[0];
-            let l2 = self.continuations[1].restore_spec(l1).0;
-            let l3 = self.continuations[2].restore_spec(l2).0;
-            let l4 = self.continuations[3].restore_spec(l3).0;
+            let l2 = self.continuations[1].restore(l1).0;
+            let l3 = self.continuations[2].restore(l2).0;
+            let l4 = self.continuations[3].restore(l3).0;
             l4.as_page_table_owner()
         } else if self.level == 2 {
             let l2 = self.continuations[1];
-            let l3 = self.continuations[2].restore_spec(l2).0;
-            let l4 = self.continuations[3].restore_spec(l3).0;
+            let l3 = self.continuations[2].restore(l2).0;
+            let l4 = self.continuations[3].restore(l3).0;
             l4.as_page_table_owner()
         } else if self.level == 3 {
             let l3 = self.continuations[2];
-            let l4 = self.continuations[3].restore_spec(l3).0;
+            let l4 = self.continuations[3].restore(l3).0;
             l4.as_page_table_owner()
         } else {
             let l4 = self.continuations[3];
@@ -2385,7 +2385,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         // which is part of metaregion_sound.
     }
 
-    pub open spec fn new_spec(owner_subtree: OwnerSubtree<C>, idx: usize, guard: PageTableGuard<'rcu, C>) -> Self {
+    pub open spec fn new(owner_subtree: OwnerSubtree<C>, idx: usize, guard: PageTableGuard<'rcu, C>) -> Self {
         let va = AbstractVaddr {
             offset: 0,
             index: Map::new(|i: int| 0 <= i < NR_LEVELS, |i: int| 0).insert(NR_LEVELS - 1, idx as int),
@@ -2398,7 +2398,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         };
         Self {
             level: NR_LEVELS as PagingLevel,
-            continuations: Map::empty().insert(NR_LEVELS - 1 as int, CursorContinuation::new_spec(owner_subtree, idx, guard)),
+            continuations: Map::empty().insert(NR_LEVELS - 1 as int, CursorContinuation::new(owner_subtree, idx, guard)),
             va,
             guard_level: NR_LEVELS as PagingLevel,
             prefix: va,
@@ -2406,10 +2406,10 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         }
     }
 
-    pub axiom fn new(tracked owner_subtree: OwnerSubtree<C>, idx: usize, guard: PageTableGuard<'rcu, C>)
+    pub axiom fn tracked_new(tracked owner_subtree: OwnerSubtree<C>, idx: usize, guard: PageTableGuard<'rcu, C>)
     -> (tracked res: Self)
         ensures
-            res == Self::new_spec(owner_subtree, idx, guard);
+            res == Self::new(owner_subtree, idx, guard);
 }
 
 pub ghost struct CursorView<C: PageTableConfig> {

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -64,8 +64,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         (child, cont)
     }
 
-    #[verifier::returns(proof)]
-    pub proof fn tracked_take_child(tracked &mut self) -> (res: OwnerSubtree<C>)
+    pub proof fn tracked_take_child(tracked &mut self) -> (tracked res: OwnerSubtree<C>)
         requires
             old(self).inv(),
             old(self).idx < old(self).children.len(),
@@ -88,7 +87,6 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         }
     }
 
-    #[verifier::returns(proof)]
     pub proof fn tracked_put_child(tracked &mut self, tracked child: OwnerSubtree<C>)
         requires
             old(self).idx < old(self).children.len(),
@@ -128,8 +126,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         (child, cont)
     }
 
-    #[verifier::returns(proof)]
-    pub axiom fn tracked_make_cont(tracked &mut self, idx: usize, guard: PageTableGuard<'rcu, C>) -> (res: Self)
+    pub axiom fn tracked_make_cont(tracked &mut self, idx: usize, guard: PageTableGuard<'rcu, C>) -> (tracked res: Self)
         requires
             old(self).all_some(),
             old(self).idx < NR_ENTRIES,
@@ -147,7 +144,6 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         (Self { children: self.children.update(self.idx as int, Some(child_node)), ..self }, child.guard)
     }
 
-    #[verifier::returns(proof)]
     pub axiom fn tracked_restore(tracked &mut self, tracked child: Self) -> (tracked guard: PageTableGuard<'rcu, C>)
         ensures
             *final(self) == old(self).restore(child).0,

--- a/ostd/specs/mm/page_table/cursor/tree_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/tree_lemmas.rs
@@ -108,10 +108,10 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             self.all_but_index_some(),
             child.all_some(),
         ensures
-            self.restore_spec(child).0.as_subtree() ==
-            self.put_child_spec(child.as_subtree()).as_subtree(),
+            self.restore(child).0.as_subtree() ==
+            self.put_child(child.as_subtree()).as_subtree(),
     {
-        assert(self.put_child_spec(child.as_subtree()).children ==
+        assert(self.put_child(child.as_subtree()).children ==
         self.children.update(self.idx as int, Some(child.as_subtree())));
     }
 }

--- a/ostd/specs/mm/page_table/cursor/va_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/va_lemmas.rs
@@ -63,14 +63,14 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         Range { start, end }
     }
 
-    pub open spec fn set_va_spec(self, new_va: AbstractVaddr) -> Self {
+    pub open spec fn set_va(self, new_va: AbstractVaddr) -> Self {
         Self {
             va: new_va,
             ..self
         }
     }
 
-    pub open spec fn set_va_in_node_spec(self, new_va: AbstractVaddr) -> Self {
+    pub open spec fn set_va_in_node(self, new_va: AbstractVaddr) -> Self {
         let old_cont = self.continuations[self.level - 1];
         Self {
             va: new_va,
@@ -366,17 +366,17 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
     // ─── Axioms: VA mutation ─────────────────────────────────────────────
 
-    pub axiom fn set_va(tracked &mut self, new_va: AbstractVaddr)
+    pub axiom fn tracked_set_va(tracked &mut self, new_va: AbstractVaddr)
         requires
             forall |i: int| #![auto] old(self).level - 1 <= i < NR_LEVELS ==> new_va.index[i] == old(self).va.index[i],
             forall |i: int| #![auto] old(self).guard_level - 1 <= i < NR_LEVELS ==> new_va.index[i] == old(self).prefix.index[i],
         ensures
-            *final(self) == old(self).set_va_spec(new_va);
+            *final(self) == old(self).set_va(new_va);
 
     /// When jumping within the same page-table node, only indices at levels
     /// >= level are guaranteed to match. The entry-within-node index (level - 1)
     /// may change, so we update continuations[level-1].idx along with va.
-    pub axiom fn set_va_in_node(tracked &mut self, new_va: AbstractVaddr)
+    pub axiom fn tracked_set_va_in_node(tracked &mut self, new_va: AbstractVaddr)
         requires
             old(self).inv(),
             new_va.inv(),
@@ -391,7 +391,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             // we require `level <= guard_level`.
             old(self).level <= old(self).guard_level,
         ensures
-            *final(self) == old(self).set_va_in_node_spec(new_va),
+            *final(self) == old(self).set_va_in_node(new_va),
             final(self).inv(),;
 }
 

--- a/ostd/specs/mm/page_table/node/entry_owners.rs
+++ b/ostd/specs/mm/page_table/node/entry_owners.rs
@@ -73,7 +73,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
         self.borrowed is Some
     }
 
-    pub open spec fn new_absent_spec(path: TreePath<NR_ENTRIES>, parent_level: PagingLevel) -> Self {
+    pub open spec fn new_absent(path: TreePath<NR_ENTRIES>, parent_level: PagingLevel) -> Self {
         EntryOwner {
             node: None,
             frame: None,
@@ -86,7 +86,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
         }
     }
 
-    pub open spec fn new_frame_spec(paddr: Paddr, path: TreePath<NR_ENTRIES>, parent_level: PagingLevel, prop: PageProperty, is_tracked: bool) -> Self {
+    pub open spec fn new_frame(paddr: Paddr, path: TreePath<NR_ENTRIES>, parent_level: PagingLevel, prop: PageProperty, is_tracked: bool) -> Self {
         EntryOwner {
             node: None,
             frame: Some(FrameEntryOwner {
@@ -104,7 +104,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
         }
     }
 
-    pub open spec fn new_node_spec(node: NodeOwner<C>, path: TreePath<NR_ENTRIES>) -> Self {
+    pub open spec fn new_node(node: NodeOwner<C>, path: TreePath<NR_ENTRIES>) -> Self {
         EntryOwner {
             node: Some(node),
             frame: None,
@@ -119,7 +119,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
 
     /// Constructor spec for a translation-only / borrowed entry. See
     /// [`EntryOwner`]'s `borrowed` field for semantics.
-    pub open spec fn new_borrowed_spec(
+    pub open spec fn new_borrowed(
         path: TreePath<NR_ENTRIES>,
         parent_level: PagingLevel,
         mappings: Set<Mapping>,
@@ -136,15 +136,15 @@ impl<C: PageTableConfig> EntryOwner<C> {
         }
     }
 
-    pub axiom fn new_borrowed(
+    pub axiom fn tracked_new_borrowed(
         path: TreePath<NR_ENTRIES>,
         parent_level: PagingLevel,
         mappings: Set<Mapping>,
     ) -> tracked Self
-        returns Self::new_borrowed_spec(path, parent_level, mappings);
+        returns Self::new_borrowed(path, parent_level, mappings);
 
-    pub axiom fn new_absent(path: TreePath<NR_ENTRIES>, parent_level: PagingLevel) -> tracked Self
-        returns Self::new_absent_spec(path, parent_level);
+    pub axiom fn tracked_new_absent(path: TreePath<NR_ENTRIES>, parent_level: PagingLevel) -> tracked Self
+        returns Self::new_absent(path, parent_level);
 
     /// Rewrites the `path` field of a tracked `EntryOwner` in place. Used by
     /// `rebase_freshly_allocated_children` to propagate the cursor path down
@@ -154,8 +154,8 @@ impl<C: PageTableConfig> EntryOwner<C> {
         ensures
             *final(self) == (EntryOwner { path, ..*old(self) });
 
-    pub axiom fn new_frame(paddr: Paddr, path: TreePath<NR_ENTRIES>, parent_level: PagingLevel, prop: PageProperty, is_tracked: bool) -> tracked Self
-        returns Self::new_frame_spec(paddr, path, parent_level, prop, is_tracked);
+    pub axiom fn tracked_new_frame(paddr: Paddr, path: TreePath<NR_ENTRIES>, parent_level: PagingLevel, prop: PageProperty, is_tracked: bool) -> tracked Self
+        returns Self::new_frame(paddr, path, parent_level, prop, is_tracked);
 
     /// Structural connection between a frame entry's recorded `is_tracked` flag and
     /// the trackedness of the item that would be reconstructed by `item_from_raw_spec`.
@@ -198,8 +198,8 @@ impl<C: PageTableConfig> EntryOwner<C> {
                 != crate::specs::mm::frame::meta_owners::is_mmio_paddr(
                     entry.frame.unwrap().mapped_pa);
 
-    pub axiom fn new_node(node: NodeOwner<C>, path: TreePath<NR_ENTRIES>) -> tracked Self
-        returns Self::new_node_spec(node, path);
+    pub axiom fn tracked_new_node(node: NodeOwner<C>, path: TreePath<NR_ENTRIES>) -> tracked Self
+        returns Self::new_node(node, path);
 
     /// Creates a ghost entry owner for mapping an untracked (device memory) frame.
     /// Unlike `new_frame`, this does not consume a slot permission from the meta region,

--- a/ostd/specs/mm/tlb.rs
+++ b/ostd/specs/mm/tlb.rs
@@ -32,7 +32,7 @@ impl Inv for TlbModel {
 }
 
 impl TlbModel {
-    pub open spec fn update_spec(self, pt: PageTableView, va: Vaddr) -> Self
+    pub open spec fn update(self, pt: PageTableView, va: Vaddr) -> Self
     {
         let m = pt.mappings.filter(|m: Mapping| m.va_range.start <= va < m.va_range.end).choose();
         TlbModel {
@@ -41,15 +41,15 @@ impl TlbModel {
         }
     }
 
-    pub axiom fn update(&mut self, pt: PageTableView, va: Vaddr)
+    pub axiom fn tracked_update(&mut self, pt: PageTableView, va: Vaddr)
         requires
             old(self).inv(),
             forall|m: Mapping| old(self).mappings has m ==> !(m.va_range.start <= va < m.va_range.end),
             exists|m: Mapping| pt.mappings has m ==> m.va_range.start <= va < m.va_range.end,
         ensures
-            *final(self) == old(self).update_spec(pt, va);
+            *final(self) == old(self).update(pt, va);
 
-    pub open spec fn flush_spec(self, va: Vaddr) -> Self
+    pub open spec fn flush(self, va: Vaddr) -> Self
     {
         let m = self.mappings.filter(|m: Mapping| m.va_range.start <= va < m.va_range.end);
         TlbModel {
@@ -58,11 +58,11 @@ impl TlbModel {
         }
     }
 
-    pub axiom fn flush(&mut self, va: Vaddr)
+    pub axiom fn tracked_flush(&mut self, va: Vaddr)
         requires
             old(self).inv(),
         ensures
-            *final(self) == old(self).flush_spec(va);
+            *final(self) == old(self).flush(va);
 
     pub open spec fn consistent_with_pt(self, pt: PageTableView) -> bool {
         self.mappings <= pt.mappings
@@ -72,7 +72,7 @@ impl TlbModel {
         requires
             self.inv(),
         ensures
-            self.flush_spec(va).inv()
+            self.flush(va).inv()
     { }
 
     pub proof fn lemma_update_preserves_consistent(self, pt: PageTableView, va: Vaddr)
@@ -82,7 +82,7 @@ impl TlbModel {
             self.consistent_with_pt(pt),
             exists|m: Mapping| pt.mappings has m && m.va_range.start <= va < m.va_range.end,
         ensures
-            self.update_spec(pt, va).consistent_with_pt(pt),
+            self.update(pt, va).consistent_with_pt(pt),
     {
         let filtered = pt.mappings.filter(|m: Mapping| m.va_range.start <= va < m.va_range.end);
         let m = filtered.choose();
@@ -107,7 +107,7 @@ impl TlbModel {
             self.inv()
     { }
 
-    pub open spec fn issue_tlb_flush_spec(self, op: TlbFlushOp) -> Self
+    pub open spec fn issue_tlb_flush(self, op: TlbFlushOp) -> Self
     {
         TlbModel {
             pending: self.pending.push(op),
@@ -115,11 +115,11 @@ impl TlbModel {
         }
     }
 
-    pub proof fn issue_tlb_flush(tracked &mut self, tracked op: TlbFlushOp)
+    pub proof fn tracked_issue_tlb_flush(tracked &mut self, tracked op: TlbFlushOp)
         requires
             old(self).inv(),
         ensures
-            *final(self) == old(self).issue_tlb_flush_spec(op),
+            *final(self) == old(self).issue_tlb_flush(op),
             final(self).inv()
         {
             self.pending.tracked_push(op);
@@ -134,8 +134,8 @@ impl TlbModel {
         };
         match op {
             TlbFlushOp::All => popped,
-            TlbFlushOp::Address(va) => popped.flush_spec(va),
-            TlbFlushOp::Range(range) => popped.flush_spec(range.start),
+            TlbFlushOp::Address(va) => popped.flush(va),
+            TlbFlushOp::Range(range) => popped.flush(range.start),
         }
     }
 

--- a/ostd/specs/mm/virt_mem.rs
+++ b/ostd/specs/mm/virt_mem.rs
@@ -229,7 +229,7 @@ impl MemView {
     ///
     /// The result keeps overlapping mappings and restricts memory to physical
     /// frames reachable from that virtual range.
-    pub open spec fn borrow_at_spec(&self, vaddr: usize, len: usize) -> MemView {
+    pub open spec fn borrow_at(&self, vaddr: usize, len: usize) -> MemView {
         let range_end = vaddr + len;
 
         let valid_pas = Set::new(
@@ -260,7 +260,7 @@ impl MemView {
     /// Returns `(left, right)` where:
     /// - `left` covers `[vaddr, split_end)`, i.e. all mappings overlapping that range.
     /// - `right` covers addresses `>= split_end`.
-    pub open spec fn split_spec(self, vaddr: usize, len: usize) -> (MemView, MemView) {
+    pub open spec fn split(self, vaddr: usize, len: usize) -> (MemView, MemView) {
         let split_end = vaddr + len;
 
         // The left part.
@@ -283,41 +283,41 @@ impl MemView {
         )
     }
 
-    /// Tracked wrapper of [`Self::borrow_at_spec`].
+    /// Tracked wrapper of [`Self::borrow_at`].
     ///
     /// # Verified Properties
     ///
     /// ## Postconditions
-    /// - `r == self.borrow_at_spec(vaddr, len)`.
+    /// - `r == self.borrow_at(vaddr, len)`.
     #[verifier::external_body]
-    pub proof fn borrow_at(tracked &self, vaddr: usize, len: usize) -> (tracked r: MemView)
+    pub proof fn tracked_borrow_at(tracked &self, vaddr: usize, len: usize) -> (tracked r: MemView)
         ensures
-            r == self.borrow_at_spec(vaddr, len),
+            r == self.borrow_at(vaddr, len),
     {
         unimplemented!()
     }
 
 
-    /// Tracked wrapper of [`Self::split_spec`].
+    /// Tracked wrapper of [`Self::split`].
     ///
     /// # Verified Properties
     ///
     /// ## Postconditions
-    /// - `r == self.split_spec(vaddr, len)`.
+    /// - `r == self.split(vaddr, len)`.
     #[verifier::external_body]
-    pub proof fn split(tracked self, vaddr: usize, len: usize) -> (tracked r: (Self, Self))
+    pub proof fn tracked_split(tracked self, vaddr: usize, len: usize) -> (tracked r: (Self, Self))
         ensures
-            r == self.split_spec(vaddr, len),
+            r == self.split(vaddr, len),
     {
         unimplemented!()
     }
 
-    /// Lemma: [`Self::split_spec`] preserves translation semantics on each side.
+    /// Lemma: [`Self::split`] preserves translation semantics on each side.
     ///
     /// # Verified Properties
     ///
     /// ## Preconditions
-    /// - `original.split_spec(vaddr, len) == (left, right)`.
+    /// - `original.split(vaddr, len) == (left, right)`.
     ///
     /// ## Postconditions
     /// - `right.memory.dom().subset_of(original.memory.dom())`.
@@ -333,7 +333,7 @@ impl MemView {
         right: MemView,
     )
         requires
-            original.split_spec(vaddr, len) == (left, right),
+            original.split(vaddr, len) == (left, right),
         ensures
             right.memory.dom().subset_of(original.memory.dom()),
             forall|va: usize|
@@ -392,14 +392,14 @@ impl MemView {
     ///
     /// Mappings are unioned, and memory conflicts are resolved by
     /// [`vstd::map::Map::union_prefer_right`] with `other` taking precedence.
-    pub open spec fn join_spec(self, other: MemView) -> MemView {
+    pub open spec fn join(self, other: MemView) -> MemView {
         MemView {
             mappings: self.mappings.union(other.mappings),
             memory: self.memory.union_prefer_right(other.memory),
         }
     }
 
-    /// Tracked wrapper of [`Self::join_spec`].
+    /// Tracked wrapper of [`Self::join`].
     ///
     /// # Verified Properties
     ///
@@ -407,13 +407,13 @@ impl MemView {
     /// - `old(self).mappings.disjoint(other.mappings)`.
     ///
     /// ## Postconditions
-    /// - `*self == old(self).join_spec(other)`.
+    /// - `*self == old(self).join(other)`.
     #[verifier::external_body]
-    pub proof fn join(tracked &mut self, tracked other: Self)
+    pub proof fn tracked_join(tracked &mut self, tracked other: Self)
         requires
             old(self).mappings.disjoint(other.mappings),
         ensures
-            *final(self) == old(self).join_spec(other),
+            *final(self) == old(self).join(other),
     {
         unimplemented!()
     }
@@ -423,13 +423,13 @@ impl MemView {
     /// # Verified Properties
     ///
     /// ## Preconditions
-    /// - `this.split_spec(vaddr, len) == (lhs, rhs)`.
+    /// - `this.split(vaddr, len) == (lhs, rhs)`.
     /// - Every mapping in `this` starts at or after `vaddr`.
     /// - Every physical frame tracked by `this.memory` is reachable from some
     ///   virtual address at or after `vaddr`.
     ///
     /// ## Postconditions
-    /// - `lhs.join_spec(rhs)` has the same mappings and memory contents as `this`.
+    /// - `lhs.join(rhs)` has the same mappings and memory contents as `this`.
     pub proof fn lemma_split_join_identity(
         this: MemView,
         lhs: MemView,
@@ -438,15 +438,15 @@ impl MemView {
         len: usize,
     )
         requires
-            this.split_spec(vaddr, len) == (lhs, rhs),
+            this.split(vaddr, len) == (lhs, rhs),
             forall|m: Mapping|
                 #[trigger] this.mappings.contains(m) ==> vaddr <= m.va_range.start < m.va_range.end,
             forall|pa: Paddr|
                 #[trigger] this.memory.contains_key(pa) ==> exists |va: usize|
                     vaddr <= va && #[trigger] this.is_mapped(va, pa),
         ensures
-            this.mappings == lhs.join_spec(rhs).mappings,
-            this.memory == lhs.join_spec(rhs).memory,
+            this.mappings == lhs.join(rhs).mappings,
+            this.memory == lhs.join(rhs).memory,
     {
     }
 }
@@ -1037,7 +1037,7 @@ impl GlobalMemView {
             self.is_mapped(pa) <==> !self.unmapped_pas.contains(pa)
     }
 
-    pub open spec fn take_view_spec(self, vaddr: usize, len: usize) -> (Self, MemView) {
+    pub open spec fn take_view(self, vaddr: usize, len: usize) -> (Self, MemView) {
         let range_end = vaddr + len;
 
         let leave_mappings: Set<Mapping> = self.tlb_mappings.filter(
@@ -1067,12 +1067,12 @@ impl GlobalMemView {
         )
     }
 
-    pub axiom fn take_view(tracked &mut self, vaddr: usize, len: usize) -> (tracked view: MemView)
+    pub axiom fn tracked_take_view(tracked &mut self, vaddr: usize, len: usize) -> (tracked view: MemView)
         ensures
-            *final(self) == old(self).take_view_spec(vaddr, len).0,
-            view == old(self).take_view_spec(vaddr, len).1;
+            *final(self) == old(self).take_view(vaddr, len).0,
+            view == old(self).take_view(vaddr, len).1;
 
-    pub open spec fn return_view_spec(self, view: MemView) -> Self {
+    pub open spec fn return_view(self, view: MemView) -> Self {
         GlobalMemView {
             tlb_mappings: self.tlb_mappings.union(view.mappings),
             memory: self.memory.union_prefer_right(view.memory),
@@ -1080,11 +1080,11 @@ impl GlobalMemView {
         }
     }
 
-    pub axiom fn return_view(&mut self, view: MemView)
+    pub axiom fn tracked_return_view(&mut self, view: MemView)
         ensures
-            *final(self) == old(self).return_view_spec(view);
+            *final(self) == old(self).return_view(view);
 
-    pub open spec fn tlb_flush_vaddr_spec(self, vaddr: Vaddr) -> Self {
+    pub open spec fn tlb_flush_vaddr(self, vaddr: Vaddr) -> Self {
         let tlb_mappings = self.tlb_mappings.filter(
             |m: Mapping| m.va_range.end <= vaddr || vaddr < m.va_range.start
         );
@@ -1094,14 +1094,14 @@ impl GlobalMemView {
         }
     }
 
-    pub axiom fn tlb_flush_vaddr(&mut self, vaddr: Vaddr)
+    pub axiom fn tracked_tlb_flush_vaddr(&mut self, vaddr: Vaddr)
         requires
             old(self).inv()
         ensures
-            *final(self) == old(self).tlb_flush_vaddr_spec(vaddr),
+            *final(self) == old(self).tlb_flush_vaddr(vaddr),
             final(self).inv();
 
-    pub open spec fn tlb_soft_fault_spec(self, vaddr: Vaddr) -> Self {
+    pub open spec fn tlb_soft_fault(self, vaddr: Vaddr) -> Self {
         let mapping = self.pt_mappings.filter(|m: Mapping| m.va_range.start <= vaddr < m.va_range.end).choose();
         GlobalMemView {
             tlb_mappings: self.tlb_mappings.insert(mapping),
@@ -1109,15 +1109,15 @@ impl GlobalMemView {
         }
     }
 
-    pub axiom fn tlb_soft_fault(tracked &mut self, vaddr: Vaddr)
+    pub axiom fn tracked_tlb_soft_fault(tracked &mut self, vaddr: Vaddr)
         requires
             old(self).inv(),
             old(self).addr_transl(vaddr) is None,
         ensures
-            *final(self) == old(self).tlb_soft_fault_spec(vaddr),
+            *final(self) == old(self).tlb_soft_fault(vaddr),
             final(self).inv();
 
-    pub open spec fn pt_map_spec(self, m: Mapping) -> Self {
+    pub open spec fn pt_map(self, m: Mapping) -> Self {
         let pt_mappings = self.pt_mappings.insert(m);
         let unmapped_pas = self.unmapped_pas.difference(
             Set::new(|pa: usize| m.pa_range.start <= pa < m.pa_range.end)
@@ -1129,16 +1129,16 @@ impl GlobalMemView {
         }
     }
 
-    pub axiom fn pt_map(&mut self, m: Mapping)
+    pub axiom fn tracked_pt_map(&mut self, m: Mapping)
         requires
             forall|pa: Paddr|
                 m.pa_range.start <= pa < m.pa_range.end ==>
                 old(self).unmapped_pas.contains(pa),
             old(self).inv()
         ensures
-            *final(self) == old(self).pt_map_spec(m);
+            *final(self) == old(self).pt_map(m);
 
-    pub open spec fn pt_unmap_spec(self, m: Mapping) -> Self {
+    pub open spec fn pt_unmap(self, m: Mapping) -> Self {
         let pt_mappings = self.pt_mappings.remove(m);
         let unmapped_pas = self.unmapped_pas.union(
             Set::new(|pa: usize| m.pa_range.start <= pa < m.pa_range.end)
@@ -1150,12 +1150,12 @@ impl GlobalMemView {
         }
     }
 
-    pub axiom fn pt_unmap(&mut self, m: Mapping)
+    pub axiom fn tracked_pt_unmap(&mut self, m: Mapping)
         requires
             old(self).pt_mappings.contains(m),
             old(self).inv()
         ensures
-            *final(self) == old(self).pt_unmap_spec(m),
+            *final(self) == old(self).pt_unmap(m),
             final(self).inv();
 
     pub proof fn lemma_va_mapping_unique(self, va: usize)

--- a/ostd/specs/mm/vm_space.rs
+++ b/ostd/specs/mm/vm_space.rs
@@ -331,7 +331,7 @@ impl<'a> VmSpaceOwner {
             reader.inv(),
         ensures
             reader.wf(*final(owner_r)),
-            final(owner_r).mem_view == Some(VmIoMemView::ReadView(old(self).mem_view@.unwrap().borrow_at_spec(
+            final(owner_r).mem_view == Some(VmIoMemView::ReadView(old(self).mem_view@.unwrap().borrow_at(
                 old(owner_r).range.start,
                 (old(owner_r).range.end - old(owner_r).range.start) as usize,
             ))),
@@ -341,7 +341,7 @@ impl<'a> VmSpaceOwner {
                 Some(ref mv) => mv,
                 _ => { proof_from_false() },
             };
-            let tracked borrowed_mv = mv.borrow_at(
+            let tracked borrowed_mv = mv.tracked_borrow_at(
                 owner_r.range.start,
                 (owner_r.range.end - owner_r.range.start) as usize,
             );
@@ -407,7 +407,7 @@ impl<'a> VmSpaceOwner {
             writer.inv(),
         ensures
             writer.wf(*final(owner_w)),
-            final(owner_w).mem_view == Some(VmIoMemView::WriteView(old(self).mem_view@.unwrap().split_spec(
+            final(owner_w).mem_view == Some(VmIoMemView::WriteView(old(self).mem_view@.unwrap().split(
                 old(owner_w).range.start,
                 (old(owner_w).range.end - old(owner_w).range.start) as usize,
             ).0)),
@@ -415,7 +415,7 @@ impl<'a> VmSpaceOwner {
     pub proof fn activate_writer(tracked &mut self, writer: &'a VmWriter<'a>, tracked owner_w: &'a mut VmIoOwner) {
             let tracked mut mv = self.mem_view.tracked_take();
             let ghost old_mv = mv;
-            let tracked (lhs, rhs) = mv.split(
+            let tracked (lhs, rhs) = mv.tracked_split(
                 owner_w.range.start,
                 (owner_w.range.end - owner_w.range.start) as usize,
             );
@@ -512,7 +512,7 @@ impl<'a> VmSpaceOwner {
 
         let tracked mut remaining = self.mem_view.tracked_take();
         let ghost old_remaining = remaining;
-        remaining.join(mv);
+        remaining.tracked_join(mv);
         self.mem_view = Some(remaining);
 
         assert(self.mem_view_wf()) by {

--- a/ostd/specs/mm/vm_space_embedding.rs
+++ b/ostd/specs/mm/vm_space_embedding.rs
@@ -411,7 +411,7 @@ pub axiom fn axiom_fresh_cursor_id_not_in_dom<'rcu>(
 /// Verus does not let a `proof fn` construct a tracked struct via a
 /// struct-literal when ghost-mode and tracked-mode fields are mixed; the
 /// idiomatic workaround is a constructor axiom (cf.
-/// [`CursorContinuation::new`]).
+/// [`CursorContinuation::tracked_new`]).
 pub axiom fn axiom_cursor_entry_new<'rcu>(
     vm_space: VmSpaceId,
     kind: CursorKind,

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -209,7 +209,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
     )]
     pub fn push_front(&mut self, frame: UniqueFrame<Link<M>>) {
         let current = self.front;
-        let tracked mut cursor_own = CursorOwner::front_owner(*owner);
+        let tracked mut cursor_own = CursorOwner::tracked_front_owner(*owner);
         let mut cursor = CursorMut { list: self, current };
 
         #[verus_spec(with Tracked(regions), Tracked(&mut cursor_own), Tracked(frame_own))]
@@ -249,7 +249,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
     pub fn pop_front(&mut self) -> Option<(UniqueFrame<Link<M>>, Tracked<UniqueFrameOwner<Link<M>>>)> {
         assert(owner.list.len() > 0 ==> owner.inv_at(0));
 
-        let tracked mut cursor_own = CursorOwner::front_owner(owner);
+        let tracked mut cursor_own = CursorOwner::tracked_front_owner(owner);
         let current = self.front;
         let mut cursor = CursorMut { list: self, current };
 
@@ -299,7 +299,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
     )]
     pub fn push_back(&mut self, frame: UniqueFrame<Link<M>>) {
         let current = self.back;
-        let tracked mut cursor_own = CursorOwner::back_owner(*owner);
+        let tracked mut cursor_own = CursorOwner::tracked_back_owner(*owner);
         let mut cursor = CursorMut { list: self, current };
 
         #[verus_spec(with Tracked(regions), Tracked(&mut cursor_own), Tracked(frame_own))]
@@ -341,7 +341,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
         assert(owner.list.len() > 0 ==> owner.inv_at(owner.list.len() - 1));
 
         let current = self.back;
-        let tracked mut cursor_own = CursorOwner::back_owner(owner);
+        let tracked mut cursor_own = CursorOwner::tracked_back_owner(owner);
         let mut cursor = CursorMut { list: self, current };
 
         #[verus_spec(with Tracked(regions), Tracked(&mut cursor_own))]
@@ -456,7 +456,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
 
                 let ghost link = owner.list.filter(|link: LinkOwner| link.paddr == frame).first();
                 let ghost index = owner.list.index_of(link);
-                let tracked cursor_owner = CursorOwner::cursor_mut_at_owner(owner, index);
+                let tracked cursor_owner = CursorOwner::tracked_cursor_mut_at_owner(owner, index);
 
                 proof_with!(|= Tracked(Some(cursor_owner)));
                 Some(CursorMut { list: self, current: Some(MetadataAsLink::cast_from_metadata(meta_ptr)) })
@@ -486,7 +486,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
     /// ## Postconditions
     /// - The cursor is well-formed, with the pointers to its links' metadata slots
     /// matching the tracked permission objects. The list invariants are preserved.
-    /// - See [`CursorOwner::front_owner_spec`] for the precise specification.
+    /// - See [`CursorOwner::front_owner`] for the precise specification.
     /// ## Safety
     /// - This function only uses the list permission, so there are no illegal memory accesses.
     /// - No data races are possible.
@@ -499,12 +499,12 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
         ensures
             r.0.wf(r.1@),
             r.1@.inv(),
-            r.1@ == CursorOwner::front_owner_spec(owner),
+            r.1@ == CursorOwner::front_owner(owner),
     )]
     pub fn cursor_front_mut(&mut self) -> (CursorMut<'_, M>, Tracked<CursorOwner<M>>) {
         let current = self.front;
 
-        (CursorMut { list: self, current }, Tracked(CursorOwner::front_owner(owner)))
+        (CursorMut { list: self, current }, Tracked(CursorOwner::tracked_front_owner(owner)))
     }
 
     /// Gets a cursor at the back that can mutate the linked list links.
@@ -517,7 +517,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
     /// ## Postconditions
     /// - The cursor is well-formed, with the pointers to its links' metadata slots
     /// matching the tracked permission objects. The list invariants are preserved.
-    /// See [`CursorOwner::back_owner_spec`] for the precise specification.
+    /// See [`CursorOwner::back_owner`] for the precise specification.
     /// ## Safety
     /// - This function only uses the list permission, so there are no illegal memory accesses.
     /// - No data races are possible.
@@ -532,11 +532,11 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
         ensures
             res.0.wf(res.1@),
             res.1@.inv(),
-            res.1@ == CursorOwner::back_owner_spec(owner),
+            res.1@ == CursorOwner::back_owner(owner),
     {
         let current = self.back;
 
-        (CursorMut { list: self, current }, Tracked(CursorOwner::back_owner(owner)))
+        (CursorMut { list: self, current }, Tracked(CursorOwner::tracked_back_owner(owner)))
     }
 
     /// Gets a cursor at the "ghost" non-element that can mutate the linked list links.

--- a/ostd/src/mm/frame/unique.rs
+++ b/ostd/src/mm/frame/unique.rs
@@ -82,7 +82,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrame<M> {
                 let tracked typed_perm = MetaSlot::cast_perm::<M>(slot_perm, inner_perms_taken);
                 slot_own.sync_inner(&typed_perm.inner_perms);
                 regions.slot_owners.tracked_insert(idx, slot_own);
-                let tracked owner = UniqueFrameOwner::<M>::from_unused_owner(regions, paddr, typed_perm);
+                let tracked owner = UniqueFrameOwner::<M>::tracked_from_unused_owner(regions, paddr, typed_perm);
             }
             proof_with!(|= Tracked(Some(owner)));
             Ok(Self { ptr, _marker: PhantomData })
@@ -184,7 +184,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrame<M> {
         }
         let tracked meta_perm = MetaSlot::cast_perm::<M1>(slot_perm, inner_perms);
 
-        let tracked mut new_owner = UniqueFrameOwner::<M1>::from_unused_owner(
+        let tracked mut new_owner = UniqueFrameOwner::<M1>::tracked_from_unused_owner(
             regions,
             meta_to_frame(self.ptr.addr()),
             meta_perm,

--- a/ostd/src/mm/kspace/kvirt_area.rs
+++ b/ostd/src/mm/kspace/kvirt_area.rs
@@ -971,11 +971,11 @@ impl KVirtArea {
 
                 // Reinsert a fresh owner for this paddr so later iterations on the
                 // same frame reuse it. `new_frame` fabricates an `EntryOwner` with
-                // the correct `new_frame_spec` shape for the paddr/level/prop;
+                // the correct `new_frame` shape for the paddr/level/prop;
                 // `frame_entry_wf` holds for any future frame at the same paddr.
                 // Note: `new_frame` returns with `in_scope = true`; clear it for
                 // `inv()` to hold (which requires `!in_scope`).
-                let tracked mut fresh = EntryOwner::<KernelPtConfig>::new_frame(
+                let tracked mut fresh = EntryOwner::<KernelPtConfig>::tracked_new_frame(
                     cur_mapped_pa,
                     cur_path,
                     cur_parent_level,

--- a/ostd/src/mm/page_table/cursor/locking.rs
+++ b/ostd/src/mm/page_table/cursor/locking.rs
@@ -115,7 +115,7 @@ pub fn lock_range<'rcu, C: PageTableConfig, A: InAtomicMode>(
 ) -> (Cursor<'rcu, C, A>, Tracked<CursorOwner<'rcu, C>>) {
     let ghost start_idx = AbstractVaddr::from_vaddr(va.start).index[NR_LEVELS as int - 1];
 
-    let tracked mut cursor_own: CursorOwner<'rcu, C> = CursorOwner::new(
+    let tracked mut cursor_own: CursorOwner<'rcu, C> = CursorOwner::tracked_new(
         pt_own.0,
         start_idx as usize,
         root_guard,
@@ -353,7 +353,7 @@ fn try_traverse_and_lock_subtree_root<'rcu, C: PageTableConfig, A: InAtomicMode>
                 let tracked mut cont = cursor_own.continuations.tracked_remove(
                     cursor_own.level - 1,
                 );
-                let tracked child_cont = cont.make_cont(next_idx, new_guard);
+                let tracked child_cont = cont.tracked_make_cont(next_idx, new_guard);
                 cursor_own.continuations.tracked_insert(cursor_own.level - 1, cont);
                 cursor_own.continuations.tracked_insert(cursor_own.level - 2, child_cont);
                 cursor_own.level = (cursor_own.level - 1) as PagingLevel;
@@ -401,7 +401,7 @@ fn try_traverse_and_lock_subtree_root<'rcu, C: PageTableConfig, A: InAtomicMode>
                 let tracked mut cont = cursor_own.continuations.tracked_remove(
                     cursor_own.level - 1,
                 );
-                let tracked child_cont = cont.make_cont(next_idx, new_guard);
+                let tracked child_cont = cont.tracked_make_cont(next_idx, new_guard);
                 cursor_own.continuations.tracked_insert(cursor_own.level - 1, cont);
                 cursor_own.continuations.tracked_insert(cursor_own.level - 2, child_cont);
                 cursor_own.level = (cursor_own.level - 1) as PagingLevel;
@@ -426,7 +426,7 @@ fn try_traverse_and_lock_subtree_root<'rcu, C: PageTableConfig, A: InAtomicMode>
                 let tracked mut cont = cursor_own.continuations.tracked_remove(
                     cursor_own.level - 1,
                 );
-                let tracked child_cont = cont.make_cont(next_idx, new_guard);
+                let tracked child_cont = cont.tracked_make_cont(next_idx, new_guard);
                 cursor_own.continuations.tracked_insert(cursor_own.level - 1, cont);
                 cursor_own.continuations.tracked_insert(cursor_own.level - 2, child_cont);
                 cursor_own.level = (cursor_own.level - 1) as PagingLevel;

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -552,7 +552,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
             let ghost owner_snap = *owner;
             let tracked mut continuation = owner.continuations.tracked_remove(owner.level - 1);
             let ghost cont0 = continuation;
-            let tracked child_owner = continuation.take_child();
+            let tracked child_owner = continuation.tracked_take_child();
             let tracked parent_owner = continuation.entry_own.node.tracked_borrow();
             let ghost regions_before_ref = *regions;
 
@@ -560,7 +560,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
             let cur_child = entry.to_ref();
 
             proof {
-                continuation.put_child(child_owner);
+                continuation.tracked_put_child(child_owner);
                 cont0.take_put_child();
                 owner.continuations.tracked_insert(owner.level - 1, continuation);
                 owner.metaregion_slot_owners_preserved(regions_before_ref, *regions);
@@ -580,7 +580,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                     let tracked mut continuation = owner.continuations.tracked_remove(
                         owner.level - 1,
                     );
-                    let tracked mut child_owner = continuation.take_child();
+                    let tracked mut child_owner = continuation.tracked_take_child();
                     let tracked mut child_node = child_owner.value.node.tracked_take();
 
                     let ghost guards0 = *guards;
@@ -592,7 +592,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
 
                     proof {
                         child_owner.value.node = Some(child_node);
-                        continuation.put_child(child_owner);
+                        continuation.tracked_put_child(child_owner);
                         owner.continuations.tracked_insert(owner.level - 1, continuation);
 
                         owner.map_children_implies(
@@ -1045,7 +1045,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
 
             let tracked mut continuation = owner.continuations.tracked_remove(owner.level - 1);
             let ghost cont0 = continuation;
-            let tracked child_owner = continuation.take_child();
+            let tracked child_owner = continuation.tracked_take_child();
             let tracked node_owner = continuation.entry_own.node.tracked_borrow();
 
             let ghost regions_before_ref = *regions;
@@ -1054,7 +1054,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
             let cur_child = cur_entry.to_ref();
 
             proof {
-                continuation.put_child(child_owner);
+                continuation.tracked_put_child(child_owner);
                 assert(continuation.children == cont0.children);
                 owner.continuations.tracked_insert(owner.level - 1, continuation);
                 assert(owner.continuations == owner0.continuations);
@@ -1104,7 +1104,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                         owner.level - 1,
                     );
                     let ghost cont0 = continuation;
-                    let tracked mut child_owner = continuation.take_child();
+                    let tracked mut child_owner = continuation.tracked_take_child();
 
                     let tracked mut parent_node_owner = continuation.entry_own.node.tracked_take();
                     let tracked mut child_node_owner = child_owner.value.node.tracked_take();
@@ -1120,7 +1120,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
 
                     proof {
                         child_owner.value.node = Some(child_node_owner);
-                        continuation.put_child(child_owner);
+                        continuation.tracked_put_child(child_owner);
                         continuation.entry_own.node = Some(parent_node_owner);
                         assert(cont0.children == continuation.children);
                         owner.continuations.tracked_insert(self.level - 1, continuation);
@@ -1354,7 +1354,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                     );
                     let ghost cont_pre_split = continuation;
                     let ghost parent_pre_split = continuation.entry_own.node.unwrap();
-                    let tracked mut child_owner = continuation.take_child();
+                    let tracked mut child_owner = continuation.tracked_take_child();
                     let tracked mut parent_owner = continuation.entry_own.node.tracked_take();
 
                     proof {
@@ -1410,7 +1410,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                             cont0.idx,
                         );
 
-                        continuation.put_child(child_owner);
+                        continuation.tracked_put_child(child_owner);
                         continuation.entry_own.node = Some(parent_owner);
                         continuation.continuation_inv_holds_after_child_restore(
                             cont_pre_split,
@@ -1434,7 +1434,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                         let old_level = owner_before_push.level;
                         let cont = owner_before_push.continuations[old_level - 1];
                         let idx_below = owner_before_push.va.index[old_level - 2] as usize;
-                        let (child_cont, _) = cont.make_cont_spec(idx_below, split_child_ghost);
+                        let (child_cont, _) = cont.make_cont(idx_below, split_child_ghost);
 
                         assert(child_cont.children =~= child_owner_children);
                         assert(owner.cur_entry_owner().is_frame());
@@ -1575,7 +1575,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                     }
                     AbstractVaddr::from_vaddr_to_vaddr_roundtrip(va);
 
-                    owner.set_va_in_node(new_va);
+                    owner.tracked_set_va_in_node(new_va);
                 }
 
                 return Ok(());
@@ -1728,7 +1728,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                 abs_va_down.use_wrapped(start_level as int, self.level as int);
                 assert(owner0.va.index[self.level - 1] + 1 == NR_ENTRIES);
                 assert(owner.move_forward_owner_spec()
-                    == owner.pop_level_owner_spec().0.move_forward_owner_spec());
+                    == owner.pop_level_owner().0.move_forward_owner_spec());
                 owner.pop_level_owner_preserves_invs(*guards, *regions);
             }
 
@@ -1814,7 +1814,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
             // cursor's own VA. (Lets callers track `self.va` across the
             // ascent — e.g. `jump`'s structural panic condition.)
             final(self).va == old(self).va,
-            *final(owner) == old(owner).pop_level_owner_spec().0,
+            *final(owner) == old(owner).pop_level_owner().0,
             final(owner).va == old(owner).va,
             final(owner).prefix == old(owner).prefix,
             final(owner).guard_level == old(owner).guard_level,
@@ -1833,7 +1833,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
             ));
             owner.pop_level_owner_preserves_invs(*guards, *regions);
         }
-        let tracked guard = owner.pop_level_owner();
+        let tracked guard = owner.tracked_pop_level_owner();
 
         let ghost owner0 = *owner;
         let ghost guards0 = *guards;
@@ -1906,7 +1906,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
             final(self).barrier_va == old(self).barrier_va,
             final(self).level == old(self).level - 1,
             final(self).va == old(self).va,
-            *final(owner) == old(owner).push_level_owner_spec(child_pt),
+            *final(owner) == old(owner).push_level_owner(child_pt),
             final(owner).max_steps() < old(owner).max_steps(),
             old(owner)@.mappings == final(owner)@.mappings,
     {
@@ -1926,7 +1926,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
             owner.push_level_owner_decreases_steps(child_pt);
             owner.push_level_owner_preserves_va(child_pt);
             owner.push_level_owner_preserves_mappings(child_pt);
-            owner.push_level_owner(child_pt);
+            owner.tracked_push_level_owner(child_pt);
         }
         // debug_assert!(old.is_none());
     }
@@ -1964,7 +1964,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
 
         assert(parent_continuation.inv());
         let ghost cont0 = parent_continuation;
-        let tracked child = parent_continuation.take_child();
+        let tracked child = parent_continuation.tracked_take_child();
         let tracked parent_own = parent_continuation.entry_own.node.tracked_take();
 
         let ghost index = frame_to_index(meta_to_frame(parent_own.meta_perm.addr()));
@@ -1982,7 +1982,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
 
         proof {
             parent_continuation.entry_own.node = Some(parent_own);
-            parent_continuation.put_child(child);
+            parent_continuation.tracked_put_child(child);
             assert(parent_continuation.children == cont0.children);
             owner.continuations.tracked_insert((owner.level - 1) as int, parent_continuation);
             assert(owner.continuations == owner0.continuations);
@@ -2308,7 +2308,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         let ghost cont_orig = owner.continuations[level_key];
 
         let tracked mut continuation = owner.continuations.tracked_remove(owner.level - 1);
-        let tracked mut child_owner = continuation.take_child();
+        let tracked mut child_owner = continuation.tracked_take_child();
         let ghost orig_child_owner = child_owner;
         let tracked mut child_node = child_owner.value.node.tracked_take();
 
@@ -2319,7 +2319,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         proof {
             child_owner.value.node = Some(child_node);
             assert(child_owner == orig_child_owner);
-            continuation.put_child(child_owner);
+            continuation.tracked_put_child(child_owner);
             cont_orig.take_put_child();
             assert(continuation == cont_orig);
             owner.continuations.tracked_insert(owner.level - 1, continuation);
@@ -2449,7 +2449,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             let ghost cont0 = owner.continuations[owner.level - 1];
 
             let tracked mut continuation = owner.continuations.tracked_remove(owner.level - 1);
-            let tracked child_owner = continuation.take_child();
+            let tracked child_owner = continuation.tracked_take_child();
             let ghost child_entry_val = child_owner.value;
             let tracked parent_owner = continuation.entry_own.node.tracked_borrow();
 
@@ -2461,7 +2461,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
 
             proof {
                 cont0.take_put_child();
-                continuation.put_child(child_owner);
+                continuation.tracked_put_child(child_owner);
                 assert(continuation == cont0);
                 owner.continuations.tracked_insert(owner.level - 1, continuation);
 
@@ -2504,7 +2504,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         owner.level - 1,
                     );
                     let ghost cont_pre_alloc = continuation;
-                    let tracked mut child_owner = continuation.take_child();
+                    let tracked mut child_owner = continuation.tracked_take_child();
                     let ghost old_child_value = child_owner.value;
                     let tracked mut parent_owner = continuation.entry_own.node.tracked_take();
                     proof {
@@ -2548,7 +2548,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
 
                         cont_pre_alloc.take_put_child();
                         continuation.entry_own.node = Some(parent_owner);
-                        continuation.put_child(child_owner);
+                        continuation.tracked_put_child(child_owner);
                         owner.continuations.tracked_insert(owner.level - 1, continuation);
 
                         assert(owner.cur_entry_owner().node.unwrap().meta_perm.addr()
@@ -2701,7 +2701,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                     );
                     let ghost cont_pre_split = continuation;
                     let ghost parent_pre_split = continuation.entry_own.node.unwrap();
-                    let tracked mut child_owner = continuation.take_child();
+                    let tracked mut child_owner = continuation.tracked_take_child();
                     let tracked mut parent_owner = continuation.entry_own.node.tracked_take();
 
                     proof {
@@ -2716,7 +2716,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                     cur_entry.split_if_mapped_huge(rcu_guard)).unwrap();
 
                     proof {
-                        continuation.put_child(child_owner);
+                        continuation.tracked_put_child(child_owner);
                         continuation.entry_own.node = Some(parent_owner);
                         owner.continuations.tracked_insert(owner.level - 1, continuation);
                         assert(owner.continuations[owner.level - 1].inv()) by {
@@ -2933,7 +2933,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         proof {
             // Hoist common facts about new_owner from new_child postcondition.
             let cont = owner1.continuations[owner1.level as int - 1];
-            assert(new_owner.value == EntryOwner::<C>::new_frame_spec(
+            assert(new_owner.value == EntryOwner::<C>::new_frame(
                 pa,
                 cont.path().push_tail(cont.idx as usize),
                 cont.level(),
@@ -3289,7 +3289,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             }
             return None;
         }
-        let tracked mut absent_entry_owner = EntryOwner::new_absent(
+        let tracked mut absent_entry_owner = EntryOwner::tracked_new_absent(
             owner.cur_entry_owner().path,
             owner.level,
         );
@@ -3596,7 +3596,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         // entry.idx == cont0.idx from cur_entry postcondition (entry.idx == owner0.cont[level-1].idx)
         // and cont0 == owner0.cont[level-1] from tracked_remove.
         assert(entry.idx == cont0.idx as usize);
-        let tracked mut child_owner = continuation.take_child();
+        let tracked mut child_owner = continuation.tracked_take_child();
         let tracked mut parent_owner = continuation.entry_own.node.tracked_take();
 
         #[verus_spec(with Tracked(&mut child_owner.value), Tracked(&mut parent_owner))]
@@ -3611,7 +3611,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         proof {
             let ghost child_not_in_scope = !child_owner.value.in_scope;
 
-            continuation.put_child(child_owner);
+            continuation.tracked_put_child(child_owner);
             continuation.entry_own.node = Some(parent_owner);
             cont0.take_put_child();
             owner.continuations.tracked_insert(owner.level - 1, continuation);
@@ -3802,13 +3802,13 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         let ghost cont0 = continuation;
         let ghost owner1 = *owner;
 
-        let tracked old_child_owner = continuation.take_child();
+        let tracked old_child_owner = continuation.tracked_take_child();
 
         let ghost cont1 = continuation;
         assert(cont1.view_mappings() == cont0.view_mappings()
             - cont0.view_mappings_take_child_spec()) by {
             cont0.view_mappings_take_child();
-            assert(cont1 == cont0.take_child_spec().1);
+            assert(cont1 == cont0.take_child().1);
         }
         assert(owner.continuations == owner0.continuations.remove(owner.level - 1));
 
@@ -3854,7 +3854,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
 
         proof {
             continuation.entry_own.node = Some(parent_owner);
-            continuation.put_child(new_owner);
+            continuation.tracked_put_child(new_owner);
             cont1.view_mappings_put_child(new_owner);
 
             let ghost final_cont = continuation;

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -961,7 +961,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
 
             assert(small_pa % PAGE_SIZE == 0);
 
-            let tracked child_owner = EntryOwner::new_frame(
+            let tracked child_owner = EntryOwner::tracked_new_frame(
                 small_pa,
                 new_owner.value.path.push_tail(i as usize),
                 (level - 1) as PagingLevel,

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -187,7 +187,7 @@ impl<C: PageTableConfig> PageTableNode<C> {
     )]
     #[verifier::external_body]
     pub fn alloc<'rcu>(level: PagingLevel) -> Self {
-        let tracked entry_owner = EntryOwner::new_absent(TreePath::new(Seq::empty()), level);
+        let tracked entry_owner = EntryOwner::tracked_new_absent(TreePath::new(Seq::empty()), level);
 
         let tracked mut owner = OwnerSubtree::<C>::new_val_tracked(entry_owner, level as nat);
         let meta = PageTablePageMeta::new(level);

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -187,7 +187,10 @@ impl<C: PageTableConfig> PageTableNode<C> {
     )]
     #[verifier::external_body]
     pub fn alloc<'rcu>(level: PagingLevel) -> Self {
-        let tracked entry_owner = EntryOwner::tracked_new_absent(TreePath::new(Seq::empty()), level);
+        let tracked entry_owner = EntryOwner::tracked_new_absent(
+            TreePath::new(Seq::empty()),
+            level,
+        );
 
         let tracked mut owner = OwnerSubtree::<C>::new_val_tracked(entry_owner, level as nat);
         let meta = PageTablePageMeta::new(level);

--- a/ostd/src/mm/tlb.rs
+++ b/ostd/src/mm/tlb.rs
@@ -64,7 +64,7 @@ impl<'a  /*, G: PinCurrentCpu*/ > TlbFlusher<'a  /*, G*/ > {
     #[verus_spec(
         with Tracked(model): Tracked<&mut TlbModel>
         ensures
-            *final(model) == old(model).issue_tlb_flush_spec(op),
+            *final(model) == old(model).issue_tlb_flush(op),
             final(model).inv(),
     )]
     #[verifier::external_body]
@@ -82,7 +82,7 @@ impl<'a  /*, G: PinCurrentCpu*/ > TlbFlusher<'a  /*, G*/ > {
     #[verus_spec(r =>
         with Tracked(model): Tracked<&mut TlbModel>
         ensures
-            *final(model) == old(model).issue_tlb_flush_spec(op),
+            *final(model) == old(model).issue_tlb_flush(op),
             final(model).inv(),
     )]
     #[verifier::external_body]


### PR DESCRIPTION
Pretty simple, just renames `X_spec` to `X` and `Y` to `tracked_Y`.