### PR TITLE
refactor: introcude an `EntryOwnerKind` enum in `EntryOwner`

### DIFF
--- a/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
@@ -48,8 +48,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             other.cur_entry_owner().is_frame(),
             other.cur_entry_owner().inv(),
             // protect preserves PA, path, parent_level
-            other.cur_entry_owner().frame.unwrap().mapped_pa
-                == self.cur_entry_owner().frame.unwrap().mapped_pa,
+            other.cur_entry_owner().frame().unwrap().mapped_pa
+                == self.cur_entry_owner().frame().unwrap().mapped_pa,
             other.cur_entry_owner().path == self.cur_entry_owner().path,
             other.cur_entry_owner().parent_level == self.cur_entry_owner().parent_level,
             // cursor level and structural fields unchanged
@@ -426,3 +426,4 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 }
 
 } // verus!
+

--- a/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
@@ -48,8 +48,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             other.cur_entry_owner().is_frame(),
             other.cur_entry_owner().inv(),
             // protect preserves PA, path, parent_level
-            other.cur_entry_owner().frame().unwrap().mapped_pa
-                == self.cur_entry_owner().frame().unwrap().mapped_pa,
+            other.cur_entry_owner().frame().mapped_pa == self.cur_entry_owner().frame().mapped_pa,
             other.cur_entry_owner().path == self.cur_entry_owner().path,
             other.cur_entry_owner().parent_level == self.cur_entry_owner().parent_level,
             // cursor level and structural fields unchanged

--- a/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
@@ -426,4 +426,3 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 }
 
 } // verus!
-

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -122,7 +122,7 @@ pub proof fn subtree_unlock_upgrade<'rcu, C: PageTableConfig>(
     assert(f(subtree.value, path));
     assert(g(subtree.value, path));
     if subtree.value.is_node() {
-        if subtree.value.node.unwrap().meta_addr_self() == excepted_addr {
+        if subtree.value.node().unwrap().meta_addr_self() == excepted_addr {
             // addr == excepted_addr contradicts path != excepted_path
             // via metaregion_sound's singleton paths_in_pt.
             let idx = frame_to_index(meta_to_frame(excepted_addr));
@@ -495,7 +495,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             // The current entry is a node (we're descending into it)
             self.cur_entry_owner().is_node(),
             // The child node's guard relates to the new guard
-            self.cur_entry_owner().node.unwrap().relate_guard(guard),
+            self.cur_entry_owner().node().unwrap().relate_guard(guard),
             // Guard distinctness: the new guard points to a different node than all existing continuations
             forall|i: int|
                 #![trigger self.continuations[i]]
@@ -538,15 +538,15 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             old_cont.inv_children_unroll(old_cont.idx as int);
         };
 
-        assert(child.entry_own.path.len() == old_cont.entry_own.node.unwrap().tree_level + 1);
-        assert(old_cont.entry_own.node.unwrap().tree_level == old_cont.tree_level) by {
+        assert(child.entry_own.path.len() == old_cont.entry_own.node().unwrap().tree_level + 1);
+        assert(old_cont.entry_own.node().unwrap().tree_level == old_cont.tree_level) by {
             assert(old_cont.tree_level == INC_LEVELS - old_cont.level() - 1);
         };
         assert(child.entry_own.path.len() == child.tree_level) by {
             assert(child.tree_level == old_cont.tree_level + 1);
         };
 
-        assert(child.entry_own.node.unwrap().tree_level == child.entry_own.path.len()) by {
+        assert(child.entry_own.node().unwrap().tree_level == child.entry_own.path.len()) by {
             assert(child.children[0] is Some);
             let gc = child.children[0].unwrap();
             assert(<EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
@@ -554,7 +554,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 0,
                 Some(gc.value),
             ));
-            assert(gc.value.path.len() == child.entry_own.node.unwrap().tree_level + 1);
+            assert(gc.value.path.len() == child.entry_own.node().unwrap().tree_level + 1);
             assert(gc.value.path == child.entry_own.path.push_tail(0usize));
             assert(child.entry_own.inv_base());
             assert(child.entry_own.path.inv());
@@ -562,7 +562,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             assert(child.entry_own.path.push_tail(0usize).len() == child.entry_own.path.len() + 1);
         };
 
-        assert(child.tree_level == child.entry_own.node.unwrap().tree_level);
+        assert(child.tree_level == child.entry_own.node().unwrap().tree_level);
         assert(child.tree_level == INC_LEVELS - child.level() - 1);
 
         assert(child.inv_children()) by {
@@ -674,7 +674,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         };
         assert(modified_cont.entry_own.is_node());
         assert(modified_cont.entry_own.inv());
-        assert(modified_cont.entry_own.node.unwrap().relate_guard(modified_cont.guard));
+        assert(modified_cont.entry_own.node().unwrap().relate_guard(modified_cont.guard));
         assert(modified_cont.tree_level == INC_LEVELS - modified_cont.level() - 1);
         assert(modified_cont.tree_level < INC_LEVELS - 1);
         assert(modified_cont.path().len() == modified_cont.tree_level);
@@ -910,7 +910,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             // The current entry is a node (we're descending into it)
             self.cur_entry_owner().is_node(),
             // The child node's guard relates to the new guard
-            self.cur_entry_owner().node.unwrap().relate_guard(guard),
+            self.cur_entry_owner().node().unwrap().relate_guard(guard),
             // The new guard must be locked in guards
             guards.lock_held(guard.inner.inner@.ptr.addr()),
         ensures
@@ -932,7 +932,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         );
 
         let cur_entry = self.cur_entry_owner();
-        let cur_entry_addr = cur_entry.node.unwrap().meta_addr_self();
+        let cur_entry_addr = cur_entry.node().unwrap().meta_addr_self();
         let cur_entry_path = old_cont.path().push_tail(old_cont.idx as usize);
         self.cont_entries_metaregion(regions);
 
@@ -944,8 +944,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             let cont_i = self.continuations[i];
 
             if cont_i.guard.inner.inner@.ptr.addr() == guard.inner.inner@.ptr.addr() {
-                let addr = cont_i.entry_own.node.unwrap().meta_addr_self();
-                assert(addr == cur_entry.node.unwrap().meta_addr_self());
+                let addr = cont_i.entry_own.node().unwrap().meta_addr_self();
+                assert(addr == cur_entry.node().unwrap().meta_addr_self());
                 let idx = frame_to_index(meta_to_frame(addr));
                 assert(regions.slot_owners[idx].paths_in_pt == set![cont_i.path()]);
                 assert(regions.slot_owners[idx].paths_in_pt == set![cur_entry_path]);
@@ -1524,7 +1524,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             };
         };
 
-        let child_addr = child.entry_own.node.unwrap().meta_addr_self();
+        let child_addr = child.entry_own.node().unwrap().meta_addr_self();
         let child_subtree = child.as_subtree();
 
         assert forall|j: int|
@@ -2473,3 +2473,4 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 }
 
 } // verus!
+

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -2473,4 +2473,3 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 }
 
 } // verus!
