### PR TITLE
fix: warnings & add `unsafe` back

### DIFF
--- a/ostd/specs/mm/frame/meta_owners.rs
+++ b/ostd/specs/mm/frame/meta_owners.rs
@@ -153,7 +153,7 @@ pub enum MetaSlotStorage {
 /// `MetaSlotStorage` is an inductive tagged union of all of the frame meta types that
 /// we work with in this development. So, it should itself implement `AnyFrameMeta`, and
 /// it can then be used to stand in for `dyn AnyFrameMeta`.
-impl AnyFrameMeta for MetaSlotStorage {
+unsafe impl AnyFrameMeta for MetaSlotStorage {
     uninterp spec fn vtable_ptr(&self) -> usize;
 }
 

--- a/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
@@ -359,6 +359,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 PageTableOwner::<C>::pt_inv_implies_path_correct(child, child_path);
                 // Every mapping of this child subtree is in self@.mappings.
                 assert forall|m: Mapping|
+                    #![trigger self@.mappings.contains(m)]
                     PageTableOwner(child).view_rec(child_path).contains(
                         m,
                     ) implies self@.mappings.contains(m) by {

--- a/ostd/src/mm/dma/dma_coherent.rs
+++ b/ostd/src/mm/dma/dma_coherent.rs
@@ -313,7 +313,7 @@ impl<M: AnyUFrameMeta + ?Sized> DmaCoherent<M> {
             self.inner.wf(),
             r@.inv(),
     )]
-    pub fn read_inner(&self) -> RwLockReadGuard<DmaCoherentInnerAtomic<M>, PreemptDisabled> {
+    pub fn read_inner(&self) -> RwLockReadGuard<'_, DmaCoherentInnerAtomic<M>, PreemptDisabled> {
         self.inner.read()
     }
 }

--- a/ostd/src/mm/dma/dma_stream.rs
+++ b/ostd/src/mm/dma/dma_stream.rs
@@ -696,7 +696,7 @@ impl<M: AnyUFrameMeta + ?Sized> DmaStream<M> {
             self.inner.wf(),
             r@.inv(),
     )]
-    pub fn read_inner(&self) -> RwLockReadGuard<DmaStreanInnerAtomic<M>, PreemptDisabled> {
+    pub fn read_inner(&self) -> RwLockReadGuard<'_, DmaStreanInnerAtomic<M>, PreemptDisabled> {
         self.inner.read()
     }
 }

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -871,8 +871,10 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
         let tracked cur_perm = owner.list_own.perms.tracked_remove(owner.index);
         let tracked mut cur_own = owner.list_own.list.tracked_remove(owner.index);
 
-        #[verus_spec(with Tracked(regions), Tracked(cur_perm), Tracked(cur_own))]
-        let (frame, frame_own) = UniqueFrame::<Link<M>>::from_raw(paddr);
+        let (frame, frame_own) = unsafe {
+            #[verus_spec(with Tracked(regions), Tracked(cur_perm), Tracked(cur_own))]
+            UniqueFrame::<Link<M>>::from_raw(paddr)
+        };
         let mut frame = frame;
         let tracked mut frame_own = frame_own.get();
 
