### PR TITLE
refactor: `CursorOwner::view_mappings` and `CursorContinuation::view_mappings`

### DIFF
--- a/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
@@ -219,7 +219,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         ensures
             self.view_mappings() == owner0.view_mappings(),
     {
-        broadcast use CursorContinuation::lemma_view_mappings_contains; 
+        broadcast use CursorContinuation::group_lemmas;
+
         let L = self.level as int;
         let cont = self.continuations[L - 1];
         let cont0 = owner0.continuations[L - 1];
@@ -242,7 +243,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     assert(false);
                 } else {
                     assert(cont.children[j] == cont0.children[j]);
-                    cont0.view_mappings_intro(m, j);
                 }
             };
             assert forall|m: Mapping|
@@ -257,7 +257,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     assert(false);
                 } else {
                     assert(cont0.children[j] == cont.children[j]);
-                    cont.view_mappings_intro(m, j);
                 }
             };
         };
@@ -271,10 +270,10 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         && #[trigger] self.continuations[i].view_mappings().contains(m);
                 if i == L - 1 {
                     assert(cont0.view_mappings().contains(m));
-                    owner0.view_mappings_intro(m, i);
+                    owner0.lemma_view_mappings_intro(m, i);
                 } else {
                     assert(owner0.continuations[i] == self.continuations[i]);
-                    owner0.view_mappings_intro(m, i);
+                    owner0.lemma_view_mappings_intro(m, i);
                 }
             };
             assert forall|m: Mapping|
@@ -285,10 +284,10 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         && #[trigger] owner0.continuations[i].view_mappings().contains(m);
                 if i == L - 1 {
                     assert(cont.view_mappings().contains(m));
-                    self.view_mappings_intro(m, i);
+                    self.lemma_view_mappings_intro(m, i);
                 } else {
                     assert(self.continuations[i] == owner0.continuations[i]);
-                    self.view_mappings_intro(m, i);
+                    self.lemma_view_mappings_intro(m, i);
                 }
             };
         };

