### PR TITLE
chore: More idiomatic `VmIoOwner` definition

### DIFF
--- a/ostd/specs/mm/embedding/io.rs
+++ b/ostd/specs/mm/embedding/io.rs
@@ -138,15 +138,15 @@ pub axiom fn vm_reader_read_embedded(
         final(source_owner).read_view_initialized(),
         final(dest_owner).has_write_view(),
         // Source/dest ranges only shrink (start advances).
-        final(source_owner).range@.start >= old(source_owner).range@.start,
-        final(source_owner).range@.end == old(source_owner).range@.end,
-        final(dest_owner).range@.start >= old(dest_owner).range@.start,
-        final(dest_owner).range@.end == old(dest_owner).range@.end,
+        final(source_owner).range.start >= old(source_owner).range.start,
+        final(source_owner).range.end == old(source_owner).range.end,
+        final(dest_owner).range.start >= old(dest_owner).range.start,
+        final(dest_owner).range.end == old(dest_owner).range.end,
         consumed_w.inv(),
         consumed_w.has_write_view(),
         // consumed_w covers the just-written portion of dest.
-        consumed_w.range@.start >= old(dest_owner).range@.start,
-        consumed_w.range@.end <= final(dest_owner).range@.start,
+        consumed_w.range.start >= old(dest_owner).range.start,
+        consumed_w.range.end <= final(dest_owner).range.start,
 ;
 
 /// Mirror of [`crate::mm::io::VmReader::limit`].
@@ -192,10 +192,10 @@ pub axiom fn vm_writer_write_embedded(
         final(source_owner).read_view_initialized(),
         final(dest_owner).has_write_view(),
         // Ranges only shrink (start advances; end fixed).
-        final(source_owner).range@.start >= old(source_owner).range@.start,
-        final(source_owner).range@.end == old(source_owner).range@.end,
-        final(dest_owner).range@.start >= old(dest_owner).range@.start,
-        final(dest_owner).range@.end == old(dest_owner).range@.end,
+        final(source_owner).range.start >= old(source_owner).range.start,
+        final(source_owner).range.end == old(source_owner).range.end,
+        final(dest_owner).range.start >= old(dest_owner).range.start,
+        final(dest_owner).range.end == old(dest_owner).range.end,
 ;
 
 /// Mirror of [`crate::mm::io::VmWriter::fill_zeros`].

--- a/ostd/specs/mm/io.rs
+++ b/ostd/specs/mm/io.rs
@@ -91,13 +91,13 @@ pub tracked enum VmIoMemView {
 /// validity of the memory range and memory view tracked by this struct.
 pub tracked struct VmIoOwner {
     /// The unique identifier of this owner.
-    pub id: Ghost<nat>,
+    pub ghost id: nat,
     /// The virtual address range owned by this owner.
-    pub range: Ghost<Range<usize>>,
+    pub ghost range: Range<usize>,
     /// Whether this reader is fallible.
-    pub is_fallible: bool,
+    pub ghost is_fallible: bool,
     /// Whether this owner is for kernel space.
-    pub is_kernel: bool,
+    pub ghost is_kernel: bool,
     /// The mem view associated with this owner.
     pub mem_view: Option<VmIoMemView>,
 }
@@ -106,7 +106,7 @@ impl VmIoOwner {
     /// Structural well-formedness: the range is ordered.
     /// Always holds after construction.
     pub open spec fn inv_wf(self) -> bool {
-        self.range@.start <= self.range@.end
+        self.range.start <= self.range.end
     }
 }
 
@@ -119,7 +119,7 @@ impl Inv for VmIoOwner {
                 &&& mv.mappings.finite()
                 &&& mv.mappings_are_disjoint()
                 &&& forall|va: usize|
-                    self.range@.start <= va < self.range@.end ==> {
+                    self.range.start <= va < self.range.end ==> {
                         &&& #[trigger] mv.addr_transl(va) is Some
                     }
             },
@@ -127,7 +127,7 @@ impl Inv for VmIoOwner {
                 &&& mv.mappings.finite()
                 &&& mv.mappings_are_disjoint()
                 &&& forall|va: usize|
-                    self.range@.start <= va < self.range@.end ==> {
+                    self.range.start <= va < self.range.end ==> {
                         &&& #[trigger] mv.addr_transl(va) is Some
                     }
             },
@@ -168,7 +168,7 @@ impl VmIoOwner {
             Some(VmIoMemView::ReadView(mem_src)) => {
                 forall|i: usize|
                     #![trigger mem_src.addr_transl(i)]
-                    self.range@.start <= i < self.range@.end ==> {
+                    self.range.start <= i < self.range.end ==> {
                         &&& mem_src.addr_transl(i) is Some
                         &&& mem_src.memory.contains_key(mem_src.addr_transl(i).unwrap().0)
                         &&& mem_src.memory[mem_src.addr_transl(
@@ -188,14 +188,14 @@ impl VmIoOwner {
 
     #[verifier::inline]
     pub open spec fn overlaps_with_range(self, range: Range<usize>) -> bool {
-        &&& self.range@.start <= range.end
-        &&& range.start <= self.range@.end
+        &&& self.range.start <= range.end
+        &&& range.start <= self.range.end
     }
 
     /// Checks whether this owner is disjoint with another owner.
     #[verifier::inline]
     pub open spec fn disjoint(self, other: VmIoOwner) -> bool {
-        &&& !self.overlaps_with_range(other.range@)
+        &&& !self.overlaps_with_range(other.range)
         &&& match (self.mem_view, other.mem_view) {
             (Some(lhs), Some(rhs)) => match (lhs, rhs) {
                 (VmIoMemView::WriteView(lmv), VmIoMemView::WriteView(rmv)) => {
@@ -217,7 +217,7 @@ impl VmIoOwner {
 
     #[verifier::inline]
     pub open spec fn params_eq(self, other: VmIoOwner) -> bool {
-        &&& self.range@ == other.range@
+        &&& self.range == other.range
         &&& self.is_fallible == other.is_fallible
     }
 
@@ -260,11 +260,11 @@ impl VmIoOwner {
         requires
             old(self).inv(),
             old(self).mem_view is Some,
-            nbytes <= old(self).range@.end - old(self).range@.start,
+            nbytes <= old(self).range.end - old(self).range.start,
         ensures
             final(self).inv(),
-            final(self).range@.start == old(self).range@.start + nbytes,
-            final(self).range@.end == old(self).range@.end,
+            final(self).range.start == old(self).range.start + nbytes,
+            final(self).range.end == old(self).range.end,
             final(self).is_fallible == old(self).is_fallible,
             final(self).id == old(self).id,
             final(self).is_kernel == old(self).is_kernel,
@@ -276,7 +276,7 @@ impl VmIoOwner {
             old(self).mem_view matches Some(VmIoMemView::ReadView(_)) ==>
                 forall|va: usize|
                     #![trigger final(self).read_view_of().read(va)]
-                    old(self).range@.start + nbytes <= va < old(self).range@.end
+                    old(self).range.start + nbytes <= va < old(self).range.end
                     && old(self).read_view_of().addr_transl(va) is Some
                     && old(self).read_view_of().memory.contains_key(
                         old(self).read_view_of().addr_transl(va).unwrap().0
@@ -287,8 +287,8 @@ impl VmIoOwner {
                             == final(self).read_view_of().read(va)
                     },
     {
-        let ghost old_start = self.range@.start;
-        let ghost old_end = self.range@.end;
+        let ghost old_start = self.range.start;
+        let ghost old_end = self.range.end;
         let ghost old_view_g = self.mem_view;
         let ghost split_end = old_start + nbytes;
 
@@ -356,7 +356,7 @@ impl VmIoOwner {
                 VmIoMemView::ReadView(left)
             },
         };
-        self.range = Ghost(Range { start: split_end as usize, end: old_end });
+        self.range = Range { start: split_end as usize, end: old_end };
         res
     }
 
@@ -379,17 +379,17 @@ impl VmIoOwner {
         requires
             old(self).inv(),
             old(self).mem_view is Some,
-            nbytes <= old(self).range@.end - old(self).range@.start,
+            nbytes <= old(self).range.end - old(self).range.start,
         ensures
             r.inv(),
-            r.range@.start == old(self).range@.start,
-            r.range@.end == old(self).range@.start + nbytes,
+            r.range.start == old(self).range.start,
+            r.range.end == old(self).range.start + nbytes,
             r.is_fallible == old(self).is_fallible,
             r.is_kernel == old(self).is_kernel,
             r.mem_view is Some,
             final(self).inv(),
-            final(self).range@.start == old(self).range@.start + nbytes,
-            final(self).range@.end == old(self).range@.end,
+            final(self).range.start == old(self).range.start + nbytes,
+            final(self).range.end == old(self).range.end,
             final(self).is_fallible == old(self).is_fallible,
             final(self).id == old(self).id,
             final(self).is_kernel == old(self).is_kernel,
@@ -407,8 +407,8 @@ impl VmIoOwner {
                 &&& final(self).read_view_initialized()
             },
     {
-        let ghost old_start = self.range@.start;
-        let ghost old_end = self.range@.end;
+        let ghost old_start = self.range.start;
+        let ghost old_end = self.range.end;
         let ghost old_view_g = self.mem_view;
         let ghost split_end = old_start + nbytes;
 
@@ -509,11 +509,11 @@ impl VmIoOwner {
                 VmIoMemView::ReadView(left)
             },
         };
-        self.range = Ghost(Range { start: split_end as usize, end: old_end });
+        self.range = Range { start: split_end as usize, end: old_end };
 
         let tracked left_owner = VmIoOwner {
-            id: Ghost(arbitrary()),
-            range: Ghost(Range { start: old_start, end: split_end as usize }),
+            id: arbitrary(),
+            range: Range { start: old_start, end: split_end as usize },
             is_fallible: self.is_fallible,
             is_kernel: self.is_kernel,
             mem_view: Some(left_view),
@@ -575,7 +575,7 @@ impl VmIoOwner {
             old(self).mem_view matches Some(VmIoMemView::WriteView(_)),
         ensures
             final(self).inv(),
-            final(self).range@ == old(self).range@,
+            final(self).range == old(self).range,
             final(self).is_fallible == old(self).is_fallible,
             final(self).is_kernel == old(self).is_kernel,
             final(self).id == old(self).id,
@@ -605,12 +605,12 @@ impl<Fallibility> VmWriter<'_, Fallibility> {
     /// Relates a concrete writer to its ghost owner.
     pub open spec fn wf(self, owner: VmIoOwner) -> bool {
         &&& owner.inv()
-        &&& owner.range@.start == self.cursor.vaddr
-        &&& owner.range@.end == self.end.vaddr
-        &&& owner.id == self.ghost_id
+        &&& owner.range.start == self.cursor.vaddr
+        &&& owner.range.end == self.end.vaddr
+        &&& owner.id == self.ghost_id@
         &&& owner.mem_view matches Some(VmIoMemView::WriteView(mv)) ==> {
             forall|va: usize|
-                owner.range@.start <= va < owner.range@.end ==> {
+                owner.range.start <= va < owner.range.end ==> {
                     &&& #[trigger] mv.addr_transl(va) is Some
                 }
         }
@@ -635,12 +635,12 @@ impl<Fallibility> VmReader<'_, Fallibility> {
     /// Relates a concrete reader to its ghost owner.
     pub open spec fn wf(self, owner: VmIoOwner) -> bool {
         &&& owner.inv()
-        &&& owner.range@.start == self.cursor.vaddr
-        &&& owner.range@.end == self.end.vaddr
-        &&& owner.id == self.ghost_id
+        &&& owner.range.start == self.cursor.vaddr
+        &&& owner.range.end == self.end.vaddr
+        &&& owner.id == self.ghost_id@
         &&& owner.mem_view matches Some(VmIoMemView::ReadView(mv)) ==> {
             forall|va: usize|
-                owner.range@.start <= va < owner.range@.end ==> {
+                owner.range.start <= va < owner.range.end ==> {
                     &&& #[trigger] mv.addr_transl(va) is Some
                 }
         }

--- a/ostd/specs/mm/vm_space.rs
+++ b/ostd/specs/mm/vm_space.rs
@@ -610,9 +610,9 @@ impl<'a> VmSpaceOwner {
             final(self).inv(),
             final(self).active == old(self).active,
             final(self).shared_reader == old(self).shared_reader,
-            owner.range@.start < owner.range@.end ==> final(self).readers == old(self).readers.push(owner),
+            owner.range.start < owner.range.end ==> final(self).readers == old(self).readers.push(owner),
     {
-        if owner.range@.start < owner.range@.end {
+        if owner.range.start < owner.range.end {
             // Return the memory view back to the vm space owner.
             self.readers.tracked_push(owner);
         }

--- a/ostd/src/mm/io.rs
+++ b/ostd/src/mm/io.rs
@@ -268,8 +268,8 @@ impl<'a> VmWriter<'a, Infallible> {
             Some(VmIoMemView::WriteView(mv))
         };
         let tracked owner = VmIoOwner {
-            id: Ghost(id),
-            range: Ghost(ptr.vaddr..(ptr.vaddr + len) as usize),
+            id,
+            range: ptr.vaddr..(ptr.vaddr + len) as usize,
             is_fallible: fallible,
             is_kernel: true,
             mem_view,
@@ -379,12 +379,12 @@ impl<'a> VmWriter<'a, Infallible> {
             final(self).cursor == old(self).end,
             final(self).end == old(self).end,
             // writer_owner: fully advanced past the filled region.
-            final(writer_owner).range@.start == old(writer_owner).range@.end,
-            final(writer_owner).range@.end == old(writer_owner).range@.end,
+            final(writer_owner).range.start == old(writer_owner).range.end,
+            final(writer_owner).range.end == old(writer_owner).range.end,
             // reader_owner: brand-new ReadView over the filled region.
             reader_owner@.inv(),
-            reader_owner@.range@.start == old(writer_owner).range@.start,
-            reader_owner@.range@.end == old(writer_owner).range@.end,
+            reader_owner@.range.start == old(writer_owner).range.start,
+            reader_owner@.range.end == old(writer_owner).range.end,
             reader_owner@.has_read_view(),
             reader_owner@.is_kernel == old(writer_owner).is_kernel,
             // Return value: exactly `avail / size_of::<T>()` elements written.
@@ -656,8 +656,8 @@ impl<'a> VmWriter<'a, Infallible> {
                 self.cursor.vaddr <= i < self.cursor.vaddr + core::mem::size_of::<T>() implies {
                 mem_dst.addr_transl(i) is Some
             } by {
-                assert(owner.range@.start == self.cursor.vaddr);
-                assert(owner.range@.end == self.end.vaddr);
+                assert(owner.range.start == self.cursor.vaddr);
+                assert(owner.range.end == self.end.vaddr);
             }
         }
         #[allow(unused_unsafe)]
@@ -669,7 +669,7 @@ impl<'a> VmWriter<'a, Infallible> {
             owner.mem_view = Some(VmIoMemView::WriteView(mem_dst));
 
             assert forall|va|
-                owner.range@.start <= va < owner.range@.end implies mem_dst.addr_transl(
+                owner.range.start <= va < owner.range.end implies mem_dst.addr_transl(
                 va,
             ) is Some by {
                 assert(mem_dst.mappings == mem_dst_pre.mappings);
@@ -742,8 +742,8 @@ impl<'a> VmReader<'a, Infallible> {
         let ghost range: Range<usize> = ptr.vaddr..(ptr.vaddr + len) as usize;
         let tracked mv = axiom_kernel_mem_view(range);
         let tracked owner = VmIoOwner {
-            id: Ghost(id),
-            range: Ghost(range),
+            id,
+            range,
             is_fallible: false,
             is_kernel: true,
             mem_view: Some(VmIoMemView::ReadView(mv)),
@@ -826,8 +826,8 @@ impl<'a> VmReader<'a, Infallible> {
             final(writer).avail_spec() == old(writer).avail_spec() - r as usize,
             final(writer).cursor.vaddr == old(writer).cursor.vaddr + r as usize,
             consumed_w@.inv(),
-            consumed_w@.range@.start == old(owner_w).range@.start,
-            consumed_w@.range@.end == old(owner_w).range@.start + r as usize,
+            consumed_w@.range.start == old(owner_w).range.start,
+            consumed_w@.range.end == old(owner_w).range.start + r as usize,
             consumed_w@.has_write_view(),
     )]
     pub fn read(&mut self, writer: &mut VmWriter<'_, Infallible>) -> usize {
@@ -862,8 +862,8 @@ impl<'a> VmReader<'a, Infallible> {
                         i,
                     ).unwrap().1 as int] is Init
                 } by {
-                    assert(owner_r.range@.start == self.cursor.vaddr);
-                    assert(owner_r.range@.end == self.end.vaddr);
+                    assert(owner_r.range.start == self.cursor.vaddr);
+                    assert(owner_r.range.end == self.end.vaddr);
                 }
             }
             // SAFETY: The source and destination are subsets of memory ranges specified by the
@@ -881,7 +881,7 @@ impl<'a> VmReader<'a, Infallible> {
                 owner_r.mem_view = Some(VmIoMemView::ReadView(mv_r));
 
                 assert forall|va|
-                    owner_w.range@.start <= va < owner_w.range@.end implies mv_w.addr_transl(
+                    owner_w.range.start <= va < owner_w.range.end implies mv_w.addr_transl(
                     va,
                 ) is Some by {
                     assert(mv_w.mappings == mv_w_pre.mappings);
@@ -1089,8 +1089,8 @@ impl<'a> VmReader<'a, Fallible> {
     )]
     pub unsafe fn from_user_space(ptr: VirtPtr, len: usize) -> Self {
         let tracked owner = VmIoOwner {
-            id: Ghost(id),
-            range: Ghost(ptr.range@),
+            id,
+            range: ptr.range@,
             is_fallible: true,
             is_kernel: false,
             mem_view: None,
@@ -1810,8 +1810,8 @@ impl<'a> VmWriter<'a, Fallible> {
     )]
     pub unsafe fn from_user_space(ptr: VirtPtr, len: usize) -> Self {
         let tracked owner = VmIoOwner {
-            id: Ghost(id),
-            range: Ghost(ptr.range@),
+            id,
+            range: ptr.range@,
             is_fallible: true,
             is_kernel: false,
             mem_view: None,
@@ -1956,8 +1956,8 @@ impl<'a> VmWriter<'a, Infallible> {
             owner@.inv(),
             r.wf(*owner),
             owner@.has_write_view(),
-            r.cursor.range@ == owner@.range@,
-            owner@.range@.end - owner@.range@.start == old(slice).len(),
+            r.cursor.range == owner@.range,
+            owner@.range.end - owner@.range.start == old(slice).len(),
     )]
     pub fn from(slice: &'a mut [u8]) -> Self {
         // SAFETY:
@@ -2004,8 +2004,8 @@ impl<'a> VmReader<'a, Infallible> {
             owner@.inv(),
             r.wf(*owner),
             owner@.read_view_initialized(),
-            r.cursor.range@ == owner@.range@,
-            owner@.range@.end - owner@.range@.start == slice.len(),
+            r.cursor.range == owner@.range,
+            owner@.range.end - owner@.range.start == slice.len(),
     )]
     pub fn from(slice: &'a [u8]) -> Self {
         // SAFETY:

--- a/ostd/src/mm/io.rs
+++ b/ostd/src/mm/io.rs
@@ -668,8 +668,7 @@ impl<'a> VmWriter<'a, Infallible> {
         proof {
             owner.mem_view = Some(VmIoMemView::WriteView(mem_dst));
 
-            assert forall|va|
-                owner.range.start <= va < owner.range.end implies mem_dst.addr_transl(
+            assert forall|va| owner.range.start <= va < owner.range.end implies mem_dst.addr_transl(
                 va,
             ) is Some by {
                 assert(mem_dst.mappings == mem_dst_pre.mappings);


### PR DESCRIPTION
To declare a ghost field in a `tracked struct`, use `ghost field: Type` instead of `field: Ghost<Type>`. @SNoAnd @hiroki-chen 