### PR TITLE
fix: const value & visibility

### DIFF
--- a/ostd/specs/arch/x86_64/kspace.rs
+++ b/ostd/specs/arch/x86_64/kspace.rs
@@ -19,7 +19,7 @@ use core::ops::Range;
 verus! {
 
 /// Kernel virtual address range for storing the page frame metadata.
-pub const FRAME_METADATA_RANGE: Range<Vaddr> = 0xffff_fff0_0000_0000..0xffff_fff0_8000_0000;
+pub const FRAME_METADATA_RANGE: Range<Vaddr> = 0xffff_e000_0000_0000..0xffff_e100_0000_0000;
 
 #[verifier::inline]
 pub open spec fn paddr_to_vaddr_spec(pa: Paddr) -> usize

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -1654,9 +1654,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
     ///
     /// **KernelPtConfig**: `TOP_LEVEL_INDEX_RANGE.end == NR_ENTRIES`, but
     /// `LOCKED_END_BOUND_spec() == FRAME_METADATA_BASE_VADDR + PAGE_SIZE ==
-    /// 0xffff_fff0_0000_1000`. Combined with `leading_bits == 0xFFFF`, the
+    /// 0xffff_e000_0000_1000`. Combined with `leading_bits == 0xFFFF`, the
     /// cursor inv `locked_range().end <= LOCKED_END_BOUND_spec()` forces
-    /// `prefix.index[NR_LEVELS - 1] + 1 <= 0x1fe < NR_ENTRIES`. The full
+    /// `prefix.index[NR_LEVELS - 1] + 1 <= 0x1c0 < NR_ENTRIES`. The full
     /// arithmetic chain through `align_up` is encapsulated in this lemma.
     pub proof fn cursor_top_idx_strict_lt_nr_entries(self)
         requires

--- a/ostd/src/mm/kspace/mod.rs
+++ b/ostd/src/mm/kspace/mod.rs
@@ -39,7 +39,7 @@ use vstd::simple_pptr::PointsTo;
 
 //use log::info;
 use crate::sync::{OnceImpl, TrivialPred};
-pub mod kvirt_area;
+pub(crate) mod kvirt_area;
 #[cfg(ktest)]
 mod test;
 
@@ -96,13 +96,13 @@ pub fn kernel_loaded_offset() -> usize {
 }*/
 
 #[cfg(target_arch = "x86_64")]
-pub const KERNEL_CODE_BASE_VADDR: usize = 0xffff_ffff_8000_0000 << ADDR_WIDTH_SHIFT;
+const KERNEL_CODE_BASE_VADDR: usize = 0xffff_ffff_8000_0000 << ADDR_WIDTH_SHIFT;
 
 #[cfg(target_arch = "riscv64")]
-pub const KERNEL_CODE_BASE_VADDR: usize = 0xffff_ffff_0000_0000 << ADDR_WIDTH_SHIFT;
+const KERNEL_CODE_BASE_VADDR: usize = 0xffff_ffff_0000_0000 << ADDR_WIDTH_SHIFT;
 
 #[cfg(target_arch = "loongarch64")]
-pub const KERNEL_CODE_BASE_VADDR: usize = 0x9000_0000_0000_0000 << ADDR_WIDTH_SHIFT;
+const KERNEL_CODE_BASE_VADDR: usize = 0x9000_0000_0000_0000 << ADDR_WIDTH_SHIFT;
 
 pub const FRAME_METADATA_CAP_VADDR: Vaddr = 0xffff_e100_0000_0000 << ADDR_WIDTH_SHIFT;
 

--- a/ostd/src/mm/kspace/mod.rs
+++ b/ostd/src/mm/kspace/mod.rs
@@ -104,9 +104,9 @@ pub const KERNEL_CODE_BASE_VADDR: usize = 0xffff_ffff_0000_0000 << ADDR_WIDTH_SH
 #[cfg(target_arch = "loongarch64")]
 pub const KERNEL_CODE_BASE_VADDR: usize = 0x9000_0000_0000_0000 << ADDR_WIDTH_SHIFT;
 
-pub const FRAME_METADATA_CAP_VADDR: Vaddr = 0xffff_fff0_8000_0000 << ADDR_WIDTH_SHIFT;
+pub const FRAME_METADATA_CAP_VADDR: Vaddr = 0xffff_e100_0000_0000 << ADDR_WIDTH_SHIFT;
 
-pub const FRAME_METADATA_BASE_VADDR: Vaddr = 0xffff_fff0_0000_0000 << ADDR_WIDTH_SHIFT;
+pub const FRAME_METADATA_BASE_VADDR: Vaddr = 0xffff_e000_0000_0000 << ADDR_WIDTH_SHIFT;
 
 pub const VMALLOC_BASE_VADDR: Vaddr = 0xffff_c000_0000_0000 << ADDR_WIDTH_SHIFT;
 


### PR DESCRIPTION
Restore the const value of `FRAME_METADATA_CAP_VADDR` and `FRAME_METADATA_BASE_VADDR` to align with the 0.16.0. 
See https://github.com/asterinas/vostd/blob/f51a569a796b032fe362557a58bea69c633a6649/ostd/src/mm/kspace/mod.rs#L92-L95

I do not know why the current value is up to date with 0.17.0 (https://github.com/asterinas/asterinas/commit/6af524b4518694d6d8f6934b70daea5788a3a14f)

Besides that I also restore some of the visibility