### PR TITLE
Fix several `verus_spec` warnings

### DIFF
--- a/ostd/src/arch/x86/mm/mod.rs
+++ b/ostd/src/arch/x86/mm/mod.rs
@@ -260,6 +260,9 @@ pub unsafe fn activate_page_table(root_paddr: Paddr, root_pt_cache: CachePolicy)
 
 pub uninterp spec fn current_page_table_paddr_spec() -> Paddr;
 
+} // verus!
+
+#[verus_verify]
 #[verifier::external_body]
 #[verifier::when_used_as_spec(current_page_table_paddr_spec)]
 #[verus_spec(
@@ -268,11 +271,13 @@ pub uninterp spec fn current_page_table_paddr_spec() -> Paddr;
 )]
 pub fn current_page_table_paddr() -> Paddr {
     /* x86_64::registers::control::Cr3::read_raw()
-        .0
-        .start_address()
-        .as_u64() as Paddr*/
+    .0
+    .start_address()
+    .as_u64() as Paddr*/
     unimplemented!()
 }
+
+verus! {
 
 impl PageTableEntry {
     //cfg_if! {

--- a/ostd/src/mm/page_prop.rs
+++ b/ostd/src/mm/page_prop.rs
@@ -10,8 +10,7 @@ use verified_bitflags::bitflags;
 
 use core::ops::{Add, BitAnd, BitOr, BitXor, Sub};
 
-verus! {
-
+#[verus_verify]
 #[verifier::ext_equal]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PageProperty {
@@ -22,13 +21,28 @@ pub struct PageProperty {
     pub priv_flags: PrivilegedPageFlags,
 }
 
-global layout PageProperty is size == 3, align == 1;
-
 #[verus_verify]
-impl Inv for PageProperty {
-    open spec fn inv(self) -> bool {
-        &&& self.flags.bits() & PageFlags::all_bits() == self.flags.bits()
-        &&& self.priv_flags.bits() & PrivilegedPageFlags::all_bits() == self.priv_flags.bits()
+impl PageProperty {
+    /// Creates a new `PageProperty` with the given flags and cache policy for the user.
+    #[verus_verify(dual_spec)]
+    #[verus_spec(returns Self::new_user(flags, cache))]
+    pub fn new_user(flags: PageFlags, cache: CachePolicy) -> Self {
+        Self {
+            flags,
+            cache,
+            priv_flags: PrivilegedPageFlags::USER(),
+        }
+    }
+
+    /// Creates a page property that implies an invalid page without mappings.
+    #[verus_verify(dual_spec)]
+    #[verus_spec(returns Self::new_absent())]
+    pub fn new_absent() -> Self {
+        Self {
+            flags: PageFlags::empty(),
+            cache: CachePolicy::Writeback,
+            priv_flags: PrivilegedPageFlags::empty(),
+        }
     }
 }
 
@@ -36,6 +50,7 @@ impl Inv for PageProperty {
 /// A type to control the cacheability of the main memory.
 ///
 /// The type currently follows the definition as defined by the AMD64 manual.
+#[verus_verify]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CachePolicy {
     /// Uncacheable (UC).
@@ -92,7 +107,6 @@ pub enum CachePolicy {
     Writeback,
 }
 
-} // verus!
 bitflags! {
     /// Page protection permissions and access status.
     pub struct PageFlags: u8 {
@@ -176,28 +190,11 @@ impl PrivilegedPageFlags {
     }
 }
 
-} // verus!
-#[verus_verify]
-impl PageProperty {
-    /// Creates a new `PageProperty` with the given flags and cache policy for the user.
-    #[verus_verify(dual_spec)]
-    #[verus_spec(returns Self::new_user(flags, cache))]
-    pub fn new_user(flags: PageFlags, cache: CachePolicy) -> Self {
-        Self {
-            flags,
-            cache,
-            priv_flags: PrivilegedPageFlags::USER(),
-        }
-    }
-
-    /// Creates a page property that implies an invalid page without mappings.
-    #[verus_verify(dual_spec)]
-    #[verus_spec(returns Self::new_absent())]
-    pub fn new_absent() -> Self {
-        Self {
-            flags: PageFlags::empty(),
-            cache: CachePolicy::Writeback,
-            priv_flags: PrivilegedPageFlags::empty(),
-        }
+impl Inv for PageProperty {
+    open spec fn inv(self) -> bool {
+        &&& self.flags.bits() & PageFlags::all_bits() == self.flags.bits()
+        &&& self.priv_flags.bits() & PrivilegedPageFlags::all_bits() == self.priv_flags.bits()
     }
 }
+
+} // verus!

--- a/ostd/src/mm/page_prop.rs
+++ b/ostd/src/mm/page_prop.rs
@@ -32,27 +32,6 @@ impl Inv for PageProperty {
     }
 }
 
-#[verus_verify]
-impl PageProperty {
-    /// Creates a new `PageProperty` with the given flags and cache policy for the user.
-    #[verus_verify(dual_spec)]
-    #[verus_spec(returns Self::new_user(flags, cache))]
-    pub fn new_user(flags: PageFlags, cache: CachePolicy) -> Self {
-        Self { flags, cache, priv_flags: PrivilegedPageFlags::USER() }
-    }
-
-    /// Creates a page property that implies an invalid page without mappings.
-    #[verus_verify(dual_spec)]
-    #[verus_spec(returns Self::new_absent())]
-    pub fn new_absent() -> Self {
-        Self {
-            flags: PageFlags::empty(),
-            cache: CachePolicy::Writeback,
-            priv_flags: PrivilegedPageFlags::empty(),
-        }
-    }
-}
-
 // TODO: Make it more abstract when supporting other architectures.
 /// A type to control the cacheability of the main memory.
 ///
@@ -198,3 +177,27 @@ impl PrivilegedPageFlags {
 }
 
 } // verus!
+#[verus_verify]
+impl PageProperty {
+    /// Creates a new `PageProperty` with the given flags and cache policy for the user.
+    #[verus_verify(dual_spec)]
+    #[verus_spec(returns Self::new_user(flags, cache))]
+    pub fn new_user(flags: PageFlags, cache: CachePolicy) -> Self {
+        Self {
+            flags,
+            cache,
+            priv_flags: PrivilegedPageFlags::USER(),
+        }
+    }
+
+    /// Creates a page property that implies an invalid page without mappings.
+    #[verus_verify(dual_spec)]
+    #[verus_spec(returns Self::new_absent())]
+    pub fn new_absent() -> Self {
+        Self {
+            flags: PageFlags::empty(),
+            cache: CachePolicy::Writeback,
+            priv_flags: PrivilegedPageFlags::empty(),
+        }
+    }
+}

--- a/ostd/src/mm/tlb.rs
+++ b/ostd/src/mm/tlb.rs
@@ -41,7 +41,9 @@ pub struct TlbFlusher<'a  /*, G: PinCurrentCpu*/ > {
     //_pin_current: G,
 }
 
-impl<'a  /*, G: PinCurrentCpu*/ > TlbFlusher<'a  /*, G*/ > {
+} // verus!
+#[verus_verify]
+impl<'a /*, G: PinCurrentCpu*/> TlbFlusher<'a /*, G*/> {
     /// Creates a new TLB flusher with the specified CPUs to be flushed.
     ///
     /// The target CPUs should be a reference to an [`AtomicCpuSet`] that will
@@ -49,7 +51,7 @@ impl<'a  /*, G: PinCurrentCpu*/ > TlbFlusher<'a  /*, G*/ > {
     ///
     /// The flusher needs to stick to the current CPU. So please provide a
     /// guard that implements [`PinCurrentCpu`].
-    pub fn new(target_cpus: &'a AtomicCpuSet  /*, pin_current_guard: G*/ ) -> Self {
+    pub fn new(target_cpus: &'a AtomicCpuSet /*, pin_current_guard: G*/) -> Self {
         Self {
             target_cpus,
             have_unsynced_flush: CpuSet::new_empty(),
@@ -112,10 +114,11 @@ impl<'a  /*, G: PinCurrentCpu*/ > TlbFlusher<'a  /*, G*/ > {
             final(model).inv(),
     )]
     pub fn dispatch_tlb_flush(&mut self) {
-        unimplemented!()/*let irq_guard = crate::trap::irq::disable_local();
+        unimplemented!() /*let irq_guard = crate::trap::irq::disable_local();
+        
 
         if self.ops_stack.is_empty() {
-            return;
+        return;
         }
 
         // `Release` to make sure our modification on the PT is visible to CPUs
@@ -126,32 +129,31 @@ impl<'a  /*, G: PinCurrentCpu*/ > TlbFlusher<'a  /*, G*/ > {
         let mut need_flush_on_self = false;
 
         if target_cpus.contains(cur_cpu) {
-            target_cpus.remove(cur_cpu);
-            need_flush_on_self = true;
+        target_cpus.remove(cur_cpu);
+        need_flush_on_self = true;
         }
 
         for cpu in target_cpus.iter() {
-            {
-                let mut flush_ops = FLUSH_OPS.get_on_cpu(cpu).lock();
-                flush_ops.push_from(&self.ops_stack);
+        {
+        let mut flush_ops = FLUSH_OPS.get_on_cpu(cpu).lock();
+        flush_ops.push_from(&self.ops_stack);
 
-                // Clear ACK before dropping the lock to avoid false ACKs.
-                ACK_REMOTE_FLUSH
-                    .get_on_cpu(cpu)
-                    .store(false, Ordering::Relaxed);
-            }
-            self.have_unsynced_flush.add(cpu);
+        // Clear ACK before dropping the lock to avoid false ACKs.
+        ACK_REMOTE_FLUSH
+        .get_on_cpu(cpu)
+        .store(false, Ordering::Relaxed);
+        }
+        self.have_unsynced_flush.add(cpu);
         }
 
         crate::smp::inter_processor_call(&target_cpus, do_remote_flush);
 
         // Flush ourselves after sending all IPIs to save some time.
         if need_flush_on_self {
-            self.ops_stack.flush_all();
+        self.ops_stack.flush_all();
         } else {
-            self.ops_stack.clear_without_flush();
+        self.ops_stack.clear_without_flush();
         }*/
-
     }
 
     /// Waits for all the previous TLB flush requests to be completed.
@@ -171,23 +173,24 @@ impl<'a  /*, G: PinCurrentCpu*/ > TlbFlusher<'a  /*, G*/ > {
     /// other's TLB coherence.
     #[verifier::external_body]
     pub fn sync_tlb_flush(&mut self) {
-        unimplemented!()/*
+        unimplemented!() /*
         assert!(
-            irq::is_local_enabled(),
-            "Waiting for remote flush with IRQs disabled"
+        irq::is_local_enabled(),
+        "Waiting for remote flush with IRQs disabled"
         );
 
         for cpu in self.have_unsynced_flush.iter() {
-            while !ACK_REMOTE_FLUSH.get_on_cpu(cpu).load(Ordering::Relaxed) {
-                core::hint::spin_loop();
-            }
+        while !ACK_REMOTE_FLUSH.get_on_cpu(cpu).load(Ordering::Relaxed) {
+        core::hint::spin_loop();
+        }
         }
 
         self.have_unsynced_flush = CpuSet::new_empty();
-        */
-
+         */
     }
 }
+
+verus! {
 
 /// The operation to flush TLB entries.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/ostd/src/sync/atomic_data.rs
+++ b/ostd/src/sync/atomic_data.rs
@@ -68,6 +68,8 @@ impl<'a, V, Own, G: SpinGuardian> RwLockReadGuard<'a, crate::sync::AtomicDataWit
     }
 }
 
+} // verus!
+#[verus_verify]
 impl<V, Own> Deref for AtomicDataWithOwner<V, Own> {
     type Target = V;
 
@@ -77,6 +79,8 @@ impl<V, Own> Deref for AtomicDataWithOwner<V, Own> {
         &self.data
     }
 }
+
+verus! {
 
 impl<V, Own> AtomicDataWithOwner<V, Own> {
     #[inline]

--- a/ostd/src/sync/rcu/non_null/either.rs
+++ b/ostd/src/sync/rcu/non_null/either.rs
@@ -437,19 +437,16 @@ unsafe impl<'a, L: NonNullPtrRef<'a>, R: NonNullPtrRef<'a>> NonNullPtrRef<'a> fo
         }
     }
 }
-}
 
+} // verus!
 // A `min` implementation for use in constant evaluation.
 #[verus_verify(dual_spec)]
 const fn min(a: u32, b: u32) -> u32 {
-    if a < b {
-        a
-    } else {
-        b
-    }
+    if a < b { a } else { b }
 }
 
-verus!{
+verus! {
+
 /// # Safety
 ///
 /// The caller must ensure that removing the bits from the non-null pointer will result in another

--- a/ostd/src/sync/rcu/non_null/either.rs
+++ b/ostd/src/sync/rcu/non_null/either.rs
@@ -29,7 +29,6 @@ unsafe impl<L: NonNullPtr, R: NonNullPtr> NonNullPtr for Either<L, R> {
         "`L` and `R` alignments should be at least 2 to pack `Either` into one pointer",
     );
 
-    #[verus_spec]
     #[verifier::spinoff_prover]
     fn into_raw(self) -> (ret: (NonNull<Self::Target>, Tracked<Self::Permission>)) {
         proof_decl!{
@@ -438,9 +437,10 @@ unsafe impl<'a, L: NonNullPtrRef<'a>, R: NonNullPtrRef<'a>> NonNullPtrRef<'a> fo
         }
     }
 }
+}
 
 // A `min` implementation for use in constant evaluation.
-#[vstd::contrib::auto_spec]
+#[verus_verify(dual_spec)]
 const fn min(a: u32, b: u32) -> u32 {
     if a < b {
         a
@@ -449,10 +449,12 @@ const fn min(a: u32, b: u32) -> u32 {
     }
 }
 
+verus!{
 /// # Safety
 ///
 /// The caller must ensure that removing the bits from the non-null pointer will result in another
 /// non-null pointer.
+// FIXEME: fix when verus attribute syntax supports closure postconditions.
 #[verus_spec(ret =>
     requires
         (ptr.view_ptr_mut().addr() & bits) < ptr.view_ptr_mut().addr(),

--- a/ostd/src/sync/rcu/non_null/mod.rs
+++ b/ostd/src/sync/rcu/non_null/mod.rs
@@ -181,6 +181,7 @@ pub unsafe trait NonNullPtrRef<'a>: NonNullPtr {
     ;
 }
 
+} // verus!
 /// A type that represents `&'a Box<T>`.
 #[verus_verify]
 #[derive(Debug)]
@@ -188,24 +189,6 @@ pub struct BoxRef<'a, T> {
     inner: *mut T,
     _marker: PhantomData<&'a T>,
     tracked_perm: Tracked<BoxPointsToRef<'a, T>>,
-}
-
-impl<'a, T> BoxRef<'a, T> {
-    #[verifier::type_invariant]
-    spec fn type_inv(self) -> bool {
-        &&& self.inner@.addr != 0
-        &&& self.inner@.addr as int % vstd::layout::align_of::<T>() as int == 0
-        &&& self.tracked_perm@@.ptr() == self.inner
-        &&& self.tracked_perm@.inv()
-    }
-
-    pub closed spec fn ptr(self) -> *mut T {
-        self.inner
-    }
-
-    pub closed spec fn value(self) -> T {
-        self.tracked_perm@@.value()
-    }
 }
 
 /*
@@ -223,6 +206,8 @@ impl<T> Deref for BoxRef<'_, T> {
 }
 */
 
+verus! {
+
 #[verus_verify]
 impl<'a, T> BoxRef<'a, T> {
     /// Dereferences `self` to get a reference to `T` with the lifetime `'a`.
@@ -237,6 +222,7 @@ impl<'a, T> BoxRef<'a, T> {
 
         // The function body of ptr_ref is exactly the same as `unsafe { &*(self.inner) }`
         //unsafe { &*(self.inner) }
+        // FIXME: Fix when verus supports attribute syntax for raw pointers.
         vstd::raw_ptr::ptr_ref(
             self.inner,
             Tracked(self.tracked_perm.borrow().tracked_borrow_points_to()),
@@ -351,6 +337,25 @@ unsafe impl<'a, T: 'static> NonNullPtrRef<'a> for Box<T> {
     }
 }
 
+impl<'a, T> BoxRef<'a, T> {
+    #[verifier::type_invariant]
+    spec fn type_inv(self) -> bool {
+        &&& self.inner@.addr != 0
+        &&& self.inner@.addr as int % vstd::layout::align_of::<T>() as int == 0
+        &&& self.tracked_perm@@.ptr() == self.inner
+        &&& self.tracked_perm@.inv()
+    }
+
+    pub closed spec fn ptr(self) -> *mut T {
+        self.inner
+    }
+
+    pub closed spec fn value(self) -> T {
+        self.tracked_perm@@.value()
+    }
+}
+
+} // verus!
 /// A type that represents `&'a Arc<T>`.
 ///
 /// Note there is no verification-only permission field, because `ArcRef` uses `Arc` instead of a raw pointer internally.
@@ -359,14 +364,6 @@ unsafe impl<'a, T: 'static> NonNullPtrRef<'a> for Box<T> {
 pub struct ArcRef<'a, T: 'static> {
     inner: ManuallyDrop<Arc<T>>,
     _marker: PhantomData<&'a Arc<T>>,
-}
-
-impl<T> View for ArcRef<'_, T> {
-    type V = Arc<T>;
-
-    closed spec fn view(&self) -> Arc<T> {
-        self.inner@
-    }
 }
 
 #[verus_verify]
@@ -395,6 +392,8 @@ impl<'a, T> ArcRef<'a, T> {
         unsafe { &*(self.deref().deref() as *const T) }
     }
 }
