### PR TITLE
`vstd_extra`: Remove `ModelOf`

### DIFF
--- a/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
+++ b/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
@@ -194,10 +194,6 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> OwnerOf for Link<M> {
     }
 }
 
-impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ModelOf for Link<M> {
-
-}
-
 pub ghost struct LinkedListModel {
     pub list: Seq<LinkModel>,
 }
@@ -1020,10 +1016,6 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> OwnerOf for LinkedList<M> {
     }
 }
 
-impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ModelOf for LinkedList<M> {
-
-}
-
 pub ghost struct CursorModel {
     pub ghost fore: Seq<LinkModel>,
     pub ghost rear: Seq<LinkModel>,
@@ -1119,10 +1111,6 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
         &&& owner.index == owner.list_own.list.len() ==> self.current.is_none()
         &&& (*self.list).wf_region(owner.list_own, regions)
     }
-}
-
-impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> ModelOf for CursorMut<'a, M> {
-
 }
 
 impl CursorModel {

--- a/ostd/specs/mm/frame/meta_owners.rs
+++ b/ostd/specs/mm/frame/meta_owners.rs
@@ -359,10 +359,6 @@ impl OwnerOf for MetaSlot {
     }
 }
 
-impl ModelOf for MetaSlot {
-
-}
-
 impl MetaSlotOwner {
     pub axiom fn take_inner_perms(tracked &mut self) -> (tracked res: MetadataInnerPerms)
         ensures

--- a/ostd/specs/mm/frame/meta_region_owners.rs
+++ b/ostd/specs/mm/frame/meta_region_owners.rs
@@ -128,10 +128,6 @@ impl OwnerOf for MetaRegion {
     }
 }
 
-impl ModelOf for MetaRegion {
-
-}
-
 impl MetaRegionOwners {
     pub open spec fn ref_count(self, i: usize) -> (res: u64)
         recommends

--- a/ostd/specs/mm/frame/unique.rs
+++ b/ostd/specs/mm/frame/unique.rs
@@ -58,10 +58,6 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> OwnerOf for UniqueFrame<
     }
 }
 
-impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> ModelOf for UniqueFrame<M> {
-
-}
-
 impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrameOwner<M> {
     /// The typed permission for this frame, reconstructed from the region: the
     /// outer pointer-perm `regions.slots[slot_index]` paired with the inner

--- a/ostd/specs/mm/page_table/cursor/cursor_fn_specs.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_fn_specs.rs
@@ -40,7 +40,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
     }
 
     pub open spec fn query_some_condition(self, owner: CursorOwner<'rcu, C>) -> bool {
-        self.model(owner).present()
+        owner@.present()
     }
 
     /// Panic condition for [`Self::query`]. `query` diverges *only* via the

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -3009,8 +3009,4 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> OwnerOf for Cursor<'rcu, C, A> {
     }
 }
 
-impl<'rcu, C: PageTableConfig, A: InAtomicMode> ModelOf for Cursor<'rcu, C, A> {
-
-}
-
 } // verus!

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -132,7 +132,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
             self.wf(owner),
             owner.inv(),
         ensures
-            s == self.model(owner).list.len(),
+            s == owner@.list.len(),
     )]
     pub fn size(&self) -> usize {
         proof {
@@ -225,7 +225,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
             owner.relate_region(*old(regions)),
         ensures
             owner.list.len() == 0 ==> r.is_none(),
-            r.is_some() ==> (r->0).0.model((r->0).1@).meta == owner.list[0]@,
+            r.is_some() ==> (r->0).1@@.meta == owner.list[0]@,
             r.is_some() ==> (r->0).1@.frame_link_inv(*final(regions)),
     )]
     pub fn pop_front(&mut self) -> Option<
@@ -320,7 +320,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
             owner.relate_region(*old(regions)),
         ensures
             owner.list.len() == 0 ==> r.is_none(),
-            r.is_some() ==> (r->0).0.model((r->0).1@).meta == owner.list[owner.list.len() - 1]@,
+            r.is_some() ==> (r->0).1@@.meta == owner.list[owner.list.len() - 1]@,
             r.is_some() ==> (r->0).1@.frame_link_inv(*final(regions)),
     )]
     pub fn pop_back(&mut self) -> Option<
@@ -614,9 +614,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
             owner.inv_region(*regions),
             old(self).wf_region(owner, *regions),
         ensures
