### PR TITLE
chore(proof simplification): remove redundant wildcard patterns for triggers

### DIFF
--- a/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
+++ b/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
@@ -516,6 +516,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
         assert forall|k: int|
             #![trigger self.relate_region_at(regions2, k)]
             0 <= k < llen implies self.relate_region_at(regions2, k) by {
+            let _ = self.list[k];
             self.relate_region_at_facts(regions1, k);
             self.relate_region_at_from_clauses(regions2, k);
         }
@@ -646,15 +647,20 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
             } else {
                 k + 1
             };
+            let _ = old.list[p];
             old.relate_region_at_facts(r0, p);
+            let _ = old.list[n];
             old.relate_region_at_facts(r0, n);
             if p - 1 >= 0 {
+                let _ = old.list[p - 1];
                 old.relate_region_at_facts(r0, p - 1);
             }
             if p + 1 < old.list.len() {
+                let _ = old.list[p + 1];
                 old.relate_region_at_facts(r0, p + 1);
             }
             if n - 1 >= 0 {
+                let _ = old.list[n - 1];
                 old.relate_region_at_facts(r0, n - 1);
             }
             if n + 1 < old.list.len() {
@@ -815,15 +821,19 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
             #![trigger new.relate_region_at(fr, k)]
             0 <= k < nlen implies new.relate_region_at(fr, k) by {
             if k < n {
+                let _ = old.list[k];
                 old.relate_region_at_facts(r0, k);
             }
             if k > n {
+                let _ = old.list[k - 1];
                 old.relate_region_at_facts(r0, k - 1);
             }
             if n - 1 >= 0 && n - 1 < old.list.len() {
+                let _ = old.list[n - 1];
                 old.relate_region_at_facts(r0, n - 1);
             }
             if n >= 0 && n < old.list.len() {
+                let _ = old.list[n];
                 old.relate_region_at_facts(r0, n);
             }
             new.relate_region_at_from_clauses(fr, k);

--- a/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
+++ b/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
@@ -358,7 +358,6 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
                 #![trigger idxs.to_set().contains(x)]
                 idxs.to_set().contains(x) implies bound.contains(x) by {
                 let i = choose|i: int| 0 <= i < idxs.len() && idxs[i] == x;
-                let _ = self.list[i];
                 self.relate_region_at_facts(regions, i);
                 // `regions.inv()`: `contains_key(slot_index_at(i)) ⟹ < max_meta_slots()`.
             }
@@ -517,14 +516,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
         assert forall|k: int|
             #![trigger self.relate_region_at(regions2, k)]
             0 <= k < llen implies self.relate_region_at(regions2, k) by {
-            let _ = self.list[k];
             self.relate_region_at_facts(regions1, k);
-            if k > 0 {
-                let _ = self.list[k - 1];
-            }
-            if k < llen - 1 {
-                let _ = self.list[k + 1];
-            }
             self.relate_region_at_from_clauses(regions2, k);
         }
     }
@@ -643,7 +635,6 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
             } else {
                 m + 1
             };
-            let _ = old.list[pm];
             old.relate_region_at_facts(r0, pm);
         }
 
@@ -655,24 +646,18 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
             } else {
                 k + 1
             };
-            let _ = old.list[p];
             old.relate_region_at_facts(r0, p);
-            let _ = old.list[n];
             old.relate_region_at_facts(r0, n);
             if p - 1 >= 0 {
-                let _ = old.list[p - 1];
                 old.relate_region_at_facts(r0, p - 1);
             }
             if p + 1 < old.list.len() {
-                let _ = old.list[p + 1];
                 old.relate_region_at_facts(r0, p + 1);
             }
             if n - 1 >= 0 {
-                let _ = old.list[n - 1];
                 old.relate_region_at_facts(r0, n - 1);
             }
             if n + 1 < old.list.len() {
-                let _ = old.list[n + 1];
                 old.relate_region_at_facts(r0, n + 1);
             }
             new.relate_region_at_from_clauses(fr, k);
@@ -804,26 +789,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
         assert forall|a: int, b: int|
             #![trigger new.slot_index_at(a), new.slot_index_at(b)]
             0 <= a < nlen && 0 <= b < nlen && a != b implies new.slot_index_at(a)