@@ -1345,7 +1347,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> Link<M> {
 
 // SAFETY: If `M::on_drop` reads the page using the provided `VmReader`,
 // the safety is upheld by the one who implements `AnyFrameMeta` for `M`.
-impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> AnyFrameMeta for Link<M>
+unsafe impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> AnyFrameMeta for Link<M>
 {
     open spec fn on_drop_pre(
         &self,

--- a/ostd/src/mm/frame/meta.rs
+++ b/ostd/src/mm/frame/meta.rs
@@ -139,7 +139,7 @@ pub tracked struct OnDropArgs {
 /// because it's only used statically (the runtime vtable pointer lives on
 /// the slot, not on the instance). Sites that need `Repr<MetaSlotStorage>`
 /// must spell it out — it was previously a supertrait.
-pub trait AnyFrameMeta {
+pub unsafe trait AnyFrameMeta {
     /// Per-impl precondition for [`Self::on_drop`]. Default is `true`.
     /// Impls that need richer caller-side invariants (e.g. the PT-node's
     /// reader/region/child-perm invariants) override this; the trait
@@ -386,8 +386,10 @@ impl MetaSlot {
         // SAFETY: The slot now has a reference count of `0`, other threads will
         // not access the metadata slot so it is safe to have a mutable reference.
 
-        #[verus_spec(with Tracked(&mut slot_own.inner_perms.storage), Tracked(&mut slot_own.inner_perms.vtable_ptr))]
-        slot.borrow(Tracked(&slot_perm)).write_meta(metadata);
+        unsafe {
+            #[verus_spec(with Tracked(&mut slot_own.inner_perms.storage), Tracked(&mut slot_own.inner_perms.vtable_ptr))]
+            slot.borrow(Tracked(&slot_perm)).write_meta(metadata)
+        };
 
         if as_unique_ptr {
             // No one can create a `Frame` instance directly from the page
@@ -732,7 +734,7 @@ impl MetaSlot {
             old(rc_perm).value() < REF_COUNT_MAX,
             final(rc_perm).id() == old(rc_perm).id(),
     )]
-    pub(super) fn inc_ref_count(&self) {
+    pub(super) unsafe fn inc_ref_count(&self) {
         let last_ref_cnt = self.ref_count.fetch_add(Tracked(rc_perm), 1);
 
         if last_ref_cnt >= REF_COUNT_MAX {
@@ -855,7 +857,7 @@ impl MetaSlot {
             Metadata::<M>::metadata_from_inner_perms(*final(meta_perm)) == metadata,
     )]
     #[verifier::external_body]
-    pub(super) fn write_meta<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf>(
+    pub(super) unsafe fn write_meta<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf>(
         &self,
         metadata: M,
     ) {
@@ -910,12 +912,14 @@ impl MetaSlot {
             final(owner).raw_count == old(owner).raw_count,
             final(owner).paths_in_pt == old(owner).paths_in_pt,
     )]
-    pub(super) fn drop_last_in_place(&self) {
+    pub(super) unsafe fn drop_last_in_place(&self) {
         // This should be guaranteed as a safety requirement.
         //        debug_assert_eq!(self.ref_count.load(Tracked(&*rc_perm)), 0);
         // SAFETY: The caller ensures safety.
-        #[verus_spec(with Tracked(owner))]
-        self.drop_meta_in_place();
+        unsafe {
+            #[verus_spec(with Tracked(owner))]
+            self.drop_meta_in_place()
+        };
 
         // `Release` pairs with the `Acquire` in `Frame::from_unused` and ensures
         // `drop_meta_in_place` won't be reordered after this memory store.
@@ -960,7 +964,7 @@ impl MetaSlot {
             final(slot_own).paths_in_pt == old(slot_own).paths_in_pt,
     )]
     #[verifier::external_body]
-    pub(super) fn drop_meta_in_place(&self) {
+    pub(super) unsafe fn drop_meta_in_place(&self) {
         // Smoke test for the dyn-dispatch shape — body kept `external_body`
         // because (a) the args bundle isn't threaded through the call chain
         // yet (Tracked::assume_new forges it here), (b) `VmReader`,

--- a/ostd/src/mm/frame/mod.rs
+++ b/ostd/src/mm/frame/mod.rs
@@ -666,8 +666,10 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage>> RCClone for Frame<M> {
     fn clone(&self, Tracked(perm): Tracked<&mut MetaRegionOwners>) -> Self {
         let paddr = meta_to_frame(self.ptr.addr());
 
-        #[verus_spec(with Tracked(perm))]
-        inc_frame_ref_count(paddr);
+        unsafe {
+            #[verus_spec(with Tracked(perm))]
+            inc_frame_ref_count(paddr)
+        };
 
         Self { ptr: PPtr::<MetaSlot>::from_addr(self.ptr.0), _marker: PhantomData }
     }
@@ -845,8 +847,10 @@ impl<M: ?Sized> Drop for Frame<M> {
                 assert(MetaSlot::drop_last_in_place_safety_cond(slot_own));
                 assert(slot.ref_count.id() == slot_own.inner_perms.ref_count.id());
             }
-            #[verus_spec(with Tracked(&mut slot_own))]
-            slot.drop_last_in_place();
+            unsafe {
+                #[verus_spec(with Tracked(&mut slot_own))]
+                slot.drop_last_in_place()
+            };
 
             proof {
                 // last-ref teardown: slot is UNUSED, identity preserved
@@ -1072,7 +1076,7 @@ impl TryFrom<Frame<dyn AnyFrameMeta>> for UFrame {
             ).slot_owners[i]),
         final(regions).slot_owners.dom() =~= old(regions).slot_owners.dom(),
 )]
-pub(in crate::mm) fn inc_frame_ref_count(paddr: Paddr) {
+pub(in crate::mm) unsafe fn inc_frame_ref_count(paddr: Paddr) {
     let tracked mut slot_own = regions.slot_owners.tracked_remove(frame_to_index(paddr));
     let tracked perm = regions.slots.tracked_borrow(frame_to_index(paddr));
     let tracked mut inner_perms = slot_own.take_inner_perms();
@@ -1082,8 +1086,10 @@ pub(in crate::mm) fn inc_frame_ref_count(paddr: Paddr) {
     // an immutable reference to it is always safe.
     let slot = PPtr::<MetaSlot>::from_addr(vaddr);
 
-    #[verus_spec(with Tracked(&mut inner_perms.ref_count))]
-    slot.borrow(Tracked(perm)).inc_ref_count();
+    unsafe {
+        #[verus_spec(with Tracked(&mut inner_perms.ref_count))]
+        slot.borrow(Tracked(perm)).inc_ref_count()
+    };
 
     proof {
         let idx = frame_to_index(paddr);

--- a/ostd/src/mm/frame/segment.rs
+++ b/ostd/src/mm/frame/segment.rs
@@ -301,8 +301,10 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> RCClone for Segment<M> {
                 assert(paddr + PAGE_SIZE <= MAX_PADDR);
             }
 
-            #[verus_spec(with Tracked(perm))]
-            crate::mm::frame::inc_frame_ref_count(paddr);
+            unsafe {
+                #[verus_spec(with Tracked(perm))]
+                crate::mm::frame::inc_frame_ref_count(paddr)
+            };
 
             paddr = paddr + PAGE_SIZE;
         }
@@ -883,8 +885,10 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
             // `inc_ref_count` via `ptr.borrow`. Disjoint from the
             // `slot_owners` `tracked_remove` above (distinct map fields) —
             // same pattern as `Frame::inc_frame_ref_count`.
-            #[verus_spec(with Tracked(&mut inner_perms.ref_count))]
-            ptr.borrow(Tracked(regions.slots.tracked_borrow(slot_idx))).inc_ref_count();
+            unsafe {
+                #[verus_spec(with Tracked(&mut inner_perms.ref_count))]
+                ptr.borrow(Tracked(regions.slots.tracked_borrow(slot_idx))).inc_ref_count()
+            };
 
             proof {
                 assert(old_regions.slot_owners[slot_idx].inner_perms.ref_count.value()

--- a/ostd/src/mm/frame/unique.rs
+++ b/ostd/src/mm/frame/unique.rs
@@ -170,8 +170,10 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrame<M> {
         }
 
         // SAFETY: We are the sole owner and the metadata is initialized.
-        #[verus_spec(with Tracked(&mut slot_own))]
-        slot.drop_meta_in_place();
+        unsafe {
+            #[verus_spec(with Tracked(&mut slot_own))]
+            slot.drop_meta_in_place()
+        };
 
         // After drop_meta_in_place, slot_own.inner_perms has uninit storage+vtable.
         // Extract them for write_meta, which requires uninit vtable_ptr.
@@ -189,11 +191,13 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrame<M> {
         // Write the new metadata into the slot.
         let slot = self.ptr.borrow(Tracked(&slot_perm));
 
-        #[verus_spec(with
-            Tracked(&mut inner_perms.storage),
-            Tracked(&mut inner_perms.vtable_ptr)
-        )]
-        slot.write_meta(metadata);
+        unsafe {
+            #[verus_spec(with
+                Tracked(&mut inner_perms.storage),
+                Tracked(&mut inner_perms.vtable_ptr)
+            )]
+            slot.write_meta(metadata)
+        };
 
         // Re-sync slot_own with the updated inner_perms (now storage+vtable are init).
         proof {
@@ -403,8 +407,10 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> 
 
         // SAFETY: We are the sole owner and the reference count is 0.
         // The slot is initialized.
-        #[verus_spec(with Tracked(&mut slot_own))]
-        slot.drop_last_in_place();
+        unsafe {
+            #[verus_spec(with Tracked(&mut slot_own))]
+            slot.drop_last_in_place()
+        };
 
         proof {
             regions.slot_owners.tracked_insert(idx, slot_own);
@@ -468,7 +474,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> 
                 regions,
             ).slot_owners[frame_to_index(paddr)].raw_count - 1,
     )]
-    pub(crate) fn from_raw(paddr: Paddr) -> (Self, Tracked<UniqueFrameOwner<M>>) {
+    pub(crate) unsafe fn from_raw(paddr: Paddr) -> (Self, Tracked<UniqueFrameOwner<M>>) {
         let vaddr = frame_to_meta(paddr);
         let ptr = vstd::simple_pptr::PPtr::<MetaSlot>::from_addr(vaddr);
 
@@ -566,8 +572,10 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> 
         #[verus_spec(with Tracked(&perm))]
         let slot = self.slot();
 
-        #[verus_spec(with Tracked(&mut slot_own))]
-        slot.drop_last_in_place();
+        unsafe {
+            #[verus_spec(with Tracked(&mut slot_own))]
+            slot.drop_last_in_place()
+        };
 
         proof {
             regions.slot_owners.tracked_insert(idx, slot_own);

--- a/ostd/src/mm/kspace/kvirt_area.rs
+++ b/ostd/src/mm/kspace/kvirt_area.rs
@@ -893,8 +893,10 @@ impl KVirtArea {
                     assert(may_panic());
                 }
             }
-            #[verus_spec(with Tracked(&mut cursor_owner), Tracked(entry_owner), Tracked(regions), Tracked(guards))]
-            let res = cursor.map(item);
+            let res = unsafe {
+                #[verus_spec(with Tracked(&mut cursor_owner), Tracked(entry_owner), Tracked(regions), Tracked(guards))]
+                cursor.map(item)
+            };
 
             // `item_slot_in_regions` preservation for the remaining frames
             // follows from cursor.map's strengthened ensures: ref_count is
@@ -1249,8 +1251,10 @@ impl KVirtArea {
                         *regions,
                     ));
                 }
-                #[verus_spec(with Tracked(&mut cursor_owner), Tracked(entry_owner), Tracked(regions), Tracked(guards))]
-                let _ = cursor.map(item);
+                let _ = unsafe {
+                    #[verus_spec(with Tracked(&mut cursor_owner), Tracked(entry_owner), Tracked(regions), Tracked(guards))]
+                    cursor.map(item)
+                };
 
                 proof {
                     cursor_owner.va.reflect_prop(cursor.0.va);

--- a/ostd/src/mm/kspace/mod.rs
+++ b/ostd/src/mm/kspace/mod.rs
@@ -228,7 +228,8 @@ unsafe impl PageTableConfig for KernelPtConfig {
 
     //#[verifier::when_used_as_spec(item_from_raw_spec)]
     #[verifier::external_body]
-    fn item_from_raw(paddr: Paddr, level: PagingLevel, prop: PageProperty) -> (res: Self::Item)
+    unsafe fn item_from_raw(paddr: Paddr, level: PagingLevel, prop: PageProperty) -> (res:
+        Self::Item)
         ensures
             res == Self::item_from_raw_spec(paddr, level, prop),
     {

--- a/ostd/src/mm/page_table/cursor/locking.rs
+++ b/ostd/src/mm/page_table/cursor/locking.rs
@@ -334,7 +334,7 @@ fn try_traverse_and_lock_subtree_root<'rcu, C: PageTableConfig, A: InAtomicMode>
         //    (2) all child nodes cannot be recycled because we're in the RCU critical section.
         //  - The index is inside the bound, so the page table entry is valid.
         //  - All page table entries are aligned and accessed with atomic operations only.
-        let cur_pte = load_pte(cur_pt_ptr.add(start_idx), Ordering::Acquire);
+        let cur_pte = unsafe { load_pte(cur_pt_ptr.add(start_idx), Ordering::Acquire) };
 
         if cur_pte.is_present() {
             if cur_pte.is_last(end - cur_level + 1) {
@@ -556,8 +556,10 @@ unsafe fn dfs_release_lock<'rcu, C: PageTableConfig, A: InAtomicMode>(
         match child.to_ref() {
             ChildRef::PageTable(pt) => {
                 // SAFETY: The caller ensures that the node is locked and the new guard is unique.
-                #[verus_spec(with Tracked(entry_own.node.tracked_borrow()), Tracked(guards))]
-                let mut child_node = pt.make_guard_unchecked(guard);
+                let mut child_node = unsafe {
+                    #[verus_spec(with Tracked(entry_own.node.tracked_borrow()), Tracked(guards))]
+                    pt.make_guard_unchecked(guard)
+                };
                 let child_node_va = cur_node_va + (end - i) * page_size(cur_level);
                 let child_node_va_end = child_node_va + page_size(cur_level);
                 let va_start = va_range.start.max(child_node_va);
@@ -629,7 +631,7 @@ unsafe fn dfs_release_lock<'rcu, C: PageTableConfig, A: InAtomicMode>(
         forall |addr: usize| addr != locked_addr && old(guards).lock_held(addr) ==> final(guards).lock_held(addr),
 )]
 #[verifier::external_body]
-pub fn dfs_mark_stray_and_unlock<'a, C: PageTableConfig, A: InAtomicMode>(
+pub unsafe fn dfs_mark_stray_and_unlock<'a, C: PageTableConfig, A: InAtomicMode>(
     rcu_guard: &A,
     sub_tree: &PageTableGuard<'a, C>,
 ) -> usize {
@@ -659,10 +661,10 @@ pub fn dfs_mark_stray_and_unlock<'a, C: PageTableConfig, A: InAtomicMode>(
         match child.to_ref() {
             ChildRef::PageTable(pt) => {
                 // SAFETY: The caller ensures that the node is locked and the new guard is unique.
-                let locked_pt = pt.make_guard_unchecked(rcu_guard);
+                let locked_pt = unsafe { pt.make_guard_unchecked(rcu_guard) };
                 // SAFETY: The caller ensures that all the nodes in the sub-tree are locked and all
                 // guards are forgotten.
-                num_frames += dfs_mark_stray_and_unlock(rcu_guard, locked_pt);
+                num_frames += unsafe { dfs_mark_stray_and_unlock(rcu_guard, locked_pt) };
             },
             ChildRef::None | ChildRef::Frame(_, _, _) => {},
         }

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -624,8 +624,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                     // For page table configs that require the `AVAIL1` flag to be kept
                     // (currently, only kernel page tables), the callers of the unsafe
                     // `protect_next` method uphold this invariant.
-                    let item =   /*ManuallyDrop::new(unsafe {*/
-                    C::item_from_raw(pa, level, prop)  /*})*/
+                    let item =   /*ManuallyDrop::new(*/
+                    unsafe { C::item_from_raw(pa, level, prop) }  /*)*/
                     ;
 
                     proof {
@@ -3451,6 +3451,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                     owner_before_replace.level);
                 };
                 assert forall|mm: Mapping|
+                    #![trigger owner_final@.mappings.contains(mm)]
                     owner_final@.mappings.contains(mm) implies mm.va_range.start != sv by {
                     if mm.va_range.start == sv {
                         assert(owner_before_replace@.mappings.contains(mm));
@@ -4126,7 +4127,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 // For page table configs that require the `AVAIL1` flag to be kept
                 // (currently, only kernel page tables), the callers of the unsafe
                 // `protect_next` method uphold this invariant.
-                let item = C::item_from_raw(pa, level, prop);
+                let item = unsafe { C::item_from_raw(pa, level, prop) };
                 proof {
                     C::item_roundtrip(item, pa, level, prop);
                 }

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -582,8 +582,10 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
 
                     // SAFETY: The `pt` must be locked and no other guards exist.
 
-                    #[verus_spec(with Tracked(&child_node), Tracked(guards))]
-                    let guard = pt.make_guard_unchecked(rcu_guard);
+                    let guard = unsafe {
+                        #[verus_spec(with Tracked(&child_node), Tracked(guards))]
+                        pt.make_guard_unchecked(rcu_guard)
+                    };
 
                     proof {
                         child_owner.value.node = Some(child_node);
@@ -1107,8 +1109,10 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                     let ghost guards0 = *guards;
 
                     // SAFETY: The `pt` must be locked and no other guards exist.
-                    #[verus_spec(with Tracked(&child_node_owner), Tracked(guards))]
-                    let mut pt_guard = pt.make_guard_unchecked(rcu_guard);
+                    let mut pt_guard = unsafe {
+                        #[verus_spec(with Tracked(&child_node_owner), Tracked(guards))]
+                        pt.make_guard_unchecked(rcu_guard)
+                    };
 
                     #[verus_spec(with Tracked(&mut child_node_owner))]
                     let nr_children = pt_guard.nr_children();
@@ -2308,8 +2312,10 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         let tracked mut child_node = child_owner.value.node.tracked_take();
 
         // SAFETY: The `pt` must be locked and no other guards exist.
-        #[verus_spec(with Tracked(&child_node), Tracked(guards))]
-        let pt_guard = pt.make_guard_unchecked(rcu_guard);
+        let pt_guard = unsafe {
+            #[verus_spec(with Tracked(&child_node), Tracked(guards))]
+            pt.make_guard_unchecked(rcu_guard)
+        };
 
         proof {
             child_owner.value.node = Some(child_node);
@@ -2871,7 +2877,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             final(self).0.barrier_va == old(self).0.barrier_va,
     )]
     #[verifier::rlimit(1200)]
-    pub fn map(&mut self, item: C::Item) -> (res: Result<(), PageTableFrag<C>>) {
+    pub unsafe fn map(&mut self, item: C::Item) -> (res: Result<(), PageTableFrag<C>>) {
         let ghost self0 = *self;
         let ghost owner0 = *owner;
 
@@ -4158,8 +4164,10 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
 
                 let ghost guards0 = *guards;
 
-                #[verus_spec(with Tracked(&old_node_owner), Tracked(guards))]
-                let locked_pt = borrow_pt.make_guard_unchecked(rcu_guard);
+                let locked_pt = unsafe {
+                    #[verus_spec(with Tracked(&old_node_owner), Tracked(guards))]
+                    borrow_pt.make_guard_unchecked(rcu_guard)
+                };
 
                 proof {
                     owner.map_children_implies(
@@ -4176,8 +4184,10 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 //  - We checked that we are not unmapping shared kernel page table nodes.
                 //  - We must have locked the entire sub-tree since the range is locked.
                 let ghost subtree_count = PageTableOwner::<C>(owner0.cur_subtree())@.mappings.len();
-                #[verus_spec(with Tracked(owner), Tracked(guards), Ghost(locked_addr), Ghost(subtree_count))]
-                let num_frames = locking::dfs_mark_stray_and_unlock(rcu_guard, &locked_pt);
+                let num_frames = unsafe {
+                    #[verus_spec(with Tracked(owner), Tracked(guards), Ghost(locked_addr), Ghost(subtree_count))]
+                    locking::dfs_mark_stray_and_unlock(rcu_guard, &locked_pt)
+                };
 
                 proof {
                     owner.map_children_implies(

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -274,7 +274,7 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
     spec fn item_from_raw_spec(paddr: Paddr, level: PagingLevel, prop: PageProperty) -> Self::Item;
 
     #[verifier::when_used_as_spec(item_from_raw_spec)]
-    fn item_from_raw(paddr: Paddr, level: PagingLevel, prop: PageProperty) -> Self::Item
+    unsafe fn item_from_raw(paddr: Paddr, level: PagingLevel, prop: PageProperty) -> Self::Item
         returns
             Self::item_from_raw_spec(paddr, level, prop),
     ;

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -1480,8 +1480,10 @@ impl PageTable<KernelPtConfig> {
             let pt_addr = pt.start_paddr();
             let pte = PageTableEntry::new_pt(pt_addr);
 
-            #[verus_spec(with Tracked(&mut new_node_owner))]
-            new_node.write_pte(i, pte);
+            unsafe {
+                #[verus_spec(with Tracked(&mut new_node_owner))]
+                new_node.write_pte(i, pte)
+            };
 
             i = i + 1;
         }
@@ -1851,7 +1853,7 @@ pub(super) unsafe fn page_walk<C: PageTableConfig>(root_paddr: Paddr, vaddr: Vad
     returns
         perm.value()[ptr.index as int],
 )]
-pub fn load_pte<E: PageTableEntryTrait>(
+pub unsafe fn load_pte<E: PageTableEntryTrait>(
     ptr: vstd_extra::array_ptr::ArrayPtr<E, NR_ENTRIES>,
     ordering: Ordering,
 ) -> (pte: E) {
@@ -1883,7 +1885,7 @@ pub fn load_pte<E: PageTableEntryTrait>(
         final(perm).addr() == old(perm).addr(),
         final(perm).is_init_all(),
 )]
-pub fn store_pte<E: PageTableEntryTrait>(
+pub unsafe fn store_pte<E: PageTableEntryTrait>(
     ptr: vstd_extra::array_ptr::ArrayPtr<E, NR_ENTRIES>,
     new_val: E,
     ordering: Ordering,

--- a/ostd/src/mm/page_table/node/child.rs
+++ b/ostd/src/mm/page_table/node/child.rs
@@ -131,7 +131,7 @@ impl<C: PageTableConfig> Child<C> {
         with Tracked(regions): Tracked<&mut MetaRegionOwners>,
             Tracked(entry_own): Tracked<&mut EntryOwner<C>>,
     )]
-    pub fn from_pte(pte: C::E, level: PagingLevel) -> (res: Self)
+    pub unsafe fn from_pte(pte: C::E, level: PagingLevel) -> (res: Self)
         requires
             old(entry_own).pte_invariants(pte, *old(regions)),
             level == old(entry_own).parent_level,
@@ -223,7 +223,7 @@ impl<C: PageTableConfig> ChildRef<'_, C> {
         with Tracked(regions): Tracked<&mut MetaRegionOwners>,
             Tracked(entry_owner): Tracked<&EntryOwner<C>>
     )]
-    pub fn from_pte(pte: &C::E, level: PagingLevel) -> (res: Self)
+    pub unsafe fn from_pte(pte: &C::E, level: PagingLevel) -> (res: Self)
         requires
             entry_owner.pte_invariants(*pte, *old(regions)),
             level == entry_owner.parent_level,

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -160,8 +160,10 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         // SAFETY:
         //  - The PTE outlives the reference (since we have `&self`).
         //  - The level matches the current node.
-        #[verus_spec(with Tracked(regions), Tracked(owner))]
-        let res = ChildRef::from_pte(&self.pte, level);
+        let res = unsafe {
+            #[verus_spec(with Tracked(regions), Tracked(owner))]
+            ChildRef::from_pte(&self.pte, level)
+        };
 
         res
     }
@@ -254,8 +256,10 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         //  2. We replace the PTE with a new one, which differs only in
         //     `PageProperty`, so the level still matches the current
         //     page table node.
-        #[verus_spec(with Tracked(parent_owner))]
-        self.node.write_pte(self.idx, self.pte);
+        unsafe {
+            #[verus_spec(with Tracked(parent_owner))]
+            self.node.write_pte(self.idx, self.pte)
+        };
 
         proof {
             let tracked mut frame_owner = owner.frame.tracked_take();
@@ -381,8 +385,10 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         #[verus_spec(with Tracked(&parent_owner.meta_perm))]
         let level = self.node.level();
 
-        #[verus_spec(with Tracked(regions), Tracked(owner))]
-        let old_child = Child::from_pte(self.pte, level);
+        let old_child = unsafe {
+            #[verus_spec(with Tracked(regions), Tracked(owner))]
+            Child::from_pte(self.pte, level)
+        };
 
         let ghost regions_after_from = *regions;
 
@@ -424,8 +430,10 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         //  1. The index is within the bounds.
         //  2. The new PTE is a valid child whose level matches the current page table node.
         //  3. The ownership of the child is passed to the page table node.
-        #[verus_spec(with Tracked(parent_owner))]
-        self.node.write_pte(self.idx, new_pte);
+        unsafe {
+            #[verus_spec(with Tracked(parent_owner))]
+            self.node.write_pte(self.idx, new_pte)
+        };
 
         self.pte = new_pte;
 
@@ -651,8 +659,10 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             //  1. The index is within the bounds.
             //  2. The new PTE is a child in `C` and at the correct paging level.
             //  3. The ownership of the child is passed to the page table node.
-            #[verus_spec(with Tracked(parent_owner))]
-            self.node.write_pte(self.idx, self.pte);
+            unsafe {
+                #[verus_spec(with Tracked(parent_owner))]
+                self.node.write_pte(self.idx, self.pte)
+            };
 
             #[verus_spec(with Tracked(&parent_owner.meta_perm))]
             let nr_children = self.node.nr_children_mut();
@@ -1175,8 +1185,10 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         //  1. The index is within the bounds.
         //  2. The new PTE is a child in `C` and at the correct paging level.
         //  3. The ownership of the child is passed to the page table node.
-        #[verus_spec(with Tracked(&mut node_owner))]
-        self.node.write_pte(self.idx, self.pte);
+        unsafe {
+            #[verus_spec(with Tracked(&mut node_owner))]
+            self.node.write_pte(self.idx, self.pte)
+        };
 
         proof {
             owner.value.node = Some(node_owner);
@@ -1204,7 +1216,8 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         with Tracked(owner): Tracked<&EntryOwner<C>>,
             Tracked(parent_owner): Tracked<&NodeOwner<C>>,
     )]
-    pub(in crate::mm) fn new_at(guard: &'a mut PageTableGuard<'rcu, C>, idx: usize) -> (res: Self)
+    pub(in crate::mm) unsafe fn new_at(guard: &'a mut PageTableGuard<'rcu, C>, idx: usize) -> (res:
+        Self)
         requires
             owner.inv(),
             !owner.in_scope,
@@ -1226,8 +1239,10 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         // SAFETY: The index is within the bound. Routed through `Self::new`
         // (already `external_body`) so the reborrow's spec-level identity is
         // captured by `new_spec`'s definition rather than recomputed here.
-        #[verus_spec(with Tracked(parent_owner))]
-        let pte = guard.read_pte(idx);
+        let pte = unsafe {
+            #[verus_spec(with Tracked(parent_owner))]
+            guard.read_pte(idx)
+        };
         Self::new(pte, idx, guard)
     }
 }

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -105,7 +105,7 @@ pub struct PageTablePageMeta<C: PageTableConfig> {
 /// [`PageTableGuard`].
 pub type PageTableNode<C> = Frame<PageTablePageMeta<C>>;
 
-impl<C: PageTableConfig> AnyFrameMeta for PageTablePageMeta<C> {
+unsafe impl<C: PageTableConfig> AnyFrameMeta for PageTablePageMeta<C> {
     /// Caller invariants the PT-node `on_drop` body relies on:
     /// - Reader well-formedness + `vm_io_owner` matching + read view
     ///   initialized + at least `PAGE_SIZE` bytes remaining for the
@@ -681,10 +681,10 @@ impl<'a, C: PageTableConfig> PageTableNodeRef<'a, C> {
             Self::locks_preserved_except(owner.meta_perm.addr(), *old(guards), *final(guards)),
             owner.relate_guard(res),
     )]
-    pub fn make_guard_unchecked<'rcu, A: InAtomicMode>(self, _guard: &'rcu A) -> PageTableGuard<
-        'rcu,
-        C,
-    > where 'a: 'rcu {
+    pub unsafe fn make_guard_unchecked<'rcu, A: InAtomicMode>(
+        self,
+        _guard: &'rcu A,
+    ) -> PageTableGuard<'rcu, C> where 'a: 'rcu {
         let guard = PageTableGuard { inner: self };
 
         proof {
@@ -740,8 +740,10 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
         // Entry::new_at's `*res.node == *old(guard)` ensures says the wrapped
         // node equals the input guard's value, and the reborrow makes
         // `*final(self) == *res.node`.
-        #[verus_spec(with Tracked(child_owner), Tracked(owner))]
-        Entry::new_at(self, idx)
+        unsafe {
+            #[verus_spec(with Tracked(child_owner), Tracked(owner))]
+            Entry::new_at(self, idx)
+        }
     }
 
     /// Gets the number of valid PTEs in a page table node.
@@ -802,7 +804,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
     #[verus_spec(
         with Tracked(owner): Tracked<&NodeOwner<C>>
     )]
-    pub fn read_pte(&self, idx: usize) -> (pte: C::E)
+    pub unsafe fn read_pte(&self, idx: usize) -> (pte: C::E)
         requires
             self.inner.inner@.invariants(*owner),
             idx < NR_ENTRIES,
@@ -820,8 +822,10 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
         // SAFETY:
         // - The page table node is alive. The index is inside the bound, so the page table entry is valid.
         // - All page table entries are aligned and accessed with atomic operations only.
-        #[verus_spec(with Tracked(&owner.children_perm))]
-        load_pte(ptr.add(idx), Ordering::Relaxed)
+        unsafe {
+            #[verus_spec(with Tracked(&owner.children_perm))]
+            load_pte(ptr.add(idx), Ordering::Relaxed)
+        }
     }
 
     /// Writes a page table entry at a given index.
@@ -839,7 +843,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
     #[verus_spec(
         with Tracked(owner): Tracked<&mut NodeOwner<C>>
     )]
-    pub fn write_pte(&mut self, idx: usize, pte: C::E)
+    pub unsafe fn write_pte(&mut self, idx: usize, pte: C::E)
         requires
             old(self).inner.inner@.invariants(*old(owner)),
             idx < NR_ENTRIES,
@@ -868,8 +872,10 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
         // SAFETY:
         // - The page table node is alive. The index is inside the bound, so the page table entry is valid.
         // - All page table entries are aligned and accessed with atomic operations only.
-        #[verus_spec(with Tracked(&mut owner.children_perm))]
-        store_pte(ptr.add(idx), pte, Ordering::Release)
+        unsafe {
+            #[verus_spec(with Tracked(&mut owner.children_perm))]
+            store_pte(ptr.add(idx), pte, Ordering::Release)
+        }
     }
 
     /// Gets the mutable reference to the number of valid PTEs in the node.

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -1643,7 +1643,7 @@ unsafe impl PageTableConfig for UserPtConfig {
     ) -> Self::Item;
 
     #[verifier::external_body]
-    fn item_from_raw(paddr: Paddr, level: PagingLevel, prop: PageProperty) -> Self::Item {
+    unsafe fn item_from_raw(paddr: Paddr, level: PagingLevel, prop: PageProperty) -> Self::Item {
         let frame = unsafe { UFrame::from_raw(paddr) };
         MappedItem { frame, prop }
     }

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -821,9 +821,10 @@ impl<'a, A: InAtomicMode> CursorMut<'a, A> {
         assert(self.pt_cursor.item_wf(item, entry_owner)) by {};
 
         // SAFETY: It is safe to map untyped memory into the userspace.
-        let Err(frag) = (
-        #[verus_spec(with Tracked(cursor_owner), Tracked(entry_owner), Tracked(regions), Tracked(guards))]
-        self.pt_cursor.map(item)) else {
+        let Err(frag) = (unsafe {
+            #[verus_spec(with Tracked(cursor_owner), Tracked(entry_owner), Tracked(regions), Tracked(guards))]
+            self.pt_cursor.map(item)
+        }) else {
             return;  // No mapping exists at the current address.
         };
 


### PR DESCRIPTION
~~I'm not sure, is there any more missing `unsafe`?~~

Of course there are...