--- a/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
@@ -264,7 +264,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         assert(self.view_mappings() == owner0.view_mappings()) by {
             assert forall|m: Mapping|
                 self.view_mappings().contains(m) implies owner0.view_mappings().contains(m) by {
-                self.view_mappings_contains(m);
+                self.lemma_view_mappings_contains();
                 let i = choose|i: int|
                     self.level - 1 <= i < NR_LEVELS
                         && #[trigger] self.continuations[i].view_mappings().contains(m);
@@ -278,7 +278,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             };
             assert forall|m: Mapping|
                 owner0.view_mappings().contains(m) implies self.view_mappings().contains(m) by {
-                owner0.view_mappings_contains(m);
+                owner0.lemma_view_mappings_contains();
                 let i = choose|i: int|
                     owner0.level - 1 <= i < NR_LEVELS
                         && #[trigger] owner0.continuations[i].view_mappings().contains(m);

--- a/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
@@ -219,7 +219,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         ensures
             self.view_mappings() == owner0.view_mappings(),
     {
-        broadcast use CursorContinuation::group_lemmas;
+        broadcast use {CursorContinuation::group_lemmas, CursorOwner::group_lemmas};
 
         let L = self.level as int;
         let cont = self.continuations[L - 1];
@@ -264,30 +264,24 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         assert(self.view_mappings() == owner0.view_mappings()) by {
             assert forall|m: Mapping|
                 self.view_mappings().contains(m) implies owner0.view_mappings().contains(m) by {
-                self.lemma_view_mappings_contains();
                 let i = choose|i: int|
                     self.level - 1 <= i < NR_LEVELS
                         && #[trigger] self.continuations[i].view_mappings().contains(m);
                 if i == L - 1 {
                     assert(cont0.view_mappings().contains(m));
-                    owner0.lemma_view_mappings_intro(m, i);
                 } else {
                     assert(owner0.continuations[i] == self.continuations[i]);
-                    owner0.lemma_view_mappings_intro(m, i);
                 }
             };
             assert forall|m: Mapping|
                 owner0.view_mappings().contains(m) implies self.view_mappings().contains(m) by {
-                owner0.lemma_view_mappings_contains();
                 let i = choose|i: int|
                     owner0.level - 1 <= i < NR_LEVELS
                         && #[trigger] owner0.continuations[i].view_mappings().contains(m);
                 if i == L - 1 {
                     assert(cont.view_mappings().contains(m));
-                    self.lemma_view_mappings_intro(m, i);
                 } else {
                     assert(self.continuations[i] == owner0.continuations[i]);
-                    self.lemma_view_mappings_intro(m, i);
                 }
             };
         };

--- a/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
@@ -219,6 +219,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         ensures
             self.view_mappings() == owner0.view_mappings(),
     {
+        broadcast use CursorContinuation::lemma_view_mappings_contains; 
         let L = self.level as int;
         let cont = self.continuations[L - 1];
         let cont0 = owner0.continuations[L - 1];
@@ -231,7 +232,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             );
             assert forall|m: Mapping|
                 cont.view_mappings().contains(m) implies cont0.view_mappings().contains(m) by {
-                cont.lemma_view_mappings_contains(m);
                 let j = choose|j: int|
                     0 <= j < cont.children.len() && #[trigger] cont.children[j] is Some
                         && PageTableOwner(cont.children[j].unwrap()).view_rec(
@@ -247,7 +247,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             };
             assert forall|m: Mapping|
                 cont0.view_mappings().contains(m) implies cont.view_mappings().contains(m) by {
-                cont0.lemma_view_mappings_contains(m);
                 let j = choose|j: int|
                     0 <= j < cont0.children.len() && #[trigger] cont0.children[j] is Some
                         && PageTableOwner(cont0.children[j].unwrap()).view_rec(

--- a/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
@@ -231,7 +231,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             );
             assert forall|m: Mapping|
                 cont.view_mappings().contains(m) implies cont0.view_mappings().contains(m) by {
-                cont.view_mappings_contains(m);
+                cont.lemma_view_mappings_contains(m);
                 let j = choose|j: int|
                     0 <= j < cont.children.len() && #[trigger] cont.children[j] is Some
                         && PageTableOwner(cont.children[j].unwrap()).view_rec(
@@ -247,7 +247,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             };
             assert forall|m: Mapping|
                 cont0.view_mappings().contains(m) implies cont.view_mappings().contains(m) by {
-                cont0.view_mappings_contains(m);
+                cont0.lemma_view_mappings_contains(m);
                 let j = choose|j: int|
                     0 <= j < cont0.children.len() && #[trigger] cont0.children[j] is Some
                         && PageTableOwner(cont0.children[j].unwrap()).view_rec(

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -436,7 +436,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
         assert forall|m: Mapping|
             self.view_mappings().contains(m) implies new_owner.view_mappings().contains(m) by {
-            self.view_mappings_contains(m);
+            self.lemma_view_mappings_contains();
             let i = choose|i: int|
                 self.level - 1 <= i < NR_LEVELS && (
                 #[trigger] self.continuations[i]).view_mappings().contains(m);
@@ -457,7 +457,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         };
         assert forall|m: Mapping|
             new_owner.view_mappings().contains(m) implies self.view_mappings().contains(m) by {
-            new_owner.view_mappings_contains(m);
+            new_owner.lemma_view_mappings_contains();
             let i = choose|i: int|
                 new_owner.level - 1 <= i < NR_LEVELS && (
                 #[trigger] new_owner.continuations[i]).view_mappings().contains(m);
@@ -2299,7 +2299,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         assert(popped.view_mappings() == self.view_mappings()) by {
             assert forall|m: Mapping|
                 self.view_mappings().contains(m) implies popped.view_mappings().contains(m) by {
-                self.view_mappings_contains(m);
+                self.lemma_view_mappings_contains();
                 let i = choose|i: int|
                     self.level - 1 <= i < NR_LEVELS && (
                     #[trigger] self.continuations[i]).view_mappings().contains(m);
@@ -2320,7 +2320,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             };
             assert forall|m: Mapping|
                 popped.view_mappings().contains(m) implies self.view_mappings().contains(m) by {
-                popped.view_mappings_contains(m);
+                popped.lemma_view_mappings_contains();
                 let i = choose|i: int|
                     popped.level - 1 <= i < NR_LEVELS && (
                     #[trigger] popped.continuations[i]).view_mappings().contains(m);
@@ -2396,7 +2396,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             assert(result.view_mappings() == self.view_mappings()) by {
                 assert forall|m: Mapping|
                     self.view_mappings().contains(m) implies result.view_mappings().contains(m) by {
-                    self.view_mappings_contains(m);
+                    self.lemma_view_mappings_contains();
                     let i = choose|i: int|
                         self.level - 1 <= i < NR_LEVELS && (
                         #[trigger] self.continuations[i]).view_mappings().contains(m);
@@ -2410,7 +2410,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 };
                 assert forall|m: Mapping|
                     result.view_mappings().contains(m) implies self.view_mappings().contains(m) by {
-                    result.view_mappings_contains(m);
+                    result.lemma_view_mappings_contains();
                     let i = choose|i: int|
                         result.level - 1 <= i < NR_LEVELS && (
                         #[trigger] result.continuations[i]).view_mappings().contains(m);
@@ -2446,7 +2446,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             assert(fwd.view_mappings() == self.view_mappings()) by {
                 assert forall|m: Mapping|
                     self.view_mappings().contains(m) implies fwd.view_mappings().contains(m) by {
-                    self.view_mappings_contains(m);
+                    self.lemma_view_mappings_contains();
                     let i = choose|i: int|
                         self.level - 1 <= i < NR_LEVELS
                             && #[trigger] self.continuations[i].view_mappings().contains(m);
@@ -2455,7 +2455,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 };
                 assert forall|m: Mapping|
                     fwd.view_mappings().contains(m) implies self.view_mappings().contains(m) by {
-                    fwd.view_mappings_contains(m);
+                    fwd.lemma_view_mappings_contains();
                     let i = choose|i: int|
                         fwd.level - 1 <= i < NR_LEVELS
                             && #[trigger] fwd.continuations[i].view_mappings().contains(m);

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -2336,7 +2336,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.move_forward_owner_spec()@.mappings == self@.mappings,
         decreases NR_LEVELS - self.level,
     {
-        broadcast use CursorContinuation::group_lemmas;
+        broadcast use {CursorContinuation::group_lemmas, CursorOwner::group_lemmas};
 
         if self.index() + 1 < NR_ENTRIES {
             let inc = self.inc_index();
@@ -2382,7 +2382,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             assert(result.view_mappings() == self.view_mappings()) by {
                 assert forall|m: Mapping|
                     self.view_mappings().contains(m) implies result.view_mappings().contains(m) by {
-                    self.lemma_view_mappings_contains();
                     let i = choose|i: int|
                         self.level - 1 <= i < NR_LEVELS && (
                         #[trigger] self.continuations[i]).view_mappings().contains(m);
@@ -2396,16 +2395,13 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 };
                 assert forall|m: Mapping|
                     result.view_mappings().contains(m) implies self.view_mappings().contains(m) by {
-                    result.lemma_view_mappings_contains();
                     let i = choose|i: int|
                         result.level - 1 <= i < NR_LEVELS && (
                         #[trigger] result.continuations[i]).view_mappings().contains(m);
                     if i == self.level - 1 {
                         assert(self.continuations[i].view_mappings().contains(m));
-                        self.lemma_view_mappings_intro(m, i);
                     } else {
                         assert(self.continuations[i] == result.continuations[i]);
-                        self.lemma_view_mappings_intro(m, i);
                     }
                 };
             };
@@ -2432,7 +2428,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             assert(fwd.view_mappings() == self.view_mappings()) by {
                 assert forall|m: Mapping|
                     self.view_mappings().contains(m) implies fwd.view_mappings().contains(m) by {
-                    self.lemma_view_mappings_contains();
                     let i = choose|i: int|
                         self.level - 1 <= i < NR_LEVELS
                             && #[trigger] self.continuations[i].view_mappings().contains(m);
@@ -2441,7 +2436,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 };
                 assert forall|m: Mapping|
                     fwd.view_mappings().contains(m) implies self.view_mappings().contains(m) by {
-                    fwd.lemma_view_mappings_contains();
                     let i = choose|i: int|
                         fwd.level - 1 <= i < NR_LEVELS
                             && #[trigger] fwd.continuations[i].view_mappings().contains(m);

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -359,7 +359,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         ensures
             self.push_level_owner(guard)@.mappings == self@.mappings,
     {
-        broadcast use CursorContinuation::group_lemmas;
+        broadcast use {CursorContinuation::group_lemmas, CursorOwner::group_lemmas};
 
         let new_owner = self.push_level_owner(guard);
         let old_cont = self.continuations[self.level - 1];
@@ -436,7 +436,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
         assert forall|m: Mapping|
             self.view_mappings().contains(m) implies new_owner.view_mappings().contains(m) by {
-            self.lemma_view_mappings_contains();
             let i = choose|i: int|
                 self.level - 1 <= i < NR_LEVELS && (
                 #[trigger] self.continuations[i]).view_mappings().contains(m);
@@ -448,7 +447,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     assert(taken.view_mappings().contains(m));
                     assert(modified_cont.view_mappings().contains(m));
                     assert(new_owner.continuations[self.level - 1].view_mappings().contains(m));
-                    new_owner.lemma_view_mappings_intro(m, self.level - 1);
                 }
             } else {
                 assert(new_owner.continuations[i] == self.continuations[i]);
@@ -457,7 +455,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         };
         assert forall|m: Mapping|
             new_owner.view_mappings().contains(m) implies self.view_mappings().contains(m) by {
-            new_owner.lemma_view_mappings_contains();
             let i = choose|i: int|
                 new_owner.level - 1 <= i < NR_LEVELS && (
                 #[trigger] new_owner.continuations[i]).view_mappings().contains(m);
@@ -469,16 +466,13 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     old_cont.path().push_tail(old_cont.idx as usize),
                 ).contains(m));
                 assert(self.continuations[self.level - 1].view_mappings().contains(m));
-                self.lemma_view_mappings_intro(m, self.level - 1);
             } else if i == self.level - 1 {
                 assert(modified_cont.view_mappings().contains(m));
                 assert(taken.view_mappings().contains(m));
                 assert(old_cont.view_mappings().contains(m));
                 assert(self.continuations[self.level - 1].view_mappings().contains(m));
-                self.lemma_view_mappings_intro(m, self.level - 1);
             } else {
                 assert(self.continuations[i] == new_owner.continuations[i]);
-                self.lemma_view_mappings_intro(m, i);
             }
         };
         assert(new_owner.view_mappings() == self.view_mappings());
@@ -2205,7 +2199,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         ensures
             self.pop_level_owner().0@.mappings == self@.mappings,
     {
-        broadcast use CursorContinuation::group_lemmas;
+        broadcast use {CursorContinuation::group_lemmas, CursorOwner::group_lemmas};
 
         let child = self.continuations[self.level - 1];
         let parent = self.continuations[self.level as int];
@@ -2299,7 +2293,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         assert(popped.view_mappings() == self.view_mappings()) by {
             assert forall|m: Mapping|
                 self.view_mappings().contains(m) implies popped.view_mappings().contains(m) by {
-                self.lemma_view_mappings_contains();
                 let i = choose|i: int|
                     self.level - 1 <= i < NR_LEVELS && (
                     #[trigger] self.continuations[i]).view_mappings().contains(m);
@@ -2307,20 +2300,16 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     assert(child.view_mappings().contains(m));
                     assert(restored_parent.view_mappings().contains(m));
                     assert(popped.continuations[self.level as int].view_mappings().contains(m));
-                    popped.lemma_view_mappings_intro(m, self.level as int);
                 } else if i == self.level as int {
                     assert(parent.view_mappings().contains(m));
                     assert(restored_parent.view_mappings().contains(m));
                     assert(popped.continuations[self.level as int].view_mappings().contains(m));
-                    popped.lemma_view_mappings_intro(m, self.level as int);
                 } else {
                     assert(popped.continuations[i] == self.continuations[i]);
-                    popped.lemma_view_mappings_intro(m, i);
                 }
             };
             assert forall|m: Mapping|
                 popped.view_mappings().contains(m) implies self.view_mappings().contains(m) by {
-                popped.lemma_view_mappings_contains();
                 let i = choose|i: int|
                     popped.level - 1 <= i < NR_LEVELS && (
                     #[trigger] popped.continuations[i]).view_mappings().contains(m);
@@ -2328,15 +2317,12 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     assert(restored_parent.view_mappings().contains(m));
                     if child.view_mappings().contains(m) {
                         assert(self.continuations[self.level - 1].view_mappings().contains(m));
-                        self.lemma_view_mappings_intro(m, self.level - 1);
                     } else {
                         assert(parent.view_mappings().contains(m));
                         assert(self.continuations[self.level as int].view_mappings().contains(m));
-                        self.lemma_view_mappings_intro(m, self.level as int);
                     }
                 } else {
                     assert(self.continuations[i] == popped.continuations[i]);
-                    self.lemma_view_mappings_intro(m, i);
                 }
             };
         };

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -359,7 +359,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         ensures
             self.push_level_owner(guard)@.mappings == self@.mappings,
     {
-        broadcast use CursorContinuation::lemma_view_mappings_contains; 
+        broadcast use CursorContinuation::group_lemmas;
+
         let new_owner = self.push_level_owner(guard);
         let old_cont = self.continuations[self.level - 1];
         let (child_cont, modified_cont) = old_cont.make_cont(
@@ -429,7 +430,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     ).view_rec(child_path.push_tail(j as usize)).contains(m);
                 assert(child_cont.children[j] == pto.0.children[j]);
                 assert(child_cont.children[j] is Some);
-                child_cont.view_mappings_intro(m, j);
             };
         };
         assert(child_cont.view_mappings() == old_cont.view_mappings_take_child_spec());
@@ -443,16 +443,16 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             if i == self.level - 1 {
                 if old_cont.view_mappings_take_child_spec().contains(m) {
                     assert(new_owner.continuations[self.level - 2].view_mappings().contains(m));
-                    new_owner.view_mappings_intro(m, self.level - 2);
+                    new_owner.lemma_view_mappings_intro(m, self.level - 2);
                 } else {
                     assert(taken.view_mappings().contains(m));
                     assert(modified_cont.view_mappings().contains(m));
                     assert(new_owner.continuations[self.level - 1].view_mappings().contains(m));
-                    new_owner.view_mappings_intro(m, self.level - 1);
+                    new_owner.lemma_view_mappings_intro(m, self.level - 1);
                 }
             } else {
                 assert(new_owner.continuations[i] == self.continuations[i]);
-                new_owner.view_mappings_intro(m, i);
+                new_owner.lemma_view_mappings_intro(m, i);
             }
         };
         assert forall|m: Mapping|
@@ -468,18 +468,17 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 assert(PageTableOwner(child_subtree).view_rec(
                     old_cont.path().push_tail(old_cont.idx as usize),
                 ).contains(m));
-                old_cont.view_mappings_intro(m, old_cont.idx as int);
                 assert(self.continuations[self.level - 1].view_mappings().contains(m));
-                self.view_mappings_intro(m, self.level - 1);
+                self.lemma_view_mappings_intro(m, self.level - 1);
             } else if i == self.level - 1 {
                 assert(modified_cont.view_mappings().contains(m));
                 assert(taken.view_mappings().contains(m));
                 assert(old_cont.view_mappings().contains(m));
                 assert(self.continuations[self.level - 1].view_mappings().contains(m));
-                self.view_mappings_intro(m, self.level - 1);
+                self.lemma_view_mappings_intro(m, self.level - 1);
             } else {
                 assert(self.continuations[i] == new_owner.continuations[i]);
-                self.view_mappings_intro(m, i);
+                self.lemma_view_mappings_intro(m, i);
             }
         };
         assert(new_owner.view_mappings() == self.view_mappings());
@@ -2206,7 +2205,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         ensures
             self.pop_level_owner().0@.mappings == self@.mappings,
     {
-        broadcast use CursorContinuation::lemma_view_mappings_contains;
+        broadcast use CursorContinuation::group_lemmas;
+
         let child = self.continuations[self.level - 1];
         let parent = self.continuations[self.level as int];
         let (restored_parent, _) = parent.restore(child);
@@ -2278,7 +2278,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         r.children[j].unwrap(),
                     ).view_rec(r.path().push_tail(j as usize)).contains(m);
                 assert(p.children[j] is Some);
-                p.view_mappings_intro(m, j);
             };
             assert forall|m: Mapping|
                 p.view_mappings().contains(m) implies r.view_mappings().contains(m) by {
@@ -2288,7 +2287,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         p.children[j].unwrap(),
                     ).view_rec(p.path().push_tail(j as usize)).contains(m);
                 assert(r.children[j] is Some);
-                r.view_mappings_intro(m, j);
             };
         };
 
@@ -2309,15 +2307,15 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     assert(child.view_mappings().contains(m));
                     assert(restored_parent.view_mappings().contains(m));
                     assert(popped.continuations[self.level as int].view_mappings().contains(m));
-                    popped.view_mappings_intro(m, self.level as int);
+                    popped.lemma_view_mappings_intro(m, self.level as int);
                 } else if i == self.level as int {
                     assert(parent.view_mappings().contains(m));
                     assert(restored_parent.view_mappings().contains(m));
                     assert(popped.continuations[self.level as int].view_mappings().contains(m));
-                    popped.view_mappings_intro(m, self.level as int);
+                    popped.lemma_view_mappings_intro(m, self.level as int);
                 } else {
                     assert(popped.continuations[i] == self.continuations[i]);
-                    popped.view_mappings_intro(m, i);
+                    popped.lemma_view_mappings_intro(m, i);
                 }
             };
             assert forall|m: Mapping|
@@ -2330,15 +2328,15 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     assert(restored_parent.view_mappings().contains(m));
                     if child.view_mappings().contains(m) {
                         assert(self.continuations[self.level - 1].view_mappings().contains(m));
-                        self.view_mappings_intro(m, self.level - 1);
+                        self.lemma_view_mappings_intro(m, self.level - 1);
                     } else {
                         assert(parent.view_mappings().contains(m));
                         assert(self.continuations[self.level as int].view_mappings().contains(m));
-                        self.view_mappings_intro(m, self.level as int);
+                        self.lemma_view_mappings_intro(m, self.level as int);
                     }
                 } else {
                     assert(self.continuations[i] == popped.continuations[i]);
-                    self.view_mappings_intro(m, i);
+                    self.lemma_view_mappings_intro(m, i);
                 }
             };
         };
@@ -2352,7 +2350,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.move_forward_owner_spec()@.mappings == self@.mappings,
         decreases NR_LEVELS - self.level,
     {
-        broadcast use CursorContinuation::lemma_view_mappings_contains; 
+        broadcast use CursorContinuation::group_lemmas;
+
         if self.index() + 1 < NR_ENTRIES {
             let inc = self.inc_index();
             let result = inc.zero_below_level();
@@ -2379,7 +2378,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                             old_cont.path().push_tail(i as usize),
                         ).contains(m);
                     assert(new_cont.children[i] is Some);
-                    new_cont.view_mappings_intro(m, i);
                 };
                 assert forall|m: Mapping|
                     new_cont.view_mappings().contains(m) implies old_cont.view_mappings().contains(
@@ -2392,7 +2390,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                             new_cont.path().push_tail(i as usize),
                         ).contains(m);
                     assert(old_cont.children[i] is Some);
-                    old_cont.view_mappings_intro(m, i);
                 };
             };
 
@@ -2405,10 +2402,10 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         #[trigger] self.continuations[i]).view_mappings().contains(m);
                     if i == self.level - 1 {
                         assert(result.continuations[i].view_mappings().contains(m));
-                        result.view_mappings_intro(m, i);
+                        result.lemma_view_mappings_intro(m, i);
                     } else {
                         assert(result.continuations[i] == self.continuations[i]);
-                        result.view_mappings_intro(m, i);
+                        result.lemma_view_mappings_intro(m, i);
                     }
                 };
                 assert forall|m: Mapping|
@@ -2419,10 +2416,10 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         #[trigger] result.continuations[i]).view_mappings().contains(m);
                     if i == self.level - 1 {
                         assert(self.continuations[i].view_mappings().contains(m));
-                        self.view_mappings_intro(m, i);
+                        self.lemma_view_mappings_intro(m, i);
                     } else {
                         assert(self.continuations[i] == result.continuations[i]);
-                        self.view_mappings_intro(m, i);
+                        self.lemma_view_mappings_intro(m, i);
                     }
                 };
             };
@@ -2454,7 +2451,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         self.level - 1 <= i < NR_LEVELS
                             && #[trigger] self.continuations[i].view_mappings().contains(m);
                     assert(fwd.continuations[i] == self.continuations[i]);
-                    fwd.view_mappings_intro(m, i);
+                    fwd.lemma_view_mappings_intro(m, i);
                 };
                 assert forall|m: Mapping|
                     fwd.view_mappings().contains(m) implies self.view_mappings().contains(m) by {
@@ -2463,7 +2460,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         fwd.level - 1 <= i < NR_LEVELS
                             && #[trigger] fwd.continuations[i].view_mappings().contains(m);
                     assert(self.continuations[i] == fwd.continuations[i]);
-                    self.view_mappings_intro(m, i);
+                    self.lemma_view_mappings_intro(m, i);
                 };
             };
         }

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -359,6 +359,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         ensures
             self.push_level_owner(guard)@.mappings == self@.mappings,
     {
+        broadcast use CursorContinuation::lemma_view_mappings_contains; 
         let new_owner = self.push_level_owner(guard);
         let old_cont = self.continuations[self.level - 1];
         let (child_cont, modified_cont) = old_cont.make_cont(
@@ -406,7 +407,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 child_cont.view_mappings().contains(m) implies pto.view_rec(child_path).contains(
                 m,
             ) by {
-                child_cont.lemma_view_mappings_contains(m);
                 let j = choose|j: int|
                     #![auto]
                     0 <= j < child_cont.children.len() && child_cont.children[j] is Some
@@ -2206,6 +2206,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         ensures
             self.pop_level_owner().0@.mappings == self@.mappings,
     {
+        broadcast use CursorContinuation::lemma_view_mappings_contains;
         let child = self.continuations[self.level - 1];
         let parent = self.continuations[self.level as int];
         let (restored_parent, _) = parent.restore(child);
@@ -2271,7 +2272,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             assert(r.path() == p.path());
             assert forall|m: Mapping|
                 r.view_mappings().contains(m) implies p.view_mappings().contains(m) by {
-                r.lemma_view_mappings_contains(m);
                 let j = choose|j: int|
                     #![auto]
                     0 <= j < r.children.len() && r.children[j] is Some && PageTableOwner(
@@ -2282,7 +2282,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             };
             assert forall|m: Mapping|
                 p.view_mappings().contains(m) implies r.view_mappings().contains(m) by {
-                p.lemma_view_mappings_contains(m);
                 let j = choose|j: int|
                     #![auto]
                     0 <= j < p.children.len() && p.children[j] is Some && PageTableOwner(
@@ -2353,6 +2352,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.move_forward_owner_spec()@.mappings == self@.mappings,
         decreases NR_LEVELS - self.level,
     {
+        broadcast use CursorContinuation::lemma_view_mappings_contains; 
         if self.index() + 1 < NR_ENTRIES {
             let inc = self.inc_index();
             let result = inc.zero_below_level();
@@ -2372,7 +2372,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     old_cont.view_mappings().contains(m) implies new_cont.view_mappings().contains(
                     m,
                 ) by {
-                    old_cont.lemma_view_mappings_contains(m);
                     let i = choose|i: int|
                         #![auto]
                         0 <= i < old_cont.children.len() && old_cont.children[i] is Some
@@ -2386,7 +2385,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     new_cont.view_mappings().contains(m) implies old_cont.view_mappings().contains(
                     m,
                 ) by {
-                    new_cont.lemma_view_mappings_contains(m);
                     let i = choose|i: int|
                         #![auto]
                         0 <= i < new_cont.children.len() && new_cont.children[i] is Some

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -406,7 +406,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 child_cont.view_mappings().contains(m) implies pto.view_rec(child_path).contains(
                 m,
             ) by {
-                child_cont.view_mappings_contains(m);
+                child_cont.lemma_view_mappings_contains(m);
                 let j = choose|j: int|
                     #![auto]
                     0 <= j < child_cont.children.len() && child_cont.children[j] is Some
@@ -2271,7 +2271,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             assert(r.path() == p.path());
             assert forall|m: Mapping|
                 r.view_mappings().contains(m) implies p.view_mappings().contains(m) by {
-                r.view_mappings_contains(m);
+                r.lemma_view_mappings_contains(m);
                 let j = choose|j: int|
                     #![auto]
                     0 <= j < r.children.len() && r.children[j] is Some && PageTableOwner(
@@ -2282,7 +2282,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             };
             assert forall|m: Mapping|
                 p.view_mappings().contains(m) implies r.view_mappings().contains(m) by {
-                p.view_mappings_contains(m);
+                p.lemma_view_mappings_contains(m);
                 let j = choose|j: int|
                     #![auto]
                     0 <= j < p.children.len() && p.children[j] is Some && PageTableOwner(
@@ -2372,7 +2372,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     old_cont.view_mappings().contains(m) implies new_cont.view_mappings().contains(
                     m,
                 ) by {
-                    old_cont.view_mappings_contains(m);
+                    old_cont.lemma_view_mappings_contains(m);
                     let i = choose|i: int|
                         #![auto]
                         0 <= i < old_cont.children.len() && old_cont.children[i] is Some
@@ -2386,7 +2386,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     new_cont.view_mappings().contains(m) implies old_cont.view_mappings().contains(
                     m,
                 ) by {
-                    new_cont.view_mappings_contains(m);
+                    new_cont.lemma_view_mappings_contains(m);
                     let i = choose|i: int|
                         #![auto]
                         0 <= i < new_cont.children.len() && new_cont.children[i] is Some

--- a/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
@@ -328,6 +328,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         ensures
             self.no_frame_with_path(removed_path),
     {
+        broadcast use CursorContinuation::group_lemmas;
+
         let g = |e: EntryOwner<C>, _p: TreePath<NR_ENTRIES>|
             e.is_frame() ==> e.path != removed_path;
 
@@ -361,8 +363,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     PageTableOwner(child).view_rec(child_path).contains(
                         m,
                     ) implies self@.mappings.contains(m) by {
-                    cont.view_mappings_intro(m, j);
-                    self.view_mappings_intro(m, i);
+                    self.lemma_view_mappings_intro(m, i);
                 };
                 // L-rec: no frame entry in this subtree carries removed_path.
                 PageTableOwner(child).no_frame_with_path_rec(

--- a/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
@@ -838,21 +838,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         m,
                     ) implies self.continuations[2].view_mappings().contains(m)
                     || self.continuations[3].view_mappings().contains(m) by {
-                    self.lemma_view_mappings_contains();
                     let i = choose|i: int|
                         2 <= i < NR_LEVELS
                             && #[trigger] self.continuations[i].view_mappings().contains(m);
-                };
-                assert forall|m: Mapping|
-                    (self.continuations[2].view_mappings().contains(m)
-                        || self.continuations[3].view_mappings().contains(
-                        m,
-                    )) implies #[trigger] self.view_mappings().contains(m) by {
-                    if self.continuations[2].view_mappings().contains(m) {
-                        self.lemma_view_mappings_intro(m, 2);
-                    } else {
-                        self.lemma_view_mappings_intro(m, 3);
-                    }
                 };
             };
         } else if self.level == 2 {

--- a/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
@@ -32,15 +32,16 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             self.as_subtree().inv(),
             PageTableOwner(self.as_subtree()).pt_inv(),
     {
-        broadcast use CursorContinuation::lemma_view_mappings_contains; 
+        broadcast use CursorContinuation::group_lemmas;
+
         self.inv_children_unroll_all();
         self.as_subtree_inv();
         self.as_page_table_owner_pt_inv();
         let pto = self.as_page_table_owner();
         assert(self.as_page_table_owner().view_rec(self.path()) == self.view_mappings()) by {
-            assert forall|m: Mapping| self.view_mappings().contains(m) implies pto.view_rec(
-                self.path(),
-            ).contains(m) by {
+            assert forall|m: Mapping|
+                #![auto]
+                self.view_mappings().contains(m) implies pto.view_rec(self.path()).contains(m) by {
                 let i = choose|i: int|
                     #![auto]
                     0 <= i < self.children.len() && self.children[i] is Some && PageTableOwner(
@@ -49,14 +50,15 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
                 pto.view_rec_contains_intro(self.path(), m, i);
             };
             assert forall|m: Mapping|
-                pto.view_rec(self.path()).contains(m) implies self.view_mappings().contains(m) by {
+                pto.view_rec(self.path()).contains(
+                    m,
+                ) implies #[trigger] self.view_mappings().contains(m) by {
                 pto.view_rec_contains(self.path(), m);
                 let i = choose|i: int|
                     #![auto]
                     0 <= i < pto.0.children.len() && pto.0.children[i] is Some && PageTableOwner(
                         pto.0.children[i].unwrap(),
                     ).view_rec(self.path().push_tail(i as usize)).contains(m);
-                self.view_mappings_intro(m, i);
             };
         };
     }
@@ -69,7 +71,8 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             self.take_child().1.view_mappings() == self.view_mappings()
                 - self.view_mappings_take_child_spec(),
     {
-        broadcast use CursorContinuation::lemma_view_mappings_contains; 
+        broadcast use CursorContinuation::group_lemmas;
+
         self.inv_children_unroll_all();
         let def = self.take_child().1.view_mappings();
         let diff = self.view_mappings() - self.view_mappings_take_child_spec();
@@ -81,7 +84,6 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
                 ).contains(m);
             assert(i != self.idx);
             assert(self.take_child().1.children[i] is Some);
-            self.take_child().1.view_mappings_intro(m, i);
         };
         assert forall|m: Mapping| #![trigger def.contains(m)] def.contains(m) implies diff.contains(
             m,
@@ -95,7 +97,6 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
                     left.children[i].unwrap(),
                 ).view_rec(left.path().push_tail(i as usize)).contains(m);
             assert(self.children[wi] == left.children[wi]);
-            self.view_mappings_intro(m, wi);
             if self.view_mappings_take_child_spec().contains(m) {
                 assert(PageTableOwner(self.children[self.idx as int].unwrap()).view_rec(
                     self.path().push_tail(self.idx as usize),
@@ -138,8 +139,8 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
                 child,
             ).view_rec(self.path().push_tail(self.idx as usize)),
     {
-        broadcast use CursorContinuation::lemma_view_mappings_contains; 
-        
+        broadcast use CursorContinuation::group_lemmas;
+
         let def = self.put_child(child).view_mappings();
         let sum = self.view_mappings() + PageTableOwner(child).view_rec(
             self.path().push_tail(self.idx as usize),
@@ -153,13 +154,13 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
                     ).contains(m);
                 assert(i != self.idx);
                 assert(self.put_child(child).children[i] == self.children[i]);
-                self.put_child(child).view_mappings_intro(m, i);
+                self.put_child(child).lemma_view_mappings_intro(m, i);
             } else {
                 assert(PageTableOwner(child).view_rec(
                     self.path().push_tail(self.idx as usize),
                 ).contains(m));
                 assert(self.put_child(child).children[self.idx as int] == Some(child));
-                self.put_child(child).view_mappings_intro(m, self.idx as int);
+                self.put_child(child).lemma_view_mappings_intro(m, self.idx as int);
             }
         };
         assert forall|m: Mapping| def.contains(m) implies sum.contains(m) by {
@@ -172,7 +173,6 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             if i == self.idx as int {
             } else {
                 assert(self.children[i] == self.put_child(child).children[i]);
-                self.view_mappings_intro(m, i);
             }
         };
     }
@@ -228,8 +228,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 )
             }),
     {
-        broadcast use CursorContinuation::lemma_view_mappings_contains; 
-        
+        broadcast use CursorContinuation::group_lemmas;
+
         let cur_subtree = self.cur_subtree();
         let cur_path = cur_subtree.value.path;
         let subtree_va = vaddr_of::<C>(cur_path) as int;
@@ -252,8 +252,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             // m is in the current subtree's view_rec => in cont[level-1].view_mappings() => in self.view_mappings()
             assert(cont.children[self.index() as int] is Some);
             assert(cont.children[self.index() as int].unwrap() == cur_subtree);
-            cont.view_mappings_intro(m, self.index() as int);
-            self.view_mappings_intro(m, (self.level - 1) as int);
+            self.lemma_view_mappings_intro(m, (self.level - 1) as int);
 
             // view_rec_vaddr_range gives m.va_range.start in
             // [vaddr_of(cur_path), vaddr_of(cur_path) + page_size(level)),
@@ -587,8 +586,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         ensures
             PageTableOwner(self.cur_subtree()).view_rec(self.cur_subtree().value.path).contains(m),
     {
-        broadcast use CursorContinuation::lemma_view_mappings_contains; 
-        
+        broadcast use CursorContinuation::group_lemmas;
+
         let cur_va = self.cur_va();
 
         // m comes from some continuation level i
@@ -651,7 +650,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 new_cont.view_mappings(),
             ),
     {
-        broadcast use CursorContinuation::lemma_view_mappings_contains; 
+        broadcast use CursorContinuation::group_lemmas;
+
         let level = old_self.level;
 
         assert forall|m: Mapping| new_self.view_mappings().contains(m) implies ((
@@ -666,7 +666,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             } else {
                 assert(old_self.continuations[i] == new_self.continuations[i]);
                 assert(old_self.continuations[i].view_mappings().contains(m));
-                old_self.view_mappings_intro(m, i);
+                old_self.lemma_view_mappings_intro(m, i);
 
                 if old_cont.view_mappings().contains(m) {
                     old_self.inv_continuation(i);
@@ -756,7 +756,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         ) by {
             if new_cont.view_mappings().contains(m) {
                 assert(new_self.continuations[level - 1].view_mappings().contains(m));
-                new_self.view_mappings_intro(m, level - 1);
+                new_self.lemma_view_mappings_intro(m, level - 1);
             } else {
                 // m in old.vm() and not in old_cont.vm(), so m in some higher cont
                 old_self.view_mappings_contains(m);
@@ -769,7 +769,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 } else {
                     assert(new_self.continuations[i] == old_self.continuations[i]);
                     assert(new_self.continuations[i].view_mappings().contains(m));
-                    new_self.view_mappings_intro(m, i);
+                    new_self.lemma_view_mappings_intro(m, i);
                 }
             }
         };
@@ -794,16 +794,18 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.inv_continuation(3);
             assert(self.view_mappings() == self.continuations[3].view_mappings()) by {
                 assert forall|m: Mapping|
+                    #![auto]
                     self.view_mappings().contains(
                         m,
                     ) implies self.continuations[3].view_mappings().contains(m) by {
                     self.view_mappings_contains(m);
                 };
                 assert forall|m: Mapping|
+                    #![auto]
                     self.continuations[3].view_mappings().contains(
                         m,
                     ) implies self.view_mappings().contains(m) by {
-                    self.view_mappings_intro(m, 3);
+                    self.lemma_view_mappings_intro(m, 3);
                 };
             };
         } else if self.level == 3 {
@@ -868,9 +870,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         m,
                     )) implies #[trigger] self.view_mappings().contains(m) by {
                     if self.continuations[2].view_mappings().contains(m) {
-                        self.view_mappings_intro(m, 2);
+                        self.lemma_view_mappings_intro(m, 2);
                     } else {
-                        self.view_mappings_intro(m, 3);
+                        self.lemma_view_mappings_intro(m, 3);
                     }
                 };
             };
@@ -970,11 +972,11 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     m,
                 ) by {
                     if c1.view_mappings().contains(m) {
-                        self.view_mappings_intro(m, 1);
+                        self.lemma_view_mappings_intro(m, 1);
                     } else if c2.view_mappings().contains(m) {
-                        self.view_mappings_intro(m, 2);
+                        self.lemma_view_mappings_intro(m, 2);
                     } else {
-                        self.view_mappings_intro(m, 3);
+                        self.lemma_view_mappings_intro(m, 3);
                     }
                 };
             };
@@ -1107,13 +1109,13 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         m,
                     )) implies self.view_mappings().contains(m) by {
                     if c0.view_mappings().contains(m) {
-                        self.view_mappings_intro(m, 0);
+                        self.lemma_view_mappings_intro(m, 0);
                     } else if c1.view_mappings().contains(m) {
-                        self.view_mappings_intro(m, 1);
+                        self.lemma_view_mappings_intro(m, 1);
                     } else if c2.view_mappings().contains(m) {
-                        self.view_mappings_intro(m, 2);
+                        self.lemma_view_mappings_intro(m, 2);
                     } else {
-                        self.view_mappings_intro(m, 3);
+                        self.lemma_view_mappings_intro(m, 3);
                     }
                 };
             };

--- a/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
@@ -228,7 +228,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 )
             }),
     {
-        broadcast use CursorContinuation::group_lemmas;
+        broadcast use {CursorContinuation::group_lemmas, CursorOwner::group_lemmas};
 
         let cur_subtree = self.cur_subtree();
         let cur_path = cur_subtree.value.path;
@@ -263,7 +263,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         // Reverse: filtered mappings are in the subtree
         assert forall|m: Mapping| filtered.contains(m) implies subtree_mappings.contains(m) by {
             // m is in self.view_mappings() and subtree_va <= m.va_range.start < subtree_va + size
-            self.lemma_view_mappings_contains();
             let i = choose|i: int|
                 self.level - 1 <= i < NR_LEVELS
                     && #[trigger] self.continuations[i].view_mappings().contains(m);
@@ -586,12 +585,11 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         ensures
             PageTableOwner(self.cur_subtree()).view_rec(self.cur_subtree().value.path).contains(m),
     {
-        broadcast use CursorContinuation::group_lemmas;
+        broadcast use {CursorContinuation::group_lemmas, CursorOwner::group_lemmas};
 
         let cur_va = self.cur_va();
 
         // m comes from some continuation level i
-        self.lemma_view_mappings_contains();
         let i = choose|i: int|
             self.level - 1 <= i < NR_LEVELS
                 && #[trigger] self.continuations[i].view_mappings().contains(m);
@@ -650,14 +648,13 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 new_cont.view_mappings(),
             ),
     {
-        broadcast use CursorContinuation::group_lemmas;
+        broadcast use {CursorContinuation::group_lemmas, CursorOwner::group_lemmas};
 
         let level = old_self.level;
 
         assert forall|m: Mapping| new_self.view_mappings().contains(m) implies ((
         old_self.view_mappings().contains(m) && !old_cont.view_mappings().contains(m))
             || new_cont.view_mappings().contains(m)) by {
-            new_self.lemma_view_mappings_contains();
             let i = choose|i: int|
                 level - 1 <= i < NR_LEVELS
                     && #[trigger] new_self.continuations[i].view_mappings().contains(m);
@@ -666,7 +663,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             } else {
                 assert(old_self.continuations[i] == new_self.continuations[i]);
                 assert(old_self.continuations[i].view_mappings().contains(m));
-                old_self.lemma_view_mappings_intro(m, i);
 
                 if old_cont.view_mappings().contains(m) {
                     old_self.inv_continuation(i);
@@ -758,8 +754,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 assert(new_self.continuations[level - 1].view_mappings().contains(m));
                 new_self.lemma_view_mappings_intro(m, level - 1);
             } else {
-                // m in old.vm() and not in old_cont.vm(), so m in some higher cont
-                old_self.lemma_view_mappings_contains();
                 let i = choose|i: int|
                     level - 1 <= i < NR_LEVELS
                         && #[trigger] old_self.continuations[i].view_mappings().contains(m);
@@ -769,7 +763,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 } else {
                     assert(new_self.continuations[i] == old_self.continuations[i]);
                     assert(new_self.continuations[i].view_mappings().contains(m));
-                    new_self.lemma_view_mappings_intro(m, i);
                 }
             }
         };

--- a/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
@@ -928,23 +928,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 assert forall|m: Mapping| self.view_mappings().contains(m) implies (
                 c1.view_mappings().contains(m) || c2.view_mappings().contains(m)
                     || c3.view_mappings().contains(m)) by {
-                    self.lemma_view_mappings_contains();
                     let i = choose|i: int|
                         1 <= i < NR_LEVELS
                             && #[trigger] self.continuations[i].view_mappings().contains(m);
-                };
-                assert forall|m: Mapping|
-                    (c1.view_mappings().contains(m) || c2.view_mappings().contains(m)
-                        || c3.view_mappings().contains(m)) implies self.view_mappings().contains(
-                    m,
-                ) by {
-                    if c1.view_mappings().contains(m) {
-                        self.lemma_view_mappings_intro(m, 1);
-                    } else if c2.view_mappings().contains(m) {
-                        self.lemma_view_mappings_intro(m, 2);
-                    } else {
-                        self.lemma_view_mappings_intro(m, 3);
-                    }
                 };
             };
         } else {

--- a/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
@@ -1056,21 +1056,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         0 <= i < NR_LEVELS
                             && #[trigger] self.continuations[i].view_mappings().contains(m);
                 };
-                assert forall|m: Mapping|
-                    (c0.view_mappings().contains(m) || c1.view_mappings().contains(m)
-                        || c2.view_mappings().contains(m) || c3.view_mappings().contains(
-                        m,
-                    )) implies self.view_mappings().contains(m) by {
-                    if c0.view_mappings().contains(m) {
-                        self.lemma_view_mappings_intro(m, 0);
-                    } else if c1.view_mappings().contains(m) {
-                        self.lemma_view_mappings_intro(m, 1);
-                    } else if c2.view_mappings().contains(m) {
-                        self.lemma_view_mappings_intro(m, 2);
-                    } else {
-                        self.lemma_view_mappings_intro(m, 3);
-                    }
-                };
             };
         }
     }

--- a/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
@@ -32,6 +32,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             self.as_subtree().inv(),
             PageTableOwner(self.as_subtree()).pt_inv(),
     {
+        broadcast use CursorContinuation::lemma_view_mappings_contains; 
         self.inv_children_unroll_all();
         self.as_subtree_inv();
         self.as_page_table_owner_pt_inv();
@@ -40,7 +41,6 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             assert forall|m: Mapping| self.view_mappings().contains(m) implies pto.view_rec(
                 self.path(),
             ).contains(m) by {
-                self.lemma_view_mappings_contains(m);
                 let i = choose|i: int|
                     #![auto]
                     0 <= i < self.children.len() && self.children[i] is Some && PageTableOwner(
@@ -69,11 +69,11 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             self.take_child().1.view_mappings() == self.view_mappings()
                 - self.view_mappings_take_child_spec(),
     {
+        broadcast use CursorContinuation::lemma_view_mappings_contains; 
         self.inv_children_unroll_all();
         let def = self.take_child().1.view_mappings();
         let diff = self.view_mappings() - self.view_mappings_take_child_spec();
         assert forall|m: Mapping| diff.contains(m) implies def.contains(m) by {
-            self.lemma_view_mappings_contains(m);
             let i = choose|i: int|
                 0 <= i < self.children.len() && #[trigger] self.children[i] is Some
                     && PageTableOwner(self.children[i].unwrap()).view_rec(
@@ -89,7 +89,6 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             let left = self.take_child().1;
             assert(left.view_mappings().contains(m));
             // Establish self.view_mappings().contains(m) from left's child
-            left.lemma_view_mappings_contains(m);
             let wi = choose|i: int|
                 #![auto]
                 0 <= i < left.children.len() && left.children[i] is Some && PageTableOwner(
@@ -101,7 +100,6 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
                 assert(PageTableOwner(self.children[self.idx as int].unwrap()).view_rec(
                     self.path().push_tail(self.idx as usize),
                 ).contains(m));
-                left.lemma_view_mappings_contains(m);
                 let i = choose|i: int|
                     0 <= i < left.children.len() && #[trigger] left.children[i] is Some
                         && PageTableOwner(left.children[i].unwrap()).view_rec(
@@ -140,13 +138,14 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
                 child,
             ).view_rec(self.path().push_tail(self.idx as usize)),
     {
+        broadcast use CursorContinuation::lemma_view_mappings_contains; 
+        
         let def = self.put_child(child).view_mappings();
         let sum = self.view_mappings() + PageTableOwner(child).view_rec(
             self.path().push_tail(self.idx as usize),
         );
         assert forall|m: Mapping| sum.contains(m) implies def.contains(m) by {
             if self.view_mappings().contains(m) {
-                self.lemma_view_mappings_contains(m);
                 let i = choose|i: int|
                     0 <= i < self.children.len() && #[trigger] self.children[i] is Some
                         && PageTableOwner(self.children[i].unwrap()).view_rec(
@@ -164,7 +163,6 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             }
         };
         assert forall|m: Mapping| def.contains(m) implies sum.contains(m) by {
-            self.put_child(child).lemma_view_mappings_contains(m);
             let i = choose|i: int|
                 0 <= i < self.put_child(child).children.len() && #[trigger] self.put_child(
                     child,
@@ -230,6 +228,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 )
             }),
     {
+        broadcast use CursorContinuation::lemma_view_mappings_contains; 
+        
         let cur_subtree = self.cur_subtree();
         let cur_path = cur_subtree.value.path;
         let subtree_va = vaddr_of::<C>(cur_path) as int;
@@ -271,7 +271,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.inv_continuation(i);
 
             let cont_i = self.continuations[i];
-            cont_i.lemma_view_mappings_contains(m);
             let j = choose|j: int|
                 #![auto]
                 0 <= j < NR_ENTRIES && cont_i.children[j] is Some && PageTableOwner(
@@ -588,6 +587,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         ensures
             PageTableOwner(self.cur_subtree()).view_rec(self.cur_subtree().value.path).contains(m),
     {
+        broadcast use CursorContinuation::lemma_view_mappings_contains; 
+        
         let cur_va = self.cur_va();
 
         // m comes from some continuation level i
@@ -598,7 +599,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         self.inv_continuation(i);
 
         let cont_i = self.continuations[i];
-        cont_i.lemma_view_mappings_contains(m);
         let j = choose|j: int|
             #![auto]
             0 <= j < NR_ENTRIES && cont_i.children[j] is Some && PageTableOwner(
@@ -651,6 +651,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 new_cont.view_mappings(),
             ),
     {
+        broadcast use CursorContinuation::lemma_view_mappings_contains; 
         let level = old_self.level;
 
         assert forall|m: Mapping| new_self.view_mappings().contains(m) implies ((
@@ -671,7 +672,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     old_self.inv_continuation(i);
                     old_self.inv_continuation(level - 1);
                     let cont_i = old_self.continuations[i];
-                    cont_i.lemma_view_mappings_contains(m);
                     let j = choose|j: int|
                         #![auto]
                         0 <= j < NR_ENTRIES && cont_i.children[j] is Some && PageTableOwner(
@@ -683,7 +683,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         m,
                     );
 
-                    old_cont.lemma_view_mappings_contains(m);
                     let k = choose|k: int|
                         #![auto]
                         0 <= k < NR_ENTRIES && old_cont.children[k] is Some && PageTableOwner(

--- a/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
@@ -781,6 +781,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.as_page_table_owner().pt_inv(),
     {
         broadcast use CursorOwner::group_lemmas;
+
         if self.level == 4 {
             self.continuations[3].as_page_table_owner_preserves_view_mappings();
             self.inv_continuation(3);

--- a/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
@@ -263,7 +263,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         // Reverse: filtered mappings are in the subtree
         assert forall|m: Mapping| filtered.contains(m) implies subtree_mappings.contains(m) by {
             // m is in self.view_mappings() and subtree_va <= m.va_range.start < subtree_va + size
-            self.view_mappings_contains(m);
+            self.lemma_view_mappings_contains();
             let i = choose|i: int|
                 self.level - 1 <= i < NR_LEVELS
                     && #[trigger] self.continuations[i].view_mappings().contains(m);
@@ -591,7 +591,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         let cur_va = self.cur_va();
 
         // m comes from some continuation level i
-        self.view_mappings_contains(m);
+        self.lemma_view_mappings_contains();
         let i = choose|i: int|
             self.level - 1 <= i < NR_LEVELS
                 && #[trigger] self.continuations[i].view_mappings().contains(m);
@@ -657,7 +657,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         assert forall|m: Mapping| new_self.view_mappings().contains(m) implies ((
         old_self.view_mappings().contains(m) && !old_cont.view_mappings().contains(m))
             || new_cont.view_mappings().contains(m)) by {
-            new_self.view_mappings_contains(m);
+            new_self.lemma_view_mappings_contains();
             let i = choose|i: int|
                 level - 1 <= i < NR_LEVELS
                     && #[trigger] new_self.continuations[i].view_mappings().contains(m);
@@ -759,7 +759,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 new_self.lemma_view_mappings_intro(m, level - 1);
             } else {
                 // m in old.vm() and not in old_cont.vm(), so m in some higher cont
-                old_self.view_mappings_contains(m);
+                old_self.lemma_view_mappings_contains();
                 let i = choose|i: int|
                     level - 1 <= i < NR_LEVELS
                         && #[trigger] old_self.continuations[i].view_mappings().contains(m);
@@ -798,7 +798,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     self.view_mappings().contains(
                         m,
                     ) implies self.continuations[3].view_mappings().contains(m) by {
-                    self.view_mappings_contains(m);
+                    self.lemma_view_mappings_contains();
                 };
                 assert forall|m: Mapping|
                     #![auto]
@@ -859,7 +859,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         m,
                     ) implies self.continuations[2].view_mappings().contains(m)
                     || self.continuations[3].view_mappings().contains(m) by {
-                    self.view_mappings_contains(m);
+                    self.lemma_view_mappings_contains();
                     let i = choose|i: int|
                         2 <= i < NR_LEVELS
                             && #[trigger] self.continuations[i].view_mappings().contains(m);
@@ -961,7 +961,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 assert forall|m: Mapping| self.view_mappings().contains(m) implies (
                 c1.view_mappings().contains(m) || c2.view_mappings().contains(m)
                     || c3.view_mappings().contains(m)) by {
-                    self.view_mappings_contains(m);
+                    self.lemma_view_mappings_contains();
                     let i = choose|i: int|
                         1 <= i < NR_LEVELS
                             && #[trigger] self.continuations[i].view_mappings().contains(m);
@@ -1098,7 +1098,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 assert forall|m: Mapping| self.view_mappings().contains(m) implies (
                 c0.view_mappings().contains(m) || c1.view_mappings().contains(m)
                     || c2.view_mappings().contains(m) || c3.view_mappings().contains(m)) by {
-                    self.view_mappings_contains(m);
+                    self.lemma_view_mappings_contains();
                     let i = choose|i: int|
                         0 <= i < NR_LEVELS
                             && #[trigger] self.continuations[i].view_mappings().contains(m);

--- a/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
@@ -782,25 +782,11 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.as_page_table_owner().0.level == self.continuations[3].tree_level,
             self.as_page_table_owner().pt_inv(),
     {
+        broadcast use CursorOwner::group_lemmas;
         if self.level == 4 {
             self.continuations[3].as_page_table_owner_preserves_view_mappings();
             self.inv_continuation(3);
-            assert(self.view_mappings() == self.continuations[3].view_mappings()) by {
-                assert forall|m: Mapping|
-                    #![auto]
-                    self.view_mappings().contains(
-                        m,
-                    ) implies self.continuations[3].view_mappings().contains(m) by {
-                    self.lemma_view_mappings_contains();
-                };
-                assert forall|m: Mapping|
-                    #![auto]
-                    self.continuations[3].view_mappings().contains(
-                        m,
-                    ) implies self.view_mappings().contains(m) by {
-                    self.lemma_view_mappings_intro(m, 3);
-                };
-            };
+            assert(self.view_mappings() == self.continuations[3].view_mappings());
         } else if self.level == 3 {
             let c2 = self.continuations[2];
             let c3 = self.continuations[3];

--- a/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
@@ -40,7 +40,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             assert forall|m: Mapping| self.view_mappings().contains(m) implies pto.view_rec(
                 self.path(),
             ).contains(m) by {
-                self.view_mappings_contains(m);
+                self.lemma_view_mappings_contains(m);
                 let i = choose|i: int|
                     #![auto]
                     0 <= i < self.children.len() && self.children[i] is Some && PageTableOwner(
@@ -73,7 +73,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         let def = self.take_child().1.view_mappings();
         let diff = self.view_mappings() - self.view_mappings_take_child_spec();
         assert forall|m: Mapping| diff.contains(m) implies def.contains(m) by {
-            self.view_mappings_contains(m);
+            self.lemma_view_mappings_contains(m);
             let i = choose|i: int|
                 0 <= i < self.children.len() && #[trigger] self.children[i] is Some
                     && PageTableOwner(self.children[i].unwrap()).view_rec(
@@ -89,7 +89,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             let left = self.take_child().1;
             assert(left.view_mappings().contains(m));
             // Establish self.view_mappings().contains(m) from left's child
-            left.view_mappings_contains(m);
+            left.lemma_view_mappings_contains(m);
             let wi = choose|i: int|
                 #![auto]
                 0 <= i < left.children.len() && left.children[i] is Some && PageTableOwner(
@@ -101,7 +101,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
                 assert(PageTableOwner(self.children[self.idx as int].unwrap()).view_rec(
                     self.path().push_tail(self.idx as usize),
                 ).contains(m));
-                left.view_mappings_contains(m);
+                left.lemma_view_mappings_contains(m);
                 let i = choose|i: int|
                     0 <= i < left.children.len() && #[trigger] left.children[i] is Some
                         && PageTableOwner(left.children[i].unwrap()).view_rec(
@@ -146,7 +146,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         );
         assert forall|m: Mapping| sum.contains(m) implies def.contains(m) by {
             if self.view_mappings().contains(m) {
-                self.view_mappings_contains(m);
+                self.lemma_view_mappings_contains(m);
                 let i = choose|i: int|
                     0 <= i < self.children.len() && #[trigger] self.children[i] is Some
                         && PageTableOwner(self.children[i].unwrap()).view_rec(
@@ -164,7 +164,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             }
         };
         assert forall|m: Mapping| def.contains(m) implies sum.contains(m) by {
-            self.put_child(child).view_mappings_contains(m);
+            self.put_child(child).lemma_view_mappings_contains(m);
             let i = choose|i: int|
                 0 <= i < self.put_child(child).children.len() && #[trigger] self.put_child(
                     child,
@@ -271,7 +271,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.inv_continuation(i);
 
             let cont_i = self.continuations[i];
-            cont_i.view_mappings_contains(m);
+            cont_i.lemma_view_mappings_contains(m);
             let j = choose|j: int|
                 #![auto]
                 0 <= j < NR_ENTRIES && cont_i.children[j] is Some && PageTableOwner(
@@ -598,7 +598,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         self.inv_continuation(i);
 
         let cont_i = self.continuations[i];
-        cont_i.view_mappings_contains(m);
+        cont_i.lemma_view_mappings_contains(m);
         let j = choose|j: int|
             #![auto]
             0 <= j < NR_ENTRIES && cont_i.children[j] is Some && PageTableOwner(
@@ -671,7 +671,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     old_self.inv_continuation(i);
                     old_self.inv_continuation(level - 1);
                     let cont_i = old_self.continuations[i];
-                    cont_i.view_mappings_contains(m);
+                    cont_i.lemma_view_mappings_contains(m);
                     let j = choose|j: int|
                         #![auto]
                         0 <= j < NR_ENTRIES && cont_i.children[j] is Some && PageTableOwner(
@@ -683,7 +683,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         m,
                     );
 
-                    old_cont.view_mappings_contains(m);
+                    old_cont.lemma_view_mappings_contains(m);
                     let k = choose|k: int|
                         #![auto]
                         0 <= k < NR_ENTRIES && old_cont.children[k] is Some && PageTableOwner(

--- a/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
@@ -252,7 +252,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             // m is in the current subtree's view_rec => in cont[level-1].view_mappings() => in self.view_mappings()
             assert(cont.children[self.index() as int] is Some);
             assert(cont.children[self.index() as int].unwrap() == cur_subtree);
-            self.lemma_view_mappings_intro(m, (self.level - 1) as int);
 
             // view_rec_vaddr_range gives m.va_range.start in
             // [vaddr_of(cur_path), vaddr_of(cur_path) + page_size(level)),
@@ -752,7 +751,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         ) by {
             if new_cont.view_mappings().contains(m) {
                 assert(new_self.continuations[level - 1].view_mappings().contains(m));
-                new_self.lemma_view_mappings_intro(m, level - 1);
             } else {
                 let i = choose|i: int|
                     level - 1 <= i < NR_LEVELS

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -2490,6 +2490,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         };
         assert(PageTableOwner(subtree).view_rec(path) == set![m]);
         assert(PageTableOwner(subtree).view_rec(path).contains(m));
+        cont.lemma_view_mappings_intro(m, cont.idx as int);
         self.lemma_view_mappings_intro(m, (self.level - 1) as int);
         assert(m.inv());
         assert(m.va_range.start <= self@.cur_va < m.va_range.end) by {

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -346,17 +346,19 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
     pub broadcast proof fn lemma_view_mappings_contains(self)
         ensures
             #![trigger self.view_mappings()]
-            forall |m: Mapping|
-                #[trigger] self.view_mappings().contains(m) ==> exists |i: int| #![auto]
+            forall|m: Mapping| #[trigger]
+                self.view_mappings().contains(m) ==> exists|i: int|
+                    #![auto]
                     0 <= i < self.children.len() && self.children[i] is Some && PageTableOwner(
                         self.children[i]->0,
                     ).view_rec(self.path().push_tail(i as usize)).contains(m),
     {
         broadcast use vstd::seq_lib::group_seq_properties;
 
-        assert forall |m: Mapping| self.view_mappings().contains(m) implies exists|i: int|
-            0 <= i < self.children.len() && self.children[i] is Some
-                && PageTableOwner(self.children[i]->0).view_rec(self.path().push_tail(i as usize)).contains(m) by {
+        assert forall|m: Mapping| self.view_mappings().contains(m) implies exists|i: int|
+            0 <= i < self.children.len() && self.children[i] is Some && PageTableOwner(
+                self.children[i]->0,
+            ).view_rec(self.path().push_tail(i as usize)).contains(m) by {
             let mapped = self.children.map(
                 |i, child: Option<OwnerSubtree<C>>|
                     if child is Some {
@@ -383,11 +385,11 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         }
     }
 
-    pub proof fn view_mappings_intro(self, m: Mapping, i: int)
+    pub broadcast proof fn lemma_view_mappings_intro(self, m: Mapping, i: int)
         requires
             0 <= i < self.children.len(),
             self.children[i] is Some,
-            PageTableOwner(self.children[i]->0).view_rec(
+            #[trigger] PageTableOwner(self.children[i]->0).view_rec(
                 self.path().push_tail(i as usize),
             ).contains(m),
         ensures
@@ -638,6 +640,11 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         );
         owner.in_scope = false;
         OwnerSubtree::new_val_tracked(owner, self.tree_level + 1)
+    }
+
+    pub broadcast group group_lemmas {
+        CursorContinuation::lemma_view_mappings_contains,
+        CursorContinuation::lemma_view_mappings_intro,
     }
 }
 
@@ -1072,7 +1079,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         assert(mapped[i] == self.continuations[i].view_mappings());
     }
 
-    pub proof fn view_mappings_intro(self, m: Mapping, i: int)
+    pub proof fn lemma_view_mappings_intro(self, m: Mapping, i: int)
         requires
             1 <= self.level <= NR_LEVELS,
             self.level - 1 <= i < NR_LEVELS,
@@ -1082,8 +1089,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.view_mappings().contains(m),
     {
         broadcast use vstd::map_lib::group_map_properties;
-        broadcast use vstd::set::group_set_lemmas;
-        broadcast use vstd::set_lib::group_set_lib_default;
 
         let filtered = self.continuations.filter_keys(|k| self.level - 1 <= k < NR_LEVELS);
         let mapped = filtered.map_values(|cont: CursorContinuation<'rcu, C>| cont.view_mappings());
@@ -2485,8 +2490,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         };
         assert(PageTableOwner(subtree).view_rec(path) == set![m]);
         assert(PageTableOwner(subtree).view_rec(path).contains(m));
-        cont.view_mappings_intro(m, cont.idx as int);
-        self.view_mappings_intro(m, (self.level - 1) as int);
+        self.lemma_view_mappings_intro(m, (self.level - 1) as int);
         assert(m.inv());
         assert(m.va_range.start <= self@.cur_va < m.va_range.end) by {
             self.cur_va_in_subtree_range();

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -332,71 +332,18 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         guards.lock_held(self.guard.inner.inner@.ptr.addr())
     }
 
-    pub open spec fn view_mappings_children_union(self, up_to: int) -> Set<Mapping>
-        decreases up_to,
-        when up_to >= 0
-    {
-        if up_to <= 0 {
-            Set::empty()
-        } else if up_to - 1 < self.children.len() && self.children[up_to - 1] is Some {
-            self.view_mappings_children_union(up_to - 1).union(
-                PageTableOwner(self.children[up_to - 1]->0).view_rec(
-                    self.path().push_tail((up_to - 1) as usize),
-                ),
-            )
-        } else {
-            self.view_mappings_children_union(up_to - 1)
-        }
-    }
-
     pub open spec fn view_mappings(self) -> Set<Mapping> {
-        self.view_mappings_children_union(self.children.len() as int)
+        self.children.map(
+            |i, child: Option<OwnerSubtree<C>>|
+                if child is Some {
+                    PageTableOwner(child->0).view_rec(self.path().push_tail(i as usize))
+                } else {
+                    Set::empty()
+                },
+        ).to_set().flatten()
     }
 
-    proof fn view_mappings_children_union_contains(self, up_to: int, m: Mapping)
-        requires
-            0 <= up_to <= self.children.len(),
-            self.view_mappings_children_union(up_to).contains(m),
-        ensures
-            exists|i: int|
-                #![auto]
-                0 <= i < up_to && self.children[i] is Some && PageTableOwner(
-                    self.children[i]->0,
-                ).view_rec(self.path().push_tail(i as usize)).contains(m),
-        decreases up_to,
-    {
-        if up_to <= 0 {
-        } else if up_to - 1 < self.children.len() && self.children[up_to - 1] is Some {
-            if PageTableOwner(self.children[up_to - 1].unwrap()).view_rec(
-                self.path().push_tail((up_to - 1) as usize),
-            ).contains(m) {
-            } else {
-                self.view_mappings_children_union_contains(up_to - 1, m);
-            }
-        } else {
-            self.view_mappings_children_union_contains(up_to - 1, m);
-        }
-    }
-
-    proof fn view_mappings_children_union_intro(self, up_to: int, m: Mapping, witness: int)
-        requires
-            0 <= witness < up_to,
-            up_to <= self.children.len(),
-            self.children[witness] is Some,
-            PageTableOwner(self.children[witness]->0).view_rec(
-                self.path().push_tail(witness as usize),
-            ).contains(m),
-        ensures
-            self.view_mappings_children_union(up_to).contains(m),
-        decreases up_to,
-    {
-        if witness == up_to - 1 {
-        } else {
-            self.view_mappings_children_union_intro(up_to - 1, m, witness);
-        }
-    }
-
-    pub proof fn view_mappings_contains(self, m: Mapping)
+    pub proof fn lemma_view_mappings_contains(self, m: Mapping)
         requires
             self.children.len() > 0,
             self.view_mappings().contains(m),
@@ -407,7 +354,31 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
                     self.children[i]->0,
                 ).view_rec(self.path().push_tail(i as usize)).contains(m),
     {
-        self.view_mappings_children_union_contains(self.children.len() as int, m);
+        broadcast use vstd::seq_lib::group_seq_properties;
+
+        let mapped = self.children.map(
+            |i, child: Option<OwnerSubtree<C>>|
+                if child is Some {
+                    PageTableOwner(child->0).view_rec(self.path().push_tail(i as usize))
+                } else {
+                    Set::empty()
+                },
+        );
+        mapped.to_set().lemma_flatten_contains(m);
+        let elem_s = choose|elem_s: Set<Mapping>| #[trigger]
+            mapped.to_set().contains(elem_s) && elem_s.contains(m);
+        mapped.to_set_ensures();
+        assert(mapped.contains(elem_s));
+        let i = mapped.lemma_contains_to_index(elem_s);
+        assert(0 <= i < self.children.len());
+        if self.children[i] is Some {
+            assert(mapped[i] == PageTableOwner(self.children[i]->0).view_rec(
+                self.path().push_tail(i as usize),
+            ));
+        } else {
+            assert(mapped[i] == Set::<Mapping>::empty());
+            assert(false);
+        }
     }
 
     pub proof fn view_mappings_intro(self, m: Mapping, i: int)
@@ -420,7 +391,22 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         ensures
             self.view_mappings().contains(m),
     {
-        self.view_mappings_children_union_intro(self.children.len() as int, m, i);
+        broadcast use vstd::set::group_set_lemmas;
+        broadcast use vstd::set_lib::group_set_lib_default;
+        broadcast use vstd::seq_lib::group_seq_properties;
+
+        let mapped = self.children.map(
+            |i, child: Option<OwnerSubtree<C>>|
+                if child is Some {
+                    PageTableOwner(child->0).view_rec(self.path().push_tail(i as usize))
+                } else {
+                    Set::empty()
+                },
+        );
+        assert(mapped[i].contains(m));
+        mapped.to_set_ensures();
+        assert(mapped.to_set().contains(mapped[i]));
+        mapped.to_set().lemma_flatten_contains(m);
     }
 
     pub open spec fn as_subtree(self) -> OwnerSubtree<C> {
@@ -1051,60 +1037,10 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         assert(self.continuations.contains_key(i));
     }
 
-    pub open spec fn view_mappings_conts_union(self, up_to: int) -> Set<Mapping>
-        decreases up_to - (self.level - 1),
-        when up_to >= self.level - 1
-    {
-        if up_to <= self.level - 1 {
-            Set::empty()
-        } else if up_to - 1 < NR_LEVELS && self.continuations.contains_key(up_to - 1) {
-            self.view_mappings_conts_union(up_to - 1).union(
-                self.continuations[up_to - 1].view_mappings(),
-            )
-        } else {
-            self.view_mappings_conts_union(up_to - 1)
-        }
-    }
-
     pub open spec fn view_mappings(self) -> Set<Mapping> {
-        self.view_mappings_conts_union(NR_LEVELS as int)
-    }
-
-    proof fn view_mappings_conts_union_contains(self, up_to: int, m: Mapping)
-        requires
-            self.level - 1 <= up_to <= NR_LEVELS,
-            self.view_mappings_conts_union(up_to).contains(m),
-        ensures
-            exists|i: int|
-                #![trigger self.continuations[i]]
-                self.level - 1 <= i < up_to && self.continuations[i].view_mappings().contains(m),
-        decreases up_to - (self.level - 1),
-    {
-        if up_to <= self.level - 1 {
-        } else if up_to - 1 < NR_LEVELS && self.continuations.contains_key(up_to - 1) {
-            if self.continuations[up_to - 1].view_mappings().contains(m) {
-            } else {
-                self.view_mappings_conts_union_contains(up_to - 1, m);
-            }
-        } else {
-            self.view_mappings_conts_union_contains(up_to - 1, m);
-        }
-    }
-
-    proof fn view_mappings_conts_union_intro(self, up_to: int, m: Mapping, witness: int)
-        requires
-            self.level - 1 <= witness < up_to,
-            up_to <= NR_LEVELS,
-            self.continuations.contains_key(witness),
-            self.continuations[witness].view_mappings().contains(m),
-        ensures
-            self.view_mappings_conts_union(up_to).contains(m),
-        decreases up_to - (self.level - 1),
-    {
-        if witness == up_to - 1 {
-        } else {
-            self.view_mappings_conts_union_intro(up_to - 1, m, witness);
-        }
+        self.continuations.filter_keys(|k| self.level - 1 <= k < NR_LEVELS).map_values(
+            |cont: CursorContinuation<'rcu, C>| cont.view_mappings(),
+        ).values().flatten()
     }
 
     pub proof fn view_mappings_contains(self, m: Mapping)
@@ -1118,7 +1054,22 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     m,
                 ),
     {
-        self.view_mappings_conts_union_contains(NR_LEVELS as int, m);
+        broadcast use vstd::map_lib::group_map_properties;
+        broadcast use vstd::set::group_set_lemmas;
+        broadcast use vstd::set_lib::group_set_lib_default;
+
+        let filtered = self.continuations.filter_keys(|k| self.level - 1 <= k < NR_LEVELS);
+        let mapped = filtered.map_values(|cont: CursorContinuation<'rcu, C>| cont.view_mappings());
+        let values = mapped.values();
+        values.lemma_flatten_contains(m);
+        let elem_s = choose|elem_s: Set<Mapping>| #[trigger]
+            values.contains(elem_s) && elem_s.contains(m);
+        assert(exists|i: int| #[trigger] mapped.dom().contains(i) && mapped[i] == elem_s);
+        let i = choose|i: int| #[trigger] mapped.dom().contains(i) && mapped[i] == elem_s;
+        assert(filtered.dom().contains(i));
+        assert(self.level - 1 <= i < NR_LEVELS);
+        assert(filtered[i] == self.continuations[i]);
+        assert(mapped[i] == self.continuations[i].view_mappings());
     }
 
     pub proof fn view_mappings_intro(self, m: Mapping, i: int)
@@ -1130,7 +1081,19 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         ensures
             self.view_mappings().contains(m),
     {
-        self.view_mappings_conts_union_intro(NR_LEVELS as int, m, i);
+        broadcast use vstd::map_lib::group_map_properties;
+        broadcast use vstd::set::group_set_lemmas;
+        broadcast use vstd::set_lib::group_set_lib_default;
+
+        let filtered = self.continuations.filter_keys(|k| self.level - 1 <= k < NR_LEVELS);
+        let mapped = filtered.map_values(|cont: CursorContinuation<'rcu, C>| cont.view_mappings());
+        let values = mapped.values();
+        assert(filtered.dom().contains(i));
+        assert(filtered[i] == self.continuations[i]);
+        assert(mapped.dom().contains(i));
+        assert(mapped[i] == self.continuations[i].view_mappings());
+        assert(values.contains(mapped[i]));
+        values.lemma_flatten_contains(m);
     }
 
     pub open spec fn as_page_table_owner(self) -> PageTableOwner<C> {

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -343,41 +343,43 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         ).to_set().flatten()
     }
 
-    pub proof fn lemma_view_mappings_contains(self, m: Mapping)
-        requires
-            self.children.len() > 0,
-            self.view_mappings().contains(m),
+    pub broadcast proof fn lemma_view_mappings_contains(self)
         ensures
-            exists|i: int|
-                #![auto]
-                0 <= i < self.children.len() && self.children[i] is Some && PageTableOwner(
-                    self.children[i]->0,
-                ).view_rec(self.path().push_tail(i as usize)).contains(m),
+            #![trigger self.view_mappings()]
+            forall |m: Mapping|
+                #[trigger] self.view_mappings().contains(m) ==> exists |i: int| #![auto]
+                    0 <= i < self.children.len() && self.children[i] is Some && PageTableOwner(
+                        self.children[i]->0,
+                    ).view_rec(self.path().push_tail(i as usize)).contains(m),
     {
         broadcast use vstd::seq_lib::group_seq_properties;
 
-        let mapped = self.children.map(
-            |i, child: Option<OwnerSubtree<C>>|
-                if child is Some {
-                    PageTableOwner(child->0).view_rec(self.path().push_tail(i as usize))
-                } else {
-                    Set::empty()
-                },
-        );
-        mapped.to_set().lemma_flatten_contains(m);
-        let elem_s = choose|elem_s: Set<Mapping>| #[trigger]
-            mapped.to_set().contains(elem_s) && elem_s.contains(m);
-        mapped.to_set_ensures();
-        assert(mapped.contains(elem_s));
-        let i = mapped.lemma_contains_to_index(elem_s);
-        assert(0 <= i < self.children.len());
-        if self.children[i] is Some {
-            assert(mapped[i] == PageTableOwner(self.children[i]->0).view_rec(
-                self.path().push_tail(i as usize),
-            ));
-        } else {
-            assert(mapped[i] == Set::<Mapping>::empty());
-            assert(false);
+        assert forall |m: Mapping| self.view_mappings().contains(m) implies exists|i: int|
+            0 <= i < self.children.len() && self.children[i] is Some
+                && PageTableOwner(self.children[i]->0).view_rec(self.path().push_tail(i as usize)).contains(m) by {
+            let mapped = self.children.map(
+                |i, child: Option<OwnerSubtree<C>>|
+                    if child is Some {
+                        PageTableOwner(child->0).view_rec(self.path().push_tail(i as usize))
+                    } else {
+                        Set::empty()
+                    },
+            );
+            mapped.to_set().lemma_flatten_contains(m);
+            let elem_s = choose|elem_s: Set<Mapping>| #[trigger]
+                mapped.to_set().contains(elem_s) && elem_s.contains(m);
+            mapped.to_set_ensures();
+            assert(mapped.contains(elem_s));
+            let i = mapped.lemma_contains_to_index(elem_s);
+            assert(0 <= i < self.children.len());
+            if self.children[i] is Some {
+                assert(mapped[i] == PageTableOwner(self.children[i]->0).view_rec(
+                    self.path().push_tail(i as usize),
+                ));
+            } else {
+                assert(mapped[i] == Set::<Mapping>::empty());
+                assert(false);
+            }
         }
     }
 
@@ -391,8 +393,6 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         ensures
             self.view_mappings().contains(m),
     {
-        broadcast use vstd::set::group_set_lemmas;
-        broadcast use vstd::set_lib::group_set_lib_default;
         broadcast use vstd::seq_lib::group_seq_properties;
 
         let mapped = self.children.map(

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -347,7 +347,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         ensures
             #![trigger self.view_mappings()]
             forall|m: Mapping| #[trigger]
-                self.view_mappings().contains(m) ==> exists |i: int|
+                self.view_mappings().contains(m) ==> exists|i: int|
                     #![auto]
                     0 <= i < self.children.len() && self.children[i] is Some && PageTableOwner(
                         self.children[i]->0,
@@ -1052,33 +1052,38 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
     pub broadcast proof fn lemma_view_mappings_contains(self)
         requires
-        1 <= self.level <= NR_LEVELS,
+            1 <= self.level <= NR_LEVELS,
         ensures
-        #![trigger self.view_mappings()]
-            forall |m: Mapping| #[trigger] self.view_mappings().contains(m) ==> exists |i: int|
-                #![trigger self.continuations[i]]
-                self.level - 1 <= i < NR_LEVELS && self.continuations[i].view_mappings().contains(
-                    m,
-                ),
+            #![trigger self.view_mappings()]
+            forall|m: Mapping| #[trigger]
+                self.view_mappings().contains(m) ==> exists|i: int|
+                    #![trigger self.continuations[i]]
+                    self.level - 1 <= i < NR_LEVELS
+                        && self.continuations[i].view_mappings().contains(m),
     {
         broadcast use vstd::map_lib::group_map_properties;
 
-        assert forall |m: Mapping| #[trigger] self.view_mappings().contains(m) implies exists |i: int|
+        assert forall|m: Mapping| #[trigger] self.view_mappings().contains(m) implies exists|i: int|
+
             #![trigger self.continuations[i]]
-            self.level - 1 <= i < NR_LEVELS && self.continuations[i].view_mappings().contains(m) by {
-                let filtered = self.continuations.filter_keys(|k| self.level - 1 <= k < NR_LEVELS);
-                let mapped = filtered.map_values(|cont: CursorContinuation<'rcu, C>| cont.view_mappings());
-                let values = mapped.values();
-                values.lemma_flatten_contains(m);
-                let elem_s = choose|elem_s: Set<Mapping>| #[trigger]
-                    values.contains(elem_s) && elem_s.contains(m);
-                assert(exists|i: int| #[trigger] mapped.dom().contains(i) && mapped[i] == elem_s);
-                let i = choose|i: int| #[trigger] mapped.dom().contains(i) && mapped[i] == elem_s;
-                assert(filtered.dom().contains(i));
-                assert(self.level - 1 <= i < NR_LEVELS);
-                assert(filtered[i] == self.continuations[i]);
-                assert(mapped[i] == self.continuations[i].view_mappings());
-            }
+            self.level - 1 <= i < NR_LEVELS && self.continuations[i].view_mappings().contains(
+                m,
+            ) by {
+            let filtered = self.continuations.filter_keys(|k| self.level - 1 <= k < NR_LEVELS);
+            let mapped = filtered.map_values(
+                |cont: CursorContinuation<'rcu, C>| cont.view_mappings(),
+            );
+            let values = mapped.values();
+            values.lemma_flatten_contains(m);
+            let elem_s = choose|elem_s: Set<Mapping>| #[trigger]
+                values.contains(elem_s) && elem_s.contains(m);
+            assert(exists|i: int| #[trigger] mapped.dom().contains(i) && mapped[i] == elem_s);
+            let i = choose|i: int| #[trigger] mapped.dom().contains(i) && mapped[i] == elem_s;
+            assert(filtered.dom().contains(i));
+            assert(self.level - 1 <= i < NR_LEVELS);
+            assert(filtered[i] == self.continuations[i]);
+            assert(mapped[i] == self.continuations[i].view_mappings());
+        }
     }
 
     pub broadcast proof fn lemma_view_mappings_intro(self, m: Mapping, i: int)

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -347,7 +347,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         ensures
             #![trigger self.view_mappings()]
             forall|m: Mapping| #[trigger]
-                self.view_mappings().contains(m) ==> exists|i: int|
+                self.view_mappings().contains(m) ==> exists |i: int|
                     #![auto]
                     0 <= i < self.children.len() && self.children[i] is Some && PageTableOwner(
                         self.children[i]->0,
@@ -1050,41 +1050,43 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         ).values().flatten()
     }
 
-    pub proof fn view_mappings_contains(self, m: Mapping)
+    pub broadcast proof fn lemma_view_mappings_contains(self)
         requires
-            1 <= self.level <= NR_LEVELS,
-            self.view_mappings().contains(m),
+        1 <= self.level <= NR_LEVELS,
         ensures
-            exists|i: int|
+        #![trigger self.view_mappings()]
+            forall |m: Mapping| #[trigger] self.view_mappings().contains(m) ==> exists |i: int|
                 #![trigger self.continuations[i]]
                 self.level - 1 <= i < NR_LEVELS && self.continuations[i].view_mappings().contains(
                     m,
                 ),
     {
         broadcast use vstd::map_lib::group_map_properties;
-        broadcast use vstd::set::group_set_lemmas;
-        broadcast use vstd::set_lib::group_set_lib_default;
 
-        let filtered = self.continuations.filter_keys(|k| self.level - 1 <= k < NR_LEVELS);
-        let mapped = filtered.map_values(|cont: CursorContinuation<'rcu, C>| cont.view_mappings());
-        let values = mapped.values();
-        values.lemma_flatten_contains(m);
-        let elem_s = choose|elem_s: Set<Mapping>| #[trigger]
-            values.contains(elem_s) && elem_s.contains(m);
-        assert(exists|i: int| #[trigger] mapped.dom().contains(i) && mapped[i] == elem_s);
-        let i = choose|i: int| #[trigger] mapped.dom().contains(i) && mapped[i] == elem_s;
-        assert(filtered.dom().contains(i));
-        assert(self.level - 1 <= i < NR_LEVELS);
-        assert(filtered[i] == self.continuations[i]);
-        assert(mapped[i] == self.continuations[i].view_mappings());
+        assert forall |m: Mapping| #[trigger] self.view_mappings().contains(m) implies exists |i: int|
+            #![trigger self.continuations[i]]
+            self.level - 1 <= i < NR_LEVELS && self.continuations[i].view_mappings().contains(m) by {
+                let filtered = self.continuations.filter_keys(|k| self.level - 1 <= k < NR_LEVELS);
+                let mapped = filtered.map_values(|cont: CursorContinuation<'rcu, C>| cont.view_mappings());
+                let values = mapped.values();
+                values.lemma_flatten_contains(m);
+                let elem_s = choose|elem_s: Set<Mapping>| #[trigger]
+                    values.contains(elem_s) && elem_s.contains(m);
+                assert(exists|i: int| #[trigger] mapped.dom().contains(i) && mapped[i] == elem_s);
+                let i = choose|i: int| #[trigger] mapped.dom().contains(i) && mapped[i] == elem_s;
+                assert(filtered.dom().contains(i));
+                assert(self.level - 1 <= i < NR_LEVELS);
+                assert(filtered[i] == self.continuations[i]);
+                assert(mapped[i] == self.continuations[i].view_mappings());
+            }
     }
 
-    pub proof fn lemma_view_mappings_intro(self, m: Mapping, i: int)
+    pub broadcast proof fn lemma_view_mappings_intro(self, m: Mapping, i: int)
         requires
             1 <= self.level <= NR_LEVELS,
             self.level - 1 <= i < NR_LEVELS,
             self.continuations.contains_key(i),
-            self.continuations[i].view_mappings().contains(m),
+            #[trigger] self.continuations[i].view_mappings().contains(m),
         ensures
             self.view_mappings().contains(m),
     {
@@ -2823,6 +2825,11 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         ensures
             res == Self::new(owner_subtree, idx, guard),
     ;
+
+    pub broadcast group group_lemmas {
+        CursorOwner::lemma_view_mappings_contains,
+        CursorOwner::lemma_view_mappings_intro,
+    }
 }
 
 pub ghost struct CursorView<C: PageTableConfig> {

--- a/ostd/specs/mm/page_table/cursor/va_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/va_lemmas.rs
@@ -218,6 +218,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.cur_va_range().start.reflect(self@.query_range().start as Vaddr),
             self.cur_va_range().end.reflect(self@.query_range().end as Vaddr),
     {
+        broadcast use CursorContinuation::group_lemmas;
+
         self.cur_subtree_inv();
         self.cur_va_in_subtree_range();
         self.view_preserves_inv();
@@ -250,8 +252,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         };
         assert(PageTableOwner(subtree).view_rec(path) == set![m]);
         assert(PageTableOwner(subtree).view_rec(path).contains(m));
-        cont.view_mappings_intro(m, cont.idx as int);
-        self.view_mappings_intro(m, (self.level - 1) as int);
+        self.lemma_view_mappings_intro(m, (self.level - 1) as int);
         assert(m.inv());
 
         self.cur_va_in_subtree_range();

--- a/ostd/specs/mm/page_table/cursor/va_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/va_lemmas.rs
@@ -206,6 +206,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
     }
 
     // ─── Proofs: VA range / view ─────────────────────────────────────────
+    #[verifier::spinoff_prover]
+    #[verifier::rlimit(100)]
     pub proof fn cur_va_range_reflects_view(self)
         requires
             self.inv(),

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -4389,7 +4389,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                             owner.view_mappings().contains(
                                 m,
                             ) implies owner_before_dfs.view_mappings().contains(m) by {
-                            owner.view_mappings_contains(m);
+                            owner.lemma_view_mappings_contains();
                             let i = choose|i: int|
                                 owner.level - 1 <= i < NR_LEVELS
                                     && #[trigger] owner.continuations[i].view_mappings().contains(
@@ -4401,7 +4401,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                             owner_before_dfs.view_mappings().contains(
                                 m,
                             ) implies owner.view_mappings().contains(m) by {
-                            owner_before_dfs.view_mappings_contains(m);
+                            owner_before_dfs.lemma_view_mappings_contains();
                             let i = choose|i: int|
                                 owner_before_dfs.level - 1 <= i < NR_LEVELS
                                     && #[trigger] owner_before_dfs.continuations[i].view_mappings().contains(

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -3957,7 +3957,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 final_cont.view_mappings().contains(m) implies cont1.put_child(
                 new_owner,
             ).view_mappings().contains(m) by {
-                final_cont.view_mappings_contains(m);
+                final_cont.lemma_view_mappings_contains(m);
                 let j = choose|j: int|
                     #![auto]
                     0 <= j < final_cont.children.len() && final_cont.children[j] is Some
@@ -3970,7 +3970,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 cont1.put_child(new_owner).view_mappings().contains(
                     m,
                 ) implies final_cont.view_mappings().contains(m) by {
-                cont1.put_child(new_owner).view_mappings_contains(m);
+                cont1.put_child(new_owner).lemma_view_mappings_contains(m);
                 let j = choose|j: int|
                     #![auto]
                     0 <= j < cont1.put_child(new_owner).children.len() && cont1.put_child(
@@ -4353,7 +4353,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                                     m,
                                 ) implies owner_before_dfs.continuations[i].view_mappings().contains(
                             m) by {
-                                owner.continuations[i].view_mappings_contains(m);
+                                owner.continuations[i].lemma_view_mappings_contains(m);
                                 let j = choose|j: int|
                                     #![auto]
                                     0 <= j < owner.continuations[i].children.len()
@@ -4371,7 +4371,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                                 owner_before_dfs.continuations[i].view_mappings().contains(
                                     m,
                                 ) implies owner.continuations[i].view_mappings().contains(m) by {
-                                owner_before_dfs.continuations[i].view_mappings_contains(m);
+                                owner_before_dfs.continuations[i].lemma_view_mappings_contains(m);
                                 let j = choose|j: int|
                                     #![auto]
                                     0 <= j < owner_before_dfs.continuations[i].children.len()

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -3861,6 +3861,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             // fully preserves `regions.slots`.
             res is None ==> final(regions).slots == old(regions).slots,
     {
+        broadcast use CursorContinuation::lemma_view_mappings_contains; 
         let ghost owner0 = *owner;
         let ghost regions0 = *regions;
         let ghost guard_level = owner.guard_level;
@@ -3957,7 +3958,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 final_cont.view_mappings().contains(m) implies cont1.put_child(
                 new_owner,
             ).view_mappings().contains(m) by {
-                final_cont.lemma_view_mappings_contains(m);
                 let j = choose|j: int|
                     #![auto]
                     0 <= j < final_cont.children.len() && final_cont.children[j] is Some
@@ -3970,7 +3970,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 cont1.put_child(new_owner).view_mappings().contains(
                     m,
                 ) implies final_cont.view_mappings().contains(m) by {
-                cont1.put_child(new_owner).lemma_view_mappings_contains(m);
                 let j = choose|j: int|
                     #![auto]
                     0 <= j < cont1.put_child(new_owner).children.len() && cont1.put_child(
@@ -4353,7 +4352,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                                     m,
                                 ) implies owner_before_dfs.continuations[i].view_mappings().contains(
                             m) by {
-                                owner.continuations[i].lemma_view_mappings_contains(m);
                                 let j = choose|j: int|
                                     #![auto]
                                     0 <= j < owner.continuations[i].children.len()
@@ -4371,7 +4369,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                                 owner_before_dfs.continuations[i].view_mappings().contains(
                                     m,
                                 ) implies owner.continuations[i].view_mappings().contains(m) by {
-                                owner_before_dfs.continuations[i].lemma_view_mappings_contains(m);
                                 let j = choose|j: int|
                                     #![auto]
                                     0 <= j < owner_before_dfs.continuations[i].children.len()

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -3471,7 +3471,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                     crate::specs::mm::page_table::cursor::page_size_lemmas::lemma_page_size_ge_page_size(
                     owner_before_replace.level);
                 };
-                assert forall|mm: Mapping|
+                assert forall|mm: Mapping| #[trigger]
                     owner_final@.mappings.contains(mm) implies mm.va_range.start != sv by {
                     if mm.va_range.start == sv {
                         assert(owner_before_replace@.mappings.contains(mm));
@@ -3955,7 +3955,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             ));
             assert(cont1.put_child(new_owner).view_mappings() == cont1.view_mappings() + new_sub);
             assert(final_cont.children == cont1.put_child(new_owner).children);
-            assert forall|m: Mapping|
+            assert forall|m: Mapping| #[trigger]
                 final_cont.view_mappings().contains(m) implies cont1.put_child(
                 new_owner,
             ).view_mappings().contains(m) by {
@@ -3969,7 +3969,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             assert forall|m: Mapping|
                 cont1.put_child(new_owner).view_mappings().contains(
                     m,
-                ) implies final_cont.view_mappings().contains(m) by {
+                ) implies #[trigger] final_cont.view_mappings().contains(m) by {
                 let j = choose|j: int|
                     #![auto]
                     0 <= j < cont1.put_child(new_owner).children.len() && cont1.put_child(
@@ -3991,8 +3991,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 // Known: owner.vm == (a - b).union(c)
                 // Known: c == (b - d) + e
                 // Want:  (a - b).union(c) == (a - d) + e
-                assert forall|m: Mapping| owner.view_mappings().contains(m) implies (a - d
-                    + e).contains(m) by {
+                assert forall|m: Mapping| #[trigger] owner.view_mappings().contains(m) implies (a
+                    - d + e).contains(m) by {
                     if c.contains(m) {
                         if e.contains(m) {
                         } else {
@@ -4005,19 +4005,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         assert((a - b).contains(m));
                         assert(a.contains(m));
                         assert(!b.contains(m));
-                    }
-                };
-                assert forall|m: Mapping|
-                    (a - d + e).contains(m) implies owner.view_mappings().contains(m) by {
-                    if e.contains(m) {
-                        // m in new_sub => m in c (since c == (b-d) + e)
-                        // => m in (a-b).union(c) = owner.vm
-                    } else {
-                        // m in a - d and not in e
-                        // m in a and not in d
-                        // Need: m in (a - b).union(c)
-                        // Case 1: m not in b => m in a - b => done
-                        // Case 2: m in b => m in b - d (since not in d) => m in c => done
                     }
                 };
             };
@@ -4344,7 +4331,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                             assert forall|m: Mapping|
                                 owner.continuations[i].view_mappings().contains(
                                     m,
-                                ) implies owner_before_dfs.continuations[i].view_mappings().contains(
+                                ) implies #[trigger] owner_before_dfs.continuations[i].view_mappings().contains(
                             m) by {
                                 let j = choose|j: int|
                                     #![auto]
@@ -4358,7 +4345,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                                 assert(owner_before_dfs.continuations[i].children[j]
                                     == owner.continuations[i].children[j]);
                             };
-                            assert forall|m: Mapping|
+                            assert forall|m: Mapping| #[trigger]
                                 owner_before_dfs.continuations[i].view_mappings().contains(
                                     m,
                                 ) implies owner.continuations[i].view_mappings().contains(m) by {
@@ -4385,14 +4372,14 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         assert forall|m: Mapping|
                             owner.view_mappings().contains(
                                 m,
-                            ) implies owner_before_dfs.view_mappings().contains(m) by {
+                            ) implies #[trigger] owner_before_dfs.view_mappings().contains(m) by {
                             let i = choose|i: int|
                                 owner.level - 1 <= i < NR_LEVELS
                                     && #[trigger] owner.continuations[i].view_mappings().contains(
                                     m,
                                 );
                         };
-                        assert forall|m: Mapping|
+                        assert forall|m: Mapping| #[trigger]
                             owner_before_dfs.view_mappings().contains(
                                 m,
                             ) implies owner.view_mappings().contains(m) by {

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -3861,7 +3861,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             // fully preserves `regions.slots`.
             res is None ==> final(regions).slots == old(regions).slots,
     {
-        broadcast use CursorContinuation::group_lemmas;
+        broadcast use {CursorContinuation::group_lemmas, CursorOwner::group_lemmas};
 
         let ghost owner0 = *owner;
         let ghost regions0 = *regions;
@@ -3998,7 +3998,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         } else {
                             assert((b - d).contains(m));
                             assert(b.contains(m));
-                            owner0.lemma_view_mappings_intro(m, (owner0.level - 1) as int);
                             assert(a.contains(m));
                             assert(!d.contains(m));
                         }
@@ -4358,7 +4357,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                                     ).contains(m);
                                 assert(owner_before_dfs.continuations[i].children[j]
                                     == owner.continuations[i].children[j]);
-                                owner_before_dfs.continuations[i].lemma_view_mappings_intro(m, j);
                             };
                             assert forall|m: Mapping|
                                 owner_before_dfs.continuations[i].view_mappings().contains(
@@ -4377,7 +4375,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                                     ).contains(m);
                                 assert(owner.continuations[i].children[j]
                                     == owner_before_dfs.continuations[i].children[j]);
-                                owner.continuations[i].lemma_view_mappings_intro(m, j);
                             };
                         };
                     };
@@ -4389,24 +4386,20 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                             owner.view_mappings().contains(
                                 m,
                             ) implies owner_before_dfs.view_mappings().contains(m) by {
-                            owner.lemma_view_mappings_contains();
                             let i = choose|i: int|
                                 owner.level - 1 <= i < NR_LEVELS
                                     && #[trigger] owner.continuations[i].view_mappings().contains(
                                     m,
                                 );
-                            owner_before_dfs.lemma_view_mappings_intro(m, i);
                         };
                         assert forall|m: Mapping|
                             owner_before_dfs.view_mappings().contains(
                                 m,
                             ) implies owner.view_mappings().contains(m) by {
-                            owner_before_dfs.lemma_view_mappings_contains();
                             let i = choose|i: int|
                                 owner_before_dfs.level - 1 <= i < NR_LEVELS
                                     && #[trigger] owner_before_dfs.continuations[i].view_mappings().contains(
                                 m);
-                            owner.lemma_view_mappings_intro(m, i);
                         };
                     };
                 }

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -3861,7 +3861,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             // fully preserves `regions.slots`.
             res is None ==> final(regions).slots == old(regions).slots,
     {
-        broadcast use CursorContinuation::lemma_view_mappings_contains; 
+        broadcast use CursorContinuation::group_lemmas;
+
         let ghost owner0 = *owner;
         let ghost regions0 = *regions;
         let ghost guard_level = owner.guard_level;
@@ -3964,7 +3965,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         && PageTableOwner(final_cont.children[j].unwrap()).view_rec(
                         final_cont.path().push_tail(j as usize),
                     ).contains(m);
-                cont1.put_child(new_owner).view_mappings_intro(m, j);
             };
             assert forall|m: Mapping|
                 cont1.put_child(new_owner).view_mappings().contains(
@@ -3977,7 +3977,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                     ).children[j] is Some && PageTableOwner(
                         cont1.put_child(new_owner).children[j].unwrap(),
                     ).view_rec(cont1.put_child(new_owner).path().push_tail(j as usize)).contains(m);
-                final_cont.view_mappings_intro(m, j);
             };
             assert(final_cont.view_mappings() == cont1.view_mappings() + new_sub);
             // Set arithmetic: (A - B) + C == A - D + E
@@ -3999,7 +3998,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         } else {
                             assert((b - d).contains(m));
                             assert(b.contains(m));
-                            owner0.view_mappings_intro(m, (owner0.level - 1) as int);
+                            owner0.lemma_view_mappings_intro(m, (owner0.level - 1) as int);
                             assert(a.contains(m));
                             assert(!d.contains(m));
                         }
@@ -4007,10 +4006,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         assert((a - b).contains(m));
                         assert(a.contains(m));
                         assert(!b.contains(m));
-                        if d.contains(m) {
-                            cont0.view_mappings_intro(m, cont0.idx as int);
-                            assert(false);
-                        }
                     }
                 };
                 assert forall|m: Mapping|
@@ -4363,7 +4358,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                                     ).contains(m);
                                 assert(owner_before_dfs.continuations[i].children[j]
                                     == owner.continuations[i].children[j]);
-                                owner_before_dfs.continuations[i].view_mappings_intro(m, j);
+                                owner_before_dfs.continuations[i].lemma_view_mappings_intro(m, j);
                             };
                             assert forall|m: Mapping|
                                 owner_before_dfs.continuations[i].view_mappings().contains(
@@ -4382,7 +4377,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                                     ).contains(m);
                                 assert(owner.continuations[i].children[j]
                                     == owner_before_dfs.continuations[i].children[j]);
-                                owner.continuations[i].view_mappings_intro(m, j);
+                                owner.continuations[i].lemma_view_mappings_intro(m, j);
                             };
                         };
                     };
@@ -4400,7 +4395,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                                     && #[trigger] owner.continuations[i].view_mappings().contains(
                                     m,
                                 );
-                            owner_before_dfs.view_mappings_intro(m, i);
+                            owner_before_dfs.lemma_view_mappings_intro(m, i);
                         };
                         assert forall|m: Mapping|
                             owner_before_dfs.view_mappings().contains(
@@ -4411,7 +4406,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                                 owner_before_dfs.level - 1 <= i < NR_LEVELS
                                     && #[trigger] owner_before_dfs.continuations[i].view_mappings().contains(
                                 m);
-                            owner.view_mappings_intro(m, i);
+                            owner.lemma_view_mappings_intro(m, i);
                         };
                     };
                 }


### PR DESCRIPTION
#511 introduces inductive definitions to solve `Set::new_assuming_finite`, this PR refactors these definitions with more idiomatic `vstd` constructs.