-            != new.slot_index_at(b) by {
-            let _ = new.slot_index_at(a);
-            let _ = new.slot_index_at(b);
-            if a != n {
-                let pa = if a < n {
-                    a
-                } else {
-                    a - 1
-                };
-                let _ = old.slot_index_at(pa);
-            }
-            if b != n {
-                let pb = if b < n {
-                    b
-                } else {
-                    b - 1
-                };
-                let _ = old.slot_index_at(pb);
-            }
-        }
+            != new.slot_index_at(b) by {}
 
         assert forall|m: int| #![trigger new.meta_perm_of(fr, m)] 0 <= m < nlen implies ({
             &&& (m < n ==> new.meta_perm_of(fr, m).addr() == old.meta_perm_of(r0, m).addr()
@@ -838,11 +804,9 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
             ).points_to.pptr())
         }) by {
             if m < n {
-                let _ = old.list[m];
                 old.relate_region_at_facts(r0, m);
             }
             if m > n {
-                let _ = old.list[m - 1];
                 old.relate_region_at_facts(r0, m - 1);
             }
         }
@@ -851,23 +815,17 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
             #![trigger new.relate_region_at(fr, k)]
             0 <= k < nlen implies new.relate_region_at(fr, k) by {
             if k < n {
-                let _ = old.list[k];
                 old.relate_region_at_facts(r0, k);
             }
             if k > n {
-                let _ = old.list[k - 1];
                 old.relate_region_at_facts(r0, k - 1);
             }
             if n - 1 >= 0 && n - 1 < old.list.len() {
-                let _ = old.list[n - 1];
                 old.relate_region_at_facts(r0, n - 1);
             }
             if n >= 0 && n < old.list.len() {
-                let _ = old.list[n];
                 old.relate_region_at_facts(r0, n);
             }
-            let _ = old.slot_index_at(n - 1);
-            let _ = old.slot_index_at(n);
             new.relate_region_at_from_clauses(fr, k);
         }
 

--- a/ostd/specs/mm/frame/segment.rs
+++ b/ostd/specs/mm/frame/segment.rs
@@ -434,7 +434,6 @@ pub proof fn tracked_mint_seg_obligations(
             // i < n-1: recursion gives `gmid.count(idx_i) >= g0.count(idx_i)+1`;
             // the mint only grows counts. i == n-1: `gmid.count(idx) >= g0.count(idx)`
             // (monotone), and the mint adds exactly one at `idx`.
-            let _ = frame_to_index((range_start + i * PAGE_SIZE) as usize);
         };
     }
 }

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -237,7 +237,6 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
 
         proof {
             if owner.list.len() > 0 {
-                let _ = owner.list[0];
                 owner.relate_region_at_facts(*regions, 0);
             }
         }
@@ -332,7 +331,6 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
 
         proof {
             if owner.list.len() > 0 {
-                let _ = owner.list[owner.list.len() - 1];
                 owner.relate_region_at_facts(*regions, owner.list.len() - 1);
             }
         }
@@ -624,11 +622,9 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
 
         proof {
             if self.current is Some {
-                let _ = owner.list_own.list[owner.index];
                 owner.list_own.relate_region_at_facts(*regions, owner.index);
             }
             if owner.index < owner.length() - 1 {
-                let _ = owner.list_own.list[owner.index + 1];
                 owner.list_own.relate_region_at_facts(*regions, owner.index + 1);
             }
         }
@@ -688,11 +684,9 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
 
         proof {
             if self.current is Some {
-                let _ = owner.list_own.list[owner.index];
                 owner.list_own.relate_region_at_facts(*regions, owner.index);
             }
             if 0 < owner.index {
-                let _ = owner.list_own.list[owner.index - 1];
                 owner.list_own.relate_region_at_facts(*regions, owner.index - 1);
             }
         }