-

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -122,7 +122,7 @@ pub proof fn subtree_unlock_upgrade<'rcu, C: PageTableConfig>(
     assert(f(subtree.value, path));
     assert(g(subtree.value, path));
     if subtree.value.is_node() {
-        if subtree.value.node().unwrap().meta_addr_self() == excepted_addr {
+        if subtree.value.node().meta_addr_self() == excepted_addr {
             // addr == excepted_addr contradicts path != excepted_path
             // via metaregion_sound's singleton paths_in_pt.
             let idx = frame_to_index(meta_to_frame(excepted_addr));
@@ -495,7 +495,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             // The current entry is a node (we're descending into it)
             self.cur_entry_owner().is_node(),
             // The child node's guard relates to the new guard
-            self.cur_entry_owner().node().unwrap().relate_guard(guard),
+            self.cur_entry_owner().node().relate_guard(guard),
             // Guard distinctness: the new guard points to a different node than all existing continuations
             forall|i: int|
                 #![trigger self.continuations[i]]
@@ -538,15 +538,15 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             old_cont.inv_children_unroll(old_cont.idx as int);
         };
 
-        assert(child.entry_own.path.len() == old_cont.entry_own.node().unwrap().tree_level + 1);
-        assert(old_cont.entry_own.node().unwrap().tree_level == old_cont.tree_level) by {
+        assert(child.entry_own.path.len() == old_cont.entry_own.node().tree_level + 1);
+        assert(old_cont.entry_own.node().tree_level == old_cont.tree_level) by {
             assert(old_cont.tree_level == INC_LEVELS - old_cont.level() - 1);
         };
         assert(child.entry_own.path.len() == child.tree_level) by {
             assert(child.tree_level == old_cont.tree_level + 1);
         };
 
-        assert(child.entry_own.node().unwrap().tree_level == child.entry_own.path.len()) by {
+        assert(child.entry_own.node().tree_level == child.entry_own.path.len()) by {
             assert(child.children[0] is Some);
             let gc = child.children[0].unwrap();
             assert(<EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
@@ -554,7 +554,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 0,
                 Some(gc.value),
             ));
-            assert(gc.value.path.len() == child.entry_own.node().unwrap().tree_level + 1);
+            assert(gc.value.path.len() == child.entry_own.node().tree_level + 1);
             assert(gc.value.path == child.entry_own.path.push_tail(0usize));
             assert(child.entry_own.inv_base());
             assert(child.entry_own.path.inv());
@@ -562,7 +562,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             assert(child.entry_own.path.push_tail(0usize).len() == child.entry_own.path.len() + 1);
         };
 
-        assert(child.tree_level == child.entry_own.node().unwrap().tree_level);
+        assert(child.tree_level == child.entry_own.node().tree_level);
         assert(child.tree_level == INC_LEVELS - child.level() - 1);
 
         assert(child.inv_children()) by {
@@ -674,7 +674,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         };
         assert(modified_cont.entry_own.is_node());
         assert(modified_cont.entry_own.inv());
-        assert(modified_cont.entry_own.node().unwrap().relate_guard(modified_cont.guard));
+        assert(modified_cont.entry_own.node().relate_guard(modified_cont.guard));
         assert(modified_cont.tree_level == INC_LEVELS - modified_cont.level() - 1);
         assert(modified_cont.tree_level < INC_LEVELS - 1);
         assert(modified_cont.path().len() == modified_cont.tree_level);
@@ -910,7 +910,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             // The current entry is a node (we're descending into it)
             self.cur_entry_owner().is_node(),
             // The child node's guard relates to the new guard
-            self.cur_entry_owner().node().unwrap().relate_guard(guard),
+            self.cur_entry_owner().node().relate_guard(guard),
             // The new guard must be locked in guards
             guards.lock_held(guard.inner.inner@.ptr.addr()),
         ensures
@@ -932,7 +932,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         );
 
         let cur_entry = self.cur_entry_owner();
-        let cur_entry_addr = cur_entry.node().unwrap().meta_addr_self();
+        let cur_entry_addr = cur_entry.node().meta_addr_self();
         let cur_entry_path = old_cont.path().push_tail(old_cont.idx as usize);
         self.cont_entries_metaregion(regions);
 
@@ -944,8 +944,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             let cont_i = self.continuations[i];
 
             if cont_i.guard.inner.inner@.ptr.addr() == guard.inner.inner@.ptr.addr() {
-                let addr = cont_i.entry_own.node().unwrap().meta_addr_self();
-                assert(addr == cur_entry.node().unwrap().meta_addr_self());
+                let addr = cont_i.entry_own.node().meta_addr_self();
+                assert(addr == cur_entry.node().meta_addr_self());
                 let idx = frame_to_index(meta_to_frame(addr));
                 assert(regions.slot_owners[idx].paths_in_pt == set![cont_i.path()]);
                 assert(regions.slot_owners[idx].paths_in_pt == set![cur_entry_path]);
@@ -1524,7 +1524,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             };
         };
 
-        let child_addr = child.entry_own.node().unwrap().meta_addr_self();
+        let child_addr = child.entry_own.node().meta_addr_self();
         let child_subtree = child.as_subtree();
 
         assert forall|j: int|

--- a/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
@@ -201,7 +201,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         // preserved (this lemma only changes paths_in_pt), so the
                         // r0 facts (from frame_sub_pages_valid) carry to r1.
                         assert(entry.is_frame() && entry.parent_level > 1 ==> {
-                            let pa = entry.frame.unwrap().mapped_pa;
+                            let pa = entry.frame().unwrap().mapped_pa;
                             let nr_pages = page_size(entry.parent_level) / PAGE_SIZE;
                             forall|j: usize|
                                 0 < j < nr_pages ==> {
@@ -240,7 +240,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             if cont_entry.meta_slot_paddr() is Some {
                 // Same sub-page bridge as above (continuations branch).
                 assert(cont_entry.is_frame() && cont_entry.parent_level > 1 ==> {
-                    let pa = cont_entry.frame.unwrap().mapped_pa;
+                    let pa = cont_entry.frame().unwrap().mapped_pa;
                     let nr_pages = page_size(cont_entry.parent_level) / PAGE_SIZE;
                     forall|j: usize|
                         0 < j < nr_pages ==> {
@@ -500,7 +500,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         // there (inner_perms / usage preserved), so the
                         // r0 sub-page facts carry to r1.
                         assert(entry.is_frame() && entry.parent_level > 1 ==> {
-                            let pa = entry.frame.unwrap().mapped_pa;
+                            let pa = entry.frame().unwrap().mapped_pa;
                             let nr_pages = page_size(entry.parent_level) / PAGE_SIZE;
                             forall|j: usize|
                                 0 < j < nr_pages ==> {
@@ -553,7 +553,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 let eidx = frame_to_index(cont_entry.meta_slot_paddr().unwrap());
                 if eidx != changed_idx {
                     assert(cont_entry.is_frame() && cont_entry.parent_level > 1 ==> {
-                        let pa = cont_entry.frame.unwrap().mapped_pa;
+                        let pa = cont_entry.frame().unwrap().mapped_pa;
                         let nr_pages = page_size(cont_entry.parent_level) / PAGE_SIZE;
                         forall|j: usize|
                             0 < j < nr_pages ==> {
@@ -590,3 +590,4 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 }
 
 } // verus!
+

--- a/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
@@ -201,7 +201,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         // preserved (this lemma only changes paths_in_pt), so the
                         // r0 facts (from frame_sub_pages_valid) carry to r1.
                         assert(entry.is_frame() && entry.parent_level > 1 ==> {
-                            let pa = entry.frame().unwrap().mapped_pa;
+                            let pa = entry.frame().mapped_pa;
                             let nr_pages = page_size(entry.parent_level) / PAGE_SIZE;
                             forall|j: usize|
                                 0 < j < nr_pages ==> {
@@ -240,7 +240,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             if cont_entry.meta_slot_paddr() is Some {
                 // Same sub-page bridge as above (continuations branch).
                 assert(cont_entry.is_frame() && cont_entry.parent_level > 1 ==> {
-                    let pa = cont_entry.frame().unwrap().mapped_pa;
+                    let pa = cont_entry.frame().mapped_pa;
                     let nr_pages = page_size(cont_entry.parent_level) / PAGE_SIZE;
                     forall|j: usize|
                         0 < j < nr_pages ==> {
@@ -500,7 +500,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         // there (inner_perms / usage preserved), so the
                         // r0 sub-page facts carry to r1.
                         assert(entry.is_frame() && entry.parent_level > 1 ==> {
-                            let pa = entry.frame().unwrap().mapped_pa;
+                            let pa = entry.frame().mapped_pa;
                             let nr_pages = page_size(entry.parent_level) / PAGE_SIZE;
                             forall|j: usize|
                                 0 < j < nr_pages ==> {
@@ -553,7 +553,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 let eidx = frame_to_index(cont_entry.meta_slot_paddr().unwrap());
                 if eidx != changed_idx {
                     assert(cont_entry.is_frame() && cont_entry.parent_level > 1 ==> {
-                        let pa = cont_entry.frame().unwrap().mapped_pa;
+                        let pa = cont_entry.frame().mapped_pa;
                         let nr_pages = page_size(cont_entry.parent_level) / PAGE_SIZE;
                         forall|j: usize|
                             0 < j < nr_pages ==> {

--- a/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
@@ -590,4 +590,3 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 }
 
 } // verus!
-

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -196,7 +196,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
     // map_children_lift, map_children_lift_skip_idx, as_subtree_restore
     // have been moved to tree_lemmas.rs.
     pub open spec fn level(self) -> PagingLevel {
-        self.entry_own.node().unwrap().level
+        self.entry_own.node().level
     }
 
     pub open spec fn inv_children(self) -> bool {
@@ -239,11 +239,10 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
                     &&& child.unwrap().value.parent_level == self.level()
                     &&& child.unwrap().level == self.tree_level + 1
                     &&& !child.unwrap().value.in_scope
-                    &&& child.unwrap().value.path.len() == self.entry_own.node().unwrap().tree_level
-                        + 1
+                    &&& child.unwrap().value.path.len() == self.entry_own.node().tree_level + 1
                     &&& child.unwrap().value.match_pte(
-                        self.entry_own.node().unwrap().children_perm.value()[i],
-                        self.entry_own.node().unwrap().level,
+                        self.entry_own.node().children_perm.value()[i],
+                        self.entry_own.node().level,
                     )
                     &&& child.unwrap().value.path == self.path().push_tail(i as usize)
                 }
@@ -283,11 +282,10 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             self.children[i].unwrap().value.parent_level == self.level(),
             self.children[i].unwrap().level == self.tree_level + 1,
             !self.children[i].unwrap().value.in_scope,
-            self.children[i].unwrap().value.path.len() == self.entry_own.node().unwrap().tree_level
-                + 1,
+            self.children[i].unwrap().value.path.len() == self.entry_own.node().tree_level + 1,
             self.children[i].unwrap().value.match_pte(
-                self.entry_own.node().unwrap().children_perm.value()[i],
-                self.entry_own.node().unwrap().level,
+                self.entry_own.node().children_perm.value()[i],
+                self.entry_own.node().level,
             ),
             self.children[i].unwrap().value.path == self.path().push_tail(i as usize),
     {
@@ -303,7 +301,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         &&& self.entry_own.is_node()
         &&& self.entry_own.inv()
         &&& !self.entry_own.in_scope
-        &&& self.entry_own.node().unwrap().relate_guard(self.guard)
+        &&& self.entry_own.node().relate_guard(self.guard)
         &&& self.tree_level == INC_LEVELS - self.level() - 1
         &&& self.tree_level < INC_LEVELS - 1
         &&& self.path().len() == self.tree_level
@@ -463,7 +461,8 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         requires
             entry.node_matching(child_value, parent_owner, guard),
             entry.idx == idx,
-            entry_own.node() == Some(parent_owner),
+            entry_own.is_node(),
+            entry_own.node() == parent_owner,
             child_value.path == entry_own.path.push_tail(idx),
             child_value.path.len() == parent_owner.tree_level + 1,
         ensures
@@ -495,16 +494,16 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
     // Old continuation was inv with parent_old wired in
 
             cont_old.inv(),
-            cont_old.entry_own.node() == Some(parent_old),
+            cont_old.entry_own.is_node(),
+            cont_old.entry_own.node() == parent_old,
             // Frozen fields shared with cont_old
             self.children.len() == cont_old.children.len(),
             self.idx == cont_old.idx,
             self.tree_level == cont_old.tree_level,
             self.guard == cont_old.guard,
             self.path == cont_old.path,
-            // entry_own changed only by .node field
-            self.entry_own.frame() == cont_old.entry_own.frame(),
-            self.entry_own.locked() == cont_old.entry_own.locked(),
+            // entry_own changed only by the Node payload and otherwise keeps
+            // the surrounding owner metadata.
             self.entry_own.is_absent() == cont_old.entry_own.is_absent(),
             self.entry_own.in_scope == cont_old.entry_own.in_scope,
             self.entry_own.path == cont_old.entry_own.path,
@@ -512,13 +511,13 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             // entry_own's new parent is well-formed and structurally matches the old
             self.entry_own.is_node(),
             self.entry_own.inv(),
-            self.entry_own.node().unwrap().relate_guard(self.guard),
-            self.entry_own.node().unwrap().level == parent_old.level,
-            self.entry_own.node().unwrap().tree_level == parent_old.tree_level,
+            self.entry_own.node().relate_guard(self.guard),
+            self.entry_own.node().level == parent_old.level,
+            self.entry_own.node().tree_level == parent_old.tree_level,
             // Other PTEs preserved (operation only touched the entry at idx)
             forall|j: int|
                 0 <= j < NR_ENTRIES && j != self.idx as int
-                    ==> #[trigger] self.entry_own.node().unwrap().children_perm.value()[j]
+                    ==> #[trigger] self.entry_own.node().children_perm.value()[j]
                     == parent_old.children_perm.value()[j],
             // Children at j != idx untouched
             forall|j: int|
@@ -540,10 +539,10 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             ),
             self.children[self.idx as int].unwrap().level == self.tree_level + 1,
             self.children[self.idx as int].unwrap().value.path.len()
-                == self.entry_own.node().unwrap().tree_level + 1,
+                == self.entry_own.node().tree_level + 1,
             self.children[self.idx as int].unwrap().value.match_pte(
-                self.entry_own.node().unwrap().children_perm.value()[self.idx as int],
-                self.entry_own.node().unwrap().level,
+                self.entry_own.node().children_perm.value()[self.idx as int],
+                self.entry_own.node().level,
             ),
             !self.children[self.idx as int].unwrap().value.in_scope,
             // The new child satisfies the PT-specific tree invariant. This is
@@ -555,7 +554,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             self.inv(),
     {
         let cont_idx = self.idx as int;
-        let new_parent = self.entry_own.node().unwrap();
+        let new_parent = self.entry_own.node();
         let new_child = self.children[cont_idx].unwrap();
 
         // (1) inv_children: every Some child is inv.
@@ -771,13 +770,13 @@ impl<'rcu, C: PageTableConfig> Inv for CursorOwner<'rcu, C> {
             )
             // PTE consistency
             &&& self.continuations[2].entry_own.path.len()
-                == self.continuations[3].entry_own.node().unwrap().tree_level + 1
+                == self.continuations[3].entry_own.node().tree_level + 1
             &&& self.continuations[2].entry_own.match_pte(
-                self.continuations[3].entry_own.node().unwrap().children_perm.value()[self.continuations[3].idx as int],
-                self.continuations[3].entry_own.node().unwrap().level,
+                self.continuations[3].entry_own.node().children_perm.value()[self.continuations[3].idx as int],
+                self.continuations[3].entry_own.node().level,
             )
             &&& self.continuations[2].entry_own.parent_level
-                == self.continuations[3].entry_own.node().unwrap().level
+                == self.continuations[3].entry_own.node().level
         }
         &&& self.level <= 2 ==> {
             &&& self.continuations.contains_key(1)
@@ -795,13 +794,13 @@ impl<'rcu, C: PageTableConfig> Inv for CursorOwner<'rcu, C> {
             )
             // PTE consistency
             &&& self.continuations[1].entry_own.path.len()
-                == self.continuations[2].entry_own.node().unwrap().tree_level + 1
+                == self.continuations[2].entry_own.node().tree_level + 1
             &&& self.continuations[1].entry_own.match_pte(
-                self.continuations[2].entry_own.node().unwrap().children_perm.value()[self.continuations[2].idx as int],
-                self.continuations[2].entry_own.node().unwrap().level,
+                self.continuations[2].entry_own.node().children_perm.value()[self.continuations[2].idx as int],
+                self.continuations[2].entry_own.node().level,
             )
             &&& self.continuations[1].entry_own.parent_level
-                == self.continuations[2].entry_own.node().unwrap().level
+                == self.continuations[2].entry_own.node().level
         }
         &&& self.level == 1 ==> {
             &&& self.continuations.contains_key(0)
@@ -821,13 +820,13 @@ impl<'rcu, C: PageTableConfig> Inv for CursorOwner<'rcu, C> {
             )
             // PTE consistency
             &&& self.continuations[0].entry_own.path.len()
-                == self.continuations[1].entry_own.node().unwrap().tree_level + 1
+                == self.continuations[1].entry_own.node().tree_level + 1
             &&& self.continuations[0].entry_own.match_pte(
-                self.continuations[1].entry_own.node().unwrap().children_perm.value()[self.continuations[1].idx as int],
-                self.continuations[1].entry_own.node().unwrap().level,
+                self.continuations[1].entry_own.node().children_perm.value()[self.continuations[1].idx as int],
+                self.continuations[1].entry_own.node().level,
             )
             &&& self.continuations[0].entry_own.parent_level
-                == self.continuations[1].entry_own.node().unwrap().level
+                == self.continuations[1].entry_own.node().level
         }
     }
 }
@@ -838,7 +837,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         TreePath<NR_ENTRIES>,
     ) -> bool) {
         |owner: EntryOwner<C>, path: TreePath<NR_ENTRIES>|
-            owner.is_node() ==> guards.unlocked(owner.node().unwrap().meta_addr_self())
+            owner.is_node() ==> guards.unlocked(owner.node().meta_addr_self())
     }
 
     pub open spec fn node_unlocked_except(guards: Guards<'rcu>, addr: usize) -> (spec_fn(
@@ -846,8 +845,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         TreePath<NR_ENTRIES>,
     ) -> bool) {
         |owner: EntryOwner<C>, path: TreePath<NR_ENTRIES>|
-            owner.is_node() ==> owner.node().unwrap().meta_addr_self() != addr ==> guards.unlocked(
-                owner.node().unwrap().meta_addr_self(),
+            owner.is_node() ==> owner.node().meta_addr_self() != addr ==> guards.unlocked(
+                owner.node().meta_addr_self(),
             )
     }
 
@@ -875,10 +874,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
     pub open spec fn only_current_locked(self, guards: Guards<'rcu>) -> bool {
         self.map_only_children(
-            Self::node_unlocked_except(
-                guards,
-                self.cur_entry_owner().node().unwrap().meta_addr_self(),
-            ),
+            Self::node_unlocked_except(guards, self.cur_entry_owner().node().meta_addr_self()),
         )
     }
 
@@ -901,12 +897,11 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             ),
             // The dropped guard is for the current entry's node (from pop_level).
             self.cur_entry_owner().is_node(),
-            guard.inner.inner@.ptr.addr()
-                == self.cur_entry_owner().node().unwrap().meta_addr_self(),
+            guard.inner.inner@.ptr.addr() == self.cur_entry_owner().node().meta_addr_self(),
         ensures
             self.children_not_locked(guards1),
     {
-        let current_addr = self.cur_entry_owner().node().unwrap().meta_addr_self();
+        let current_addr = self.cur_entry_owner().node().meta_addr_self();
         let f = Self::node_unlocked_except(guards0, current_addr);
         let g = Self::node_unlocked(guards1);
         assert(OwnerSubtree::implies(f, g));
@@ -1197,11 +1192,11 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             regions.inv(),
             self.metaregion_sound(regions),
             self.cur_entry_owner().is_frame(),
-            pa == self.cur_entry_owner().frame().unwrap().mapped_pa,
+            pa == self.cur_entry_owner().frame().mapped_pa,
             C::item_from_raw_spec(pa, level, prop) == item,
             crate::mm::frame::meta::has_safe_slot(pa),
             // The recorded entry trackedness matches the item being cloned.
-            C::tracked(item) == self.cur_entry_owner().frame().unwrap().is_tracked,
+            C::tracked(item) == self.cur_entry_owner().frame().is_tracked,
             // Saturation aborts (Arc-style) via `inc_ref_count`'s diverging panic.
             C::tracked(item) ==> (regions.slot_owners[frame_to_index(
                 pa,
@@ -1249,7 +1244,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.metaregion_sound(old_regions),
             old_regions.inv(),
             self.cur_entry_owner().is_frame(),
-            idx == frame_to_index(self.cur_entry_owner().frame().unwrap().mapped_pa),
+            idx == frame_to_index(self.cur_entry_owner().frame().mapped_pa),
             old_regions.slot_owners.contains_key(idx),
             new_regions.slot_owners.contains_key(idx),
             // rc at idx is incremented by 1
@@ -1325,8 +1320,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             new_subtree.value.path == self.continuations[self.level as int - 1].path().push_tail(
                 self.continuations[self.level as int - 1].idx as usize,
             ),
-            new_subtree.value.frame().unwrap().mapped_pa == pa,
-            new_subtree.value.frame().unwrap().prop == prop,
+            new_subtree.value.frame().mapped_pa == pa,
+            new_subtree.value.frame().prop == prop,
         ensures
             PageTableOwner(new_subtree)@.mappings
                 == set![Mapping {
@@ -2491,9 +2486,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         ensures
             self@.present(),
             self@.query(
-                self.cur_entry_owner().frame().unwrap().mapped_pa,
-                self.cur_entry_owner().frame().unwrap().size,
-                self.cur_entry_owner().frame().unwrap().prop,
+                self.cur_entry_owner().frame().mapped_pa,
+                self.cur_entry_owner().frame().size,
+                self.cur_entry_owner().frame().prop,
             ),
     {
         self.cur_subtree_inv();
@@ -2501,7 +2496,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         self.view_preserves_inv();
         let subtree = self.cur_subtree();
         let path = subtree.value.path;
-        let frame = self.cur_entry_owner().frame().unwrap();
+        let frame = self.cur_entry_owner().frame();
         let pt_level = INC_LEVELS - path.len();
         let cont = self.continuations[self.level - 1];
 

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -196,7 +196,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
     // map_children_lift, map_children_lift_skip_idx, as_subtree_restore
     // have been moved to tree_lemmas.rs.
     pub open spec fn level(self) -> PagingLevel {
-        self.entry_own.node.unwrap().level
+        self.entry_own.node().unwrap().level
     }
 
     pub open spec fn inv_children(self) -> bool {
@@ -239,11 +239,11 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
                     &&& child.unwrap().value.parent_level == self.level()
                     &&& child.unwrap().level == self.tree_level + 1
                     &&& !child.unwrap().value.in_scope
-                    &&& child.unwrap().value.path.len() == self.entry_own.node.unwrap().tree_level
+                    &&& child.unwrap().value.path.len() == self.entry_own.node().unwrap().tree_level
                         + 1
                     &&& child.unwrap().value.match_pte(
-                        self.entry_own.node.unwrap().children_perm.value()[i],
-                        self.entry_own.node.unwrap().level,
+                        self.entry_own.node().unwrap().children_perm.value()[i],
+                        self.entry_own.node().unwrap().level,
                     )
                     &&& child.unwrap().value.path == self.path().push_tail(i as usize)
                 }
@@ -283,11 +283,11 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             self.children[i].unwrap().value.parent_level == self.level(),
             self.children[i].unwrap().level == self.tree_level + 1,
             !self.children[i].unwrap().value.in_scope,
-            self.children[i].unwrap().value.path.len() == self.entry_own.node.unwrap().tree_level
+            self.children[i].unwrap().value.path.len() == self.entry_own.node().unwrap().tree_level
                 + 1,
             self.children[i].unwrap().value.match_pte(
-                self.entry_own.node.unwrap().children_perm.value()[i],
-                self.entry_own.node.unwrap().level,
+                self.entry_own.node().unwrap().children_perm.value()[i],
+                self.entry_own.node().unwrap().level,
             ),
             self.children[i].unwrap().value.path == self.path().push_tail(i as usize),
     {
@@ -303,7 +303,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         &&& self.entry_own.is_node()
         &&& self.entry_own.inv()
         &&& !self.entry_own.in_scope
-        &&& self.entry_own.node.unwrap().relate_guard(self.guard)
+        &&& self.entry_own.node().unwrap().relate_guard(self.guard)
         &&& self.tree_level == INC_LEVELS - self.level() - 1
         &&& self.tree_level < INC_LEVELS - 1
         &&& self.path().len() == self.tree_level
@@ -463,7 +463,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         requires
             entry.node_matching(child_value, parent_owner, guard),
             entry.idx == idx,
-            entry_own.node == Some(parent_owner),
+            entry_own.node() == Some(parent_owner),
             child_value.path == entry_own.path.push_tail(idx),
             child_value.path.len() == parent_owner.tree_level + 1,
         ensures
@@ -495,7 +495,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
     // Old continuation was inv with parent_old wired in
 
             cont_old.inv(),
-            cont_old.entry_own.node == Some(parent_old),
+            cont_old.entry_own.node() == Some(parent_old),
             // Frozen fields shared with cont_old
             self.children.len() == cont_old.children.len(),
             self.idx == cont_old.idx,
@@ -503,22 +503,22 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             self.guard == cont_old.guard,
             self.path == cont_old.path,
             // entry_own changed only by .node field
-            self.entry_own.frame == cont_old.entry_own.frame,
-            self.entry_own.locked == cont_old.entry_own.locked,
-            self.entry_own.absent == cont_old.entry_own.absent,
+            self.entry_own.frame() == cont_old.entry_own.frame(),
+            self.entry_own.locked() == cont_old.entry_own.locked(),
+            self.entry_own.is_absent() == cont_old.entry_own.is_absent(),
             self.entry_own.in_scope == cont_old.entry_own.in_scope,
             self.entry_own.path == cont_old.entry_own.path,
             self.entry_own.parent_level == cont_old.entry_own.parent_level,
             // entry_own's new parent is well-formed and structurally matches the old
             self.entry_own.is_node(),
             self.entry_own.inv(),
-            self.entry_own.node.unwrap().relate_guard(self.guard),
-            self.entry_own.node.unwrap().level == parent_old.level,
-            self.entry_own.node.unwrap().tree_level == parent_old.tree_level,
+            self.entry_own.node().unwrap().relate_guard(self.guard),
+            self.entry_own.node().unwrap().level == parent_old.level,
+            self.entry_own.node().unwrap().tree_level == parent_old.tree_level,
             // Other PTEs preserved (operation only touched the entry at idx)
             forall|j: int|
                 0 <= j < NR_ENTRIES && j != self.idx as int
-                    ==> #[trigger] self.entry_own.node.unwrap().children_perm.value()[j]
+                    ==> #[trigger] self.entry_own.node().unwrap().children_perm.value()[j]
                     == parent_old.children_perm.value()[j],
             // Children at j != idx untouched
             forall|j: int|
@@ -540,10 +540,10 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             ),
             self.children[self.idx as int].unwrap().level == self.tree_level + 1,
             self.children[self.idx as int].unwrap().value.path.len()
-                == self.entry_own.node.unwrap().tree_level + 1,
+                == self.entry_own.node().unwrap().tree_level + 1,
             self.children[self.idx as int].unwrap().value.match_pte(
-                self.entry_own.node.unwrap().children_perm.value()[self.idx as int],
-                self.entry_own.node.unwrap().level,
+                self.entry_own.node().unwrap().children_perm.value()[self.idx as int],
+                self.entry_own.node().unwrap().level,
             ),
             !self.children[self.idx as int].unwrap().value.in_scope,
             // The new child satisfies the PT-specific tree invariant. This is
@@ -555,7 +555,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             self.inv(),
     {
         let cont_idx = self.idx as int;
-        let new_parent = self.entry_own.node.unwrap();
+        let new_parent = self.entry_own.node().unwrap();
         let new_child = self.children[cont_idx].unwrap();
 
         // (1) inv_children: every Some child is inv.
@@ -771,13 +771,13 @@ impl<'rcu, C: PageTableConfig> Inv for CursorOwner<'rcu, C> {
             )
             // PTE consistency
             &&& self.continuations[2].entry_own.path.len()
-                == self.continuations[3].entry_own.node.unwrap().tree_level + 1
+                == self.continuations[3].entry_own.node().unwrap().tree_level + 1
             &&& self.continuations[2].entry_own.match_pte(
-                self.continuations[3].entry_own.node.unwrap().children_perm.value()[self.continuations[3].idx as int],
-                self.continuations[3].entry_own.node.unwrap().level,
+                self.continuations[3].entry_own.node().unwrap().children_perm.value()[self.continuations[3].idx as int],
+                self.continuations[3].entry_own.node().unwrap().level,
             )
             &&& self.continuations[2].entry_own.parent_level
-                == self.continuations[3].entry_own.node.unwrap().level
+                == self.continuations[3].entry_own.node().unwrap().level
         }
         &&& self.level <= 2 ==> {
             &&& self.continuations.contains_key(1)
@@ -795,13 +795,13 @@ impl<'rcu, C: PageTableConfig> Inv for CursorOwner<'rcu, C> {
             )
             // PTE consistency
             &&& self.continuations[1].entry_own.path.len()
-                == self.continuations[2].entry_own.node.unwrap().tree_level + 1
+                == self.continuations[2].entry_own.node().unwrap().tree_level + 1
             &&& self.continuations[1].entry_own.match_pte(
-                self.continuations[2].entry_own.node.unwrap().children_perm.value()[self.continuations[2].idx as int],
-                self.continuations[2].entry_own.node.unwrap().level,
+                self.continuations[2].entry_own.node().unwrap().children_perm.value()[self.continuations[2].idx as int],
+                self.continuations[2].entry_own.node().unwrap().level,
             )
             &&& self.continuations[1].entry_own.parent_level
-                == self.continuations[2].entry_own.node.unwrap().level
+                == self.continuations[2].entry_own.node().unwrap().level
         }
         &&& self.level == 1 ==> {
             &&& self.continuations.contains_key(0)
@@ -821,13 +821,13 @@ impl<'rcu, C: PageTableConfig> Inv for CursorOwner<'rcu, C> {
             )
             // PTE consistency
             &&& self.continuations[0].entry_own.path.len()
-                == self.continuations[1].entry_own.node.unwrap().tree_level + 1
+                == self.continuations[1].entry_own.node().unwrap().tree_level + 1
             &&& self.continuations[0].entry_own.match_pte(
-                self.continuations[1].entry_own.node.unwrap().children_perm.value()[self.continuations[1].idx as int],
-                self.continuations[1].entry_own.node.unwrap().level,
+                self.continuations[1].entry_own.node().unwrap().children_perm.value()[self.continuations[1].idx as int],
+                self.continuations[1].entry_own.node().unwrap().level,
             )
             &&& self.continuations[0].entry_own.parent_level
-                == self.continuations[1].entry_own.node.unwrap().level
+                == self.continuations[1].entry_own.node().unwrap().level
         }
     }
 }
@@ -838,7 +838,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         TreePath<NR_ENTRIES>,
     ) -> bool) {
         |owner: EntryOwner<C>, path: TreePath<NR_ENTRIES>|
-            owner.is_node() ==> guards.unlocked(owner.node.unwrap().meta_addr_self())
+            owner.is_node() ==> guards.unlocked(owner.node().unwrap().meta_addr_self())
     }
 
     pub open spec fn node_unlocked_except(guards: Guards<'rcu>, addr: usize) -> (spec_fn(
@@ -846,8 +846,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         TreePath<NR_ENTRIES>,
     ) -> bool) {
         |owner: EntryOwner<C>, path: TreePath<NR_ENTRIES>|
-            owner.is_node() ==> owner.node.unwrap().meta_addr_self() != addr ==> guards.unlocked(
-                owner.node.unwrap().meta_addr_self(),
+            owner.is_node() ==> owner.node().unwrap().meta_addr_self() != addr ==> guards.unlocked(
+                owner.node().unwrap().meta_addr_self(),
             )
     }
 
@@ -877,7 +877,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         self.map_only_children(
             Self::node_unlocked_except(
                 guards,
-                self.cur_entry_owner().node.unwrap().meta_addr_self(),
+                self.cur_entry_owner().node().unwrap().meta_addr_self(),
             ),
         )
     }
@@ -901,11 +901,11 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             ),
             // The dropped guard is for the current entry's node (from pop_level).
             self.cur_entry_owner().is_node(),
-            guard.inner.inner@.ptr.addr() == self.cur_entry_owner().node.unwrap().meta_addr_self(),
+            guard.inner.inner@.ptr.addr() == self.cur_entry_owner().node().unwrap().meta_addr_self(),
         ensures
             self.children_not_locked(guards1),
     {
-        let current_addr = self.cur_entry_owner().node.unwrap().meta_addr_self();
+        let current_addr = self.cur_entry_owner().node().unwrap().meta_addr_self();
         let f = Self::node_unlocked_except(guards0, current_addr);
         let g = Self::node_unlocked(guards1);
         assert(OwnerSubtree::implies(f, g));
@@ -1196,11 +1196,11 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             regions.inv(),
             self.metaregion_sound(regions),
             self.cur_entry_owner().is_frame(),
-            pa == self.cur_entry_owner().frame.unwrap().mapped_pa,
+            pa == self.cur_entry_owner().frame().unwrap().mapped_pa,
             C::item_from_raw_spec(pa, level, prop) == item,
             crate::mm::frame::meta::has_safe_slot(pa),
             // The recorded entry trackedness matches the item being cloned.
-            C::tracked(item) == self.cur_entry_owner().frame.unwrap().is_tracked,
+            C::tracked(item) == self.cur_entry_owner().frame().unwrap().is_tracked,
             // Saturation aborts (Arc-style) via `inc_ref_count`'s diverging panic.
             C::tracked(item) ==> (regions.slot_owners[frame_to_index(
                 pa,
@@ -1248,7 +1248,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.metaregion_sound(old_regions),
             old_regions.inv(),
             self.cur_entry_owner().is_frame(),
-            idx == frame_to_index(self.cur_entry_owner().frame.unwrap().mapped_pa),
+            idx == frame_to_index(self.cur_entry_owner().frame().unwrap().mapped_pa),
             old_regions.slot_owners.contains_key(idx),
             new_regions.slot_owners.contains_key(idx),
             // rc at idx is incremented by 1
@@ -1324,8 +1324,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             new_subtree.value.path == self.continuations[self.level as int - 1].path().push_tail(
                 self.continuations[self.level as int - 1].idx as usize,
             ),
-            new_subtree.value.frame.unwrap().mapped_pa == pa,
-            new_subtree.value.frame.unwrap().prop == prop,
+            new_subtree.value.frame().unwrap().mapped_pa == pa,
+            new_subtree.value.frame().unwrap().prop == prop,
         ensures
             PageTableOwner(new_subtree)@.mappings
                 == set![Mapping {
@@ -2490,9 +2490,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         ensures
             self@.present(),
             self@.query(
-                self.cur_entry_owner().frame.unwrap().mapped_pa,
-                self.cur_entry_owner().frame.unwrap().size,
-                self.cur_entry_owner().frame.unwrap().prop,
+                self.cur_entry_owner().frame().unwrap().mapped_pa,
+                self.cur_entry_owner().frame().unwrap().size,
+                self.cur_entry_owner().frame().unwrap().prop,
             ),
     {
         self.cur_subtree_inv();
@@ -2500,7 +2500,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         self.view_preserves_inv();
         let subtree = self.cur_subtree();
         let path = subtree.value.path;
-        let frame = self.cur_entry_owner().frame.unwrap();
+        let frame = self.cur_entry_owner().frame().unwrap();
         let pt_level = INC_LEVELS - path.len();
         let cont = self.continuations[self.level - 1];
 
@@ -3064,3 +3064,4 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> ModelOf for Cursor<'rcu, C, A> {
 }
 
 } // verus!
+

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -901,7 +901,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             ),
             // The dropped guard is for the current entry's node (from pop_level).
             self.cur_entry_owner().is_node(),
-            guard.inner.inner@.ptr.addr() == self.cur_entry_owner().node().unwrap().meta_addr_self(),
+            guard.inner.inner@.ptr.addr()
+                == self.cur_entry_owner().node().unwrap().meta_addr_self(),
         ensures
             self.children_not_locked(guards1),
     {
@@ -3064,4 +3065,3 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> ModelOf for Cursor<'rcu, C, A> {
 }
 
 } // verus!
-

--- a/ostd/specs/mm/page_table/cursor/va_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/va_lemmas.rs
@@ -222,7 +222,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         self.cur_entry_frame_present();
         let subtree = self.cur_subtree();
         let path = subtree.value.path;
-        let frame = self.cur_entry_owner().frame.unwrap();
+        let frame = self.cur_entry_owner().frame().unwrap();
         let pt_level = INC_LEVELS - path.len();
         let cont = self.continuations[self.level - 1];
 
@@ -431,3 +431,4 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 }
 
 } // verus!
+

--- a/ostd/specs/mm/page_table/cursor/va_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/va_lemmas.rs
@@ -222,7 +222,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         self.cur_entry_frame_present();
         let subtree = self.cur_subtree();
         let path = subtree.value.path;
-        let frame = self.cur_entry_owner().frame().unwrap();
+        let frame = self.cur_entry_owner().frame();
         let pt_level = INC_LEVELS - path.len();
         let cont = self.continuations[self.level - 1];
 

--- a/ostd/specs/mm/page_table/cursor/va_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/va_lemmas.rs
@@ -431,4 +431,3 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 }
 
 } // verus!
-

--- a/ostd/specs/mm/page_table/node/child.rs
+++ b/ostd/specs/mm/page_table/node/child.rs
@@ -20,13 +20,13 @@ impl<C: PageTableConfig> OwnerOf for Child<C> {
         match self {
             Self::PageTable(node) => {
                 &&& owner.is_node()
-                &&& node.ptr.addr() == owner.node().unwrap().meta_addr_self()
+                &&& node.ptr.addr() == owner.node().meta_addr_self()
                 &&& node.index() == frame_to_index(meta_to_frame(node.ptr.addr()))
             },
             Self::Frame(paddr, level, prop) => {
                 &&& owner.is_frame()
-                &&& owner.frame().unwrap().mapped_pa == paddr
-                &&& owner.frame().unwrap().prop == prop
+                &&& owner.frame().mapped_pa == paddr
+                &&& owner.frame().prop == prop
                 &&& level == owner.parent_level
             },
             Self::None => owner.is_absent(),
@@ -41,12 +41,12 @@ impl<'a, C: PageTableConfig> OwnerOf for ChildRef<'a, C> {
         match self {
             Self::PageTable(node) => {
                 &&& owner.is_node()
-                &&& node.inner.0.ptr.addr() == owner.node().unwrap().meta_addr_self()
+                &&& node.inner.0.ptr.addr() == owner.node().meta_addr_self()
             },
             Self::Frame(paddr, level, prop) => {
                 &&& owner.is_frame()
-                &&& owner.frame().unwrap().mapped_pa == paddr
-                &&& owner.frame().unwrap().prop == prop
+                &&& owner.frame().mapped_pa == paddr
+                &&& owner.frame().prop == prop
             },
             Self::None => owner.is_absent(),
         }

--- a/ostd/specs/mm/page_table/node/child.rs
+++ b/ostd/specs/mm/page_table/node/child.rs
@@ -171,4 +171,3 @@ impl<C: PageTableConfig> EntryOwner<C> {
 }
 
 } // verus!
-

--- a/ostd/specs/mm/page_table/node/child.rs
+++ b/ostd/specs/mm/page_table/node/child.rs
@@ -20,13 +20,13 @@ impl<C: PageTableConfig> OwnerOf for Child<C> {
         match self {
             Self::PageTable(node) => {
                 &&& owner.is_node()
-                &&& node.ptr.addr() == owner.node.unwrap().meta_addr_self()
+                &&& node.ptr.addr() == owner.node().unwrap().meta_addr_self()
                 &&& node.index() == frame_to_index(meta_to_frame(node.ptr.addr()))
             },
             Self::Frame(paddr, level, prop) => {
                 &&& owner.is_frame()
-                &&& owner.frame.unwrap().mapped_pa == paddr
-                &&& owner.frame.unwrap().prop == prop
+                &&& owner.frame().unwrap().mapped_pa == paddr
+                &&& owner.frame().unwrap().prop == prop
                 &&& level == owner.parent_level
             },
             Self::None => owner.is_absent(),
@@ -41,12 +41,12 @@ impl<'a, C: PageTableConfig> OwnerOf for ChildRef<'a, C> {
         match self {
             Self::PageTable(node) => {
                 &&& owner.is_node()
-                &&& node.inner.0.ptr.addr() == owner.node.unwrap().meta_addr_self()
+                &&& node.inner.0.ptr.addr() == owner.node().unwrap().meta_addr_self()
             },
             Self::Frame(paddr, level, prop) => {
                 &&& owner.is_frame()
-                &&& owner.frame.unwrap().mapped_pa == paddr
-                &&& owner.frame.unwrap().prop == prop
+                &&& owner.frame().unwrap().mapped_pa == paddr
+                &&& owner.frame().unwrap().prop == prop
             },
             Self::None => owner.is_absent(),
         }
@@ -171,3 +171,4 @@ impl<C: PageTableConfig> EntryOwner<C> {
 }
 
 } // verus!
+

--- a/ostd/specs/mm/page_table/node/entry.rs
+++ b/ostd/specs/mm/page_table/node/entry.rs
@@ -48,7 +48,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         new_owner: EntryOwner<C>,
     ) -> bool {
         if new_owner.is_node() {
-            parent_owner.level - 1 == new_owner.node().unwrap().level
+            parent_owner.level - 1 == new_owner.node().level
         } else if new_owner.is_frame() {
             parent_owner.level == new_owner.parent_level
         } else {

--- a/ostd/specs/mm/page_table/node/entry.rs
+++ b/ostd/specs/mm/page_table/node/entry.rs
@@ -48,7 +48,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         new_owner: EntryOwner<C>,
     ) -> bool {
         if new_owner.is_node() {
-            parent_owner.level - 1 == new_owner.node.unwrap().level
+            parent_owner.level - 1 == new_owner.node().unwrap().level
         } else if new_owner.is_frame() {
             parent_owner.level == new_owner.parent_level
         } else {
@@ -184,3 +184,4 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
 }
 
 } // verus!
+

--- a/ostd/specs/mm/page_table/node/entry.rs
+++ b/ostd/specs/mm/page_table/node/entry.rs
@@ -184,4 +184,3 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
 }
 
 } // verus!
-

--- a/ostd/specs/mm/page_table/node/entry_owners.rs
+++ b/ostd/specs/mm/page_table/node/entry_owners.rs
@@ -83,32 +83,20 @@ impl<C: PageTableConfig> EntryOwner<C> {
         self.kind is Borrowed
     }
 
-    pub open spec fn node(self) -> Option<NodeOwner<C>> {
-        match self.kind {
-            EntryOwnerKind::Node(node) => Some(node),
-            _ => None,
-        }
+    pub open spec fn node(self) -> NodeOwner<C> {
+        self.kind->Node_0
     }
 
-    pub open spec fn frame(self) -> Option<FrameEntryOwner> {
-        match self.kind {
-            EntryOwnerKind::Frame(frame) => Some(frame),
-            _ => None,
-        }
+    pub open spec fn frame(self) -> FrameEntryOwner {
+        self.kind->Frame_0
     }
 
-    pub open spec fn locked(self) -> Option<Seq<FrameView<C>>> {
-        match self.kind {
-            EntryOwnerKind::Locked(views) => Some(views),
-            _ => None,
-        }
+    pub open spec fn locked(self) -> Seq<FrameView<C>> {
+        self.kind->Locked_0
     }
 
-    pub open spec fn borrowed(self) -> Option<Set<Mapping>> {
-        match self.kind {
-            EntryOwnerKind::Borrowed(mappings) => Some(mappings),
-            _ => None,
-        }
+    pub open spec fn borrowed(self) -> Set<Mapping> {
+        self.kind->Borrowed_0
     }
 
     pub open spec fn new_absent(path: TreePath<NR_ENTRIES>, parent_level: PagingLevel) -> Self {
@@ -281,11 +269,11 @@ impl<C: PageTableConfig> EntryOwner<C> {
             entry.is_frame(),
             entry.inv_base(),
         ensures
-            entry.frame().unwrap().is_tracked == C::tracked(
+            entry.frame().is_tracked == C::tracked(
                 C::item_from_raw_spec(
-                    entry.frame().unwrap().mapped_pa,
+                    entry.frame().mapped_pa,
                     entry.parent_level,
-                    entry.frame().unwrap().prop,
+                    entry.frame().prop,
                 ),
             ),
     ;
@@ -300,10 +288,8 @@ impl<C: PageTableConfig> EntryOwner<C> {
             entry.is_frame(),
             entry.inv_base(),
         ensures
-            #[trigger] entry.frame().unwrap().is_tracked
-                != crate::specs::mm::frame::meta_owners::is_mmio_paddr(
-                entry.frame().unwrap().mapped_pa,
-            ),
+            #[trigger] entry.frame().is_tracked
+                != crate::specs::mm::frame::meta_owners::is_mmio_paddr(entry.frame().mapped_pa),
     ;
 
     pub axiom fn tracked_new_node(node: NodeOwner<C>, path: TreePath<NR_ENTRIES>) -> tracked Self
@@ -330,10 +316,10 @@ impl<C: PageTableConfig> EntryOwner<C> {
             parent_level <= NR_LEVELS,
         ensures
             res.is_frame(),
-            res.frame().unwrap().mapped_pa == paddr,
-            res.frame().unwrap().prop == prop,
-            res.frame().unwrap().size == page_size(parent_level),
-            res.frame().unwrap().is_tracked == false,
+            res.frame().mapped_pa == paddr,
+            res.frame().prop == prop,
+            res.frame().size == page_size(parent_level),
+            res.frame().is_tracked == false,
             res.parent_level == parent_level,
             res.path.inv(),
             res.in_scope,
@@ -350,12 +336,12 @@ impl<C: PageTableConfig> EntryOwner<C> {
         }
         &&& pte.is_present() && !pte.is_last(parent_level) ==> {
             &&& self.is_node()
-            &&& meta_to_frame(self.node().unwrap().meta_addr_self()) == pte.paddr()
+            &&& meta_to_frame(self.node().meta_addr_self()) == pte.paddr()
         }
         &&& pte.is_present() && pte.is_last(parent_level) ==> {
             &&& self.is_frame()
-            &&& self.frame().unwrap().mapped_pa == pte.paddr()
-            &&& self.frame().unwrap().prop == pte.prop()
+            &&& self.frame().mapped_pa == pte.paddr()
+            &&& self.frame().prop == pte.prop()
         }
     }
 
@@ -407,8 +393,8 @@ impl<C: PageTableConfig> EntryOwner<C> {
             pte.is_last(parent_level),
         ensures
             self.is_frame(),
-            self.frame().unwrap().mapped_pa == pte.paddr(),
-            self.frame().unwrap().prop == pte.prop(),
+            self.frame().mapped_pa == pte.paddr(),
+            self.frame().prop == pte.prop(),
     {
         if !pte.is_present() {
             assert(self.is_absent());
@@ -416,8 +402,8 @@ impl<C: PageTableConfig> EntryOwner<C> {
             assert(false);
         }
         assert(self.is_frame());
-        assert(self.frame().unwrap().mapped_pa == pte.paddr());
-        assert(self.frame().unwrap().prop == pte.prop());
+        assert(self.frame().mapped_pa == pte.paddr());
+        assert(self.frame().prop == pte.prop());
     }
 
     pub proof fn huge_frame_split_child_at(self, regions: MetaRegionOwners, idx: usize)
@@ -428,20 +414,19 @@ impl<C: PageTableConfig> EntryOwner<C> {
             1 < self.parent_level < NR_LEVELS,
             idx < NR_ENTRIES,
         ensures
-            self.frame().unwrap().mapped_pa + idx * page_size(
-                (self.parent_level - 1) as PagingLevel,
-            ) < MAX_PADDR,
-            ((self.frame().unwrap().mapped_pa + idx * page_size(
+            self.frame().mapped_pa + idx * page_size((self.parent_level - 1) as PagingLevel)
+                < MAX_PADDR,
+            ((self.frame().mapped_pa + idx * page_size(
                 (self.parent_level - 1) as PagingLevel,
             )) as Paddr) % page_size((self.parent_level - 1) as PagingLevel) == 0,
-            ((self.frame().unwrap().mapped_pa + idx * page_size(
+            ((self.frame().mapped_pa + idx * page_size(
                 (self.parent_level - 1) as PagingLevel,
             )) as Paddr) + page_size((self.parent_level - 1) as PagingLevel) <= MAX_PADDR,
-            ((self.frame().unwrap().mapped_pa + idx * page_size(
+            ((self.frame().mapped_pa + idx * page_size(
                 (self.parent_level - 1) as PagingLevel,
             )) as Paddr) % PAGE_SIZE == 0,
     {
-        let pa = self.frame().unwrap().mapped_pa;
+        let pa = self.frame().mapped_pa;
         let child_pa = (pa + idx * page_size((self.parent_level - 1) as PagingLevel)) as Paddr;
         assert(self.parent_level == 2 || self.parent_level == 3);
         assert(NR_ENTRIES == 512) by {
@@ -527,7 +512,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
             self.frame_sub_pages_valid(r1),
     {
         if self.parent_level > 1 {
-            let pa = self.frame().unwrap().mapped_pa;
+            let pa = self.frame().mapped_pa;
             let nr_pages = page_size(self.parent_level) / PAGE_SIZE;
             let self_idx = frame_to_index(self.meta_slot_paddr().unwrap());
             assert forall|j: usize|
@@ -590,7 +575,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
     /// the corresponding subrange of indices.
     pub open spec fn frame_sub_pages_valid(self, regions: MetaRegionOwners) -> bool {
         self.is_frame() && self.parent_level > 1 ==> {
-            let pa = self.frame().unwrap().mapped_pa;
+            let pa = self.frame().mapped_pa;
             let nr_pages = page_size(self.parent_level) / PAGE_SIZE;
             forall|j: usize|
                 #![trigger frame_to_index((pa + j * PAGE_SIZE) as usize)]
@@ -619,10 +604,10 @@ impl<C: PageTableConfig> EntryOwner<C> {
             let idx = frame_to_index(self.meta_slot_paddr().unwrap());
             &&& regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
             &&& 0 < regions.slot_owners[idx].inner_perms.ref_count.value() <= REF_COUNT_MAX
-            &&& regions.slot_owners[idx].self_addr == self.node().unwrap().meta_addr_self()
+            &&& regions.slot_owners[idx].self_addr == self.node().meta_addr_self()
             &&& regions.slots[idx].value().wf(regions.slot_owners[idx])
             &&& regions.slot_owners[idx].paths_in_pt == set![self.path]
-            &&& self.node().unwrap().metaregion_sound_node(regions)
+            &&& self.node().metaregion_sound_node(regions)
         } else if self.is_frame() {
             let idx = frame_to_index(self.meta_slot_paddr().unwrap());
             &&& regions.slots.contains_key(idx)
@@ -674,9 +659,9 @@ impl<C: PageTableConfig> EntryOwner<C> {
 
     pub open spec fn meta_slot_paddr(self) -> Option<Paddr> {
         if self.is_node() {
-            Some(meta_to_frame(self.node().unwrap().meta_addr_self()))
+            Some(meta_to_frame(self.node().meta_addr_self()))
         } else if self.is_frame() {
-            Some(self.frame().unwrap().mapped_pa)
+            Some(self.frame().mapped_pa)
         } else {
             None
         }
@@ -701,9 +686,9 @@ impl<C: PageTableConfig> EntryOwner<C> {
             self.metaregion_sound(r1),
     {
         if self.is_node() {
-            let slot_idx = self.node().unwrap().slot_index;
+            let slot_idx = self.node().slot_index;
             assert(r0.slots.contains_key(slot_idx));
-            assert(self.node().unwrap().meta_perm_of(r1) == self.node().unwrap().meta_perm_of(r0));
+            assert(self.node().meta_perm_of(r1) == self.node().meta_perm_of(r0));
         }
     }
 
@@ -731,7 +716,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
             // that sub-slot is non-MMIO, the sub-page validity at changed_idx must still
             // hold in r1. MMIO sub-pages keep `usage == MMIO` and `rc == UNUSED`.
             self.is_frame() && self.parent_level > 1 ==> {
-                let pa = self.frame().unwrap().mapped_pa;
+                let pa = self.frame().mapped_pa;
                 let nr_pages = page_size(self.parent_level) / PAGE_SIZE;
                 forall|j: usize|
                     0 < j < nr_pages ==> {
@@ -748,12 +733,12 @@ impl<C: PageTableConfig> EntryOwner<C> {
             self.metaregion_sound(r1),
     {
         if self.is_node() {
-            let slot_idx = self.node().unwrap().slot_index;
+            let slot_idx = self.node().slot_index;
             let outer_idx = frame_to_index(self.meta_slot_paddr().unwrap());
             assert(r0.slots.contains_key(slot_idx));
             assert(slot_idx != changed_idx);
             assert(r1.slot_owners[slot_idx] == r0.slot_owners[slot_idx]);
-            assert(self.node().unwrap().meta_perm_of(r1) == self.node().unwrap().meta_perm_of(r0));
+            assert(self.node().meta_perm_of(r1) == self.node().meta_perm_of(r0));
         }
     }
 
@@ -790,7 +775,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
             // For huge frames: if changed_idx is one of this frame's sub-page slots (j > 0),
             // the new paths_in_pt at changed_idx must remain empty.
             self.is_frame() && self.parent_level > 1 ==> {
-                let pa = self.frame().unwrap().mapped_pa;
+                let pa = self.frame().mapped_pa;
                 let sub_level = (self.parent_level - 1) as PagingLevel;
                 forall|j: usize|
                     0 < j < NR_ENTRIES ==> {
@@ -816,7 +801,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
                 // Sub-page validity for huge frames: slot existence (unconditional)
                 // plus `rc` bookkeeping when tracked.
                 if self.parent_level > 1 {
-                    let pa = self.frame().unwrap().mapped_pa;
+                    let pa = self.frame().mapped_pa;
                     let nr_pages = page_size(self.parent_level) / PAGE_SIZE;
                     let self_idx = frame_to_index(self.meta_slot_paddr().unwrap());
                     assert forall|j: usize|
@@ -901,7 +886,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
             self.metaregion_sound(r1),
     {
         if self.is_frame() && self.parent_level > 1 {
-            let pa = self.frame().unwrap().mapped_pa;
+            let pa = self.frame().mapped_pa;
             let nr_pages = page_size(self.parent_level) / PAGE_SIZE;
             let self_idx = frame_to_index(self.meta_slot_paddr().unwrap());
             assert forall|j: usize|
@@ -960,10 +945,10 @@ impl<C: PageTableConfig> EntryOwner<C> {
             )].paths_in_pt == set![other.path],
             self.path != other.path,
         ensures
-            self.node().unwrap().meta_addr_self() != other.node().unwrap().meta_addr_self(),
+            self.node().meta_addr_self() != other.node().meta_addr_self(),
     {
-        let self_addr = self.node().unwrap().meta_addr_self();
-        let other_addr = other.node().unwrap().meta_addr_self();
+        let self_addr = self.node().meta_addr_self();
+        let other_addr = other.node().meta_addr_self();
         let self_idx = frame_to_index(meta_to_frame(self_addr));
         let other_idx = frame_to_index(meta_to_frame(other_addr));
 
@@ -1009,8 +994,8 @@ impl<C: PageTableConfig> EntryOwner<C> {
     /// for entries that have been taken out of the tree (`in_scope == true`).
     pub open spec fn inv_base(self) -> bool {
         &&& self.is_node() ==> {
-            &&& self.node().unwrap().inv()
-            &&& self.parent_level == self.node().unwrap().level + 1
+            &&& self.node().inv()
+            &&& self.parent_level == self.node().level + 1
         }
         &&& self.is_frame() ==> {
             // Architectural constraint: frames only exist at PT levels that the
@@ -1018,11 +1003,11 @@ impl<C: PageTableConfig> EntryOwner<C> {
             // == NR_LEVELS` would be a 512 GiB huge page, which no current arch
             // permits — and `Mapping::inv` would reject its page_size.
             &&& 1 <= self.parent_level < NR_LEVELS
-            &&& self.frame().unwrap().mapped_pa % PAGE_SIZE == 0
-            &&& self.frame().unwrap().mapped_pa < MAX_PADDR
-            &&& self.frame().unwrap().size == page_size(self.parent_level)
-            &&& self.frame().unwrap().mapped_pa % page_size(self.parent_level) == 0
-            &&& self.frame().unwrap().mapped_pa + page_size(self.parent_level) <= MAX_PADDR
+            &&& self.frame().mapped_pa % PAGE_SIZE == 0
+            &&& self.frame().mapped_pa < MAX_PADDR
+            &&& self.frame().size == page_size(self.parent_level)
+            &&& self.frame().mapped_pa % page_size(self.parent_level) == 0
+            &&& self.frame().mapped_pa + page_size(self.parent_level) <= MAX_PADDR
         }
         &&& self.is_locked() ==> { true }
         &&& self.is_borrowed() ==> { true }
@@ -1046,7 +1031,8 @@ impl<C: PageTableConfig> View for EntryOwner<C> {
 
     #[verifier::external_body]
     open spec fn view(&self) -> <Self as View>::V {
-        if let Some(frame) = self.frame() {
+        if self.is_frame() {
+            let frame = self.frame();
             EntryView::Leaf {
                 leaf: LeafPageTableEntryView {
                     map_va: vaddr(self.path) as int,
@@ -1058,7 +1044,8 @@ impl<C: PageTableConfig> View for EntryOwner<C> {
                     phantom: PhantomData,
                 },
             }
-        } else if let Some(node) = self.node() {
+        } else if self.is_node() {
+            let node = self.node();
             EntryView::Intermediate {
                 node: IntermediatePageTableEntryView {
                     map_va: vaddr(self.path) as int,
@@ -1069,7 +1056,8 @@ impl<C: PageTableConfig> View for EntryOwner<C> {
                     phantom: PhantomData,
                 },
             }
-        } else if let Some(view) = self.locked() {
+        } else if self.is_locked() {
+            let view = self.locked();
             EntryView::LockedSubtree { views: view }
         } else {
             EntryView::Absent

--- a/ostd/specs/mm/page_table/node/entry_owners.rs
+++ b/ostd/specs/mm/page_table/node/entry_owners.rs
@@ -1008,19 +1008,11 @@ impl<C: PageTableConfig> EntryOwner<C> {
     /// Structural invariant without `!in_scope`. Used by `Child::invariants`
     /// for entries that have been taken out of the tree (`in_scope == true`).
     pub open spec fn inv_base(self) -> bool {
-        &&& self.node() is Some ==> {
-            &&& self.frame() is None
-            &&& self.locked() is None
-            &&& self.borrowed() is None
+        &&& self.is_node() ==> {
             &&& self.node().unwrap().inv()
-            &&& !self.is_absent()
             &&& self.parent_level == self.node().unwrap().level + 1
         }
-        &&& self.frame() is Some ==> {
-            &&& self.node() is None
-            &&& self.locked() is None
-            &&& self.borrowed() is None
-            &&& !self.is_absent()
+        &&& self.is_frame() ==> {
             // Architectural constraint: frames only exist at PT levels that the
             // ISA actually supports as leaves (4K, 2M, 1G on x86). `parent_level
             // == NR_LEVELS` would be a 512 GiB huge page, which no current arch
@@ -1032,18 +1024,8 @@ impl<C: PageTableConfig> EntryOwner<C> {
             &&& self.frame().unwrap().mapped_pa % page_size(self.parent_level) == 0
             &&& self.frame().unwrap().mapped_pa + page_size(self.parent_level) <= MAX_PADDR
         }
-        &&& self.locked() is Some ==> {
-            &&& self.frame() is None
-            &&& self.node() is None
-            &&& self.borrowed() is None
-            &&& !self.is_absent()
-        }
-        &&& self.borrowed() is Some ==> {
-            &&& self.node() is None
-            &&& self.frame() is None
-            &&& self.locked() is None
-            &&& !self.is_absent()
-        }
+        &&& self.is_locked() ==> { true }
+        &&& self.is_borrowed() ==> { true }
         &&& self.path.inv()
     }
 

--- a/ostd/specs/mm/page_table/node/entry_owners.rs
+++ b/ostd/specs/mm/page_table/node/entry_owners.rs
@@ -174,7 +174,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
         requires
             old(self).kind is Node,
         ensures
-            res == old(self).kind->Node_0,
+            res == old(self).node(),
             *final(self) == (EntryOwner { kind: EntryOwnerKind::Absent, ..*old(self) }),
     {
         let tracked mut tmp = EntryOwnerKind::Absent;
@@ -196,7 +196,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
         requires
             self.kind is Node,
         ensures
-            *res == self.kind->Node_0,
+            *res == self.node(),
     {
         match self.kind {
             EntryOwnerKind::Node(ref node) => node,
@@ -204,11 +204,12 @@ impl<C: PageTableConfig> EntryOwner<C> {
         }
     }
 
-    pub proof fn tracked_borrow_node_mut(tracked &mut self) -> (tracked res: &mut NodeOwner<C>)
+    pub proof fn tracked_borrow_mut_node(tracked &mut self) -> (tracked res: &mut NodeOwner<C>)
         requires
             old(self).kind is Node,
         ensures
-            *res == old(self).kind->Node_0,
+            *res == old(self).node(),
+            *final(self) == (EntryOwner { kind: EntryOwnerKind::Node(*final(res)), ..*old(self) }),
     {
         match self.kind {
             EntryOwnerKind::Node(ref mut node) => node,
@@ -220,7 +221,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
         requires
             old(self).kind is Frame,
         ensures
-            res == old(self).kind->Frame_0,
+            res == old(self).frame(),
             *final(self) == (EntryOwner { kind: EntryOwnerKind::Absent, ..*old(self) }),
     {
         let tracked mut tmp = EntryOwnerKind::Absent;
@@ -236,6 +237,18 @@ impl<C: PageTableConfig> EntryOwner<C> {
             *final(self) == (EntryOwner { kind: EntryOwnerKind::Frame(frame), ..*old(self) }),
     {
         self.kind = EntryOwnerKind::Frame(frame);
+    }
+
+    pub proof fn tracked_borrow_frame(tracked &self) -> (tracked res: &FrameEntryOwner)
+        requires
+            self.kind is Frame,
+        ensures
+            *res == self.frame(),
+    {
+        match self.kind {
+            EntryOwnerKind::Frame(ref frame) => frame,
+            _ => { proof_from_false() },
+        }
     }
 
     pub axiom fn tracked_new_frame(

--- a/ostd/specs/mm/page_table/node/entry_owners.rs
+++ b/ostd/specs/mm/page_table/node/entry_owners.rs
@@ -1029,7 +1029,6 @@ impl<C: PageTableConfig> Inv for EntryOwner<C> {
 impl<C: PageTableConfig> View for EntryOwner<C> {
     type V = EntryView<C>;
 
-    #[verifier::external_body]
     open spec fn view(&self) -> <Self as View>::V {
         if self.is_frame() {
             let frame = self.frame();

--- a/ostd/specs/mm/page_table/node/entry_owners.rs
+++ b/ostd/specs/mm/page_table/node/entry_owners.rs
@@ -35,7 +35,7 @@ pub tracked struct FrameEntryOwner {
 pub tracked struct EntryOwner<C: PageTableConfig> {
     pub node: Option<NodeOwner<C>>,
     pub frame: Option<FrameEntryOwner>,
-    pub locked: Option<Ghost<Seq<FrameView<C>>>>,
+    pub ghost locked: Option<Seq<FrameView<C>>>,
     /// Translation-only / borrowed-sub-tree variant.
     ///
     /// Present when the slot's PTE references a sub-tree owned by *another*
@@ -45,7 +45,7 @@ pub tracked struct EntryOwner<C: PageTableConfig> {
     /// embedding can reason about what the borrowed translation provides
     /// without descending into a sub-tree it does not own. Mutually
     /// exclusive with `node`, `frame`, and `locked`.
-    pub borrowed: Option<Ghost<Set<Mapping>>>,
+    pub ghost borrowed: Option<Set<Mapping>>,
     pub absent: bool,
     pub in_scope: bool,
     pub path: TreePath<NR_ENTRIES>,
@@ -136,7 +136,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
             node: None,
             frame: None,
             locked: None,
-            borrowed: Some(Ghost(mappings)),
+            borrowed: Some(mappings),
             absent: false,
             in_scope: true,
             path,
@@ -1007,7 +1007,7 @@ impl<C: PageTableConfig> View for EntryOwner<C> {
                 },
             }
         } else if let Some(view) = self.locked {
-            EntryView::LockedSubtree { views: view@ }
+            EntryView::LockedSubtree { views: view }
         } else {
             EntryView::Absent
         }

--- a/ostd/specs/mm/page_table/node/entry_owners.rs
+++ b/ostd/specs/mm/page_table/node/entry_owners.rs
@@ -1,6 +1,7 @@
 use vstd::prelude::*;
 
 use vstd::cell;
+use vstd::modes::tracked_swap;
 use vstd::simple_pptr::PointsTo;
 use vstd_extra::array_ptr;
 use vstd_extra::ghost_tree::*;
@@ -32,10 +33,16 @@ pub tracked struct FrameEntryOwner {
     pub is_tracked: bool,
 }
 
+pub tracked enum EntryOwnerKind<C: PageTableConfig> {
+    Node(NodeOwner<C>),
+    Frame(FrameEntryOwner),
+    Locked(ghost Seq<FrameView<C>>),
+    Borrowed(ghost Set<Mapping>),
+    Absent,
+}
+
 pub tracked struct EntryOwner<C: PageTableConfig> {
-    pub node: Option<NodeOwner<C>>,
-    pub frame: Option<FrameEntryOwner>,
-    pub ghost locked: Option<Seq<FrameView<C>>>,
+    pub kind: EntryOwnerKind<C>,
     /// Translation-only / borrowed-sub-tree variant.
     ///
     /// Present when the slot's PTE references a sub-tree owned by *another*
@@ -44,42 +51,69 @@ pub tracked struct EntryOwner<C: PageTableConfig> {
     /// records the mappings reachable through that sub-tree so the
     /// embedding can reason about what the borrowed translation provides
     /// without descending into a sub-tree it does not own. Mutually
-    /// exclusive with `node`, `frame`, and `locked`.
-    pub ghost borrowed: Option<Set<Mapping>>,
-    pub absent: bool,
+    /// exclusive with `node`, `frame`, `locked`, and `absent` by construction.
     pub in_scope: bool,
     pub path: TreePath<NR_ENTRIES>,
     pub parent_level: PagingLevel,
 }
 
 impl<C: PageTableConfig> EntryOwner<C> {
+    #[verifier::inline]
     pub open spec fn is_node(self) -> bool {
-        self.node is Some
+        self.kind is Node
     }
 
+    #[verifier::inline]
     pub open spec fn is_frame(self) -> bool {
-        self.frame is Some
+        self.kind is Frame
     }
 
+    #[verifier::inline]
     pub open spec fn is_locked(self) -> bool {
-        self.locked is Some
+        self.kind is Locked
     }
 
+    #[verifier::inline]
     pub open spec fn is_absent(self) -> bool {
-        self.absent
+        self.kind is Absent
     }
 
+    #[verifier::inline]
     pub open spec fn is_borrowed(self) -> bool {
-        self.borrowed is Some
+        self.kind is Borrowed
+    }
+
+    pub open spec fn node(self) -> Option<NodeOwner<C>> {
+        match self.kind {
+            EntryOwnerKind::Node(node) => Some(node),
+            _ => None,
+        }
+    }
+
+    pub open spec fn frame(self) -> Option<FrameEntryOwner> {
+        match self.kind {
+            EntryOwnerKind::Frame(frame) => Some(frame),
+            _ => None,
+        }
+    }
+
+    pub open spec fn locked(self) -> Option<Seq<FrameView<C>>> {
+        match self.kind {
+            EntryOwnerKind::Locked(views) => Some(views),
+            _ => None,
+        }
+    }
+
+    pub open spec fn borrowed(self) -> Option<Set<Mapping>> {
+        match self.kind {
+            EntryOwnerKind::Borrowed(mappings) => Some(mappings),
+            _ => None,
+        }
     }
 
     pub open spec fn new_absent(path: TreePath<NR_ENTRIES>, parent_level: PagingLevel) -> Self {
         EntryOwner {
-            node: None,
-            frame: None,
-            locked: None,
-            borrowed: None,
-            absent: true,
+            kind: EntryOwnerKind::Absent,
             in_scope: true,
             path,
             parent_level,
@@ -94,8 +128,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
         is_tracked: bool,
     ) -> Self {
         EntryOwner {
-            node: None,
-            frame: Some(
+            kind: EntryOwnerKind::Frame(
                 FrameEntryOwner {
                     mapped_pa: paddr,
                     size: page_size(parent_level),
@@ -103,9 +136,6 @@ impl<C: PageTableConfig> EntryOwner<C> {
                     is_tracked,
                 },
             ),
-            locked: None,
-            borrowed: None,
-            absent: false,
             in_scope: true,
             path,
             parent_level,
@@ -114,11 +144,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
 
     pub open spec fn new_node(node: NodeOwner<C>, path: TreePath<NR_ENTRIES>) -> Self {
         EntryOwner {
-            node: Some(node),
-            frame: None,
-            locked: None,
-            borrowed: None,
-            absent: false,
+            kind: EntryOwnerKind::Node(node),
             in_scope: true,
             path,
             parent_level: (node.level + 1) as PagingLevel,
@@ -133,11 +159,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
         mappings: Set<Mapping>,
     ) -> Self {
         EntryOwner {
-            node: None,
-            frame: None,
-            locked: None,
-            borrowed: Some(mappings),
-            absent: false,
+            kind: EntryOwnerKind::Borrowed(mappings),
             in_scope: true,
             path,
             parent_level,
@@ -170,6 +192,74 @@ impl<C: PageTableConfig> EntryOwner<C> {
             *final(self) == (EntryOwner { path, ..*old(self) }),
     ;
 
+    pub proof fn tracked_take_node(tracked &mut self) -> (tracked res: NodeOwner<C>)
+        requires
+            old(self).kind is Node,
+        ensures
+            res == old(self).kind->Node_0,
+            *final(self) == (EntryOwner { kind: EntryOwnerKind::Absent, ..*old(self) }),
+    {
+        let tracked mut tmp = EntryOwnerKind::Absent;
+        tracked_swap(&mut self.kind, &mut tmp);
+        match tmp {
+            EntryOwnerKind::Node(node) => node,
+            _ => { proof_from_false() },
+        }
+    }
+
+    pub proof fn tracked_put_node(tracked &mut self, tracked node: NodeOwner<C>)
+        ensures
+            *final(self) == (EntryOwner { kind: EntryOwnerKind::Node(node), ..*old(self) }),
+    {
+        self.kind = EntryOwnerKind::Node(node);
+    }
+
+    pub proof fn tracked_borrow_node(tracked &self) -> (tracked res: &NodeOwner<C>)
+        requires
+            self.kind is Node,
+        ensures
+            *res == self.kind->Node_0,
+    {
+        match self.kind {
+            EntryOwnerKind::Node(ref node) => node,
+            _ => { proof_from_false() },
+        }
+    }
+
+    pub proof fn tracked_borrow_node_mut(tracked &mut self) -> (tracked res: &mut NodeOwner<C>)
+        requires
+            old(self).kind is Node,
+        ensures
+            *res == old(self).kind->Node_0,
+    {
+        match self.kind {
+            EntryOwnerKind::Node(ref mut node) => node,
+            _ => { proof_from_false() },
+        }
+    }
+
+    pub proof fn tracked_take_frame(tracked &mut self) -> (tracked res: FrameEntryOwner)
+        requires
+            old(self).kind is Frame,
+        ensures
+            res == old(self).kind->Frame_0,
+            *final(self) == (EntryOwner { kind: EntryOwnerKind::Absent, ..*old(self) }),
+    {
+        let tracked mut tmp = EntryOwnerKind::Absent;
+        tracked_swap(&mut self.kind, &mut tmp);
+        match tmp {
+            EntryOwnerKind::Frame(frame) => frame,
+            _ => { proof_from_false() },
+        }
+    }
+
+    pub proof fn tracked_put_frame(tracked &mut self, tracked frame: FrameEntryOwner)
+        ensures
+            *final(self) == (EntryOwner { kind: EntryOwnerKind::Frame(frame), ..*old(self) }),
+    {
+        self.kind = EntryOwnerKind::Frame(frame);
+    }
+
     pub axiom fn tracked_new_frame(
         paddr: Paddr,
         path: TreePath<NR_ENTRIES>,
@@ -201,11 +291,11 @@ impl<C: PageTableConfig> EntryOwner<C> {
             entry.is_frame(),
             entry.inv_base(),
         ensures
-            entry.frame.unwrap().is_tracked == C::tracked(
+            entry.frame().unwrap().is_tracked == C::tracked(
                 C::item_from_raw_spec(
-                    entry.frame.unwrap().mapped_pa,
+                    entry.frame().unwrap().mapped_pa,
                     entry.parent_level,
-                    entry.frame.unwrap().prop,
+                    entry.frame().unwrap().prop,
                 ),
             ),
     ;
@@ -220,9 +310,9 @@ impl<C: PageTableConfig> EntryOwner<C> {
             entry.is_frame(),
             entry.inv_base(),
         ensures
-            #[trigger] entry.frame.unwrap().is_tracked
+            #[trigger] entry.frame().unwrap().is_tracked
                 != crate::specs::mm::frame::meta_owners::is_mmio_paddr(
-                entry.frame.unwrap().mapped_pa,
+                entry.frame().unwrap().mapped_pa,
             ),
     ;
 
@@ -250,10 +340,10 @@ impl<C: PageTableConfig> EntryOwner<C> {
             parent_level <= NR_LEVELS,
         ensures
             res.is_frame(),
-            res.frame.unwrap().mapped_pa == paddr,
-            res.frame.unwrap().prop == prop,
-            res.frame.unwrap().size == page_size(parent_level),
-            res.frame.unwrap().is_tracked == false,
+            res.frame().unwrap().mapped_pa == paddr,
+            res.frame().unwrap().prop == prop,
+            res.frame().unwrap().size == page_size(parent_level),
+            res.frame().unwrap().is_tracked == false,
             res.parent_level == parent_level,
             res.path.inv(),
             res.in_scope,
@@ -270,12 +360,12 @@ impl<C: PageTableConfig> EntryOwner<C> {
         }
         &&& pte.is_present() && !pte.is_last(parent_level) ==> {
             &&& self.is_node()
-            &&& meta_to_frame(self.node.unwrap().meta_addr_self()) == pte.paddr()
+            &&& meta_to_frame(self.node().unwrap().meta_addr_self()) == pte.paddr()
         }
         &&& pte.is_present() && pte.is_last(parent_level) ==> {
             &&& self.is_frame()
-            &&& self.frame.unwrap().mapped_pa == pte.paddr()
-            &&& self.frame.unwrap().prop == pte.prop()
+            &&& self.frame().unwrap().mapped_pa == pte.paddr()
+            &&& self.frame().unwrap().prop == pte.prop()
         }
     }
 
@@ -327,8 +417,8 @@ impl<C: PageTableConfig> EntryOwner<C> {
             pte.is_last(parent_level),
         ensures
             self.is_frame(),
-            self.frame.unwrap().mapped_pa == pte.paddr(),
-            self.frame.unwrap().prop == pte.prop(),
+            self.frame().unwrap().mapped_pa == pte.paddr(),
+            self.frame().unwrap().prop == pte.prop(),
     {
         if !pte.is_present() {
             assert(self.is_absent());
@@ -336,8 +426,8 @@ impl<C: PageTableConfig> EntryOwner<C> {
             assert(false);
         }
         assert(self.is_frame());
-        assert(self.frame.unwrap().mapped_pa == pte.paddr());
-        assert(self.frame.unwrap().prop == pte.prop());
+        assert(self.frame().unwrap().mapped_pa == pte.paddr());
+        assert(self.frame().unwrap().prop == pte.prop());
     }
 
     pub proof fn huge_frame_split_child_at(self, regions: MetaRegionOwners, idx: usize)
@@ -348,19 +438,19 @@ impl<C: PageTableConfig> EntryOwner<C> {
             1 < self.parent_level < NR_LEVELS,
             idx < NR_ENTRIES,
         ensures
-            self.frame.unwrap().mapped_pa + idx * page_size((self.parent_level - 1) as PagingLevel)
+            self.frame().unwrap().mapped_pa + idx * page_size((self.parent_level - 1) as PagingLevel)
                 < MAX_PADDR,
-            ((self.frame.unwrap().mapped_pa + idx * page_size(
+            ((self.frame().unwrap().mapped_pa + idx * page_size(
                 (self.parent_level - 1) as PagingLevel,
             )) as Paddr) % page_size((self.parent_level - 1) as PagingLevel) == 0,
-            ((self.frame.unwrap().mapped_pa + idx * page_size(
+            ((self.frame().unwrap().mapped_pa + idx * page_size(
                 (self.parent_level - 1) as PagingLevel,
             )) as Paddr) + page_size((self.parent_level - 1) as PagingLevel) <= MAX_PADDR,
-            ((self.frame.unwrap().mapped_pa + idx * page_size(
+            ((self.frame().unwrap().mapped_pa + idx * page_size(
                 (self.parent_level - 1) as PagingLevel,
             )) as Paddr) % PAGE_SIZE == 0,
     {
-        let pa = self.frame.unwrap().mapped_pa;
+        let pa = self.frame().unwrap().mapped_pa;
         let child_pa = (pa + idx * page_size((self.parent_level - 1) as PagingLevel)) as Paddr;
         assert(self.parent_level == 2 || self.parent_level == 3);
         assert(NR_ENTRIES == 512) by {
@@ -446,7 +536,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
             self.frame_sub_pages_valid(r1),
     {
         if self.parent_level > 1 {
-            let pa = self.frame.unwrap().mapped_pa;
+            let pa = self.frame().unwrap().mapped_pa;
             let nr_pages = page_size(self.parent_level) / PAGE_SIZE;
             let self_idx = frame_to_index(self.meta_slot_paddr().unwrap());
             assert forall|j: usize|
@@ -509,7 +599,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
     /// the corresponding subrange of indices.
     pub open spec fn frame_sub_pages_valid(self, regions: MetaRegionOwners) -> bool {
         self.is_frame() && self.parent_level > 1 ==> {
-            let pa = self.frame.unwrap().mapped_pa;
+            let pa = self.frame().unwrap().mapped_pa;
             let nr_pages = page_size(self.parent_level) / PAGE_SIZE;
             forall|j: usize|
                 #![trigger frame_to_index((pa + j * PAGE_SIZE) as usize)]
@@ -538,10 +628,10 @@ impl<C: PageTableConfig> EntryOwner<C> {
             let idx = frame_to_index(self.meta_slot_paddr().unwrap());
             &&& regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
             &&& 0 < regions.slot_owners[idx].inner_perms.ref_count.value() <= REF_COUNT_MAX
-            &&& regions.slot_owners[idx].self_addr == self.node.unwrap().meta_addr_self()
+            &&& regions.slot_owners[idx].self_addr == self.node().unwrap().meta_addr_self()
             &&& regions.slots[idx].value().wf(regions.slot_owners[idx])
             &&& regions.slot_owners[idx].paths_in_pt == set![self.path]
-            &&& self.node.unwrap().metaregion_sound_node(regions)
+            &&& self.node().unwrap().metaregion_sound_node(regions)
         } else if self.is_frame() {
             let idx = frame_to_index(self.meta_slot_paddr().unwrap());
             &&& regions.slots.contains_key(idx)
@@ -593,9 +683,9 @@ impl<C: PageTableConfig> EntryOwner<C> {
 
     pub open spec fn meta_slot_paddr(self) -> Option<Paddr> {
         if self.is_node() {
-            Some(meta_to_frame(self.node.unwrap().meta_addr_self()))
+            Some(meta_to_frame(self.node().unwrap().meta_addr_self()))
         } else if self.is_frame() {
-            Some(self.frame.unwrap().mapped_pa)
+            Some(self.frame().unwrap().mapped_pa)
         } else {
             None
         }
@@ -620,9 +710,9 @@ impl<C: PageTableConfig> EntryOwner<C> {
             self.metaregion_sound(r1),
     {
         if self.is_node() {
-            let slot_idx = self.node.unwrap().slot_index;
+            let slot_idx = self.node().unwrap().slot_index;
             assert(r0.slots.contains_key(slot_idx));
-            assert(self.node.unwrap().meta_perm_of(r1) == self.node.unwrap().meta_perm_of(r0));
+            assert(self.node().unwrap().meta_perm_of(r1) == self.node().unwrap().meta_perm_of(r0));
         }
     }
 
@@ -650,7 +740,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
             // that sub-slot is non-MMIO, the sub-page validity at changed_idx must still
             // hold in r1. MMIO sub-pages keep `usage == MMIO` and `rc == UNUSED`.
             self.is_frame() && self.parent_level > 1 ==> {
-                let pa = self.frame.unwrap().mapped_pa;
+                let pa = self.frame().unwrap().mapped_pa;
                 let nr_pages = page_size(self.parent_level) / PAGE_SIZE;
                 forall|j: usize|
                     0 < j < nr_pages ==> {
@@ -667,12 +757,12 @@ impl<C: PageTableConfig> EntryOwner<C> {
             self.metaregion_sound(r1),
     {
         if self.is_node() {
-            let slot_idx = self.node.unwrap().slot_index;
+            let slot_idx = self.node().unwrap().slot_index;
             let outer_idx = frame_to_index(self.meta_slot_paddr().unwrap());
             assert(r0.slots.contains_key(slot_idx));
             assert(slot_idx != changed_idx);
             assert(r1.slot_owners[slot_idx] == r0.slot_owners[slot_idx]);
-            assert(self.node.unwrap().meta_perm_of(r1) == self.node.unwrap().meta_perm_of(r0));
+            assert(self.node().unwrap().meta_perm_of(r1) == self.node().unwrap().meta_perm_of(r0));
         }
     }
 
@@ -709,7 +799,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
             // For huge frames: if changed_idx is one of this frame's sub-page slots (j > 0),
             // the new paths_in_pt at changed_idx must remain empty.
             self.is_frame() && self.parent_level > 1 ==> {
-                let pa = self.frame.unwrap().mapped_pa;
+                let pa = self.frame().unwrap().mapped_pa;
                 let sub_level = (self.parent_level - 1) as PagingLevel;
                 forall|j: usize|
                     0 < j < NR_ENTRIES ==> {
@@ -735,7 +825,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
                 // Sub-page validity for huge frames: slot existence (unconditional)
                 // plus `rc` bookkeeping when tracked.
                 if self.parent_level > 1 {
-                    let pa = self.frame.unwrap().mapped_pa;
+                    let pa = self.frame().unwrap().mapped_pa;
                     let nr_pages = page_size(self.parent_level) / PAGE_SIZE;
                     let self_idx = frame_to_index(self.meta_slot_paddr().unwrap());
                     assert forall|j: usize|
@@ -820,7 +910,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
             self.metaregion_sound(r1),
     {
         if self.is_frame() && self.parent_level > 1 {
-            let pa = self.frame.unwrap().mapped_pa;
+            let pa = self.frame().unwrap().mapped_pa;
             let nr_pages = page_size(self.parent_level) / PAGE_SIZE;
             let self_idx = frame_to_index(self.meta_slot_paddr().unwrap());
             assert forall|j: usize|
@@ -879,10 +969,10 @@ impl<C: PageTableConfig> EntryOwner<C> {
             )].paths_in_pt == set![other.path],
             self.path != other.path,
         ensures
-            self.node.unwrap().meta_addr_self() != other.node.unwrap().meta_addr_self(),
+            self.node().unwrap().meta_addr_self() != other.node().unwrap().meta_addr_self(),
     {
-        let self_addr = self.node.unwrap().meta_addr_self();
-        let other_addr = other.node.unwrap().meta_addr_self();
+        let self_addr = self.node().unwrap().meta_addr_self();
+        let other_addr = other.node().unwrap().meta_addr_self();
         let self_idx = frame_to_index(meta_to_frame(self_addr));
         let other_idx = frame_to_index(meta_to_frame(other_addr));
 
@@ -927,41 +1017,41 @@ impl<C: PageTableConfig> EntryOwner<C> {
     /// Structural invariant without `!in_scope`. Used by `Child::invariants`
     /// for entries that have been taken out of the tree (`in_scope == true`).
     pub open spec fn inv_base(self) -> bool {
-        &&& self.node is Some ==> {
-            &&& self.frame is None
-            &&& self.locked is None
-            &&& self.borrowed is None
-            &&& self.node.unwrap().inv()
-            &&& !self.absent
-            &&& self.parent_level == self.node.unwrap().level + 1
+        &&& self.node() is Some ==> {
+            &&& self.frame() is None
+            &&& self.locked() is None
+            &&& self.borrowed() is None
+            &&& self.node().unwrap().inv()
+            &&& !self.is_absent()
+            &&& self.parent_level == self.node().unwrap().level + 1
         }
-        &&& self.frame is Some ==> {
-            &&& self.node is None
-            &&& self.locked is None
-            &&& self.borrowed is None
-            &&& !self.absent
+        &&& self.frame() is Some ==> {
+            &&& self.node() is None
+            &&& self.locked() is None
+            &&& self.borrowed() is None
+            &&& !self.is_absent()
             // Architectural constraint: frames only exist at PT levels that the
             // ISA actually supports as leaves (4K, 2M, 1G on x86). `parent_level
             // == NR_LEVELS` would be a 512 GiB huge page, which no current arch
             // permits — and `Mapping::inv` would reject its page_size.
             &&& 1 <= self.parent_level < NR_LEVELS
-            &&& self.frame.unwrap().mapped_pa % PAGE_SIZE == 0
-            &&& self.frame.unwrap().mapped_pa < MAX_PADDR
-            &&& self.frame.unwrap().size == page_size(self.parent_level)
-            &&& self.frame.unwrap().mapped_pa % page_size(self.parent_level) == 0
-            &&& self.frame.unwrap().mapped_pa + page_size(self.parent_level) <= MAX_PADDR
+            &&& self.frame().unwrap().mapped_pa % PAGE_SIZE == 0
+            &&& self.frame().unwrap().mapped_pa < MAX_PADDR
+            &&& self.frame().unwrap().size == page_size(self.parent_level)
+            &&& self.frame().unwrap().mapped_pa % page_size(self.parent_level) == 0
+            &&& self.frame().unwrap().mapped_pa + page_size(self.parent_level) <= MAX_PADDR
         }
-        &&& self.locked is Some ==> {
-            &&& self.frame is None
-            &&& self.node is None
-            &&& self.borrowed is None
-            &&& !self.absent
+        &&& self.locked() is Some ==> {
+            &&& self.frame() is None
+            &&& self.node() is None
+            &&& self.borrowed() is None
+            &&& !self.is_absent()
         }
-        &&& self.borrowed is Some ==> {
-            &&& self.node is None
-            &&& self.frame is None
-            &&& self.locked is None
-            &&& !self.absent
+        &&& self.borrowed() is Some ==> {
+            &&& self.node() is None
+            &&& self.frame() is None
+            &&& self.locked() is None
+            &&& !self.is_absent()
         }
         &&& self.path.inv()
     }
@@ -983,7 +1073,7 @@ impl<C: PageTableConfig> View for EntryOwner<C> {
 
     #[verifier::external_body]
     open spec fn view(&self) -> <Self as View>::V {
-        if let Some(frame) = self.frame {
+        if let Some(frame) = self.frame() {
             EntryView::Leaf {
                 leaf: LeafPageTableEntryView {
                     map_va: vaddr(self.path) as int,
@@ -995,7 +1085,7 @@ impl<C: PageTableConfig> View for EntryOwner<C> {
                     phantom: PhantomData,
                 },
             }
-        } else if let Some(node) = self.node {
+        } else if let Some(node) = self.node() {
             EntryView::Intermediate {
                 node: IntermediatePageTableEntryView {
                     map_va: vaddr(self.path) as int,
@@ -1006,7 +1096,7 @@ impl<C: PageTableConfig> View for EntryOwner<C> {
                     phantom: PhantomData,
                 },
             }
-        } else if let Some(view) = self.locked {
+        } else if let Some(view) = self.locked() {
             EntryView::LockedSubtree { views: view }
         } else {
             EntryView::Absent
@@ -1034,3 +1124,4 @@ impl<'a, 'rcu, C: PageTableConfig> OwnerOf for Entry<'a, 'rcu, C> {
 }
 
 } // verus!
+

--- a/ostd/specs/mm/page_table/node/entry_owners.rs
+++ b/ostd/specs/mm/page_table/node/entry_owners.rs
@@ -112,12 +112,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
     }
 
     pub open spec fn new_absent(path: TreePath<NR_ENTRIES>, parent_level: PagingLevel) -> Self {
-        EntryOwner {
-            kind: EntryOwnerKind::Absent,
-            in_scope: true,
-            path,
-            parent_level,
-        }
+        EntryOwner { kind: EntryOwnerKind::Absent, in_scope: true, path, parent_level }
     }
 
     pub open spec fn new_frame(
@@ -158,12 +153,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
         parent_level: PagingLevel,
         mappings: Set<Mapping>,
     ) -> Self {
-        EntryOwner {
-            kind: EntryOwnerKind::Borrowed(mappings),
-            in_scope: true,
-            path,
-            parent_level,
-        }
+        EntryOwner { kind: EntryOwnerKind::Borrowed(mappings), in_scope: true, path, parent_level }
     }
 
     pub axiom fn tracked_new_borrowed(
@@ -438,8 +428,9 @@ impl<C: PageTableConfig> EntryOwner<C> {
             1 < self.parent_level < NR_LEVELS,
             idx < NR_ENTRIES,
         ensures
-            self.frame().unwrap().mapped_pa + idx * page_size((self.parent_level - 1) as PagingLevel)
-                < MAX_PADDR,
+            self.frame().unwrap().mapped_pa + idx * page_size(
+                (self.parent_level - 1) as PagingLevel,
+            ) < MAX_PADDR,
             ((self.frame().unwrap().mapped_pa + idx * page_size(
                 (self.parent_level - 1) as PagingLevel,
             )) as Paddr) % page_size((self.parent_level - 1) as PagingLevel) == 0,
@@ -1124,4 +1115,3 @@ impl<'a, 'rcu, C: PageTableConfig> OwnerOf for Entry<'a, 'rcu, C> {
 }
 
 } // verus!
-

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -2333,4 +2333,3 @@ impl<C: PageTableConfig> View for PageTableOwner<C> {
 }
 
 } // verus!
-

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -407,9 +407,9 @@ pub open spec fn allocated_empty_node_owner<C: PageTableConfig>(
     &&& owner.value.in_scope
     &&& owner.value.path == TreePath::<NR_ENTRIES>::new(Seq::empty())
     &&& owner.value.parent_level == (level + 1) as PagingLevel
-    &&& owner.value.node().unwrap().level == level
-    &&& owner.value.node().unwrap().inv()
-    &&& !owner.value.node().unwrap().children_perm.value().all(|child: C::E| child.is_present())
+    &&& owner.value.node().level == level
+    &&& owner.value.node().inv()
+    &&& !owner.value.node().children_perm.value().all(|child: C::E| child.is_present())
     &&& forall|i: int|
         #![auto]
         0 <= i < NR_ENTRIES ==> {
@@ -422,19 +422,19 @@ pub open spec fn allocated_empty_node_owner<C: PageTableConfig>(
     &&& forall|i: int|
         #![auto]
         0 <= i < NR_ENTRIES ==> owner.children[i].unwrap().value.match_pte(
-            owner.value.node().unwrap().children_perm.value()[i],
+            owner.value.node().children_perm.value()[i],
             owner.children[i].unwrap().value.parent_level,
         )
     &&& forall|i: int|
         #![auto]
         0 <= i < NR_ENTRIES ==> owner.children[i].unwrap().value.parent_level
-            == owner.value.node().unwrap().level
+            == owner.value.node().level
     // The freshly-allocated PT node is zero-filled, so every PTE in
     // `children_perm` is the absent PTE. (Stronger than the existing
     // "not all are present" clause; needed by `split_if_mapped_huge`'s
     // loop invariant which inspects each slot's PTE.)
     &&& forall|j: int|
-        0 <= j < NR_ENTRIES ==> #[trigger] owner.value.node().unwrap().children_perm.value()[j]
+        0 <= j < NR_ENTRIES ==> #[trigger] owner.value.node().children_perm.value()[j]
             == C::E::new_absent_spec()
 }
 
@@ -539,14 +539,13 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     /// Per-edge constraint between a node-parent and its child at index `i`.
     pub open spec fn pt_edge_at(parent: OwnerSubtree<C>, i: int) -> bool {
         &&& parent.children[i] is Some
-        &&& parent.children[i].unwrap().value.path.len() == parent.value.node().unwrap().tree_level
-            + 1
+        &&& parent.children[i].unwrap().value.path.len() == parent.value.node().tree_level + 1
         &&& parent.children[i].unwrap().value.match_pte(
-            parent.value.node().unwrap().children_perm.value()[i],
-            parent.value.node().unwrap().level,
+            parent.value.node().children_perm.value()[i],
+            parent.value.node().level,
         )
         &&& parent.children[i].unwrap().value.path == parent.value.path.push_tail(i as usize)
-        &&& parent.children[i].unwrap().value.parent_level == parent.value.node().unwrap().level
+        &&& parent.children[i].unwrap().value.parent_level == parent.value.node().level
     }
 
     /// Depth-indexed PT-specific per-edge invariant. `depth` is a manifest
@@ -643,13 +642,13 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                     let c = #[trigger] owner.children[i];
                     &&& c is Some
                     &&& c.unwrap().value.is_absent()
-                    &&& c.unwrap().value.path.len() == owner.value.node().unwrap().tree_level + 1
+                    &&& c.unwrap().value.path.len() == owner.value.node().tree_level + 1
                     &&& c.unwrap().value.match_pte(
-                        owner.value.node().unwrap().children_perm.value()[i],
-                        owner.value.node().unwrap().level,
+                        owner.value.node().children_perm.value()[i],
+                        owner.value.node().level,
                     )
                     &&& c.unwrap().value.path == owner.value.path.push_tail(i as usize)
-                    &&& c.unwrap().value.parent_level == owner.value.node().unwrap().level
+                    &&& c.unwrap().value.parent_level == owner.value.node().level
                 },
             allocated_empty_node_grandchildren_none(owner),
         ensures
@@ -798,11 +797,11 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             set![Mapping {
                 va_range: Range { start: va as int, end: va as int + page_size as int },
                 pa_range: Range {
-                    start: self.0.value.frame().unwrap().mapped_pa,
-                    end: (self.0.value.frame().unwrap().mapped_pa + page_size) as Paddr,
+                    start: self.0.value.frame().mapped_pa,
+                    end: (self.0.value.frame().mapped_pa + page_size) as Paddr,
                 },
                 page_size: page_size,
-                property: self.0.value.frame().unwrap().prop,
+                property: self.0.value.frame().prop,
             }]
         } else if self.0.value.is_node() && path.len() < INC_LEVELS - 1 {
             self.view_rec_children_union(path, self.0.children.len() as int)
@@ -1014,7 +1013,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         lemma_page_size_spec_values();
         if self.0.value.is_frame() {
             Self::lemma_vaddr_path_alignment_and_bound(path);
-            let frame = self.0.value.frame().unwrap();
+            let frame = self.0.value.frame();
             let pt_level = (INC_LEVELS - path.len()) as PagingLevel;
             let expected = Mapping {
                 va_range: Range {
@@ -1174,7 +1173,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
 
         // Root entry satisfies `g`.
         if self.0.value.is_frame() {
-            let frame = self.0.value.frame().unwrap();
+            let frame = self.0.value.frame();
             let pt_level = (INC_LEVELS - path.len()) as PagingLevel;
             let expected = Mapping {
                 va_range: Range {
@@ -1516,7 +1515,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     {
         if self.0.value.is_frame() {
             lemma_page_size_spec_values();
-            let frame = self.0.value.frame().unwrap();
+            let frame = self.0.value.frame();
             let pt_level = (INC_LEVELS - path.len()) as PagingLevel;
             Self::lemma_vaddr_path_alignment_and_bound(path);
             let m = Mapping {
@@ -1625,7 +1624,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         requires
             self.0.inv(),
             self.0.value.is_node(),
-            self.0.value.node().unwrap().meta_own.nr_children.value() == 0,
+            self.0.value.node().meta_own.nr_children.value() == 0,
             path.len() <= INC_LEVELS - 1,
             path.len() == self.0.level,
         ensures
@@ -1737,7 +1736,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 self.0.value.path,
                 |e: EntryOwner<C>, p: TreePath<NR_ENTRIES>|
                     e.is_frame() && e.parent_level > 1 ==> {
-                        let pa = e.frame().unwrap().mapped_pa;
+                        let pa = e.frame().mapped_pa;
                         let nr_pages = page_size(e.parent_level) / PAGE_SIZE;
                         forall|j: usize|
                             0 < j < nr_pages ==> {
@@ -1789,7 +1788,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 path,
                 |e: EntryOwner<C>, p: TreePath<NR_ENTRIES>|
                     e.is_frame() && e.parent_level > 1 ==> {
-                        let pa = e.frame().unwrap().mapped_pa;
+                        let pa = e.frame().mapped_pa;
                         let nr_pages = page_size(e.parent_level) / PAGE_SIZE;
                         forall|j: usize|
                             0 < j < nr_pages ==> {
@@ -2198,7 +2197,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             m.va_range.start == vaddr_of::<C>(entry.path) as int,
             m.page_size == page_size((INC_LEVELS - entry.path.len()) as PagingLevel),
             entry.is_frame(),
-            m.property == entry.frame().unwrap().prop,
+            m.property == entry.frame().prop,
             self.0.tree_predicate_map(path, Self::is_at_pred(entry, entry.path)),
             self.0.tree_predicate_map(path, Self::path_in_tree_pred(entry.path)),
             entry.inv(),
@@ -2318,7 +2317,7 @@ impl<C: PageTableConfig> Inv for PageTableOwner<C> {
         &&& self.0.value.path.inv()
         &&& self.0.value.path.len() == self.0.level
         &&& self.0.value.parent_level == (INC_LEVELS - self.0.level) as PagingLevel
-        &&& self.0.value.node().unwrap().tree_level == self.0.value.path.len()
+        &&& self.0.value.node().tree_level == self.0.value.path.len()
         &&& self.0.tree_predicate_map(self.0.value.path, Self::path_correct_pred())
     }
 }

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -13,7 +13,10 @@ use vstd_extra::ghost_tree::*;
 use vstd_extra::ownership::*;
 use vstd_extra::prelude::TreeNodeValue;
 
-use crate::mm::{MAX_NR_LEVELS, Paddr, PagingLevel, Vaddr, page_table::EntryOwner};
+use crate::mm::{
+    MAX_NR_LEVELS, Paddr, PagingLevel, Vaddr,
+    page_table::{EntryOwner, EntryOwnerKind},
+};
 
 use crate::mm::frame::frame_to_index;
 use crate::mm::page_table::{PageTableEntryTrait, PageTableGuard, page_size_spec};
@@ -343,14 +346,10 @@ pub proof fn sibling_paths_disjoint<C: PageTableConfig>(
 impl<C: PageTableConfig, const L: usize> TreeNodeValue<L> for EntryOwner<C> {
     open spec fn default(lv: nat) -> Self {
         Self {
+            kind: EntryOwnerKind::Absent,
             in_scope: false,
             path: TreePath::new(Seq::empty()),
             parent_level: (INC_LEVELS - lv) as PagingLevel,
-            node: None,
-            frame: None,
-            locked: None,
-            borrowed: None,
-            absent: true,
         }
     }
 
@@ -408,9 +407,9 @@ pub open spec fn allocated_empty_node_owner<C: PageTableConfig>(
     &&& owner.value.in_scope
     &&& owner.value.path == TreePath::<NR_ENTRIES>::new(Seq::empty())
     &&& owner.value.parent_level == (level + 1) as PagingLevel
-    &&& owner.value.node.unwrap().level == level
-    &&& owner.value.node.unwrap().inv()
-    &&& !owner.value.node.unwrap().children_perm.value().all(|child: C::E| child.is_present())
+    &&& owner.value.node().unwrap().level == level
+    &&& owner.value.node().unwrap().inv()
+    &&& !owner.value.node().unwrap().children_perm.value().all(|child: C::E| child.is_present())
     &&& forall|i: int|
         #![auto]
         0 <= i < NR_ENTRIES ==> {
@@ -423,19 +422,19 @@ pub open spec fn allocated_empty_node_owner<C: PageTableConfig>(
     &&& forall|i: int|
         #![auto]
         0 <= i < NR_ENTRIES ==> owner.children[i].unwrap().value.match_pte(
-            owner.value.node.unwrap().children_perm.value()[i],
+            owner.value.node().unwrap().children_perm.value()[i],
             owner.children[i].unwrap().value.parent_level,
         )
     &&& forall|i: int|
         #![auto]
         0 <= i < NR_ENTRIES ==> owner.children[i].unwrap().value.parent_level
-            == owner.value.node.unwrap().level
+            == owner.value.node().unwrap().level
     // The freshly-allocated PT node is zero-filled, so every PTE in
     // `children_perm` is the absent PTE. (Stronger than the existing
     // "not all are present" clause; needed by `split_if_mapped_huge`'s
     // loop invariant which inspects each slot's PTE.)
     &&& forall|j: int|
-        0 <= j < NR_ENTRIES ==> #[trigger] owner.value.node.unwrap().children_perm.value()[j]
+        0 <= j < NR_ENTRIES ==> #[trigger] owner.value.node().unwrap().children_perm.value()[j]
             == C::E::new_absent_spec()
 }
 
@@ -540,14 +539,14 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     /// Per-edge constraint between a node-parent and its child at index `i`.
     pub open spec fn pt_edge_at(parent: OwnerSubtree<C>, i: int) -> bool {
         &&& parent.children[i] is Some
-        &&& parent.children[i].unwrap().value.path.len() == parent.value.node.unwrap().tree_level
+        &&& parent.children[i].unwrap().value.path.len() == parent.value.node().unwrap().tree_level
             + 1
         &&& parent.children[i].unwrap().value.match_pte(
-            parent.value.node.unwrap().children_perm.value()[i],
-            parent.value.node.unwrap().level,
+            parent.value.node().unwrap().children_perm.value()[i],
+            parent.value.node().unwrap().level,
         )
         &&& parent.children[i].unwrap().value.path == parent.value.path.push_tail(i as usize)
-        &&& parent.children[i].unwrap().value.parent_level == parent.value.node.unwrap().level
+        &&& parent.children[i].unwrap().value.parent_level == parent.value.node().unwrap().level
     }
 
     /// Depth-indexed PT-specific per-edge invariant. `depth` is a manifest
@@ -644,13 +643,13 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                     let c = #[trigger] owner.children[i];
                     &&& c is Some
                     &&& c.unwrap().value.is_absent()
-                    &&& c.unwrap().value.path.len() == owner.value.node.unwrap().tree_level + 1
+                    &&& c.unwrap().value.path.len() == owner.value.node().unwrap().tree_level + 1
                     &&& c.unwrap().value.match_pte(
-                        owner.value.node.unwrap().children_perm.value()[i],
-                        owner.value.node.unwrap().level,
+                        owner.value.node().unwrap().children_perm.value()[i],
+                        owner.value.node().unwrap().level,
                     )
                     &&& c.unwrap().value.path == owner.value.path.push_tail(i as usize)
-                    &&& c.unwrap().value.parent_level == owner.value.node.unwrap().level
+                    &&& c.unwrap().value.parent_level == owner.value.node().unwrap().level
                 },
             allocated_empty_node_grandchildren_none(owner),
         ensures
@@ -799,11 +798,11 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             set![Mapping {
                 va_range: Range { start: va as int, end: va as int + page_size as int },
                 pa_range: Range {
-                    start: self.0.value.frame.unwrap().mapped_pa,
-                    end: (self.0.value.frame.unwrap().mapped_pa + page_size) as Paddr,
+                    start: self.0.value.frame().unwrap().mapped_pa,
+                    end: (self.0.value.frame().unwrap().mapped_pa + page_size) as Paddr,
                 },
                 page_size: page_size,
-                property: self.0.value.frame.unwrap().prop,
+                property: self.0.value.frame().unwrap().prop,
             }]
         } else if self.0.value.is_node() && path.len() < INC_LEVELS - 1 {
             self.view_rec_children_union(path, self.0.children.len() as int)
@@ -1015,7 +1014,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         lemma_page_size_spec_values();
         if self.0.value.is_frame() {
             Self::lemma_vaddr_path_alignment_and_bound(path);
-            let frame = self.0.value.frame.unwrap();
+            let frame = self.0.value.frame().unwrap();
             let pt_level = (INC_LEVELS - path.len()) as PagingLevel;
             let expected = Mapping {
                 va_range: Range {
@@ -1175,7 +1174,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
 
         // Root entry satisfies `g`.
         if self.0.value.is_frame() {
-            let frame = self.0.value.frame.unwrap();
+            let frame = self.0.value.frame().unwrap();
             let pt_level = (INC_LEVELS - path.len()) as PagingLevel;
             let expected = Mapping {
                 va_range: Range {
@@ -1517,7 +1516,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     {
         if self.0.value.is_frame() {
             lemma_page_size_spec_values();
-            let frame = self.0.value.frame.unwrap();
+            let frame = self.0.value.frame().unwrap();
             let pt_level = (INC_LEVELS - path.len()) as PagingLevel;
             Self::lemma_vaddr_path_alignment_and_bound(path);
             let m = Mapping {
@@ -1626,7 +1625,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         requires
             self.0.inv(),
             self.0.value.is_node(),
-            self.0.value.node.unwrap().meta_own.nr_children.value() == 0,
+            self.0.value.node().unwrap().meta_own.nr_children.value() == 0,
             path.len() <= INC_LEVELS - 1,
             path.len() == self.0.level,
         ensures
@@ -1738,7 +1737,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 self.0.value.path,
                 |e: EntryOwner<C>, p: TreePath<NR_ENTRIES>|
                     e.is_frame() && e.parent_level > 1 ==> {
-                        let pa = e.frame.unwrap().mapped_pa;
+                        let pa = e.frame().unwrap().mapped_pa;
                         let nr_pages = page_size(e.parent_level) / PAGE_SIZE;
                         forall|j: usize|
                             0 < j < nr_pages ==> {
@@ -1790,7 +1789,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 path,
                 |e: EntryOwner<C>, p: TreePath<NR_ENTRIES>|
                     e.is_frame() && e.parent_level > 1 ==> {
-                        let pa = e.frame.unwrap().mapped_pa;
+                        let pa = e.frame().unwrap().mapped_pa;
                         let nr_pages = page_size(e.parent_level) / PAGE_SIZE;
                         forall|j: usize|
                             0 < j < nr_pages ==> {
@@ -2199,7 +2198,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             m.va_range.start == vaddr_of::<C>(entry.path) as int,
             m.page_size == page_size((INC_LEVELS - entry.path.len()) as PagingLevel),
             entry.is_frame(),
-            m.property == entry.frame.unwrap().prop,
+            m.property == entry.frame().unwrap().prop,
             self.0.tree_predicate_map(path, Self::is_at_pred(entry, entry.path)),
             self.0.tree_predicate_map(path, Self::path_in_tree_pred(entry.path)),
             entry.inv(),
@@ -2319,7 +2318,7 @@ impl<C: PageTableConfig> Inv for PageTableOwner<C> {
         &&& self.0.value.path.inv()
         &&& self.0.value.path.len() == self.0.level
         &&& self.0.value.parent_level == (INC_LEVELS - self.0.level) as PagingLevel
-        &&& self.0.value.node.unwrap().tree_level == self.0.value.path.len()
+        &&& self.0.value.node().unwrap().tree_level == self.0.value.path.len()
         &&& self.0.tree_predicate_map(self.0.value.path, Self::path_correct_pred())
     }
 }
@@ -2334,3 +2333,4 @@ impl<C: PageTableConfig> View for PageTableOwner<C> {
 }
 
 } // verus!
+

--- a/ostd/specs/mm/vm_space.rs
+++ b/ostd/specs/mm/vm_space.rs
@@ -738,8 +738,8 @@ impl<'a, A: InAtomicMode> CursorMut<'a, A> {
         let item = MappedItem { frame: frame, prop: prop };
         let (paddr, level, prop0) = UserPtConfig::item_into_raw_spec(item);
         &&& prop == prop0
-        &&& entry_owner.frame.unwrap().mapped_pa == paddr
-        &&& entry_owner.frame.unwrap().prop == prop
+        &&& entry_owner.frame().unwrap().mapped_pa == paddr
+        &&& entry_owner.frame().unwrap().prop == prop
         &&& level <= UserPtConfig::HIGHEST_TRANSLATION_LEVEL()
         &&& 1 <= level <= NR_LEVELS
         &&& level < self.pt_cursor.0.guard_level
@@ -767,3 +767,4 @@ impl<'a, A: InAtomicMode> CursorMut<'a, A> {
 }
 
 } // verus!
+

--- a/ostd/specs/mm/vm_space.rs
+++ b/ostd/specs/mm/vm_space.rs
@@ -767,4 +767,3 @@ impl<'a, A: InAtomicMode> CursorMut<'a, A> {
 }
 
 } // verus!
-

--- a/ostd/specs/mm/vm_space.rs
+++ b/ostd/specs/mm/vm_space.rs
@@ -738,8 +738,8 @@ impl<'a, A: InAtomicMode> CursorMut<'a, A> {
         let item = MappedItem { frame: frame, prop: prop };
         let (paddr, level, prop0) = UserPtConfig::item_into_raw_spec(item);
         &&& prop == prop0
-        &&& entry_owner.frame().unwrap().mapped_pa == paddr
-        &&& entry_owner.frame().unwrap().prop == prop
+        &&& entry_owner.frame().mapped_pa == paddr
+        &&& entry_owner.frame().prop == prop
         &&& level <= UserPtConfig::HIGHEST_TRANSLATION_LEVEL()
         &&& 1 <= level <= NR_LEVELS
         &&& level < self.pt_cursor.0.guard_level

--- a/ostd/specs/mm/vm_space.rs
+++ b/ostd/specs/mm/vm_space.rs
@@ -36,7 +36,7 @@ pub tracked struct VmIoPermission {
 ///
 /// This struct serves as a bookkeeper for all _active_ readers/writers within a specific
 /// virtual memory space. It maintains a holistic view of the memory range covered by the
-/// VM space it is tracking using a [`Ghost<MemView>`]. It also maintains a [`Tracked<MemView>`]
+/// VM space it is tracking using a ghost [`MemView`]. It also maintains a tracked [`MemView`]
 /// for the current memories it is holding permissions for, which is a subset of the total
 /// memory range.
 ///
@@ -81,7 +81,7 @@ pub tracked struct VmSpaceOwner {
     /// of the mappings may be  transferred to the writers.
     pub mem_view: Option<MemView>,
     /// This is the holistic view of the memory range covered by this VM space owner.
-    pub mv_range: Ghost<Option<MemView>>,
+    pub ghost mv_range: Option<MemView>,
     /// Whether we allow shared reading.
     pub shared_reader: bool,
 }
@@ -177,9 +177,9 @@ impl<'a> VmSpaceOwner {
     /// * **Translation Consistency**: Reader translations must be consistent with the total view.
     pub open spec fn mem_view_wf(self) -> bool {
         &&& self.mem_view is Some
-            <==> self.mv_range@ is Some
+            <==> self.mv_range is Some
         // This requires that TotalMapping (mvv) = mv ∪ writer mappings ∪ reader mappings
-        &&& self.mem_view matches Some(remaining_view) ==> self.mv_range@ matches Some(total_view)
+        &&& self.mem_view matches Some(remaining_view) ==> self.mv_range matches Some(total_view)
             ==> {
             &&& remaining_view.mappings_are_disjoint()
             &&& total_view.mappings_are_disjoint()
@@ -495,7 +495,7 @@ impl<'a> VmSpaceOwner {
             old(self).inv(),
             old(self).active,
             old(self).mem_view is Some,
-            old(self).mv_range@ is Some,
+            old(self).mv_range is Some,
             0 <= idx < old(self).writers.len() as int,
         ensures
             final(self).inv(),
@@ -516,7 +516,7 @@ impl<'a> VmSpaceOwner {
         self.mem_view = Some(remaining);
 
         assert(self.mem_view_wf()) by {
-            let ghost total_view = self.mv_range@.unwrap();
+            let ghost total_view = self.mv_range.unwrap();
 
             assert(remaining.mappings == old_remaining.mappings.union(mv.mappings));
             assert(remaining.memory == old_remaining.memory.union_prefer_right(mv.memory));
@@ -590,7 +590,7 @@ impl<'a> VmSpaceOwner {
             owner.inv(),
             old(self).inv(),
             old(self).active,
-            old(self).mv_range@ matches Some(total_view) && owner.mem_view matches Some(
+            old(self).mv_range matches Some(total_view) && owner.mem_view matches Some(
                 VmIoMemView::ReadView(mv),
             ) && old(self).mem_view matches Some(remaining) && {
                 forall|va: usize|
@@ -630,7 +630,7 @@ impl<'a> VmSpaceOwner {
             old(self).inv(),
             old(self).active,
             owner.inv(),
-            old(self).mv_range@ matches Some(total_view) && owner.mem_view matches Some(
+            old(self).mv_range matches Some(total_view) && owner.mem_view matches Some(
                 VmIoMemView::WriteView(mv),
             ) && old(self).mem_view matches Some(remaining) && {
                 &&& forall|va: usize|

--- a/ostd/src/mm/kspace/kvirt_area.rs
+++ b/ostd/src/mm/kspace/kvirt_area.rs
@@ -205,14 +205,14 @@ pub(crate) fn get_kernel_page_table<'rcu>(
     ensures
         final(kernel_owner)@ is Some,
         final(kernel_owner)@.unwrap().inv(),
-        final(kernel_owner)@.unwrap().0.value.node() is Some,
-        r.root.ptr.addr() == final(kernel_owner)@.unwrap().0.value.node().unwrap().meta_addr_self(),
+        final(kernel_owner)@.unwrap().0.value.is_node(),
+        r.root.ptr.addr() == final(kernel_owner)@.unwrap().0.value.node().meta_addr_self(),
         !PageTable::<KernelPtConfig>::create_user_pt_panic_condition(
-            final(kernel_owner)@.unwrap().0.value.node().unwrap(),
+            final(kernel_owner)@.unwrap().0.value.node(),
         ),
         final(kernel_owner)@.unwrap().0.value.metaregion_sound(*regions),
         final(kernel_owner)@.unwrap().metaregion_sound(*regions),
-        guards.unlocked(final(kernel_owner)@.unwrap().0.value.node().unwrap().meta_addr_self()),
+        guards.unlocked(final(kernel_owner)@.unwrap().0.value.node().meta_addr_self()),
 {
     KERNEL_PAGE_TABLE.get().unwrap()
 }
@@ -802,9 +802,9 @@ impl KVirtArea {
             let ghost cur_parent_level = entry_owners[cur_mapped_pa].parent_level;
             // Capture the original-owner facts now (Verus can lose them across the
             // cursor.map call, which churns enormous proof context).
-            let ghost orig_mapped_pa = pre_remove_owners[cur_mapped_pa].frame().unwrap().mapped_pa;
-            let ghost orig_size = pre_remove_owners[cur_mapped_pa].frame().unwrap().size;
-            let ghost orig_prop = pre_remove_owners[cur_mapped_pa].frame().unwrap().prop;
+            let ghost orig_mapped_pa = pre_remove_owners[cur_mapped_pa].frame().mapped_pa;
+            let ghost orig_size = pre_remove_owners[cur_mapped_pa].frame().size;
+            let ghost orig_prop = pre_remove_owners[cur_mapped_pa].frame().prop;
             proof {
                 KernelPtConfig::item_into_raw_spec_tracked_level(MappedItem::Tracked(frame, prop));
                 KernelPtConfig::item_into_raw_spec_tracked_pa(

--- a/ostd/src/mm/kspace/kvirt_area.rs
+++ b/ostd/src/mm/kspace/kvirt_area.rs
@@ -1331,4 +1331,3 @@ impl KVirtArea {
     }
 }*/
 } // verus!
-

--- a/ostd/src/mm/kspace/kvirt_area.rs
+++ b/ostd/src/mm/kspace/kvirt_area.rs
@@ -205,14 +205,14 @@ pub(crate) fn get_kernel_page_table<'rcu>(
     ensures
         final(kernel_owner)@ is Some,
         final(kernel_owner)@.unwrap().inv(),
-        final(kernel_owner)@.unwrap().0.value.node is Some,
-        r.root.ptr.addr() == final(kernel_owner)@.unwrap().0.value.node.unwrap().meta_addr_self(),
+        final(kernel_owner)@.unwrap().0.value.node() is Some,
+        r.root.ptr.addr() == final(kernel_owner)@.unwrap().0.value.node().unwrap().meta_addr_self(),
         !PageTable::<KernelPtConfig>::create_user_pt_panic_condition(
-            final(kernel_owner)@.unwrap().0.value.node.unwrap(),
+            final(kernel_owner)@.unwrap().0.value.node().unwrap(),
         ),
         final(kernel_owner)@.unwrap().0.value.metaregion_sound(*regions),
         final(kernel_owner)@.unwrap().metaregion_sound(*regions),
-        guards.unlocked(final(kernel_owner)@.unwrap().0.value.node.unwrap().meta_addr_self()),
+        guards.unlocked(final(kernel_owner)@.unwrap().0.value.node().unwrap().meta_addr_self()),
 {
     KERNEL_PAGE_TABLE.get().unwrap()
 }
@@ -802,9 +802,9 @@ impl KVirtArea {
             let ghost cur_parent_level = entry_owners[cur_mapped_pa].parent_level;
             // Capture the original-owner facts now (Verus can lose them across the
             // cursor.map call, which churns enormous proof context).
-            let ghost orig_mapped_pa = pre_remove_owners[cur_mapped_pa].frame.unwrap().mapped_pa;
-            let ghost orig_size = pre_remove_owners[cur_mapped_pa].frame.unwrap().size;
-            let ghost orig_prop = pre_remove_owners[cur_mapped_pa].frame.unwrap().prop;
+            let ghost orig_mapped_pa = pre_remove_owners[cur_mapped_pa].frame().unwrap().mapped_pa;
+            let ghost orig_size = pre_remove_owners[cur_mapped_pa].frame().unwrap().size;
+            let ghost orig_prop = pre_remove_owners[cur_mapped_pa].frame().unwrap().prop;
             proof {
                 KernelPtConfig::item_into_raw_spec_tracked_level(MappedItem::Tracked(frame, prop));
                 KernelPtConfig::item_into_raw_spec_tracked_pa(
@@ -1331,3 +1331,4 @@ impl KVirtArea {
     }
 }*/
 } // verus!
+

--- a/ostd/src/mm/page_table/cursor/locking.rs
+++ b/ostd/src/mm/page_table/cursor/locking.rs
@@ -145,7 +145,7 @@ pub fn lock_range<'rcu, C: PageTableConfig, A: InAtomicMode>(
     // Once we have locked the sub-tree that is not stray, we won't read any
     // stray nodes in the following traversal since we must lock before reading.
     let tracked mut cont = cursor_own.continuations.tracked_remove(cursor_own.level - 1);
-    let ghost cont_slot_idx = cont.entry_own.node.tracked_borrow().slot_index;
+    let ghost cont_slot_idx = cont.entry_own.tracked_borrow_node().slot_index;
     let tracked cont_meta_perm = regions.borrow_typed_perm::<PageTablePageMeta<C>>(cont_slot_idx);
     #[verus_spec(with Tracked(cont_meta_perm))]
     let guard_level = subtree_root.level();
@@ -258,13 +258,13 @@ pub fn unlock_range<C: PageTableConfig, A: InAtomicMode>(cursor: &mut Cursor<'_,
             let cont = final(cursor_own).continuations[(final(cursor_own).level - 1) as int];
             &&& cont.entry_own.is_node()
             &&& cont.entry_own.inv()
-            &&& cont.entry_own.node.unwrap().relate_guard(cont.guard)
+            &&& cont.entry_own.node().unwrap().relate_guard(cont.guard)
             &&& cont.entry_own.metaregion_sound(*final(regions))
         },
         // The subtree root is lock_held in guards.
         final(guards).lock_held(
             final(cursor_own).continuations[(final(cursor_own).level - 1) as int]
-                .entry_own.node.unwrap().meta_addr_self()),
+                .entry_own.node().unwrap().meta_addr_self()),
         // regions invariant preserved
         final(regions).inv(),
         // Locking only allocates fresh page-table nodes from UNUSED slots;
@@ -375,7 +375,7 @@ fn try_traverse_and_lock_subtree_root<'rcu, C: PageTableConfig, A: InAtomicMode>
         };
 
         let tracked mut cont = cursor_own.continuations.tracked_remove(cursor_own.level - 1);
-        let tracked node_owner = cont.entry_own.node.tracked_take();
+        let tracked node_owner = cont.entry_own.tracked_take_node();
         let tracked node_meta_perm = regions.borrow_typed_perm::<PageTablePageMeta<C>>(
             node_owner.slot_index,
         );
@@ -384,7 +384,7 @@ fn try_traverse_and_lock_subtree_root<'rcu, C: PageTableConfig, A: InAtomicMode>
         let is_stray = *(stray.borrow(Tracked(&node_owner.meta_own.stray)));
 
         proof {
-            cont.entry_own.node = Some(node_owner);
+            cont.entry_own.tracked_put_node(node_owner);
             cursor_own.continuations.tracked_insert(cursor_own.level - 1, cont);
         }
 
@@ -452,7 +452,7 @@ fn try_traverse_and_lock_subtree_root<'rcu, C: PageTableConfig, A: InAtomicMode>
     };
 
     let tracked mut cont = cursor_own.continuations.tracked_remove(cursor_own.level - 1);
-    let tracked node_owner = cont.entry_own.node.tracked_take();
+    let tracked node_owner = cont.entry_own.tracked_take_node();
     let tracked node_meta_perm = regions.borrow_typed_perm::<PageTablePageMeta<C>>(
         node_owner.slot_index,
     );
@@ -461,7 +461,7 @@ fn try_traverse_and_lock_subtree_root<'rcu, C: PageTableConfig, A: InAtomicMode>
     let is_stray = *(stray.borrow(Tracked(&node_owner.meta_own.stray)));
 
     proof {
-        cont.entry_own.node = Some(node_owner);
+        cont.entry_own.tracked_put_node(node_owner);
         cursor_own.continuations.tracked_insert(cursor_own.level - 1, cont);
     }
 
@@ -485,17 +485,17 @@ fn try_traverse_and_lock_subtree_root<'rcu, C: PageTableConfig, A: InAtomicMode>
     requires
         entry_own.is_node(),
         entry_own.inv(),
-        entry_own.node.unwrap().relate_guard(*cur_node),
-        old(guards).lock_held(entry_own.node.unwrap().meta_addr_self()),
+        entry_own.node().unwrap().relate_guard(*cur_node),
+        old(guards).lock_held(entry_own.node().unwrap().meta_addr_self()),
         cur_node_va <= va_range.start,
         va_range.start < va_range.end,
         old(regions).inv(),
     ensures
         // The root node is still lock_held (not ManuallyDrop'd by this fn).
-        final(guards).lock_held(entry_own.node.unwrap().meta_addr_self()),
+        final(guards).lock_held(entry_own.node().unwrap().meta_addr_self()),
         // All other locks are preserved: addresses not in this subtree are unchanged.
         forall |addr: usize|
-            addr != entry_own.node.unwrap().meta_addr_self()
+            addr != entry_own.node().unwrap().meta_addr_self()
             && old(guards).guards.contains(addr) ==>
             #[trigger] final(guards).guards.contains(addr),
         // Addresses not in old guards don't appear in final guards
@@ -565,7 +565,7 @@ unsafe fn dfs_release_lock<'rcu, C: PageTableConfig, A: InAtomicMode>(
             ChildRef::PageTable(pt) => {
                 // SAFETY: The caller ensures that the node is locked and the new guard is unique.
                 let mut child_node = unsafe {
-                    #[verus_spec(with Tracked(entry_own.node.tracked_borrow()), Tracked(guards))]
+                    #[verus_spec(with Tracked(entry_own.tracked_borrow_node()), Tracked(guards))]
                     pt.make_guard_unchecked(guard)
                 };
                 let child_node_va = cur_node_va + (end - i) * page_size(cur_level);
@@ -647,13 +647,13 @@ pub unsafe fn dfs_mark_stray_and_unlock<'a, C: PageTableConfig, A: InAtomicMode>
     /*
     let mut sub_tree_val = sub_tree.take(Tracked(guard_perm));
     let stray_mut = sub_tree_val.stray_mut();
-    let tracked node_owner = entry_own.node.tracked_take();
+    let tracked node_owner = entry_own.tracked_take_node();
     let stray = stray_mut.take(Tracked(&mut node_owner.as_node.meta_own.stray));
 
     stray_mut.put(Tracked(&mut node_owner.as_node.meta_own.stray), true);
 
     proof {
-        entry_own.node = Some(node_owner);
+        entry_own.tracked_put_node(node_owner);
     }
 
     if sub_tree_val.level() == 1 {
@@ -846,3 +846,5 @@ fn dfs_get_idx_range<C: PagingConstsTrait>(
 }
 
 } // verus!
+
+

--- a/ostd/src/mm/page_table/cursor/locking.rs
+++ b/ostd/src/mm/page_table/cursor/locking.rs
@@ -375,16 +375,16 @@ fn try_traverse_and_lock_subtree_root<'rcu, C: PageTableConfig, A: InAtomicMode>
         };
 
         let tracked mut cont = cursor_own.continuations.tracked_remove(cursor_own.level - 1);
-        let tracked node_owner = cont.entry_own.tracked_take_node();
         let tracked node_meta_perm = regions.borrow_typed_perm::<PageTablePageMeta<C>>(
-            node_owner.slot_index,
+            cont.entry_own.node().slot_index,
         );
         #[verus_spec(with Tracked(node_meta_perm))]
         let stray = pt_guard.stray_mut();
-        let is_stray = *(stray.borrow(Tracked(&node_owner.meta_own.stray)));
+        let is_stray = *(stray.borrow(
+            Tracked(&cont.entry_own.tracked_borrow_node().meta_own.stray),
+        ));
 
         proof {
-            cont.entry_own.tracked_put_node(node_owner);
             cursor_own.continuations.tracked_insert(cursor_own.level - 1, cont);
         }
 
@@ -452,16 +452,14 @@ fn try_traverse_and_lock_subtree_root<'rcu, C: PageTableConfig, A: InAtomicMode>
     };
 
     let tracked mut cont = cursor_own.continuations.tracked_remove(cursor_own.level - 1);
-    let tracked node_owner = cont.entry_own.tracked_take_node();
     let tracked node_meta_perm = regions.borrow_typed_perm::<PageTablePageMeta<C>>(
-        node_owner.slot_index,
+        cont.entry_own.node().slot_index,
     );
     #[verus_spec(with Tracked(node_meta_perm))]
     let stray = pt_guard.stray_mut();
-    let is_stray = *(stray.borrow(Tracked(&node_owner.meta_own.stray)));
+    let is_stray = *(stray.borrow(Tracked(&cont.entry_own.tracked_borrow_node().meta_own.stray)));
 
     proof {
-        cont.entry_own.tracked_put_node(node_owner);
         cursor_own.continuations.tracked_insert(cursor_own.level - 1, cont);
     }
 

--- a/ostd/src/mm/page_table/cursor/locking.rs
+++ b/ostd/src/mm/page_table/cursor/locking.rs
@@ -846,5 +846,3 @@ fn dfs_get_idx_range<C: PagingConstsTrait>(
 }
 
 } // verus!
-
-

--- a/ostd/src/mm/page_table/cursor/locking.rs
+++ b/ostd/src/mm/page_table/cursor/locking.rs
@@ -258,13 +258,13 @@ pub fn unlock_range<C: PageTableConfig, A: InAtomicMode>(cursor: &mut Cursor<'_,
             let cont = final(cursor_own).continuations[(final(cursor_own).level - 1) as int];
             &&& cont.entry_own.is_node()
             &&& cont.entry_own.inv()
-            &&& cont.entry_own.node().unwrap().relate_guard(cont.guard)
+            &&& cont.entry_own.node().relate_guard(cont.guard)
             &&& cont.entry_own.metaregion_sound(*final(regions))
         },
         // The subtree root is lock_held in guards.
         final(guards).lock_held(
             final(cursor_own).continuations[(final(cursor_own).level - 1) as int]
-                .entry_own.node().unwrap().meta_addr_self()),
+                .entry_own.node().meta_addr_self()),
         // regions invariant preserved
         final(regions).inv(),
         // Locking only allocates fresh page-table nodes from UNUSED slots;
@@ -485,17 +485,17 @@ fn try_traverse_and_lock_subtree_root<'rcu, C: PageTableConfig, A: InAtomicMode>
     requires
         entry_own.is_node(),
         entry_own.inv(),
-        entry_own.node().unwrap().relate_guard(*cur_node),
-        old(guards).lock_held(entry_own.node().unwrap().meta_addr_self()),
+        entry_own.node().relate_guard(*cur_node),
+        old(guards).lock_held(entry_own.node().meta_addr_self()),
         cur_node_va <= va_range.start,
         va_range.start < va_range.end,
         old(regions).inv(),
     ensures
         // The root node is still lock_held (not ManuallyDrop'd by this fn).
-        final(guards).lock_held(entry_own.node().unwrap().meta_addr_self()),
+        final(guards).lock_held(entry_own.node().meta_addr_self()),
         // All other locks are preserved: addresses not in this subtree are unchanged.
         forall |addr: usize|
-            addr != entry_own.node().unwrap().meta_addr_self()
+            addr != entry_own.node().meta_addr_self()
             && old(guards).guards.contains(addr) ==>
             #[trigger] final(guards).guards.contains(addr),
         // Addresses not in old guards don't appear in final guards

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -1359,7 +1359,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                     let ghost cont_pre_split = continuation;
                     let ghost parent_pre_split = continuation.entry_own.node();
                     let tracked mut child_owner = continuation.tracked_take_child();
-                    let tracked mut parent_owner = continuation.entry_own.tracked_take_node();
+                    let tracked mut parent_owner = continuation.entry_own.tracked_borrow_mut_node();
 
                     proof {
                         assert(parent_owner.level > 1) by {
@@ -1386,7 +1386,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                         }
                     }
                     let split_child = (
-                    #[verus_spec(with Tracked(&mut child_owner), Tracked(&mut parent_owner), Tracked(regions),
+                    #[verus_spec(with Tracked(&mut child_owner), Tracked(parent_owner), Tracked(regions),
                         Tracked(guards))]
                     cur_entry.split_if_mapped_huge(rcu_guard)).expect(
                         "The entry must be a huge page",
@@ -1415,7 +1415,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                         );
 
                         continuation.tracked_put_child(child_owner);
-                        continuation.entry_own.tracked_put_node(parent_owner);
                         continuation.continuation_inv_holds_after_child_restore(
                             cont_pre_split,
                             parent_pre_split,

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -641,7 +641,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                         C::item_roundtrip(item, pa, level, prop);
                     }
 
-                    assert(pa == owner.cur_entry_owner().frame().unwrap().mapped_pa);
+                    assert(pa == owner.cur_entry_owner().frame().mapped_pa);
 
                     let ghost old_regions = *regions;
 
@@ -757,7 +757,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                     if e.is_frame() && e.parent_level > 1 {
                         broadcast use crate::specs::mm::frame::meta_owners::axiom_mmio_usage_iff_mmio_paddr;
 
-                        let pa = e.frame().unwrap().mapped_pa;
+                        let pa = e.frame().mapped_pa;
                         let nr_pages = page_size(e.parent_level) / PAGE_SIZE;
                         assert forall|j: usize|
                             #![trigger frame_to_index((pa + j * PAGE_SIZE) as usize)]
@@ -854,8 +854,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
         let new_cur_entry = new_owner.cur_entry_owner();
         {
             &&& new_cur_entry.is_frame()
-            &&& old_cur_entry.is_frame() ==> new_cur_entry.frame().unwrap().prop
-                == old_cur_entry.frame().unwrap().prop
+            &&& old_cur_entry.is_frame() ==> new_cur_entry.frame().prop
+                == old_cur_entry.frame().prop
         }
     }
 
@@ -1017,17 +1017,15 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                 split_happened ==> owner.cur_entry_owner().is_frame(),
                 split_happened ==> self.va < end,
                 split_happened && old(owner).cur_entry_owner().is_frame()
-                    ==> owner.cur_entry_owner().frame().unwrap().prop == old(
+                    ==> owner.cur_entry_owner().frame().prop == old(
                     owner,
-                ).cur_entry_owner().frame().unwrap().prop,
+                ).cur_entry_owner().frame().prop,
                 split_happened ==> owner@.mappings == old(owner)@.split_while_huge(
                     page_size_spec(self.level),
                 ).mappings,
                 !split_happened && old(owner).cur_entry_owner().is_frame()
-                    ==> owner.cur_entry_owner().is_frame()
-                    && owner.cur_entry_owner().frame().unwrap().prop == old(
-                    owner,
-                ).cur_entry_owner().frame().unwrap().prop,
+                    ==> owner.cur_entry_owner().is_frame() && owner.cur_entry_owner().frame().prop
+                    == old(owner).cur_entry_owner().frame().prop,
                 (self.va > old(self).va && !split_happened) ==> !old(owner)@.present(),
                 split_happened ==> self.va == old(self).va,
             decreases owner.max_steps(),
@@ -1326,9 +1324,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                     assert(owner.max_steps() == owner0.max_steps());
                     if cur_entry_fits_range || !split_huge {
                         assert(!find_unmap_subtree && old(owner).cur_entry_owner().is_frame()
-                            ==> owner.cur_entry_owner().frame().unwrap().prop == old(
+                            ==> owner.cur_entry_owner().frame().prop == old(
                             owner,
-                        ).cur_entry_owner().frame().unwrap().prop) by {
+                        ).cur_entry_owner().frame().prop) by {
                             if !find_unmap_subtree && old(owner).cur_entry_owner().is_frame() {
                                 if !split_happened {
                                     assert(owner.continuations == owner0.continuations);
@@ -1359,7 +1357,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                         owner.level - 1,
                     );
                     let ghost cont_pre_split = continuation;
-                    let ghost parent_pre_split = continuation.entry_own.node().unwrap();
+                    let ghost parent_pre_split = continuation.entry_own.node();
                     let tracked mut child_owner = continuation.tracked_take_child();
                     let tracked mut parent_owner = continuation.entry_own.tracked_take_node();
 
@@ -1896,7 +1894,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
             old(self).inv(),
             old(self).wf(*old(owner)),
             old(owner).cur_entry_owner().is_node(),
-            old(owner).cur_entry_owner().node().unwrap().relate_guard(child_pt),
+            old(owner).cur_entry_owner().node().relate_guard(child_pt),
             old(owner).level > 1,
             old(owner).only_current_locked(*guards),
             old(owner).nodes_locked(*guards),
@@ -1963,8 +1961,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
             *final(owner) == *old(owner),
             final(owner).metaregion_sound(*regions),
             res.idx == final(owner).continuations[final(owner).level - 1].idx,
-            final(owner).continuations[final(owner).level
-                - 1].entry_own.node().unwrap().relate_guard(*res.node),
+            final(owner).continuations[final(owner).level - 1].entry_own.node().relate_guard(
+                *res.node,
+            ),
     {
         let ghost owner0 = *owner;
 
@@ -2536,7 +2535,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                     #[verus_spec(with Tracked(&mut child_owner), Tracked(&mut parent_owner), Tracked(regions), Tracked(guards))]
                     cur_entry.alloc_if_none(rcu_guard)).unwrap();
 
-                    let ghost new_node_addr = child_owner.value.node().unwrap().meta_addr_self();
+                    let ghost new_node_addr = child_owner.value.node().meta_addr_self();
                     let ghost new_child_value = child_owner.value;
 
                     let ghost new_pt_idx = frame_to_index(
@@ -2568,8 +2567,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         continuation.tracked_put_child(child_owner);
                         owner.continuations.tracked_insert(owner.level - 1, continuation);
 
-                        assert(owner.cur_entry_owner().node().unwrap().meta_addr_self()
-                            == new_node_addr);
+                        assert(owner.cur_entry_owner().node().meta_addr_self() == new_node_addr);
 
                         assert forall|i: int|
                             owner_pre_none.level <= i
@@ -2637,15 +2635,16 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                                 assert(eo.inv() && eo.is_node());
                                 assert(eo.metaregion_sound(regions_after_ref));
                                 let eo_idx = frame_to_index(eo.meta_slot_paddr().unwrap());
-                                assert(eo_idx == eo.node().unwrap().slot_index);
+                                assert(eo_idx == eo.node().slot_index);
                                 assert(regions_after_ref.slot_owners[eo_idx].inner_perms.ref_count.value()
                                     != REF_COUNT_UNUSED);
                                 assert(eo_idx != new_pt_idx);
                                 assert(regions.slot_owners[eo_idx]
                                     == regions_after_ref.slot_owners[eo_idx]);
                                 assert(regions.slots[eo_idx] == regions_after_ref.slots[eo_idx]);
-                                assert(eo.node().unwrap().meta_perm_of(*regions)
-                                    == eo.node().unwrap().meta_perm_of(regions_after_ref));
+                                assert(eo.node().meta_perm_of(*regions) == eo.node().meta_perm_of(
+                                    regions_after_ref,
+                                ));
                             };
                         };
 
@@ -2672,7 +2671,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                             );
                             cont_new.continuation_inv_holds_after_child_restore(
                                 cont_pre_alloc,
-                                cont_pre_alloc.entry_own.node().unwrap(),
+                                cont_pre_alloc.entry_own.node(),
                             );
                         };
                         owner.map_branch_none_inv_holds(owner_pre_none);
@@ -2721,7 +2720,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         owner.level - 1,
                     );
                     let ghost cont_pre_split = continuation;
-                    let ghost parent_pre_split = continuation.entry_own.node().unwrap();
+                    let ghost parent_pre_split = continuation.entry_own.node();
                     let tracked mut child_owner = continuation.tracked_take_child();
                     let tracked mut parent_owner = continuation.entry_own.tracked_take_node();
 
@@ -2962,7 +2961,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 is_tracked,
             ).set_in_scope(false));
             assert(new_owner.value.is_frame());
-            assert(new_owner.value.frame().unwrap().mapped_pa == pa);
+            assert(new_owner.value.frame().mapped_pa == pa);
 
             assert(PageTableOwner(new_owner)@.mappings == set![target]) by {
                 assert(owner1.level == level);
@@ -3380,9 +3379,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 owner_before_replace.cur_subtree_inv();
                 owner_before_replace.new_child_mappings_eq_target(
                     cur_st,
-                    cur_st.value.frame().unwrap().mapped_pa,
+                    cur_st.value.frame().mapped_pa,
                     level_after_find,
-                    cur_st.value.frame().unwrap().prop,
+                    cur_st.value.frame().prop,
                 );
                 owner_before_replace.va.reflect_prop(va_after_find);
 
@@ -3409,10 +3408,10 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 owner_before_replace.cur_subtree_eq_filtered_mappings();
                 let ghost target = Mapping {
                     va_range: owner_before_replace@.cur_slot_range(m.page_size),
-                    pa_range: cur_st.value.frame().unwrap().mapped_pa..(
-                    cur_st.value.frame().unwrap().mapped_pa + m.page_size) as usize,
+                    pa_range: cur_st.value.frame().mapped_pa..(cur_st.value.frame().mapped_pa
+                        + m.page_size) as usize,
                     page_size: m.page_size,
-                    property: cur_st.value.frame().unwrap().prop,
+                    property: cur_st.value.frame().prop,
                 };
                 assert(PageTableOwner(cur_st)@.mappings == set![target]);
                 assert(owner_before_replace@.mappings.filter(
@@ -3433,7 +3432,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 // here makes the eventual exact ref-count accounting
                 // (`ref_count == #handles + paths_in_pt.len()`) a true
                 // system invariant rather than monotonically inflated.
-                let ghost removed_idx = frame_to_index(cur_st.value.frame().unwrap().mapped_pa);
+                let ghost removed_idx = frame_to_index(cur_st.value.frame().mapped_pa);
                 let ghost removed_path = cur_st.value.path;
                 let ghost regions_pre_remove = *regions;
                 let tracked mut so_rm = regions.slot_owners.tracked_remove(removed_idx);
@@ -3670,7 +3669,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         let mut entry = self.0.cur_entry();
 
         proof {
-            assert(entry.pte.prop() == owner.cur_entry_owner().frame().unwrap().prop) by {
+            assert(entry.pte.prop() == owner.cur_entry_owner().frame().prop) by {
                 owner.cur_subtree_inv();
                 assert(owner.cur_entry_owner().match_pte(
                     entry.pte,
@@ -3692,10 +3691,10 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         #[verus_spec(with Tracked(&mut child_owner.value), Tracked(&mut parent_owner), Tracked(&*regions))]
         entry.protect(op);
 
-        let ghost new_prop = child_owner.value.frame().unwrap().prop;
+        let ghost new_prop = child_owner.value.frame().prop;
 
         let ghost child_owner_path = child_owner.value.path;
-        let ghost child_owner_mapped_pa = child_owner.value.frame().unwrap().mapped_pa;
+        let ghost child_owner_mapped_pa = child_owner.value.frame().mapped_pa;
         let ghost child_owner_parent_level = child_owner.value.parent_level;
 
         proof {
@@ -3716,10 +3715,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             assert(owner.continuations[owner.level - 1].inv()) by {
                 let cont_new = owner.continuations[owner.level - 1];
                 assert(child_not_in_scope);
-                cont_new.continuation_inv_holds_after_child_restore(
-                    cont0,
-                    cont0.entry_own.node().unwrap(),
-                );
+                cont_new.continuation_inv_holds_after_child_restore(cont0, cont0.entry_own.node());
             };
             assert(owner.continuations[owner.level - 1].entry_own.metaregion_sound(*regions));
             owner0.protect_preserves_cursor_inv_metaregion(*owner, *regions);
@@ -3829,8 +3825,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             res is Some && res.unwrap() is Mapped ==> {
                 let (pa, lvl, prop) = C::item_into_raw_spec(res.unwrap()->Mapped_item);
                 &&& lvl == old(self).0.level
-                &&& pa == old(owner).cur_entry_owner().frame().unwrap().mapped_pa
-                &&& prop == old(owner).cur_entry_owner().frame().unwrap().prop
+                &&& pa == old(owner).cur_entry_owner().frame().mapped_pa
+                &&& prop == old(owner).cur_entry_owner().frame().prop
             },
             // StrayPageTable: VA and len match cursor state at call time.
             res is Some && res.unwrap() is StrayPageTable ==> {
@@ -4181,9 +4177,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                     // Old child absent/frame: regions unchanged at eo's slot.
 
                     let eo_idx = frame_to_index(eo.meta_slot_paddr().unwrap());
-                    assert(eo_idx == eo.node().unwrap().slot_index);
-                    assert(eo.node().unwrap().meta_perm_of(*regions)
-                        == eo.node().unwrap().meta_perm_of(regions0));
+                    assert(eo_idx == eo.node().slot_index);
+                    assert(eo.node().meta_perm_of(*regions) == eo.node().meta_perm_of(regions0));
                 };
             };
 

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -555,7 +555,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
             let tracked mut continuation = owner.continuations.tracked_remove(owner.level - 1);
             let ghost cont0 = continuation;
             let tracked child_owner = continuation.tracked_take_child();
-            let tracked parent_owner = continuation.entry_own.node.tracked_borrow();
+            let tracked parent_owner = continuation.entry_own.tracked_borrow_node();
             let ghost regions_before_ref = *regions;
 
             #[verus_spec(with Tracked(&child_owner.value), Tracked(&parent_owner), Tracked(regions))]
@@ -583,7 +583,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                         owner.level - 1,
                     );
                     let tracked mut child_owner = continuation.tracked_take_child();
-                    let tracked mut child_node = child_owner.value.node.tracked_take();
+                    let tracked mut child_node = child_owner.value.tracked_take_node();
 
                     let ghost guards0 = *guards;
 
@@ -595,7 +595,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                     };
 
                     proof {
-                        child_owner.value.node = Some(child_node);
+                        child_owner.value.tracked_put_node(child_node);
                         continuation.tracked_put_child(child_owner);
                         owner.continuations.tracked_insert(owner.level - 1, continuation);
 
@@ -641,7 +641,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                         C::item_roundtrip(item, pa, level, prop);
                     }
 
-                    assert(pa == owner.cur_entry_owner().frame.unwrap().mapped_pa);
+                    assert(pa == owner.cur_entry_owner().frame().unwrap().mapped_pa);
 
                     let ghost old_regions = *regions;
 
@@ -757,7 +757,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                     if e.is_frame() && e.parent_level > 1 {
                         broadcast use crate::specs::mm::frame::meta_owners::axiom_mmio_usage_iff_mmio_paddr;
 
-                        let pa = e.frame.unwrap().mapped_pa;
+                        let pa = e.frame().unwrap().mapped_pa;
                         let nr_pages = page_size(e.parent_level) / PAGE_SIZE;
                         assert forall|j: usize|
                             #![trigger frame_to_index((pa + j * PAGE_SIZE) as usize)]
@@ -854,8 +854,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
         let new_cur_entry = new_owner.cur_entry_owner();
         {
             &&& new_cur_entry.is_frame()
-            &&& old_cur_entry.is_frame() ==> new_cur_entry.frame.unwrap().prop
-                == old_cur_entry.frame.unwrap().prop
+            &&& old_cur_entry.is_frame() ==> new_cur_entry.frame().unwrap().prop
+                == old_cur_entry.frame().unwrap().prop
         }
     }
 
@@ -1017,17 +1017,17 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                 split_happened ==> owner.cur_entry_owner().is_frame(),
                 split_happened ==> self.va < end,
                 split_happened && old(owner).cur_entry_owner().is_frame()
-                    ==> owner.cur_entry_owner().frame.unwrap().prop == old(
+                    ==> owner.cur_entry_owner().frame().unwrap().prop == old(
                     owner,
-                ).cur_entry_owner().frame.unwrap().prop,
+                ).cur_entry_owner().frame().unwrap().prop,
                 split_happened ==> owner@.mappings == old(owner)@.split_while_huge(
                     page_size_spec(self.level),
                 ).mappings,
                 !split_happened && old(owner).cur_entry_owner().is_frame()
                     ==> owner.cur_entry_owner().is_frame()
-                    && owner.cur_entry_owner().frame.unwrap().prop == old(
+                    && owner.cur_entry_owner().frame().unwrap().prop == old(
                     owner,
-                ).cur_entry_owner().frame.unwrap().prop,
+                ).cur_entry_owner().frame().unwrap().prop,
                 (self.va > old(self).va && !split_happened) ==> !old(owner)@.present(),
                 split_happened ==> self.va == old(self).va,
             decreases owner.max_steps(),
@@ -1050,7 +1050,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
             let tracked mut continuation = owner.continuations.tracked_remove(owner.level - 1);
             let ghost cont0 = continuation;
             let tracked child_owner = continuation.tracked_take_child();
-            let tracked node_owner = continuation.entry_own.node.tracked_borrow();
+            let tracked node_owner = continuation.entry_own.tracked_borrow_node();
 
             let ghost regions_before_ref = *regions;
 
@@ -1110,8 +1110,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                     let ghost cont0 = continuation;
                     let tracked mut child_owner = continuation.tracked_take_child();
 
-                    let tracked mut parent_node_owner = continuation.entry_own.node.tracked_take();
-                    let tracked mut child_node_owner = child_owner.value.node.tracked_take();
+                    let tracked mut parent_node_owner = continuation.entry_own.tracked_take_node();
+                    let tracked mut child_node_owner = child_owner.value.tracked_take_node();
 
                     let ghost guards0 = *guards;
 
@@ -1125,9 +1125,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                     let nr_children = pt_guard.nr_children();
 
                     proof {
-                        child_owner.value.node = Some(child_node_owner);
+                        child_owner.value.tracked_put_node(child_node_owner);
                         continuation.tracked_put_child(child_owner);
-                        continuation.entry_own.node = Some(parent_node_owner);
+                        continuation.entry_own.tracked_put_node(parent_node_owner);
                         assert(cont0.children == continuation.children);
                         owner.continuations.tracked_insert(self.level - 1, continuation);
                         assert(owner.continuations == owner0.continuations);
@@ -1326,9 +1326,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                     assert(owner.max_steps() == owner0.max_steps());
                     if cur_entry_fits_range || !split_huge {
                         assert(!find_unmap_subtree && old(owner).cur_entry_owner().is_frame()
-                            ==> owner.cur_entry_owner().frame.unwrap().prop == old(
+                            ==> owner.cur_entry_owner().frame().unwrap().prop == old(
                             owner,
-                        ).cur_entry_owner().frame.unwrap().prop) by {
+                        ).cur_entry_owner().frame().unwrap().prop) by {
                             if !find_unmap_subtree && old(owner).cur_entry_owner().is_frame() {
                                 if !split_happened {
                                     assert(owner.continuations == owner0.continuations);
@@ -1359,9 +1359,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                         owner.level - 1,
                     );
                     let ghost cont_pre_split = continuation;
-                    let ghost parent_pre_split = continuation.entry_own.node.unwrap();
+                    let ghost parent_pre_split = continuation.entry_own.node().unwrap();
                     let tracked mut child_owner = continuation.tracked_take_child();
-                    let tracked mut parent_owner = continuation.entry_own.node.tracked_take();
+                    let tracked mut parent_owner = continuation.entry_own.tracked_take_node();
 
                     proof {
                         assert(parent_owner.level > 1) by {
@@ -1404,7 +1404,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                         let ghost child_not_in_scope = !child_owner.value.in_scope;
                         assert(cur_entry.idx == cont0.idx);
                         let ghost reconstructed_entry_own = EntryOwner {
-                            node: Some(parent_owner),
+                            kind: EntryOwnerKind::Node(parent_owner),
                             ..cont0.entry_own
                         };
                         CursorContinuation::<'rcu, C>::rel_children_from_node_matching(
@@ -1417,7 +1417,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                         );
 
                         continuation.tracked_put_child(child_owner);
-                        continuation.entry_own.node = Some(parent_owner);
+                        continuation.entry_own.tracked_put_node(parent_owner);
                         continuation.continuation_inv_holds_after_child_restore(
                             cont_pre_split,
                             parent_pre_split,
@@ -1896,7 +1896,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
             old(self).inv(),
             old(self).wf(*old(owner)),
             old(owner).cur_entry_owner().is_node(),
-            old(owner).cur_entry_owner().node.unwrap().relate_guard(child_pt),
+            old(owner).cur_entry_owner().node().unwrap().relate_guard(child_pt),
             old(owner).level > 1,
             old(owner).only_current_locked(*guards),
             old(owner).nodes_locked(*guards),
@@ -1963,7 +1963,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
             *final(owner) == *old(owner),
             final(owner).metaregion_sound(*regions),
             res.idx == final(owner).continuations[final(owner).level - 1].idx,
-            final(owner).continuations[final(owner).level - 1].entry_own.node.unwrap().relate_guard(
+            final(owner).continuations[final(owner).level - 1].entry_own.node().unwrap().relate_guard(
                 *res.node,
             ),
     {
@@ -1975,7 +1975,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
         assert(parent_continuation.inv());
         let ghost cont0 = parent_continuation;
         let tracked child = parent_continuation.tracked_take_child();
-        let tracked parent_own = parent_continuation.entry_own.node.tracked_take();
+        let tracked parent_own = parent_continuation.entry_own.tracked_take_node();
 
         let ghost index = frame_to_index(meta_to_frame(parent_own.meta_addr_self()));
 
@@ -1997,7 +1997,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
         let res = node.entry(pte_index::<C>(self.va, self.level));
 
         proof {
-            parent_continuation.entry_own.node = Some(parent_own);
+            parent_continuation.entry_own.tracked_put_node(parent_own);
             parent_continuation.tracked_put_child(child);
             assert(parent_continuation.children == cont0.children);
             owner.continuations.tracked_insert((owner.level - 1) as int, parent_continuation);
@@ -2326,7 +2326,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         let tracked mut continuation = owner.continuations.tracked_remove(owner.level - 1);
         let tracked mut child_owner = continuation.tracked_take_child();
         let ghost orig_child_owner = child_owner;
-        let tracked mut child_node = child_owner.value.node.tracked_take();
+        let tracked mut child_node = child_owner.value.tracked_take_node();
 
         // SAFETY: The `pt` must be locked and no other guards exist.
         let pt_guard = unsafe {
@@ -2335,7 +2335,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         };
 
         proof {
-            child_owner.value.node = Some(child_node);
+            child_owner.value.tracked_put_node(child_node);
             assert(child_owner == orig_child_owner);
             continuation.tracked_put_child(child_owner);
             cont_orig.take_put_child();
@@ -2469,7 +2469,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             let tracked mut continuation = owner.continuations.tracked_remove(owner.level - 1);
             let tracked child_owner = continuation.tracked_take_child();
             let ghost child_entry_val = child_owner.value;
-            let tracked parent_owner = continuation.entry_own.node.tracked_borrow();
+            let tracked parent_owner = continuation.entry_own.tracked_borrow_node();
 
             let ghost regions_before_ref = *regions;
 
@@ -2524,7 +2524,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                     let ghost cont_pre_alloc = continuation;
                     let tracked mut child_owner = continuation.tracked_take_child();
                     let ghost old_child_value = child_owner.value;
-                    let tracked mut parent_owner = continuation.entry_own.node.tracked_take();
+                    let tracked mut parent_owner = continuation.entry_own.tracked_take_node();
                     proof {
                         assert(cur_entry.node_matching(
                             child_owner.value,
@@ -2537,7 +2537,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                     #[verus_spec(with Tracked(&mut child_owner), Tracked(&mut parent_owner), Tracked(regions), Tracked(guards))]
                     cur_entry.alloc_if_none(rcu_guard)).unwrap();
 
-                    let ghost new_node_addr = child_owner.value.node.unwrap().meta_addr_self();
+                    let ghost new_node_addr = child_owner.value.node().unwrap().meta_addr_self();
                     let ghost new_child_value = child_owner.value;
 
                     let ghost new_pt_idx = frame_to_index(
@@ -2552,7 +2552,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
 
                         let ghost child_not_in_scope = !child_owner.value.in_scope;
                         let ghost reconstructed_entry_own = EntryOwner {
-                            node: Some(parent_owner),
+                            kind: EntryOwnerKind::Node(parent_owner),
                             ..cont_pre_alloc.entry_own
                         };
                         CursorContinuation::<'rcu, C>::rel_children_from_node_matching(
@@ -2565,11 +2565,11 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         );
 
                         cont_pre_alloc.take_put_child();
-                        continuation.entry_own.node = Some(parent_owner);
+                        continuation.entry_own.tracked_put_node(parent_owner);
                         continuation.tracked_put_child(child_owner);
                         owner.continuations.tracked_insert(owner.level - 1, continuation);
 
-                        assert(owner.cur_entry_owner().node.unwrap().meta_addr_self()
+                        assert(owner.cur_entry_owner().node().unwrap().meta_addr_self()
                             == new_node_addr);
 
                         assert forall|i: int|
@@ -2638,15 +2638,15 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                                 assert(eo.inv() && eo.is_node());
                                 assert(eo.metaregion_sound(regions_after_ref));
                                 let eo_idx = frame_to_index(eo.meta_slot_paddr().unwrap());
-                                assert(eo_idx == eo.node.unwrap().slot_index);
+                                assert(eo_idx == eo.node().unwrap().slot_index);
                                 assert(regions_after_ref.slot_owners[eo_idx].inner_perms.ref_count.value()
                                     != REF_COUNT_UNUSED);
                                 assert(eo_idx != new_pt_idx);
                                 assert(regions.slot_owners[eo_idx]
                                     == regions_after_ref.slot_owners[eo_idx]);
                                 assert(regions.slots[eo_idx] == regions_after_ref.slots[eo_idx]);
-                                assert(eo.node.unwrap().meta_perm_of(*regions)
-                                    == eo.node.unwrap().meta_perm_of(regions_after_ref));
+                                assert(eo.node().unwrap().meta_perm_of(*regions)
+                                    == eo.node().unwrap().meta_perm_of(regions_after_ref));
                             };
                         };
 
@@ -2673,7 +2673,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                             );
                             cont_new.continuation_inv_holds_after_child_restore(
                                 cont_pre_alloc,
-                                cont_pre_alloc.entry_own.node.unwrap(),
+                                cont_pre_alloc.entry_own.node().unwrap(),
                             );
                         };
                         owner.map_branch_none_inv_holds(owner_pre_none);
@@ -2722,9 +2722,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         owner.level - 1,
                     );
                     let ghost cont_pre_split = continuation;
-                    let ghost parent_pre_split = continuation.entry_own.node.unwrap();
+                    let ghost parent_pre_split = continuation.entry_own.node().unwrap();
                     let tracked mut child_owner = continuation.tracked_take_child();
-                    let tracked mut parent_owner = continuation.entry_own.node.tracked_take();
+                    let tracked mut parent_owner = continuation.entry_own.tracked_take_node();
 
                     proof {
                         assert(child_owner.value.metaregion_sound(*regions));
@@ -2739,7 +2739,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
 
                     proof {
                         continuation.tracked_put_child(child_owner);
-                        continuation.entry_own.node = Some(parent_owner);
+                        continuation.entry_own.tracked_put_node(parent_owner);
                         owner.continuations.tracked_insert(owner.level - 1, continuation);
                         assert(owner.continuations[owner.level - 1].inv()) by {
                             let cont_new = owner.continuations[owner.level - 1];
@@ -2963,7 +2963,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 is_tracked,
             ).set_in_scope(false));
             assert(new_owner.value.is_frame());
-            assert(new_owner.value.frame.unwrap().mapped_pa == pa);
+            assert(new_owner.value.frame().unwrap().mapped_pa == pa);
 
             assert(PageTableOwner(new_owner)@.mappings == set![target]) by {
                 assert(owner1.level == level);
@@ -3381,9 +3381,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 owner_before_replace.cur_subtree_inv();
                 owner_before_replace.new_child_mappings_eq_target(
                     cur_st,
-                    cur_st.value.frame.unwrap().mapped_pa,
+                    cur_st.value.frame().unwrap().mapped_pa,
                     level_after_find,
-                    cur_st.value.frame.unwrap().prop,
+                    cur_st.value.frame().unwrap().prop,
                 );
                 owner_before_replace.va.reflect_prop(va_after_find);
 
@@ -3410,10 +3410,10 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 owner_before_replace.cur_subtree_eq_filtered_mappings();
                 let ghost target = Mapping {
                     va_range: owner_before_replace@.cur_slot_range(m.page_size),
-                    pa_range: cur_st.value.frame.unwrap().mapped_pa..(
-                    cur_st.value.frame.unwrap().mapped_pa + m.page_size) as usize,
+                    pa_range: cur_st.value.frame().unwrap().mapped_pa..(
+                    cur_st.value.frame().unwrap().mapped_pa + m.page_size) as usize,
                     page_size: m.page_size,
-                    property: cur_st.value.frame.unwrap().prop,
+                    property: cur_st.value.frame().unwrap().prop,
                 };
                 assert(PageTableOwner(cur_st)@.mappings == set![target]);
                 assert(owner_before_replace@.mappings.filter(
@@ -3434,7 +3434,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 // here makes the eventual exact ref-count accounting
                 // (`ref_count == #handles + paths_in_pt.len()`) a true
                 // system invariant rather than monotonically inflated.
-                let ghost removed_idx = frame_to_index(cur_st.value.frame.unwrap().mapped_pa);
+                let ghost removed_idx = frame_to_index(cur_st.value.frame().unwrap().mapped_pa);
                 let ghost removed_path = cur_st.value.path;
                 let ghost regions_pre_remove = *regions;
                 let tracked mut so_rm = regions.slot_owners.tracked_remove(removed_idx);
@@ -3671,7 +3671,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         let mut entry = self.0.cur_entry();
 
         proof {
-            assert(entry.pte.prop() == owner.cur_entry_owner().frame.unwrap().prop) by {
+            assert(entry.pte.prop() == owner.cur_entry_owner().frame().unwrap().prop) by {
                 owner.cur_subtree_inv();
                 assert(owner.cur_entry_owner().match_pte(
                     entry.pte,
@@ -3688,22 +3688,22 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         // and cont0 == owner0.cont[level-1] from tracked_remove.
         assert(entry.idx == cont0.idx as usize);
         let tracked mut child_owner = continuation.tracked_take_child();
-        let tracked mut parent_owner = continuation.entry_own.node.tracked_take();
+        let tracked mut parent_owner = continuation.entry_own.tracked_take_node();
 
         #[verus_spec(with Tracked(&mut child_owner.value), Tracked(&mut parent_owner), Tracked(&*regions))]
         entry.protect(op);
 
-        let ghost new_prop = child_owner.value.frame.unwrap().prop;
+        let ghost new_prop = child_owner.value.frame().unwrap().prop;
 
         let ghost child_owner_path = child_owner.value.path;
-        let ghost child_owner_mapped_pa = child_owner.value.frame.unwrap().mapped_pa;
+        let ghost child_owner_mapped_pa = child_owner.value.frame().unwrap().mapped_pa;
         let ghost child_owner_parent_level = child_owner.value.parent_level;
 
         proof {
             let ghost child_not_in_scope = !child_owner.value.in_scope;
 
             continuation.tracked_put_child(child_owner);
-            continuation.entry_own.node = Some(parent_owner);
+            continuation.entry_own.tracked_put_node(parent_owner);
             cont0.take_put_child();
             owner.continuations.tracked_insert(owner.level - 1, continuation);
             assert(owner.continuations[owner.level - 1].all_some()) by {
@@ -3719,7 +3719,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 assert(child_not_in_scope);
                 cont_new.continuation_inv_holds_after_child_restore(
                     cont0,
-                    cont0.entry_own.node.unwrap(),
+                    cont0.entry_own.node().unwrap(),
                 );
             };
             assert(owner.continuations[owner.level - 1].entry_own.metaregion_sound(*regions));
@@ -3830,8 +3830,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             res is Some && res.unwrap() is Mapped ==> {
                 let (pa, lvl, prop) = C::item_into_raw_spec(res.unwrap()->Mapped_item);
                 &&& lvl == old(self).0.level
-                &&& pa == old(owner).cur_entry_owner().frame.unwrap().mapped_pa
-                &&& prop == old(owner).cur_entry_owner().frame.unwrap().prop
+                &&& pa == old(owner).cur_entry_owner().frame().unwrap().mapped_pa
+                &&& prop == old(owner).cur_entry_owner().frame().unwrap().prop
             },
             // StrayPageTable: VA and len match cursor state at call time.
             res is Some && res.unwrap() is StrayPageTable ==> {
@@ -3900,7 +3900,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         }
         assert(owner.continuations == owner0.continuations.remove(owner.level - 1));
 
-        let tracked mut parent_owner = continuation.entry_own.node.tracked_take();
+        let tracked mut parent_owner = continuation.entry_own.tracked_take_node();
 
         let ghost pre_new_owner_value = new_owner.value;
         // Capture the old child value before Entry::replace mutates it (from_pte_owner_spec
@@ -3941,7 +3941,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         };
 
         proof {
-            continuation.entry_own.node = Some(parent_owner);
+            continuation.entry_own.tracked_put_node(parent_owner);
             continuation.tracked_put_child(new_owner);
             cont1.view_mappings_put_child(new_owner);
 
@@ -4182,8 +4182,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                     // Old child absent/frame: regions unchanged at eo's slot.
 
                     let eo_idx = frame_to_index(eo.meta_slot_paddr().unwrap());
-                    assert(eo_idx == eo.node.unwrap().slot_index);
-                    assert(eo.node.unwrap().meta_perm_of(*regions) == eo.node.unwrap().meta_perm_of(
+                    assert(eo_idx == eo.node().unwrap().slot_index);
+                    assert(eo.node().unwrap().meta_perm_of(*regions) == eo.node().unwrap().meta_perm_of(
                         regions0,
                     ));
                 };
@@ -4260,7 +4260,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 let ghost owner2 = *owner;
                 let ghost child_entry = old_child_owner.value;
 
-                let tracked mut old_node_owner = old_child_owner.value.node.tracked_take();
+                let tracked mut old_node_owner = old_child_owner.value.tracked_take_node();
 
                 let ghost regions_before_borrow = *regions;
 
@@ -4475,3 +4475,5 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
 }
 
 } // verus!
+
+

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -1963,9 +1963,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
             *final(owner) == *old(owner),
             final(owner).metaregion_sound(*regions),
             res.idx == final(owner).continuations[final(owner).level - 1].idx,
-            final(owner).continuations[final(owner).level - 1].entry_own.node().unwrap().relate_guard(
-                *res.node,
-            ),
+            final(owner).continuations[final(owner).level
+                - 1].entry_own.node().unwrap().relate_guard(*res.node),
     {
         let ghost owner0 = *owner;
 
@@ -4183,9 +4182,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
 
                     let eo_idx = frame_to_index(eo.meta_slot_paddr().unwrap());
                     assert(eo_idx == eo.node().unwrap().slot_index);
-                    assert(eo.node().unwrap().meta_perm_of(*regions) == eo.node().unwrap().meta_perm_of(
-                        regions0,
-                    ));
+                    assert(eo.node().unwrap().meta_perm_of(*regions)
+                        == eo.node().unwrap().meta_perm_of(regions0));
                 };
             };
 
@@ -4475,5 +4473,3 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
 }
 
 } // verus!
-
-

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -1359,10 +1359,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                     let ghost cont_pre_split = continuation;
                     let ghost parent_pre_split = continuation.entry_own.node();
                     let tracked mut child_owner = continuation.tracked_take_child();
-                    let tracked mut parent_owner = continuation.entry_own.tracked_borrow_mut_node();
 
                     proof {
-                        assert(parent_owner.level > 1) by {
+                        assert(continuation.entry_own.node().level > 1) by {
                             owner0.cur_va_range().start.reflect_prop(cur_va_range.start);
                             owner0.cur_va_range().end.reflect_prop(cur_va_range.end);
                             assert(cur_entry_fits_range == (cur_va
@@ -1386,7 +1385,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                         }
                     }
                     let split_child = (
-                    #[verus_spec(with Tracked(&mut child_owner), Tracked(parent_owner), Tracked(regions),
+                    #[verus_spec(with Tracked(&mut child_owner), Tracked(continuation.entry_own.tracked_borrow_mut_node()), Tracked(regions),
                         Tracked(guards))]
                     cur_entry.split_if_mapped_huge(rcu_guard)).expect(
                         "The entry must be a huge page",
@@ -1402,13 +1401,13 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                         let ghost child_not_in_scope = !child_owner.value.in_scope;
                         assert(cur_entry.idx == cont0.idx);
                         let ghost reconstructed_entry_own = EntryOwner {
-                            kind: EntryOwnerKind::Node(parent_owner),
+                            kind: EntryOwnerKind::Node(continuation.entry_own.node()),
                             ..cont0.entry_own
                         };
                         CursorContinuation::<'rcu, C>::rel_children_from_node_matching(
                             &cur_entry,
                             child_owner.value,
-                            parent_owner,
+                            continuation.entry_own.node(),
                             continuation.guard,
                             reconstructed_entry_own,
                             cont0.idx,

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -3895,8 +3895,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         }
         assert(owner.continuations == owner0.continuations.remove(owner.level - 1));
 
-        let tracked mut parent_owner = continuation.entry_own.tracked_take_node();
-
         let ghost pre_new_owner_value = new_owner.value;
         // Capture the old child value before Entry::replace mutates it (from_pte_owner_spec
         // only changes in_scope, so meta_slot_paddr() is unchanged, but we need the pre-replace
@@ -3910,7 +3908,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         #[verus_spec(with Tracked(regions),
             Tracked(&mut old_child_owner.value),
             Tracked(&mut new_owner.value),
-            Tracked(&mut parent_owner),
+            Tracked(continuation.entry_own.tracked_borrow_mut_node()),
         )]
         let old = cur_entry.replace(new_child);
         let ghost old_child_snap = old;  // ghost alias to avoid `old(...)` keyword ambiguity in proofs
@@ -3936,7 +3934,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         };
 
         proof {
-            continuation.entry_own.tracked_put_node(parent_owner);
             continuation.tracked_put_child(new_owner);
             cont1.view_mappings_put_child(new_owner);
 

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -1169,10 +1169,10 @@ impl PageTable<KernelPtConfig> {
         requires
             kernel_owner.inv(),
             old(regions).inv(),
-            kernel_owner.0.value.node() is Some,
-            !Self::create_user_pt_panic_condition(kernel_owner.0.value.node().unwrap()),
+            kernel_owner.0.value.is_node(),
+            !Self::create_user_pt_panic_condition(kernel_owner.0.value.node()),
             // The kernel page table's root frame matches the tracked owner.
-            self.root.ptr.addr() == kernel_owner.0.value.node().unwrap().meta_addr_self(),
+            self.root.ptr.addr() == kernel_owner.0.value.node().meta_addr_self(),
             // The kernel root entry is sound with respect to the meta regions.
             kernel_owner.0.value.metaregion_sound(*old(regions)),
             // The whole kernel page-table tree is sound: every entry's metaregion
@@ -1180,7 +1180,7 @@ impl PageTable<KernelPtConfig> {
             // soundness inside the loop body.
             kernel_owner.metaregion_sound(*old(regions)),
             // The kernel root is not currently locked.
-            old(guards).unlocked(kernel_owner.0.value.node().unwrap().meta_addr_self()),
+            old(guards).unlocked(kernel_owner.0.value.node().meta_addr_self()),
         ensures
             final(regions).inv(),
     )]
@@ -1303,7 +1303,7 @@ impl PageTable<KernelPtConfig> {
                     p: vstd_extra::ghost_tree::TreePath<NR_ENTRIES>,
                 |
                     e.is_frame() && e.parent_level > 1 ==> {
-                        let pa = e.frame().unwrap().mapped_pa;
+                        let pa = e.frame().mapped_pa;
                         let nr_pages = crate::mm::page_table::cursor::page_size_spec(e.parent_level)
                             / crate::specs::arch::mm::PAGE_SIZE;
                         forall|j: usize|
@@ -1320,7 +1320,7 @@ impl PageTable<KernelPtConfig> {
                     p: vstd_extra::ghost_tree::TreePath<NR_ENTRIES>,
                 |
                     e.is_frame() && e.parent_level > 1 ==> {
-                        let pa = e.frame().unwrap().mapped_pa;
+                        let pa = e.frame().mapped_pa;
                         let nr_pages = crate::mm::page_table::cursor::page_size_spec(e.parent_level)
                             / crate::specs::arch::mm::PAGE_SIZE;
                         forall|j: usize|
@@ -1347,13 +1347,13 @@ impl PageTable<KernelPtConfig> {
         while i < KernelPtConfig::TOP_LEVEL_INDEX_RANGE().end
             invariant
                 kernel_owner.inv(),
-                kernel_owner.0.value.node() is Some,
+                kernel_owner.0.value.is_node(),
                 regions.inv(),
-                !Self::create_user_pt_panic_condition(kernel_owner.0.value.node().unwrap()),
+                !Self::create_user_pt_panic_condition(kernel_owner.0.value.node()),
                 i <= KernelPtConfig::TOP_LEVEL_INDEX_RANGE_spec().end,
                 KernelPtConfig::TOP_LEVEL_INDEX_RANGE_spec().start <= i,
                 // Lock postcondition for the kernel root.
-                *root_owner == kernel_owner.0.value.node().unwrap(),
+                *root_owner == kernel_owner.0.value.node(),
                 root_owner.relate_guard(root_node),
                 // Tree-wide soundness of the kernel page table.
                 kernel_owner.metaregion_sound(*regions),
@@ -1364,7 +1364,7 @@ impl PageTable<KernelPtConfig> {
             decreases KernelPtConfig::TOP_LEVEL_INDEX_RANGE_spec().end - i,
         {
             proof {
-                let kern_node = kernel_owner.0.value.node().unwrap();
+                let kern_node = kernel_owner.0.value.node();
                 assert forall|j: usize|
                     #![trigger kern_node.children_perm.value()[j as int]]
                     KernelPtConfig::TOP_LEVEL_INDEX_RANGE_spec().start <= j
@@ -1384,7 +1384,7 @@ impl PageTable<KernelPtConfig> {
                 let tracked child_subtree: &OwnerSubtree<KernelPtConfig> =
                     child_opt.tracked_borrow();
                 entry_owner = child_subtree.borrow_value();
-                let kern_node = kernel_owner.0.value.node().unwrap();
+                let kern_node = kernel_owner.0.value.node();
                 assert(entry_owner.match_pte(
                     kern_node.children_perm.value()[i as int],
                     entry_owner.parent_level,
@@ -1414,7 +1414,7 @@ impl PageTable<KernelPtConfig> {
             let child = root_entry.to_ref();
 
             proof {
-                let kern_node = kernel_owner.0.value.node().unwrap();
+                let kern_node = kernel_owner.0.value.node();
                 let pte = kern_node.children_perm.value()[i as int];
 
                 assert(pte.is_present() && !pte.is_last(kern_node.level)) by {
@@ -1520,11 +1520,11 @@ impl<C: PageTableConfig> PageTable<C> {
             final(owner)@ is Some,
             final(owner)@.unwrap().inv(),
             final(owner)@.unwrap().0.value.is_node(),
-            final(owner)@.unwrap().0.value.node() is Some,
-            r.root.ptr.addr() == final(owner)@.unwrap().0.value.node().unwrap().meta_addr_self(),
+            final(owner)@.unwrap().0.value.is_node(),
+            r.root.ptr.addr() == final(owner)@.unwrap().0.value.node().meta_addr_self(),
             final(owner)@.unwrap().0.value.metaregion_sound(*final(regions)),
             final(regions).inv(),
-            final(guards).unlocked(final(owner)@.unwrap().0.value.node().unwrap().meta_addr_self()),
+            final(guards).unlocked(final(owner)@.unwrap().0.value.node().meta_addr_self()),
             // Allocating a fresh node does not change the lock set, so any node
             // that was (un)locked before remains so.
             final(guards).guards == old(guards).guards,
@@ -1583,7 +1583,7 @@ impl<C: PageTableConfig> PageTable<C> {
                     |e: crate::specs::mm::page_table::node::entry_owners::EntryOwner<KernelPtConfig>,
                      p: vstd_extra::ghost_tree::TreePath<NR_ENTRIES>|
                         e.is_frame() && e.parent_level > 1 ==> {
-                            let pa = e.frame().unwrap().mapped_pa;
+                            let pa = e.frame().mapped_pa;
                             let nr_pages = crate::mm::page_table::cursor::page_size_spec(
                                 e.parent_level) / crate::specs::arch::mm::PAGE_SIZE;
                             forall |j: usize| 0 < j < nr_pages ==> {

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -1875,4 +1875,3 @@ pub unsafe fn store_pte<E: PageTableEntryTrait>(
 );
 
 } // verus!
-

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -1169,10 +1169,10 @@ impl PageTable<KernelPtConfig> {
         requires
             kernel_owner.inv(),
             old(regions).inv(),
-            kernel_owner.0.value.node is Some,
-            !Self::create_user_pt_panic_condition(kernel_owner.0.value.node.unwrap()),
+            kernel_owner.0.value.node() is Some,
+            !Self::create_user_pt_panic_condition(kernel_owner.0.value.node().unwrap()),
             // The kernel page table's root frame matches the tracked owner.
-            self.root.ptr.addr() == kernel_owner.0.value.node.unwrap().meta_addr_self(),
+            self.root.ptr.addr() == kernel_owner.0.value.node().unwrap().meta_addr_self(),
             // The kernel root entry is sound with respect to the meta regions.
             kernel_owner.0.value.metaregion_sound(*old(regions)),
             // The whole kernel page-table tree is sound: every entry's metaregion
@@ -1180,7 +1180,7 @@ impl PageTable<KernelPtConfig> {
             // soundness inside the loop body.
             kernel_owner.metaregion_sound(*old(regions)),
             // The kernel root is not currently locked.
-            old(guards).unlocked(kernel_owner.0.value.node.unwrap().meta_addr_self()),
+            old(guards).unlocked(kernel_owner.0.value.node().unwrap().meta_addr_self()),
         ensures
             final(regions).inv(),
     )]
@@ -1218,11 +1218,11 @@ impl PageTable<KernelPtConfig> {
 
         proof_decl! {
             let tracked root_owner: &NodeOwner<KernelPtConfig>
-                = kernel_owner.0.borrow_value().node.tracked_borrow();
+                = kernel_owner.0.borrow_value().tracked_borrow_node();
             let tracked mut new_pt_owner_val: PageTableOwner<UserPtConfig>
                 = new_pt_owner.tracked_take();
             let tracked mut new_node_owner: NodeOwner<UserPtConfig>
-                = new_pt_owner_val.0.value.node.tracked_take();
+                = new_pt_owner_val.0.value.tracked_take_node();
             let tracked mut entry_owner: &EntryOwner<KernelPtConfig>;
         }
 
@@ -1303,7 +1303,7 @@ impl PageTable<KernelPtConfig> {
                     p: vstd_extra::ghost_tree::TreePath<NR_ENTRIES>,
                 |
                     e.is_frame() && e.parent_level > 1 ==> {
-                        let pa = e.frame.unwrap().mapped_pa;
+                        let pa = e.frame().unwrap().mapped_pa;
                         let nr_pages = crate::mm::page_table::cursor::page_size_spec(e.parent_level)
                             / crate::specs::arch::mm::PAGE_SIZE;
                         forall|j: usize|
@@ -1320,7 +1320,7 @@ impl PageTable<KernelPtConfig> {
                     p: vstd_extra::ghost_tree::TreePath<NR_ENTRIES>,
                 |
                     e.is_frame() && e.parent_level > 1 ==> {
-                        let pa = e.frame.unwrap().mapped_pa;
+                        let pa = e.frame().unwrap().mapped_pa;
                         let nr_pages = crate::mm::page_table::cursor::page_size_spec(e.parent_level)
                             / crate::specs::arch::mm::PAGE_SIZE;
                         forall|j: usize|
@@ -1347,13 +1347,13 @@ impl PageTable<KernelPtConfig> {
         while i < KernelPtConfig::TOP_LEVEL_INDEX_RANGE().end
             invariant
                 kernel_owner.inv(),
-                kernel_owner.0.value.node is Some,
+                kernel_owner.0.value.node() is Some,
                 regions.inv(),
-                !Self::create_user_pt_panic_condition(kernel_owner.0.value.node.unwrap()),
+                !Self::create_user_pt_panic_condition(kernel_owner.0.value.node().unwrap()),
                 i <= KernelPtConfig::TOP_LEVEL_INDEX_RANGE_spec().end,
                 KernelPtConfig::TOP_LEVEL_INDEX_RANGE_spec().start <= i,
                 // Lock postcondition for the kernel root.
-                *root_owner == kernel_owner.0.value.node.unwrap(),
+                *root_owner == kernel_owner.0.value.node().unwrap(),
                 root_owner.relate_guard(root_node),
                 // Tree-wide soundness of the kernel page table.
                 kernel_owner.metaregion_sound(*regions),
@@ -1364,7 +1364,7 @@ impl PageTable<KernelPtConfig> {
             decreases KernelPtConfig::TOP_LEVEL_INDEX_RANGE_spec().end - i,
         {
             proof {
-                let kern_node = kernel_owner.0.value.node.unwrap();
+                let kern_node = kernel_owner.0.value.node().unwrap();
                 assert forall|j: usize|
                     #![trigger kern_node.children_perm.value()[j as int]]
                     KernelPtConfig::TOP_LEVEL_INDEX_RANGE_spec().start <= j
@@ -1384,7 +1384,7 @@ impl PageTable<KernelPtConfig> {
                 let tracked child_subtree: &OwnerSubtree<KernelPtConfig> =
                     child_opt.tracked_borrow();
                 entry_owner = child_subtree.borrow_value();
-                let kern_node = kernel_owner.0.value.node.unwrap();
+                let kern_node = kernel_owner.0.value.node().unwrap();
                 assert(entry_owner.match_pte(
                     kern_node.children_perm.value()[i as int],
                     entry_owner.parent_level,
@@ -1414,7 +1414,7 @@ impl PageTable<KernelPtConfig> {
             let child = root_entry.to_ref();
 
             proof {
-                let kern_node = kernel_owner.0.value.node.unwrap();
+                let kern_node = kernel_owner.0.value.node().unwrap();
                 let pte = kern_node.children_perm.value()[i as int];
 
                 assert(pte.is_present() && !pte.is_last(kern_node.level)) by {
@@ -1451,7 +1451,7 @@ impl PageTable<KernelPtConfig> {
                 _ => vstd::pervasive::unreached(),
             };
 
-            let ghost entry_node_slot_idx = entry_owner.node.tracked_borrow().slot_index;
+            let ghost entry_node_slot_idx = entry_owner.tracked_borrow_node().slot_index;
             let tracked entry_node_slot_perm = regions.slots.tracked_borrow(entry_node_slot_idx);
             #[verus_spec(with Tracked(entry_node_slot_perm))]
             let pt_addr = pt.start_paddr();
@@ -1520,11 +1520,11 @@ impl<C: PageTableConfig> PageTable<C> {
             final(owner)@ is Some,
             final(owner)@.unwrap().inv(),
             final(owner)@.unwrap().0.value.is_node(),
-            final(owner)@.unwrap().0.value.node is Some,
-            r.root.ptr.addr() == final(owner)@.unwrap().0.value.node.unwrap().meta_addr_self(),
+            final(owner)@.unwrap().0.value.node() is Some,
+            r.root.ptr.addr() == final(owner)@.unwrap().0.value.node().unwrap().meta_addr_self(),
             final(owner)@.unwrap().0.value.metaregion_sound(*final(regions)),
             final(regions).inv(),
-            final(guards).unlocked(final(owner)@.unwrap().0.value.node.unwrap().meta_addr_self()),
+            final(guards).unlocked(final(owner)@.unwrap().0.value.node().unwrap().meta_addr_self()),
             // Allocating a fresh node does not change the lock set, so any node
             // that was (un)locked before remains so.
             final(guards).guards == old(guards).guards,
@@ -1583,7 +1583,7 @@ impl<C: PageTableConfig> PageTable<C> {
                     |e: crate::specs::mm::page_table::node::entry_owners::EntryOwner<KernelPtConfig>,
                      p: vstd_extra::ghost_tree::TreePath<NR_ENTRIES>|
                         e.is_frame() && e.parent_level > 1 ==> {
-                            let pa = e.frame.unwrap().mapped_pa;
+                            let pa = e.frame().unwrap().mapped_pa;
                             let nr_pages = crate::mm::page_table::cursor::page_size_spec(
                                 e.parent_level) / crate::specs::arch::mm::PAGE_SIZE;
                             forall |j: usize| 0 < j < nr_pages ==> {
@@ -1875,3 +1875,4 @@ pub unsafe fn store_pte<E: PageTableEntryTrait>(
 );
 
 } // verus!
+

--- a/ostd/src/mm/page_table/node/child.rs
+++ b/ostd/src/mm/page_table/node/child.rs
@@ -73,8 +73,8 @@ impl<C: PageTableConfig> Child<C> {
             final(owner).pte_invariants(res, *final(regions)),
             *final(regions) == old(owner).into_pte_regions_spec(*old(regions)),
             *final(owner) == old(owner).into_pte_owner_spec(),
-            old(owner).node is Some ==> res == C::E::new_pt_spec(
-                meta_to_frame(old(owner).node.unwrap().meta_addr_self()),
+            old(owner).node() is Some ==> res == C::E::new_pt_spec(
+                meta_to_frame(old(owner).node().unwrap().meta_addr_self()),
             ),
     {
         proof {
@@ -83,7 +83,7 @@ impl<C: PageTableConfig> Child<C> {
 
         match self {
             Child::PageTable(node) => {
-                let ghost node_owner = owner.node.unwrap();
+                let ghost node_owner = owner.node().unwrap();
                 let ghost node_index = frame_to_index(meta_to_frame(node.ptr.addr()));
 
                 let tracked node_slot_perm = regions.slots.tracked_borrow(node_index);
@@ -306,3 +306,4 @@ impl<C: PageTableConfig> ChildRef<'_, C> {
 }
 
 } // verus!
+

--- a/ostd/src/mm/page_table/node/child.rs
+++ b/ostd/src/mm/page_table/node/child.rs
@@ -73,8 +73,8 @@ impl<C: PageTableConfig> Child<C> {
             final(owner).pte_invariants(res, *final(regions)),
             *final(regions) == old(owner).into_pte_regions_spec(*old(regions)),
             *final(owner) == old(owner).into_pte_owner_spec(),
-            old(owner).node() is Some ==> res == C::E::new_pt_spec(
-                meta_to_frame(old(owner).node().unwrap().meta_addr_self()),
+            old(owner).is_node() ==> res == C::E::new_pt_spec(
+                meta_to_frame(old(owner).node().meta_addr_self()),
             ),
     {
         proof {
@@ -83,7 +83,7 @@ impl<C: PageTableConfig> Child<C> {
 
         match self {
             Child::PageTable(node) => {
-                let ghost node_owner = owner.node().unwrap();
+                let ghost node_owner = owner.node();
                 let ghost node_index = frame_to_index(meta_to_frame(node.ptr.addr()));
 
                 let tracked node_slot_perm = regions.slots.tracked_borrow(node_index);

--- a/ostd/src/mm/page_table/node/child.rs
+++ b/ostd/src/mm/page_table/node/child.rs
@@ -306,4 +306,3 @@ impl<C: PageTableConfig> ChildRef<'_, C> {
 }
 
 } // verus!
-

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -237,15 +237,15 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             final(self).node_matching(*final(owner), *final(parent_owner), *final(self).node),
             final(self).parent_perms_preserved(*old(parent_owner), *final(parent_owner)),
             final(owner).is_frame(),
-            final(owner).frame().unwrap().mapped_pa == old(owner).frame().unwrap().mapped_pa,
-            final(owner).frame().unwrap().is_tracked == old(owner).frame().unwrap().is_tracked,
+            final(owner).frame().mapped_pa == old(owner).frame().mapped_pa,
+            final(owner).frame().is_tracked == old(owner).frame().is_tracked,
             final(owner).path == old(owner).path,
             final(owner).parent_level == old(owner).parent_level,
             final(owner).in_scope == old(owner).in_scope,
             final(self).idx == old(self).idx,
             old(self).pte.is_present() ==> op.ensures(
-                (old(owner).frame().unwrap().prop,),
-                final(owner).frame().unwrap().prop,
+                (old(owner).frame().prop,),
+                final(owner).frame().prop,
             ),
     {
         let ghost pte0 = self.pte;
@@ -574,18 +574,18 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 &&& final(owner).value.is_node()
                 &&& final(owner).level == old(owner).level
                 &&& final(owner).value.parent_level == old(owner).value.parent_level
-                &&& final(guards).lock_held(final(owner).value.node().unwrap().meta_addr_self())
-                &&& final(owner).value.node().unwrap().relate_guard(res.unwrap())
+                &&& final(guards).lock_held(final(owner).value.node().meta_addr_self())
+                &&& final(owner).value.node().relate_guard(res.unwrap())
                 &&& final(owner).value.path == old(owner).value.path
                 &&& final(owner).value.metaregion_sound(*final(regions))
                 &&& OwnerSubtree::implies(
                     CursorOwner::<'rcu, C>::node_unlocked(*old(guards)),
-                    CursorOwner::<'rcu, C>::node_unlocked_except(*final(guards), final(owner).value.node().unwrap().meta_addr_self()))
+                    CursorOwner::<'rcu, C>::node_unlocked_except(*final(guards), final(owner).value.node().meta_addr_self()))
                 &&& Self::metaregion_sound_neq_preserved(old(owner).value, final(owner).value, *old(regions), *final(regions))
                 &&& Self::path_tracked_pred_preserved(*old(regions), *final(regions))
                 &&& old(regions).slots.contains_key(frame_to_index(final(owner).value.meta_slot_paddr().unwrap()))
                 &&& final(owner).tree_predicate_map(final(owner).value.path,
-                    CursorOwner::<'rcu, C>::node_unlocked_except(*final(guards), final(owner).value.node().unwrap().meta_addr_self()))
+                    CursorOwner::<'rcu, C>::node_unlocked_except(*final(guards), final(owner).value.node().meta_addr_self()))
                 &&& final(owner).tree_predicate_map(final(owner).value.path, PageTableOwner::<C>::metaregion_sound_pred(*final(regions)))
                 &&& final(owner).tree_predicate_map(final(owner).value.path, PageTableOwner::<C>::path_tracked_pred(*final(regions)))
                 &&& PageTableOwner(*final(owner)).view_rec(final(owner).value.path) == set![]
@@ -608,10 +608,10 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 // Other child fields preserved from `allocated_empty_node_owner`.
                 &&& forall|i: int| 0 <= i < NR_ENTRIES ==>
                     (#[trigger] final(owner).children[i]).unwrap().value.parent_level
-                        == final(owner).value.node().unwrap().level
+                        == final(owner).value.node().level
                 &&& forall|i: int| 0 <= i < NR_ENTRIES ==>
                     (#[trigger] final(owner).children[i]).unwrap().value.match_pte(
-                        final(owner).value.node().unwrap().children_perm.value()[i],
+                        final(owner).value.node().children_perm.value()[i],
                         final(owner).children[i].unwrap().value.parent_level)
                 // slot_owners unchanged for all indices except the new PT node's index.
                 &&& forall|i: usize| i != frame_to_index(final(owner).value.meta_slot_paddr().unwrap()) ==>
@@ -638,7 +638,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 &&& *final(owner) == *old(owner)
             },
             forall |i: usize| old(guards).lock_held(i) ==> final(guards).lock_held(i),
-            forall |i: usize| old(guards).unlocked(i) && i != final(owner).value.node().unwrap().meta_addr_self() ==> final(guards).unlocked(i),
+            forall |i: usize| old(guards).unlocked(i) && i != final(owner).value.node().meta_addr_self() ==> final(guards).unlocked(i),
     )]
     pub(in crate::mm) fn alloc_if_none<A: InAtomicMode>(&mut self, guard: &'rcu A) -> (res: Option<
         PageTableGuard<'rcu, C>,
@@ -665,14 +665,14 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
 
             proof {
                 let pte = C::E::new_pt_spec(
-                    meta_to_frame(new_node_owner.value.node().unwrap().meta_addr_self()),
+                    meta_to_frame(new_node_owner.value.node().meta_addr_self()),
                 );
                 old(parent_owner).set_children_perm_axiom(self.idx, pte);
                 C::E::lemma_page_table_entry_properties();
                 assert(!pte.is_last_spec(level as PagingLevel));
             }
 
-            let ghost new_node_slot_idx = new_node_owner.value.node().unwrap().slot_index;
+            let ghost new_node_slot_idx = new_node_owner.value.node().slot_index;
             let tracked new_node_slot_perm = regions.slots.tracked_borrow(new_node_slot_idx);
             #[verus_spec(with Tracked(new_node_slot_perm))]
             let paddr = new_page.start_paddr();
@@ -802,11 +802,11 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             // (MMIO sub-pages keep `usage == MMIO` and `rc == UNUSED`.)
             old(owner).value.is_frame() && old(parent_owner).level > 1 ==>
                 forall |j: usize| #![trigger frame_to_index(
-                    (old(owner).value.frame().unwrap().mapped_pa
+                    (old(owner).value.frame().mapped_pa
                         + j * PAGE_SIZE) as usize)]
                     0 < j < page_size(old(parent_owner).level) / PAGE_SIZE ==> {
                     let sub_idx = frame_to_index(
-                        (old(owner).value.frame().unwrap().mapped_pa
+                        (old(owner).value.frame().mapped_pa
                             + j * PAGE_SIZE) as usize);
                     &&& old(regions).slots.contains_key(sub_idx)
                     &&& old(regions).slot_owners[sub_idx].usage
@@ -820,15 +820,15 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 &&& final(owner).value.is_node()
                 &&& final(owner).level == old(owner).level
                 &&& final(parent_owner).relate_guard(*final(self).node)
-                &&& final(owner).value.node().unwrap().relate_guard(res.unwrap())
-                &&& final(owner).value.node().unwrap().meta_addr_self() == res.unwrap().inner.inner@.ptr.addr()
+                &&& final(owner).value.node().relate_guard(res.unwrap())
+                &&& final(owner).value.node().meta_addr_self() == res.unwrap().inner.inner@.ptr.addr()
                 &&& final(guards).lock_held(res.unwrap().inner.inner@.ptr.addr())
                 // All children of the new node subtree are frames with the same prop (from the split loop).
                 &&& forall |j: int| 0 <= j < NR_ENTRIES ==>
                     (#[trigger] final(owner).children[j]).unwrap().value.is_frame()
                 &&& forall |j: int| 0 <= j < NR_ENTRIES ==>
-                    (#[trigger] final(owner).children[j]).unwrap().value.frame().unwrap().prop
-                        == old(owner).value.frame().unwrap().prop
+                    (#[trigger] final(owner).children[j]).unwrap().value.frame().prop
+                        == old(owner).value.frame().prop
                 &&& final(owner).value.path == old(owner).value.path
                 &&& final(owner).value.metaregion_sound(*final(regions))
                 &&& OwnerSubtree::implies(
@@ -860,16 +860,16 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             forall |i: usize| old(guards).unlocked(i) ==> final(guards).unlocked(i),
             // slot_owners unchanged for all indices except the new PT node's index.
             old(owner).value.is_frame() && old(parent_owner).level > 1 ==> {
-                &&& forall|i: usize| i != frame_to_index(meta_to_frame(final(owner).value.node().unwrap().meta_addr_self())) ==>
+                &&& forall|i: usize| i != frame_to_index(meta_to_frame(final(owner).value.node().meta_addr_self())) ==>
                     (#[trigger] final(regions).slot_owners[i]) == old(regions).slot_owners[i]
                 // slots keys preserved (alloc removes then borrow re-inserts).
                 &&& forall|i: usize| old(regions).slots.contains_key(i)
                     ==> (#[trigger] final(regions).slots.contains_key(i))
                 // The new PT node's ref_count is not UNUSED.
-                &&& final(regions).slot_owners[frame_to_index(meta_to_frame(final(owner).value.node().unwrap().meta_addr_self()))]
+                &&& final(regions).slot_owners[frame_to_index(meta_to_frame(final(owner).value.node().meta_addr_self()))]
                     .inner_perms.ref_count.value() != REF_COUNT_UNUSED
                 // The allocated slot had ref_count == UNUSED before allocation.
-                &&& old(regions).slot_owners[frame_to_index(meta_to_frame(final(owner).value.node().unwrap().meta_addr_self()))]
+                &&& old(regions).slot_owners[frame_to_index(meta_to_frame(final(owner).value.node().meta_addr_self()))]
                     .inner_perms.ref_count.value() == REF_COUNT_UNUSED
             },
             // Parent's other PTEs are preserved: only the entry at self.idx
@@ -908,7 +908,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         #[verus_spec(with Tracked(parent_owner), Tracked(regions), Tracked(guards), Ghost(self.idx) => Tracked(new_owner))]
         let new_page = PageTableNode::<C>::alloc(level - 1);
 
-        let ghost new_owner_slot_idx = new_owner.value.node().unwrap().slot_index;
+        let ghost new_owner_slot_idx = new_owner.value.node().slot_index;
         let tracked new_owner_slot_perm = regions.slots.tracked_borrow(new_owner_slot_idx);
         #[verus_spec(with Tracked(new_owner_slot_perm))]
         let paddr = new_page.start_paddr();
@@ -929,9 +929,9 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         #[verus_spec(with Tracked(&new_owner.value.tracked_borrow_node()), Tracked(guards))]
         let mut pt_lock_guard = pt_ref.lock(guard);
 
-        let ghost children_perm = new_owner.value.node().unwrap().children_perm;
+        let ghost children_perm = new_owner.value.node().children_perm;
         let ghost new_owner_path = new_owner.value.path;
-        let ghost new_owner_meta_addr = new_owner.value.node().unwrap().meta_addr_self();
+        let ghost new_owner_meta_addr = new_owner.value.node().meta_addr_self();
 
         for i in 0..nr_subpage_per_huge::<C>()
             invariant
@@ -939,9 +939,9 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 owner.inv(),
                 owner.value.is_frame(),
                 owner.value.parent_level == level,
-                owner.value.frame().unwrap().mapped_pa == pa,
-                owner.value.frame().unwrap().prop == prop,
-                pa == old(owner).value.frame().unwrap().mapped_pa,
+                owner.value.frame().mapped_pa == pa,
+                owner.value.frame().prop == prop,
+                pa == old(owner).value.frame().mapped_pa,
                 level == old(parent_owner).level,
                 pa % page_size(level) == 0,
                 pa + page_size(level) <= MAX_PADDR,
@@ -956,20 +956,20 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 new_owner.value.is_node(),
                 new_owner.inv(),
                 new_owner.value.path == new_owner_path,
-                new_owner.value.node().unwrap().meta_addr_self() == new_owner_meta_addr,
-                new_owner.value.node().unwrap().relate_guard(pt_lock_guard),
+                new_owner.value.node().meta_addr_self() == new_owner_meta_addr,
+                new_owner.value.node().relate_guard(pt_lock_guard),
                 guards.lock_held(new_owner_meta_addr),
-                new_owner.value.node().unwrap().level == (level - 1) as PagingLevel,
+                new_owner.value.node().level == (level - 1) as PagingLevel,
                 forall|j: int|
                     #![auto]
                     0 <= j < NR_ENTRIES ==> {
                         &&& new_owner.children[j] is Some
                         &&& new_owner.children[j].unwrap().value.match_pte(
-                            new_owner.value.node().unwrap().children_perm.value()[j],
-                            new_owner.value.node().unwrap().level,
+                            new_owner.value.node().children_perm.value()[j],
+                            new_owner.value.node().level,
                         )
                         &&& new_owner.children[j].unwrap().value.parent_level
-                            == new_owner.value.node().unwrap().level
+                            == new_owner.value.node().level
                         &&& new_owner.children[j].unwrap().value.inv()
                         &&& new_owner.children[j].unwrap().value.path == new_owner_path.push_tail(
                             j as usize,
@@ -980,7 +980,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                     i <= j < NR_ENTRIES ==> {
                         &&& new_owner.children[j].unwrap().value.is_absent()
                         &&& !new_owner.children[j].unwrap().value.in_scope
-                        &&& new_owner.value.node().unwrap().children_perm.value()[j]
+                        &&& new_owner.value.node().children_perm.value()[j]
                             == C::E::new_absent_spec()
                     },
                 // Children [0, i) have been replaced with frames.
@@ -1012,7 +1012,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                     &&& regions.slot_owners[frame_to_index(pa)].inner_perms.ref_count.value() > 0
                 },
                 new_page.ptr.addr() == new_owner_meta_addr,
-                new_owner.value.node().unwrap().metaregion_sound_node(*regions),
+                new_owner.value.node().metaregion_sound_node(*regions),
         {
             proof {
                 C::axiom_nr_subpage_per_huge_eq_nr_entries();
@@ -1021,7 +1021,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
 
             proof {
                 // Prove required facts while we still have new_owner.value.node available.
-                let ghost the_node = new_owner.value.node().unwrap();
+                let ghost the_node = new_owner.value.node();
                 assert(0 <= i < NR_ENTRIES);
                 assert(new_owner.children[i as int].unwrap().value.match_pte(
                     the_node.children_perm.value()[i as int],
@@ -1054,7 +1054,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 (level - 1) as PagingLevel,
                 prop,
                 /* is_tracked */
-                owner.value.frame().unwrap().is_tracked,
+                owner.value.frame().is_tracked,
             );
 
             proof {

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -237,15 +237,15 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             final(self).node_matching(*final(owner), *final(parent_owner), *final(self).node),
             final(self).parent_perms_preserved(*old(parent_owner), *final(parent_owner)),
             final(owner).is_frame(),
-            final(owner).frame.unwrap().mapped_pa == old(owner).frame.unwrap().mapped_pa,
-            final(owner).frame.unwrap().is_tracked == old(owner).frame.unwrap().is_tracked,
+            final(owner).frame().unwrap().mapped_pa == old(owner).frame().unwrap().mapped_pa,
+            final(owner).frame().unwrap().is_tracked == old(owner).frame().unwrap().is_tracked,
             final(owner).path == old(owner).path,
             final(owner).parent_level == old(owner).parent_level,
             final(owner).in_scope == old(owner).in_scope,
             final(self).idx == old(self).idx,
             old(self).pte.is_present() ==> op.ensures(
-                (old(owner).frame.unwrap().prop,),
-                final(owner).frame.unwrap().prop,
+                (old(owner).frame().unwrap().prop,),
+                final(owner).frame().unwrap().prop,
             ),
     {
         let ghost pte0 = self.pte;
@@ -274,9 +274,9 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         };
 
         proof {
-            let tracked mut frame_owner = owner.frame.tracked_take();
+            let tracked mut frame_owner = owner.tracked_take_frame();
             frame_owner.prop = new_prop;
-            owner.frame = Some(frame_owner);
+            owner.tracked_put_frame(frame_owner);
         }
         assert(owner.match_pte(self.pte, owner.parent_level));
     }
@@ -574,18 +574,18 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 &&& final(owner).value.is_node()
                 &&& final(owner).level == old(owner).level
                 &&& final(owner).value.parent_level == old(owner).value.parent_level
-                &&& final(guards).lock_held(final(owner).value.node.unwrap().meta_addr_self())
-                &&& final(owner).value.node.unwrap().relate_guard(res.unwrap())
+                &&& final(guards).lock_held(final(owner).value.node().unwrap().meta_addr_self())
+                &&& final(owner).value.node().unwrap().relate_guard(res.unwrap())
                 &&& final(owner).value.path == old(owner).value.path
                 &&& final(owner).value.metaregion_sound(*final(regions))
                 &&& OwnerSubtree::implies(
                     CursorOwner::<'rcu, C>::node_unlocked(*old(guards)),
-                    CursorOwner::<'rcu, C>::node_unlocked_except(*final(guards), final(owner).value.node.unwrap().meta_addr_self()))
+                    CursorOwner::<'rcu, C>::node_unlocked_except(*final(guards), final(owner).value.node().unwrap().meta_addr_self()))
                 &&& Self::metaregion_sound_neq_preserved(old(owner).value, final(owner).value, *old(regions), *final(regions))
                 &&& Self::path_tracked_pred_preserved(*old(regions), *final(regions))
                 &&& old(regions).slots.contains_key(frame_to_index(final(owner).value.meta_slot_paddr().unwrap()))
                 &&& final(owner).tree_predicate_map(final(owner).value.path,
-                    CursorOwner::<'rcu, C>::node_unlocked_except(*final(guards), final(owner).value.node.unwrap().meta_addr_self()))
+                    CursorOwner::<'rcu, C>::node_unlocked_except(*final(guards), final(owner).value.node().unwrap().meta_addr_self()))
                 &&& final(owner).tree_predicate_map(final(owner).value.path, PageTableOwner::<C>::metaregion_sound_pred(*final(regions)))
                 &&& final(owner).tree_predicate_map(final(owner).value.path, PageTableOwner::<C>::path_tracked_pred(*final(regions)))
                 &&& PageTableOwner(*final(owner)).view_rec(final(owner).value.path) == set![]
@@ -608,10 +608,10 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 // Other child fields preserved from `allocated_empty_node_owner`.
                 &&& forall|i: int| 0 <= i < NR_ENTRIES ==>
                     (#[trigger] final(owner).children[i]).unwrap().value.parent_level
-                        == final(owner).value.node.unwrap().level
+                        == final(owner).value.node().unwrap().level
                 &&& forall|i: int| 0 <= i < NR_ENTRIES ==>
                     (#[trigger] final(owner).children[i]).unwrap().value.match_pte(
-                        final(owner).value.node.unwrap().children_perm.value()[i],
+                        final(owner).value.node().unwrap().children_perm.value()[i],
                         final(owner).children[i].unwrap().value.parent_level)
                 // slot_owners unchanged for all indices except the new PT node's index.
                 &&& forall|i: usize| i != frame_to_index(final(owner).value.meta_slot_paddr().unwrap()) ==>
@@ -638,7 +638,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 &&& *final(owner) == *old(owner)
             },
             forall |i: usize| old(guards).lock_held(i) ==> final(guards).lock_held(i),
-            forall |i: usize| old(guards).unlocked(i) && i != final(owner).value.node.unwrap().meta_addr_self() ==> final(guards).unlocked(i),
+            forall |i: usize| old(guards).unlocked(i) && i != final(owner).value.node().unwrap().meta_addr_self() ==> final(guards).unlocked(i),
     )]
     pub(in crate::mm) fn alloc_if_none<A: InAtomicMode>(&mut self, guard: &'rcu A) -> (res: Option<
         PageTableGuard<'rcu, C>,
@@ -665,14 +665,14 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
 
             proof {
                 let pte = C::E::new_pt_spec(
-                    meta_to_frame(new_node_owner.value.node.unwrap().meta_addr_self()),
+                    meta_to_frame(new_node_owner.value.node().unwrap().meta_addr_self()),
                 );
                 old(parent_owner).set_children_perm_axiom(self.idx, pte);
                 C::E::lemma_page_table_entry_properties();
                 assert(!pte.is_last_spec(level as PagingLevel));
             }
 
-            let ghost new_node_slot_idx = new_node_owner.value.node.unwrap().slot_index;
+            let ghost new_node_slot_idx = new_node_owner.value.node().unwrap().slot_index;
             let tracked new_node_slot_perm = regions.slots.tracked_borrow(new_node_slot_idx);
             #[verus_spec(with Tracked(new_node_slot_perm))]
             let paddr = new_page.start_paddr();
@@ -708,7 +708,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             };
 
             // Lock before writing the PTE, so no one else can operate on it.
-            #[verus_spec(with Tracked(&new_node_owner.value.node.tracked_borrow()), Tracked(guards))]
+            #[verus_spec(with Tracked(&new_node_owner.value.tracked_borrow_node()), Tracked(guards))]
             let mut pt_lock_guard = pt_ref.lock(guard);
 
             proof {
@@ -802,11 +802,11 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             // (MMIO sub-pages keep `usage == MMIO` and `rc == UNUSED`.)
             old(owner).value.is_frame() && old(parent_owner).level > 1 ==>
                 forall |j: usize| #![trigger frame_to_index(
-                    (old(owner).value.frame.unwrap().mapped_pa
+                    (old(owner).value.frame().unwrap().mapped_pa
                         + j * PAGE_SIZE) as usize)]
                     0 < j < page_size(old(parent_owner).level) / PAGE_SIZE ==> {
                     let sub_idx = frame_to_index(
-                        (old(owner).value.frame.unwrap().mapped_pa
+                        (old(owner).value.frame().unwrap().mapped_pa
                             + j * PAGE_SIZE) as usize);
                     &&& old(regions).slots.contains_key(sub_idx)
                     &&& old(regions).slot_owners[sub_idx].usage
@@ -820,15 +820,15 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 &&& final(owner).value.is_node()
                 &&& final(owner).level == old(owner).level
                 &&& final(parent_owner).relate_guard(*final(self).node)
-                &&& final(owner).value.node.unwrap().relate_guard(res.unwrap())
-                &&& final(owner).value.node.unwrap().meta_addr_self() == res.unwrap().inner.inner@.ptr.addr()
+                &&& final(owner).value.node().unwrap().relate_guard(res.unwrap())
+                &&& final(owner).value.node().unwrap().meta_addr_self() == res.unwrap().inner.inner@.ptr.addr()
                 &&& final(guards).lock_held(res.unwrap().inner.inner@.ptr.addr())
                 // All children of the new node subtree are frames with the same prop (from the split loop).
                 &&& forall |j: int| 0 <= j < NR_ENTRIES ==>
                     (#[trigger] final(owner).children[j]).unwrap().value.is_frame()
                 &&& forall |j: int| 0 <= j < NR_ENTRIES ==>
-                    (#[trigger] final(owner).children[j]).unwrap().value.frame.unwrap().prop
-                        == old(owner).value.frame.unwrap().prop
+                    (#[trigger] final(owner).children[j]).unwrap().value.frame().unwrap().prop
+                        == old(owner).value.frame().unwrap().prop
                 &&& final(owner).value.path == old(owner).value.path
                 &&& final(owner).value.metaregion_sound(*final(regions))
                 &&& OwnerSubtree::implies(
@@ -860,16 +860,16 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             forall |i: usize| old(guards).unlocked(i) ==> final(guards).unlocked(i),
             // slot_owners unchanged for all indices except the new PT node's index.
             old(owner).value.is_frame() && old(parent_owner).level > 1 ==> {
-                &&& forall|i: usize| i != frame_to_index(meta_to_frame(final(owner).value.node.unwrap().meta_addr_self())) ==>
+                &&& forall|i: usize| i != frame_to_index(meta_to_frame(final(owner).value.node().unwrap().meta_addr_self())) ==>
                     (#[trigger] final(regions).slot_owners[i]) == old(regions).slot_owners[i]
                 // slots keys preserved (alloc removes then borrow re-inserts).
                 &&& forall|i: usize| old(regions).slots.contains_key(i)
                     ==> (#[trigger] final(regions).slots.contains_key(i))
                 // The new PT node's ref_count is not UNUSED.
-                &&& final(regions).slot_owners[frame_to_index(meta_to_frame(final(owner).value.node.unwrap().meta_addr_self()))]
+                &&& final(regions).slot_owners[frame_to_index(meta_to_frame(final(owner).value.node().unwrap().meta_addr_self()))]
                     .inner_perms.ref_count.value() != REF_COUNT_UNUSED
                 // The allocated slot had ref_count == UNUSED before allocation.
-                &&& old(regions).slot_owners[frame_to_index(meta_to_frame(final(owner).value.node.unwrap().meta_addr_self()))]
+                &&& old(regions).slot_owners[frame_to_index(meta_to_frame(final(owner).value.node().unwrap().meta_addr_self()))]
                     .inner_perms.ref_count.value() == REF_COUNT_UNUSED
             },
             // Parent's other PTEs are preserved: only the entry at self.idx
@@ -908,7 +908,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         #[verus_spec(with Tracked(parent_owner), Tracked(regions), Tracked(guards), Ghost(self.idx) => Tracked(new_owner))]
         let new_page = PageTableNode::<C>::alloc(level - 1);
 
-        let ghost new_owner_slot_idx = new_owner.value.node.unwrap().slot_index;
+        let ghost new_owner_slot_idx = new_owner.value.node().unwrap().slot_index;
         let tracked new_owner_slot_perm = regions.slots.tracked_borrow(new_owner_slot_idx);
         #[verus_spec(with Tracked(new_owner_slot_perm))]
         let paddr = new_page.start_paddr();
@@ -926,12 +926,12 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         };
 
         // Lock before writing the PTE, so no one else can operate on it.
-        #[verus_spec(with Tracked(&new_owner.value.node.tracked_borrow()), Tracked(guards))]
+        #[verus_spec(with Tracked(&new_owner.value.tracked_borrow_node()), Tracked(guards))]
         let mut pt_lock_guard = pt_ref.lock(guard);
 
-        let ghost children_perm = new_owner.value.node.unwrap().children_perm;
+        let ghost children_perm = new_owner.value.node().unwrap().children_perm;
         let ghost new_owner_path = new_owner.value.path;
-        let ghost new_owner_meta_addr = new_owner.value.node.unwrap().meta_addr_self();
+        let ghost new_owner_meta_addr = new_owner.value.node().unwrap().meta_addr_self();
 
         for i in 0..nr_subpage_per_huge::<C>()
             invariant
@@ -939,9 +939,9 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 owner.inv(),
                 owner.value.is_frame(),
                 owner.value.parent_level == level,
-                owner.value.frame.unwrap().mapped_pa == pa,
-                owner.value.frame.unwrap().prop == prop,
-                pa == old(owner).value.frame.unwrap().mapped_pa,
+                owner.value.frame().unwrap().mapped_pa == pa,
+                owner.value.frame().unwrap().prop == prop,
+                pa == old(owner).value.frame().unwrap().mapped_pa,
                 level == old(parent_owner).level,
                 pa % page_size(level) == 0,
                 pa + page_size(level) <= MAX_PADDR,
@@ -956,20 +956,20 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 new_owner.value.is_node(),
                 new_owner.inv(),
                 new_owner.value.path == new_owner_path,
-                new_owner.value.node.unwrap().meta_addr_self() == new_owner_meta_addr,
-                new_owner.value.node.unwrap().relate_guard(pt_lock_guard),
+                new_owner.value.node().unwrap().meta_addr_self() == new_owner_meta_addr,
+                new_owner.value.node().unwrap().relate_guard(pt_lock_guard),
                 guards.lock_held(new_owner_meta_addr),
-                new_owner.value.node.unwrap().level == (level - 1) as PagingLevel,
+                new_owner.value.node().unwrap().level == (level - 1) as PagingLevel,
                 forall|j: int|
                     #![auto]
                     0 <= j < NR_ENTRIES ==> {
                         &&& new_owner.children[j] is Some
                         &&& new_owner.children[j].unwrap().value.match_pte(
-                            new_owner.value.node.unwrap().children_perm.value()[j],
-                            new_owner.value.node.unwrap().level,
+                            new_owner.value.node().unwrap().children_perm.value()[j],
+                            new_owner.value.node().unwrap().level,
                         )
                         &&& new_owner.children[j].unwrap().value.parent_level
-                            == new_owner.value.node.unwrap().level
+                            == new_owner.value.node().unwrap().level
                         &&& new_owner.children[j].unwrap().value.inv()
                         &&& new_owner.children[j].unwrap().value.path == new_owner_path.push_tail(
                             j as usize,
@@ -980,7 +980,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                     i <= j < NR_ENTRIES ==> {
                         &&& new_owner.children[j].unwrap().value.is_absent()
                         &&& !new_owner.children[j].unwrap().value.in_scope
-                        &&& new_owner.value.node.unwrap().children_perm.value()[j]
+                        &&& new_owner.value.node().unwrap().children_perm.value()[j]
                             == C::E::new_absent_spec()
                     },
                 // Children [0, i) have been replaced with frames.
@@ -1012,7 +1012,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                     &&& regions.slot_owners[frame_to_index(pa)].inner_perms.ref_count.value() > 0
                 },
                 new_page.ptr.addr() == new_owner_meta_addr,
-                new_owner.value.node.unwrap().metaregion_sound_node(*regions),
+                new_owner.value.node().unwrap().metaregion_sound_node(*regions),
         {
             proof {
                 C::axiom_nr_subpage_per_huge_eq_nr_entries();
@@ -1021,7 +1021,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
 
             proof {
                 // Prove required facts while we still have new_owner.value.node available.
-                let ghost the_node = new_owner.value.node.unwrap();
+                let ghost the_node = new_owner.value.node().unwrap();
                 assert(0 <= i < NR_ENTRIES);
                 assert(new_owner.children[i as int].unwrap().value.match_pte(
                     the_node.children_perm.value()[i as int],
@@ -1034,7 +1034,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 OwnerSubtree::child_some_properties(new_owner, i as usize);
             }
 
-            let tracked mut new_owner_node = new_owner.value.node.tracked_take();
+            let tracked mut new_owner_node = new_owner.value.tracked_take_node();
 
             proof {
                 let ghost old_children_perm = new_owner_node.children_perm;
@@ -1054,7 +1054,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 (level - 1) as PagingLevel,
                 prop,
                 /* is_tracked */
-                owner.value.frame.unwrap().is_tracked,
+                owner.value.frame().unwrap().is_tracked,
             );
 
             proof {
@@ -1241,7 +1241,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             let old = entry.replace(Child::Frame(small_pa, level - 1, prop));
 
             proof {
-                new_owner.value.node = Some(new_owner_node);
+                new_owner.value.tracked_put_node(new_owner_node);
                 new_owner_child.value.in_scope = false;
                 child_owner.in_scope = false;
                 OwnerSubtree::set_value_property(new_owner_child, child_owner);
@@ -1271,7 +1271,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             *owner = new_owner;
         }
 
-        let tracked mut node_owner = owner.value.node.tracked_take();
+        let tracked mut node_owner = owner.value.tracked_take_node();
 
         // SAFETY:
         //  1. The index is within the bounds.
@@ -1283,7 +1283,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         };
 
         proof {
-            owner.value.node = Some(node_owner);
+            owner.value.tracked_put_node(node_owner);
         }
 
         Some(pt_lock_guard)
@@ -1341,3 +1341,5 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
 }
 
 } // verus!
+
+

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -1032,13 +1032,6 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 assert(!new_owner.children[i as int].unwrap().value.in_scope);
 
                 OwnerSubtree::child_some_properties(new_owner, i as usize);
-            }
-
-            proof {
-                let ghost old_children_perm = new_owner.value.node();
-            }
-
-            proof {
                 EntryOwner::huge_frame_split_child_at(owner.value, *regions, i as usize);
             }
 

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -1034,10 +1034,8 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 OwnerSubtree::child_some_properties(new_owner, i as usize);
             }
 
-            let tracked mut new_owner_node = new_owner.value.tracked_take_node();
-
             proof {
-                let ghost old_children_perm = new_owner_node.children_perm;
+                let ghost old_children_perm = new_owner.value.node();
             }
 
             proof {
@@ -1058,9 +1056,9 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             );
 
             proof {
-                assert(regions.slots.contains_key(new_owner_node.slot_index));
+                assert(regions.slots.contains_key(new_owner.value.node().slot_index));
             }
-            #[verus_spec(with Tracked(&new_owner_node), Tracked(&new_owner.children.tracked_borrow(i as int).tracked_borrow().value), Tracked(&*regions))]
+            #[verus_spec(with Tracked(new_owner.value.tracked_borrow_node()), Tracked(&new_owner.children.tracked_borrow(i as int).tracked_borrow().value), Tracked(&*regions))]
             let mut entry = pt_lock_guard.entry(i);
 
             proof {
@@ -1073,6 +1071,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             ).tracked_unwrap();
 
             proof {
+                let ghost new_owner_node = new_owner.value.node();
                 assert(new_owner_child.value.match_pte(
                     new_owner_node.children_perm.value()[i as int],
                     new_owner_child.value.parent_level,
@@ -1232,16 +1231,15 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             }
 
             proof {
-                assert(new_owner_node.metaregion_sound_node(*regions));
+                //assert(new_owner_node.metaregion_sound_node(*regions));
             }
             #[verus_spec(with Tracked(regions),
                 Tracked(&mut new_owner_child.value),
                 Tracked(&mut child_owner),
-                Tracked(&mut new_owner_node))]
+                Tracked(new_owner.value.tracked_borrow_mut_node()))]
             let old = entry.replace(Child::Frame(small_pa, level - 1, prop));
 
             proof {
-                new_owner.value.tracked_put_node(new_owner_node);
                 new_owner_child.value.in_scope = false;
                 child_owner.in_scope = false;
                 OwnerSubtree::set_value_property(new_owner_child, child_owner);
@@ -1271,20 +1269,14 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             *owner = new_owner;
         }
 
-        let tracked mut node_owner = owner.value.tracked_take_node();
-
         // SAFETY:
         //  1. The index is within the bounds.
         //  2. The new PTE is a child in `C` and at the correct paging level.
         //  3. The ownership of the child is passed to the page table node.
         unsafe {
-            #[verus_spec(with Tracked(&mut node_owner), Tracked(&*regions))]
+            #[verus_spec(with Tracked(owner.value.tracked_borrow_mut_node()), Tracked(&*regions))]
             self.node.write_pte(self.idx, self.pte)
         };
-
-        proof {
-            owner.value.tracked_put_node(node_owner);
-        }
 
         Some(pt_lock_guard)
     }

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -1341,5 +1341,3 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
 }
 
 } // verus!
-
-

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -515,25 +515,25 @@ impl<C: PageTableConfig> PageTableNode<C> {
             final(parent_owner).inv(),
             allocated_empty_node_owner(owner@, level),
             allocated_empty_node_grandchildren_none(owner@),
-            res.ptr.addr() == owner@.value.node.unwrap().meta_addr_self(),
-            guards.unlocked(owner@.value.node.unwrap().meta_addr_self()),
-            MetaSlot::get_from_unused_spec(meta_to_frame(owner@.value.node.unwrap().meta_addr_self()), false, *old(regions), *final(regions)),
-            MetaSlot::slot_perm_reparked_spec(meta_to_frame(owner@.value.node.unwrap().meta_addr_self()), *old(regions), *final(regions)),
+            res.ptr.addr() == owner@.value.node().unwrap().meta_addr_self(),
+            guards.unlocked(owner@.value.node().unwrap().meta_addr_self()),
+            MetaSlot::get_from_unused_spec(meta_to_frame(owner@.value.node().unwrap().meta_addr_self()), false, *old(regions), *final(regions)),
+            MetaSlot::slot_perm_reparked_spec(meta_to_frame(owner@.value.node().unwrap().meta_addr_self()), *old(regions), *final(regions)),
 
             final(regions).frame_obligations == old(regions).frame_obligations.insert(
-                frame_to_index(meta_to_frame(owner@.value.node.unwrap().meta_addr_self()))),
-            old(regions).slots.contains_key(frame_to_index(meta_to_frame(owner@.value.node.unwrap().meta_addr_self()))),
+                frame_to_index(meta_to_frame(owner@.value.node().unwrap().meta_addr_self()))),
+            old(regions).slots.contains_key(frame_to_index(meta_to_frame(owner@.value.node().unwrap().meta_addr_self()))),
 
             !crate::specs::mm::frame::meta_owners::is_mmio_paddr(
-                meta_to_frame(owner@.value.node.unwrap().meta_addr_self())),
+                meta_to_frame(owner@.value.node().unwrap().meta_addr_self())),
             owner@.value.metaregion_sound(*final(regions)),
             forall|i: usize|
                 #[trigger] old(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-                ==> i != frame_to_index(meta_to_frame(owner@.value.node.unwrap().meta_addr_self())),
-            owner@.value.match_pte(C::E::new_pt_spec(meta_to_frame(owner@.value.node.unwrap().meta_addr_self())), level as PagingLevel),
-            *final(parent_owner) == old(parent_owner).set_children_perm(idx, C::E::new_pt_spec(meta_to_frame(owner@.value.node.unwrap().meta_addr_self()))),
-            final(regions).slots.contains_key(owner@.value.node.unwrap().slot_index),
-            owner@.value.node.unwrap().metaregion_sound_node(*final(regions)),
+                ==> i != frame_to_index(meta_to_frame(owner@.value.node().unwrap().meta_addr_self())),
+            owner@.value.match_pte(C::E::new_pt_spec(meta_to_frame(owner@.value.node().unwrap().meta_addr_self())), level as PagingLevel),
+            *final(parent_owner) == old(parent_owner).set_children_perm(idx, C::E::new_pt_spec(meta_to_frame(owner@.value.node().unwrap().meta_addr_self()))),
+            final(regions).slots.contains_key(owner@.value.node().unwrap().slot_index),
+            owner@.value.node().unwrap().metaregion_sound_node(*final(regions)),
     )]
     #[verifier::external_body]
     pub fn alloc<'rcu>(level: PagingLevel) -> Self {
@@ -1065,3 +1065,4 @@ impl<C: PageTableConfig> PageTablePageMeta<C> {
 }
 
 } // verus!
+

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -1065,4 +1065,3 @@ impl<C: PageTableConfig> PageTablePageMeta<C> {
 }
 
 } // verus!
-

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -515,25 +515,25 @@ impl<C: PageTableConfig> PageTableNode<C> {
             final(parent_owner).inv(),
             allocated_empty_node_owner(owner@, level),
             allocated_empty_node_grandchildren_none(owner@),
-            res.ptr.addr() == owner@.value.node().unwrap().meta_addr_self(),
-            guards.unlocked(owner@.value.node().unwrap().meta_addr_self()),
-            MetaSlot::get_from_unused_spec(meta_to_frame(owner@.value.node().unwrap().meta_addr_self()), false, *old(regions), *final(regions)),
-            MetaSlot::slot_perm_reparked_spec(meta_to_frame(owner@.value.node().unwrap().meta_addr_self()), *old(regions), *final(regions)),
+            res.ptr.addr() == owner@.value.node().meta_addr_self(),
+            guards.unlocked(owner@.value.node().meta_addr_self()),
+            MetaSlot::get_from_unused_spec(meta_to_frame(owner@.value.node().meta_addr_self()), false, *old(regions), *final(regions)),
+            MetaSlot::slot_perm_reparked_spec(meta_to_frame(owner@.value.node().meta_addr_self()), *old(regions), *final(regions)),
 
             final(regions).frame_obligations == old(regions).frame_obligations.insert(
-                frame_to_index(meta_to_frame(owner@.value.node().unwrap().meta_addr_self()))),
-            old(regions).slots.contains_key(frame_to_index(meta_to_frame(owner@.value.node().unwrap().meta_addr_self()))),
+                frame_to_index(meta_to_frame(owner@.value.node().meta_addr_self()))),
+            old(regions).slots.contains_key(frame_to_index(meta_to_frame(owner@.value.node().meta_addr_self()))),
 
             !crate::specs::mm::frame::meta_owners::is_mmio_paddr(
-                meta_to_frame(owner@.value.node().unwrap().meta_addr_self())),
+                meta_to_frame(owner@.value.node().meta_addr_self())),
             owner@.value.metaregion_sound(*final(regions)),
             forall|i: usize|
                 #[trigger] old(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-                ==> i != frame_to_index(meta_to_frame(owner@.value.node().unwrap().meta_addr_self())),
-            owner@.value.match_pte(C::E::new_pt_spec(meta_to_frame(owner@.value.node().unwrap().meta_addr_self())), level as PagingLevel),
-            *final(parent_owner) == old(parent_owner).set_children_perm(idx, C::E::new_pt_spec(meta_to_frame(owner@.value.node().unwrap().meta_addr_self()))),
-            final(regions).slots.contains_key(owner@.value.node().unwrap().slot_index),
-            owner@.value.node().unwrap().metaregion_sound_node(*final(regions)),
+                ==> i != frame_to_index(meta_to_frame(owner@.value.node().meta_addr_self())),
+            owner@.value.match_pte(C::E::new_pt_spec(meta_to_frame(owner@.value.node().meta_addr_self())), level as PagingLevel),
+            *final(parent_owner) == old(parent_owner).set_children_perm(idx, C::E::new_pt_spec(meta_to_frame(owner@.value.node().meta_addr_self()))),
+            final(regions).slots.contains_key(owner@.value.node().slot_index),
+            owner@.value.node().metaregion_sound_node(*final(regions)),
     )]
     #[verifier::external_body]
     pub fn alloc<'rcu>(level: PagingLevel) -> Self {


### PR DESCRIPTION
An enum naturally distinguishes the kind of `EntryOwner`, which is easier to understand than four ghost fields whose exclusiveness is imposed by the invariant.