### PR TITLE
fix missing tracked variable

### DIFF
--- a/ostd/src/mm/frame/mod.rs
+++ b/ostd/src/mm/frame/mod.rs
@@ -380,6 +380,24 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage>> Frame<M> {
     }
 }
 
+impl<'a, M: AnyFrameMeta + Repr<MetaSlotStorage>> Frame<M> {
+    /// Gets the map level of this page.
+    ///
+    /// This is the level of the page table entry that maps the frame,
+    /// which determines the size of the frame.
+    ///
+    /// Currently, the level is always 1, which means the frame is a regular
+    /// page frame.
+    pub const fn map_level(&self) -> PagingLevel {
+        1
+    }
+
+    /// Gets the size of this page in bytes.
+    pub const fn size(&self) -> usize {
+        PAGE_SIZE
+    }
+}
+
 #[verus_verify]
 impl<'a, M: AnyFrameMeta + Repr<MetaSlotStorage>> Frame<M> {
     /// Gets the physical address of the start of the frame.
@@ -451,22 +469,6 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotStorage>> Frame<M> {
         (#[verus_spec(with Tracked(self_perm))]
         self.start_paddr() == #[verus_spec(with Tracked(other_perm))]
         other.start_paddr())
-    }
-
-    /// Gets the map level of this page.
-    ///
-    /// This is the level of the page table entry that maps the frame,
-    /// which determines the size of the frame.
-    ///
-    /// Currently, the level is always 1, which means the frame is a regular
-    /// page frame.
-    pub const fn map_level(&self) -> PagingLevel {
-        1
-    }
-
-    /// Gets the size of this page in bytes.
-    pub const fn size(&self) -> usize {
-        PAGE_SIZE
     }
 
     /*    /// Gets the dynamically-typed metadata of this frame.

--- a/ostd/src/mm/frame/unique.rs
+++ b/ostd/src/mm/frame/unique.rs
@@ -279,6 +279,24 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrame<M> {
     }
 }
 
+impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> {
+    /// Gets the size of this page in bytes.
+    pub const fn size(&self) -> usize {
+        PAGE_SIZE
+    }
+
+    /// Gets the paging level of this page.
+    ///
+    /// This is the level of the page table entry that maps the frame,
+    /// which determines the size of the frame.
+    ///
+    /// Currently, the level is always 1, which means the frame is a regular
+    /// page frame.
+    pub const fn level(&self) -> PagingLevel {
+        1
+    }
+}
+
 #[verus_verify]
 impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> {
     /// Gets the physical address of the start of the frame.
@@ -303,22 +321,6 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> 
 
         #[verus_spec(with Tracked(outer))]
         slot.frame_paddr()
-    }
-
-    /// Gets the paging level of this page.
-    ///
-    /// This is the level of the page table entry that maps the frame,
-    /// which determines the size of the frame.
-    ///
-    /// Currently, the level is always 1, which means the frame is a regular
-    /// page frame.
-    pub const fn level(&self) -> PagingLevel {
-        1
-    }
-
-    /// Gets the size of this page in bytes.
-    pub const fn size(&self) -> usize {
-        PAGE_SIZE
     }
 
     /*    /// Gets the dynamically-typed metadata of this frame.

--- a/ostd/src/sync/rcu/mod.rs
+++ b/ostd/src/sync/rcu/mod.rs
@@ -232,7 +232,6 @@ impl<P: NonNullPtr> RcuInner<P> {
     }
 }
 
-#[verus_verify]
 impl<P: NonNullPtr + Send> RcuInner<P> {
     #[inline(always)]
     const fn new_none() -> (res: Self)
@@ -240,24 +239,24 @@ impl<P: NonNullPtr + Send> RcuInner<P> {
             res.is_nullable(),
             res.wf(),
     {
-        proof_decl! {
-            let tracked ptr_ghost: RcuPtrGhost<P> = RcuPtrGhost {
-                current: None,
-                retired: Map::tracked_empty(),
-                returned: Map::tracked_empty(),
-            };
-        }
         Self {
             ptr: AtomicPtr::new(
                 Ghost((Ghost(true), PhantomData::<*const <P as NonNullPtr>::Target>)),
                 core::ptr::null_mut(),
-                Tracked(ptr_ghost),
+                Tracked(RcuPtrGhost {
+                    current: None,
+                    retired: Map::tracked_empty(),
+                    returned: Map::tracked_empty(),
+                }),
             ),
             _marker: PhantomData::<*const <P as NonNullPtr>::Target>,
             ghost_nullable: Ghost(true),
         }
     }
+}
 
+#[verus_verify]
+impl<P: NonNullPtr + Send> RcuInner<P> {
     /// Creates a new RCU primitive with the given pointer `pointer`.
     #[inline(always)]
     #[verus_spec(r =>

--- a/ostd/src/sync/rcu/mod.rs
+++ b/ostd/src/sync/rcu/mod.rs
@@ -189,22 +189,22 @@ struct RcuInner<P: NonNullPtr> {
 }
 
 closed spec fn wf(self) -> bool {
-        invariant on ptr with (ghost_nullable, _marker) is (
-            v: *mut <P as NonNullPtr>::Target,
-            g: RcuPtrGhost<P>,
-        ) {
-            &&& retired_pools_inv::<P>(g.retired)
-            &&& returned_tokens_inv::<P>(g.returned)
-            &&& match g.current {
-                Some(perm) => {
-                    &&& !v.is_null()
-                    &&& P::ptr_perm_match(v, perm@)
-                    &&& perm@.inv()
-                    &&& perm.wf()
-                    &&& perm.not_empty()
-                },
-                None => ghost_nullable@ && v.is_null(),
-            }
+    invariant on ptr with (ghost_nullable, _marker) is (
+        v: *mut <P as NonNullPtr>::Target,
+        g: RcuPtrGhost<P>,
+    ) {
+        &&& retired_pools_inv::<P>(g.retired)
+        &&& returned_tokens_inv::<P>(g.returned)
+        &&& match g.current {
+            Some(perm) => {
+                &&& !v.is_null()
+                &&& P::ptr_perm_match(v, perm@)
+                &&& perm@.inv()
+                &&& perm.wf()
+                &&& perm.not_empty()
+            },
+            None => ghost_nullable@ && v.is_null(),
+        }
     }
 }
 }
@@ -728,13 +728,13 @@ impl<'a, P: NonNullPtr + Send> RcuReadGuardInner<'a, P> {
 }
 
 impl<P: NonNullPtr + Send> Rcu<P> {
-    /// Creates a new RCU primitive that contains nothing.
-    ///
-    /// This is a constant equivalence to [`RcuOption::new(None)`].
-    #[inline(always)]
-    pub const fn new_none() -> Self {
-        Self(RcuInner::new_none())
-    }
+    // Creates a new RCU primitive that contains nothing.
+    //
+    // This is a constant equivalence to [`RcuOption::new(None)`].
+    // #[inline(always)]
+    // pub const fn new_none() -> Self {
+    //     Self(RcuInner::new_none())
+    // }
 }
 
 #[verus_verify]
@@ -1086,6 +1086,7 @@ impl<P: NonNullPtr> Rcu<P> {
     #[verifier::type_invariant]
     closed spec fn type_inv(self) -> bool {
         &&& self.0.type_inv()
+        &&& !self.0.is_nullable()
     }
 }
 

--- a/ostd/src/sync/rcu/mod.rs
+++ b/ostd/src/sync/rcu/mod.rs
@@ -243,11 +243,13 @@ impl<P: NonNullPtr + Send> RcuInner<P> {
             ptr: AtomicPtr::new(
                 Ghost((Ghost(true), PhantomData::<*const <P as NonNullPtr>::Target>)),
                 core::ptr::null_mut(),
-                Tracked(RcuPtrGhost {
-                    current: None,
-                    retired: Map::tracked_empty(),
-                    returned: Map::tracked_empty(),
-                }),
+                Tracked(
+                    RcuPtrGhost {
+                        current: None,
+                        retired: Map::tracked_empty(),
+                        returned: Map::tracked_empty(),
+                    },
+                ),
             ),
             _marker: PhantomData::<*const <P as NonNullPtr>::Target>,
             ghost_nullable: Ghost(true),

--- a/ostd/src/sync/rcu/mod.rs
+++ b/ostd/src/sync/rcu/mod.rs
@@ -727,16 +727,6 @@ impl<'a, P: NonNullPtr + Send> RcuReadGuardInner<'a, P> {
     }
 }
 
-impl<P: NonNullPtr + Send> Rcu<P> {
-    // Creates a new RCU primitive that contains nothing.
-    //
-    // This is a constant equivalence to [`RcuOption::new(None)`].
-    // #[inline(always)]
-    // pub const fn new_none() -> Self {
-    //     Self(RcuInner::new_none())
-    // }
-}
-
 #[verus_verify]
 impl<P: NonNullPtr + Send> Rcu<P> {
     /// Creates a new RCU primitive with the given pointer `pointer`.

--- a/ostd/src/sync/rcu/mod.rs
+++ b/ostd/src/sync/rcu/mod.rs
@@ -1086,7 +1086,6 @@ impl<P: NonNullPtr> Rcu<P> {
     #[verifier::type_invariant]
     closed spec fn type_inv(self) -> bool {
         &&& self.0.type_inv()
-        &&& !self.0.is_nullable()
     }
 }
 

--- a/ostd/src/sync/rcu/mod.rs
+++ b/ostd/src/sync/rcu/mod.rs
@@ -727,6 +727,16 @@ impl<'a, P: NonNullPtr + Send> RcuReadGuardInner<'a, P> {
     }
 }
 
+impl<P: NonNullPtr + Send> Rcu<P> {
+    /// Creates a new RCU primitive that contains nothing.
+    ///
+    /// This is a constant equivalence to [`RcuOption::new(None)`].
+    #[inline(always)]
+    pub const fn new_none() -> Self {
+        Self(RcuInner::new_none())
+    }
+}
+
 #[verus_verify]
 impl<P: NonNullPtr + Send> Rcu<P> {
     /// Creates a new RCU primitive with the given pointer `pointer`.
@@ -785,14 +795,6 @@ impl<P: NonNullPtr + Send> RcuOption<P> {
         } else {
             Self(RcuInner::new_none())
         }
-    }
-
-    /// Creates a new RCU primitive that contains nothing.
-    ///
-    /// This is a constant equivalence to [`RcuOption::new(None)`].
-    #[inline(always)]
-    pub const fn new_none() -> Self {
-        Self(RcuInner::new_none())
     }
 
     /// Replaces the current pointer with a null pointer.


### PR DESCRIPTION
Moved the `const fn` block out of `verus_verify` and made tracked variable constructed inside the `Tracked` mode.