+
+verus! {
 
 unsafe impl<T: 'static> NonNullPtr for Arc<T> {
     type Target = T;
@@ -491,6 +490,14 @@ unsafe impl<'a, T: 'static> NonNullPtrRef<'a> for Arc<T> {
 
     fn ref_as_raw(ptr_ref: Self::Ref) -> (NonNull<Self::Target>, Tracked<Self::RefPermission>) {
         NonNullPtr::into_raw(ManuallyDrop::into_inner(ptr_ref.inner))
+    }
+}
+
+impl<T> View for ArcRef<'_, T> {
+    type V = Arc<T>;
+
+    closed spec fn view(&self) -> Arc<T> {
+        self.inner@
     }
 }
 

--- a/ostd/src/sync/spin.rs
+++ b/ostd/src/sync/spin.rs
@@ -15,7 +15,6 @@ use core::{
 use super::{guard::SpinGuardian, LocalIrqDisabled /*, PreemptDisabled*/};
 //use crate::task::atomic_mode::AsAtomicModeGuard;
 
-verus! {
 /// A spin lock.
 ///
 /// # Guard behavior
@@ -82,6 +81,7 @@ verus! {
 ///
 /// [`type_inv`]: Self::type_inv
 #[repr(transparent)]
+#[verus_verify]
 //pub struct SpinLock<T: ?Sized, G = PreemptDisabled> {
 pub struct SpinLock<T, G> {
     phantom: PhantomData<G>,
@@ -107,6 +107,7 @@ closed spec fn wf(self) -> bool {
 }
 }
 
+verus!{
 impl<T> SpinLockInner<T>
 {
     #[verifier::type_invariant]
@@ -203,7 +204,6 @@ impl<T /*: ?Sized */, G: SpinGuardian> SpinLock<T, G> {
     ///    }
     ///}.is_ok()
     /// ```
-    #[verus_spec]
     pub fn lock(&self) -> SpinLockGuard<'_, T, G> {
         // Notice the guard must be created before acquiring the lock.
         proof!{ use_type_invariant(self);}
@@ -231,7 +231,6 @@ impl<T /*: ?Sized */, G: SpinGuardian> SpinLock<T, G> {
     /// If `Some(guard)` is returned, it satisfies its type invariant:
     /// - An exclusive permission to access the protected data is held by the guard.
     /// - The guard's permission matches the lock's internal cell ID.
-    #[verus_spec]
     pub fn try_lock(&self) -> Option<SpinLockGuard<'_, T, G>> {
         let inner_guard = G::guard();
         proof_decl!{
@@ -331,7 +330,7 @@ impl<T /*: ?Sized */, G: SpinGuardian> SpinLock<T, G> {
         }
     }
 }
-
+}
 
 /*
 impl<T: ?Sized + fmt::Debug, G> fmt::Debug for SpinLock<T, G> {
@@ -381,6 +380,7 @@ pub struct SpinLockGuard<'a, T /*: ?Sized*/, G: SpinGuardian> {
     tracked_perm: Tracked<PointsTo<T>>,
 }
 
+verus!{
 impl<'a, T, G: SpinGuardian> SpinLockGuard<'a, T, G>
 {
     #[verifier::type_invariant]
@@ -405,6 +405,7 @@ impl<T: ?Sized, G: SpinGuardian> AsAtomicModeGuard for SpinLockGuard<'_, T, G> {
     }
 }*/
 
+// FIXME: fix when verus attribute syntax supports Tracked.
 #[verus_verify]
 impl<T: /*?Sized*/, G: SpinGuardian> Deref for SpinLockGuard<'_, T, G> {
     type Target = T;
@@ -450,6 +451,7 @@ impl<T: /* ?Sized */, G: SpinGuardian> DerefMut for SpinLockGuard<'_, T, G> {
 }
 */
 
+#[verus_verify]
 impl<'a, T /*:?Sized */, G: SpinGuardian> SpinLockGuard<'a, T, G> {
     /// VERUS LIMITATION: We implement `drop` and call it manually because Verus's support for `Drop` is incomplete for now.
     #[verus_spec]

--- a/ostd/src/sync/spin.rs
+++ b/ostd/src/sync/spin.rs
@@ -107,7 +107,7 @@ closed spec fn wf(self) -> bool {
 }
 }
 
-verus!{
+verus! {
 impl<T> SpinLockInner<T>
 {
     #[verifier::type_invariant]
@@ -380,7 +380,7 @@ pub struct SpinLockGuard<'a, T /*: ?Sized*/, G: SpinGuardian> {
     tracked_perm: Tracked<PointsTo<T>>,
 }
 
-verus!{
+verus! {
 impl<'a, T, G: SpinGuardian> SpinLockGuard<'a, T, G>
 {
     #[verifier::type_invariant]


### PR DESCRIPTION
There are still 300+ warnings, but we can only wait until `verus_spec` is more powerful and stabilized.