-            final(self).model(owner.move_next_owner_spec()) == old(self).model(
-                owner,
-            ).move_next_spec(),
+            owner.move_next_owner_spec()@ == owner@.move_next_spec(),
             owner.move_next_owner_spec().inv_region(*regions),
             final(self).wf_region(owner.move_next_owner_spec(), *regions),
     {
@@ -654,12 +652,8 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
 
         proof {
             LinkedListOwner::<M>::view_preserves_len(owner.list_own.list);
-            assert(self.model(owner.move_next_owner_spec()).fore == old_self.model(
-                owner,
-            ).move_next_spec().fore);
-            assert(self.model(owner.move_next_owner_spec()).rear == old_self.model(
-                owner,
-            ).move_next_spec().rear);
+            assert(owner.move_next_owner_spec()@.fore == owner@.move_next_spec().fore);
+            assert(owner.move_next_owner_spec()@.rear == owner@.move_next_spec().rear);
         }
     }
 
@@ -678,9 +672,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
             owner.inv_region(*regions),
             old(self).wf_region(owner, *regions),
         ensures
-            final(self).model(owner.move_prev_owner_spec()) == old(self).model(
-                owner,
-            ).move_prev_spec(),
+            owner.move_prev_owner_spec()@ == owner@.move_prev_spec(),
             owner.move_prev_owner_spec().inv_region(*regions),
             final(self).wf_region(owner.move_prev_owner_spec(), *regions),
     {
@@ -721,12 +713,8 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
 
             if owner@.list_model.list.len() > 0 {
                 if owner@.fore.len() > 0 {
-                    assert(self.model(owner.move_prev_owner_spec()).fore == old_self.model(
-                        owner,
-                    ).move_prev_spec().fore);
-                    assert(self.model(owner.move_prev_owner_spec()).rear == old_self.model(
-                        owner,
-                    ).move_prev_spec().rear);
+                    assert(owner.move_prev_owner_spec()@.fore == owner@.move_prev_spec().fore);
+                    assert(owner.move_prev_owner_spec()@.rear == owner@.move_prev_spec().rear);
                     if owner@.rear.len() > 0 {
                         let _ = owner.list_own.list[owner.index];
                         owner.list_own.relate_region_at_facts(*regions, owner.index);
@@ -734,9 +722,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                 } else {
                     let _ = owner.list_own.list[owner.index];
                     owner.list_own.relate_region_at_facts(*regions, owner.index);
-                    assert(self.model(owner.move_prev_owner_spec()).rear == old_self.model(
-                        owner,
-                    ).move_prev_spec().rear);
+                    assert(owner.move_prev_owner_spec()@.rear == owner@.move_prev_spec().rear);
                     assert(owner@.rear == owner@.list_model.list);
                 }
             }
@@ -853,12 +839,8 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
         ensures
             old(owner).length() == 0 ==> res.is_none(),
             old(self).current.is_some() ==> res.is_some(),
-            res.is_some() ==> (res->0).0.model((res->0).1@).meta == old(owner).list_own.list[old(
-                owner,
-            ).index]@,
-            res.is_some() ==> final(self).model(*final(owner)) == old(self).model(
-                *old(owner),
-            ).remove(),
+            res.is_some() ==> (res->0).1@@.meta == old(owner).list_own.list[old(owner).index]@,
+            res.is_some() ==> final(owner)@ == old(owner)@.remove(),
             res.is_some() ==> (res->0).1@.frame_link_inv(*final(regions)),
             // Invariant preservation
             res.is_some() ==> final(owner).inv_region(*final(regions)),
@@ -1188,9 +1170,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
             final(owner).index == old(owner).index + 1,
             final(frame_own).meta_own.paddr == old(frame_own).meta_own.paddr,
             final(frame_own).meta_own.in_list == final(owner).list_own.list_id,
-            final(self).model(*final(owner)) == old(self).model(*old(owner)).insert(
-                final(frame_own).meta_own@,
-            ),
+            final(owner)@ == old(owner)@.insert(final(frame_own).meta_own@),
     {
         let ghost owner0 = *owner;
         let ghost regions0 = *regions;

--- a/ostd/src/mm/kspace/kvirt_area.rs
+++ b/ostd/src/mm/kspace/kvirt_area.rs
@@ -4,7 +4,7 @@ use vstd::prelude::*;
 
 use vstd_extra::arithmetic::nat_align_down;
 use vstd_extra::assert;
-use vstd_extra::ownership::{InvView, ModelOf, OwnerOf};
+use vstd_extra::ownership::{InvView, OwnerOf};
 use vstd_extra::panic::may_panic;
 use vstd_extra::prelude::Inv;
 
@@ -862,7 +862,7 @@ impl KVirtArea {
             assert(cursor.0.invariants(cursor_owner, *regions, *guards));
 
             let ghost regions_before_map = *regions;
-            let ghost old_cursor_model: CursorView<KernelPtConfig> = cursor.0.model(cursor_owner);
+            let ghost old_cursor_model: CursorView<KernelPtConfig> = cursor_owner@;
             let ghost old_cursor_owner_va = cursor_owner.va;
             proof {
                 cursor_owner.view_preserves_inv();  // old_cursor_model.inv()
@@ -1280,9 +1280,7 @@ impl KVirtArea {
                     entry_owner.in_scope = false;
                 }
 
-                let ghost old_cursor_model: CursorView<KernelPtConfig> = cursor.0.model(
-                    cursor_owner,
-                );
+                let ghost old_cursor_model: CursorView<KernelPtConfig> = cursor_owner@;
                 let ghost old_cursor_owner_va = cursor_owner.va;
                 let ghost old_va: nat = cursor.0.va as nat;
 

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -2835,8 +2835,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             final(self).0.invariants(*final(owner), *final(regions), *final(guards)),
             old(self).map_item_ensures(
                 item,
-                old(self).0.model(*old(owner)),
-                final(self).0.model(*final(owner)),
+                old(owner)@,
+                final(owner)@,
             ),
             (C::item_into_raw(item).1 <= old(self).0.level
                 && old(owner).cur_entry_owner().is_absent()) ==> res.is_ok(),

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -833,8 +833,8 @@ impl<'a, A: InAtomicMode> CursorMut<'a, A> {
             old(self).map_item_ensures(
                 frame,
                 prop,
-                old(self).pt_cursor.0.model(*old(cursor_owner)),
-                final(self).pt_cursor.0.model(*final(cursor_owner)),
+                old(cursor_owner)@,
+                final(cursor_owner)@,
             ),
     )]
     pub fn map(&mut self, frame: UFrame, prop: PageProperty) {
@@ -921,7 +921,7 @@ impl<'a, A: InAtomicMode> CursorMut<'a, A> {
         ensures
             !old(self).pt_cursor.0.find_next_panic_condition(len),
             final(self).pt_cursor.0.invariants(*final(cursor_owner), *final(regions), *final(guards)),
-            old(self).pt_cursor.0.model(*old(cursor_owner)).unmap_spec(len, final(self).pt_cursor.0.model(*final(cursor_owner)), r),
+            old(cursor_owner)@.unmap_spec(len, final(cursor_owner)@, r),
             final(tlb_model).inv(),
     )]
     pub fn unmap(&mut self, len: usize) -> usize {
@@ -1440,8 +1440,8 @@ impl<'a, A: InAtomicMode> CursorMut<'a, A> {
         proof {
             cursor_owner.va.reflect_prop(self.pt_cursor.0.va);
 
-            let old_view = old(self).pt_cursor.0.model(*old(cursor_owner));
-            let new_view = self.pt_cursor.0.model(*cursor_owner);
+            let old_view = old(cursor_owner)@;
+            let new_view = cursor_owner@;
 
             // Bridge from loop invariant to unmap_spec.
             let start = old_view.cur_va;

--- a/verified_libs/vstd_extra/src/ownership.rs
+++ b/verified_libs/vstd_extra/src/ownership.rs
@@ -36,13 +36,4 @@ pub trait OwnerOf where <<Self as OwnerOf>::Owner as View>::V: Inv {
     ;
 }
 
-pub trait ModelOf: OwnerOf + Sized {
-    open spec fn model(self, owner: Self::Owner) -> <Self::Owner as View>::V
-        recommends
-            self.wf(owner),
-    {
-        owner.view()
-    }
-}
-
 } // verus!


### PR DESCRIPTION
`ModelOf` seems like an unnecessary complication because it adds a transparent layer above `owner@`. This PR removes this trait. @SNoAnd, please take a look to decide whether this change is beneficial!