@@ -728,11 +722,9 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                         owner,
                     ).move_prev_spec().rear);
                     if owner@.rear.len() > 0 {
-                        let _ = owner.list_own.list[owner.index];
                         owner.list_own.relate_region_at_facts(*regions, owner.index);
                     }
                 } else {
-                    let _ = owner.list_own.list[owner.index];
                     owner.list_own.relate_region_at_facts(*regions, owner.index);
                     assert(self.model(owner.move_prev_owner_spec()).rear == old_self.model(
                         owner,
@@ -790,7 +782,6 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                         assert(self.current.is_none());
                         assert(false);
                     }
-                    let _ = owner.list_own.list[owner.index];
                     owner.list_own.relate_region_at_facts(*regions, owner.index);
                     assert(current == self.current.unwrap());
                 }
@@ -916,14 +907,11 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
 
         proof {
             assert(0 <= owner.index < owner.list_own.list.len());
-            let _ = owner.list_own.list[owner.index];
             owner.list_own.relate_region_at_facts(*regions, owner.index);
             if owner.index > 0 {
-                let _ = owner.list_own.list[owner.index - 1];
                 owner.list_own.relate_region_at_facts(*regions, owner.index - 1);
             }
             if owner.index < owner.list_own.list.len() - 1 {
-                let _ = owner.list_own.list[owner.index + 1];
                 owner.list_own.relate_region_at_facts(*regions, owner.index + 1);
             }
         }
@@ -1120,13 +1108,8 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                 ).value().metadata.prev)
             }) by {
                 let i = oldl.slot_index_at(p);
-                let _ = oldl.list[p];
                 oldl.relate_region_at_facts(regions0, p);
-                let _ = oldl.list[nn];
                 oldl.relate_region_at_facts(regions0, nn);
-                let _ = oldl.slot_index_at(nn - 1);
-                let _ = oldl.slot_index_at(nn + 1);
-                let _ = oldl.slot_index_at(nn);
             }
             LinkedListOwner::pop_preserves_relate_region(
                 oldl,
@@ -1199,11 +1182,9 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
         proof {
             owner0.list_own.length_lt_usize_max(regions0);
             if nn > 0 {
-                let _ = owner.list_own.list[nn - 1];
                 owner.list_own.relate_region_at_facts(*regions, nn - 1);
             }
             if nn < owner.list_own.list.len() {
-                let _ = owner.list_own.list[nn];
                 owner.list_own.relate_region_at_facts(*regions, nn);
             }
         }
@@ -1423,19 +1404,13 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                 ).value().metadata.prev)
             }) by {
                 let i = oldl.slot_index_at(p);
-                let _ = oldl.list[p];
                 oldl.relate_region_at_facts(regions0, p);
                 if nn - 1 >= 0 && nn - 1 < oldl.list.len() {
-                    let _ = oldl.list[nn - 1];
                     oldl.relate_region_at_facts(regions0, nn - 1);
                 }
                 if nn >= 0 && nn < oldl.list.len() {
-                    let _ = oldl.list[nn];
                     oldl.relate_region_at_facts(regions0, nn);
                 }
-                let _ = oldl.slot_index_at(nn - 1);
-                let _ = oldl.slot_index_at(nn);
-                let _ = oldl.slot_index_at(nn + 1);
             }
 
             let fpn = vstd_extra::cast_ptr::PointsTo::<MetaSlot, Metadata<Link<M>>>::new_spec(
@@ -1645,9 +1620,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> Drop for LinkedList<M> {
                 &&& original_regions.slot_owners[idx].paths_in_pt.is_empty()
                 &&& original_regions.slot_owners[idx].inner_perms.ref_count.value()
                     == crate::specs::mm::frame::meta_owners::REF_COUNT_UNIQUE
-            }) by {
-                let _ = s.0.list[j];
-            };
+            }) by {};
             list_own = LinkedListOwner::<M>::tracked_take(&mut s.0);
         }
         let tracked regions: &mut MetaRegionOwners = &mut s.1;
@@ -1659,9 +1632,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> Drop for LinkedList<M> {
 
         proof {
             if n > 0 {
-                let _ = cursor_own.list_own.list[0];
                 cursor_own.list_own.relate_region_at_facts(*regions, 0);
-                let _ = cursor_own.list_own.list[n as int - 1];
                 cursor_own.list_own.relate_region_at_facts(*regions, n as int - 1);
             }
         }
@@ -1747,7 +1718,6 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> Drop for LinkedList<M> {
             proof {
                 if cursor.current.is_some() {
                     assert(cursor_own.length() > 0);
-                    let _ = cursor_own.list_own.list[0];
                     cursor_own.list_own.relate_region_at_facts(*regions, 0);
                     let ghost _trigger = original_list[k as int];
                     assert(cursor.current.unwrap().addr() == original_list[k].paddr);
@@ -1794,7 +1764,6 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> Drop for LinkedList<M> {
                             == regions_pre_drop.frame_obligations.count(idx)
                     }) by {
                         let idx = cursor_own.list_own.slot_index_at(i);
-                        let _ = cursor_own.list_own.list[i];
                         let ghost _trig_k = original_list[k as int];
                         let ghost _trig_ik = original_list[i + k + 1];
                         assert(cursor_own.list_own.list[i] == original_list[i + k + 1]);

--- a/ostd/src/mm/frame/segment.rs
+++ b/ostd/src/mm/frame/segment.rs
@@ -818,10 +818,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                 *regions).slot_owners[frame_to_index((self.range.start + j * PAGE_SIZE) as usize)]
                     == old_regions.slot_owners[frame_to_index(
                     (self.range.start + j * PAGE_SIZE) as usize,
-                )] by {
-                    let _ = frame_to_index((self.range.start + perm_idx * PAGE_SIZE) as usize);
-                    let _ = frame_to_index((self.range.start + j * PAGE_SIZE) as usize);
-                };
+                )] by {};
             }
         }
 


### PR DESCRIPTION
This may speed up verification, I think.