### PR TITLE
New embedding ops, axiom cleanup, `in_scope` removal

### DIFF
--- a/ostd/specs/mm/embedding/kvirt_store.rs
+++ b/ostd/specs/mm/embedding/kvirt_store.rs
@@ -1,0 +1,198 @@
+//! Kernel-side one-step-soundness store for the kernel virtual area API
+//! ([`crate::mm::kspace::kvirt_area::KVirtArea`]) — the *kernel* analog of
+//! [`super::VmStore`].
+//!
+//! # Why a separate, kernel store
+//!
+//! [`super::VmStore`] models a caller of the **user** `VmSpace` API: it
+//! holds a `Map<VmSpaceId, VmSpaceOwner>`, each wrapping an
+//! `OwnerSubtree<UserPtConfig>`, plus user-space cursors
+//! (`CursorOwner<'rcu, UserPtConfig>`). `KVirtArea` instead maps frames
+//! into the single, global **kernel** page table
+//! ([`crate::mm::kspace::KERNEL_PAGE_TABLE`], a `KernelPtConfig` table),
+//! so the kernel store differs in three ways:
+//!
+//!   - **one** page table, not a map: a single
+//!     [`PageTableOwner<KernelPtConfig>`] (`kernel_pt`) rather than
+//!     `Map<VmSpaceId, _>`;
+//!   - it tracks the allocated **kernel virtual areas**
+//!     (`kvirt_areas`) — each `KVirtArea` is just a `Range<Vaddr>`
+//!     handle, since its `KVirtAreaOwner` is consumed into the page table
+//!     at construction (`map_frames`/`map_untracked_frames` take it by
+//!     value);
+//!   - cursors and owners are over `KernelPtConfig`, not `UserPtConfig`
+//!     (added when the mutating ops land).
+//!
+//! # Roadmap
+//!
+//! Landed: the store + invariant. Next: `step_query` (read-only) over
+//! `kernel_pt`, then `map_frames` / `map_untracked_frames` (the
+//! mapping-creating ops; their exec ensures may need strengthening
+//! first). Accounting (the `rc == H + P + cover_count` equation
+//! [`super::VmStore`] carries) is deferred — `KVirtArea` is
+//! mapping-focused, not reference-count-focused.
+use vstd::prelude::*;
+use vstd_extra::prelude::Inv;
+
+use core::ops::Range;
+
+use crate::mm::Vaddr;
+use crate::mm::kspace::kvirt_area::{KVirtArea, KVirtAreaOwner};
+use crate::mm::kspace::{FRAME_METADATA_BASE_VADDR, KERNEL_BASE_VADDR, KernelPtConfig, MappedItem};
+use crate::mm::page_table::PageTableGuard;
+use crate::specs::arch::PAGE_SIZE;
+use crate::specs::mm::frame::meta_region_owners::MetaRegionOwners;
+use crate::specs::mm::page_table::node::Guards;
+use crate::specs::mm::page_table::*;
+
+verus! {
+
+/// Logical identifier for an allocated [`KVirtArea`] in the store.
+pub type KVirtId = int;
+
+/// One-step-soundness store for the kernel virtual area API. Holds the
+/// shared `regions`, the single global kernel page table `kernel_pt`,
+/// and the set of allocated kernel virtual areas (each a `Range<Vaddr>`
+/// handle — see the module docs).
+///
+/// The kernel analog of [`super::VmStore`]; see the module documentation
+/// for how it differs (one global PT vs. a map of user `VmSpace`s).
+pub tracked struct KVmStore {
+    pub regions: MetaRegionOwners,
+    pub kernel_pt: PageTableOwner<KernelPtConfig>,
+    pub kvirt_areas: Map<KVirtId, Range<Vaddr>>,
+}
+
+impl KVmStore {
+    /// The store's top-level invariant.
+    ///
+    /// Mirrors the page-table-soundness portion of
+    /// [`super::VmStore::structural_inv`] (the kernel PT relates to the
+    /// region map via [`PageTableOwner::metaregion_sound`]) and adds the
+    /// per-area range well-formedness that [`KVirtArea::inv`] enforces at
+    /// the handle level (within the kernel VMALLOC bounds, page-aligned,
+    /// ordered).
+    pub open spec fn inv(self) -> bool {
+        &&& self.regions.inv()
+        &&& self.kernel_pt.inv()
+        // The global kernel page table relates to the shared region map —
+        // every present page-table node sits at a sound region slot, just
+        // as `VmStore::inv` requires of each cursor's owner.
+        &&& self.kernel_pt.metaregion_sound(self.regions)
+        &&& self.kvirt_areas.dom().finite()
+        // Each allocated area is a well-formed kernel virtual range:
+        // within `[KERNEL_BASE_VADDR, FRAME_METADATA_BASE_VADDR]` (the
+        // VMALLOC region the real allocator draws from), page-aligned,
+        // and ordered — exactly the handle-level facts `KVirtArea::inv`
+        // guarantees at construction and every op preserves.
+        &&& forall|id: KVirtId| #[trigger]
+            self.kvirt_areas.dom().contains(id) ==> {
+                let r = self.kvirt_areas[id];
+                &&& KERNEL_BASE_VADDR <= r.start
+                &&& r.end <= FRAME_METADATA_BASE_VADDR
+                &&& r.start % PAGE_SIZE == 0
+                &&& r.end % PAGE_SIZE == 0
+                &&& r.start <= r.end
+            }
+    }
+}
+
+/// Trusted reflection of the (checkout/checkin-rewired, verified)
+/// [`KVirtArea::query`]. Mirrors its `ensures` verbatim, but threads the
+/// kernel page-table ownership by `&mut` (`kernel_pt`) instead of
+/// consuming a `KVirtAreaOwner` and returning it — so a [`KVmStore`] can
+/// keep `kernel_pt` across the call. The query clones the resolved leaf
+/// (bumping its slot's refcount), then `unlock_range` hands the ownership
+/// back sound (`inv()` + `metaregion_sound` over the bumped region map).
+/// The `query_panic_condition` precondition is required *false* here: the
+/// embedding models only the non-panicking query.
+pub axiom fn query_embedded<'rcu>(
+    range: Range<Vaddr>,
+    addr: Vaddr,
+    tracked regions: &mut MetaRegionOwners,
+    tracked kernel_pt: &mut PageTableOwner<KernelPtConfig>,
+    tracked guards: &mut Guards<'rcu>,
+    root_guard: PageTableGuard<'rcu, KernelPtConfig>,
+) -> (res: Option<MappedItem>)
+    requires
+        KERNEL_BASE_VADDR <= range.start,
+        range.end <= FRAME_METADATA_BASE_VADDR,
+        range.start % PAGE_SIZE == 0,
+        range.end % PAGE_SIZE == 0,
+        range.start <= range.end,
+        range.start <= addr < range.end,
+        old(regions).inv(),
+        old(kernel_pt).inv(),
+        old(kernel_pt).metaregion_sound(*old(regions)),
+        !(KVirtArea { range }).query_panic_condition(
+            KVirtAreaOwner { pt_owner: *old(kernel_pt) },
+            addr,
+            *old(regions),
+        ),
+    ensures
+        final(regions).inv(),
+        final(kernel_pt).inv(),
+        final(kernel_pt).metaregion_sound(*final(regions)),
+        ({
+            let area = KVirtArea { range };
+            let owner = KVirtAreaOwner { pt_owner: *old(kernel_pt) };
+            &&& area.query_some_condition(owner, addr) ==> area.query_some_ensures(owner, addr, res)
+            &&& !area.query_some_condition(owner, addr) ==> KVirtArea::query_none_ensures(res)
+        }),
+;
+
+impl KVmStore {
+    /// `KVirtArea::query`: read the mapped item at the page containing
+    /// `addr` in area `id`. Checks the kernel PT out into a cursor,
+    /// queries (cloning the resolved leaf — `regions` refcount bump), and
+    /// checks it back in, so the store keeps a sound `kernel_pt`. The
+    /// caller supplies the ambient lock state (`guards` / `root_guard`),
+    /// as the exec does.
+    pub proof fn step_query<'rcu>(
+        tracked &mut self,
+        id: KVirtId,
+        addr: Vaddr,
+        tracked guards: &mut Guards<'rcu>,
+        root_guard: PageTableGuard<'rcu, KernelPtConfig>,
+    ) -> (res: Option<MappedItem>)
+        requires
+            old(self).inv(),
+            old(self).kvirt_areas.dom().contains(id),
+            old(self).kvirt_areas[id].start <= addr < old(self).kvirt_areas[id].end,
+            !(KVirtArea { range: old(self).kvirt_areas[id] }).query_panic_condition(
+                KVirtAreaOwner { pt_owner: old(self).kernel_pt },
+                addr,
+                old(self).regions,
+            ),
+        ensures
+            final(self).inv(),
+            final(self).kvirt_areas == old(self).kvirt_areas,
+            ({
+                let area = KVirtArea { range: old(self).kvirt_areas[id] };
+                let owner = KVirtAreaOwner { pt_owner: old(self).kernel_pt };
+                &&& area.query_some_condition(owner, addr) ==> area.query_some_ensures(
+                    owner,
+                    addr,
+                    res,
+                )
+                &&& !area.query_some_condition(owner, addr) ==> KVirtArea::query_none_ensures(res)
+            }),
+    {
+        let ghost old_self = *self;
+        let ghost range = self.kvirt_areas[id];
+        let res = query_embedded(
+            range,
+            addr,
+            &mut self.regions,
+            &mut self.kernel_pt,
+            guards,
+            root_guard,
+        );
+        // `kvirt_areas` is untouched; `regions`/`kernel_pt` come back sound
+        // (`inv` + `metaregion_sound`) from the axiom — so `inv()` holds.
+        assert(self.kvirt_areas =~= old_self.kvirt_areas);
+        res
+    }
+}
+
+} // verus!

--- a/ostd/specs/mm/embedding/list_store.rs
+++ b/ostd/specs/mm/embedding/list_store.rs
@@ -1,0 +1,2676 @@
+//! Self-contained one-step-soundness harness for the frame `LinkedList`
+//! ([`crate::mm::frame::LinkedList`]) — the embedding's companion to
+//! [`super::VmStore`], specialised to linked-list operations.
+//!
+//! # Why a separate, generic store
+//!
+//! Unlike `VmStore` (which fixes concrete configs such as
+//! `UserPtConfig`), `ListStore<M>` is *generic* over the link metadata
+//! `M`. The kernel's `LinkedList<M>` is a generic library with no
+//! canonical concrete instantiation in ostd, and `LinkedListOwner<M>`
+//! cannot be type-erased to `dyn`: its per-link permission is the
+//! associated type `<M as Repr<MetaSlotSmall>>::Perm`, embedded in
+//! `LinkInnerPerms<M>`, so the trait is not object-safe (cf.
+//! `Frame<dyn AnyFrameMeta>`, which works only because it exposes no
+//! associated type post-erasure).
+//!
+//! # Why `in_list` is a non-issue here
+//!
+//! `ListStore<M>` requires only `regions.inv()`
+//! ([`MetaRegionOwners::inv`]), which — unlike
+//! `VmStore::structural_inv` — does **not** constrain `in_list`. A
+//! listed frame sits at `rc == REF_COUNT_UNIQUE` with
+//! `in_list == list_id != 0`; the UNIQUE branch of `MetaSlotOwner::inv`
+//! pins only `storage`/`vtable_ptr` init, leaving `in_list` free. So
+//! listed frames are admitted with *no* invariant weakening — the
+//! `in_list == 0` constraint is purely a `VmStore` concern and does not
+//! arise in this harness.
+//!
+//! # State
+//!
+//! - `regions`: the shared metadata-region ownership.
+//! - `lists`: held [`LinkedListOwner`]s. Each link is a forgotten
+//!   `UniqueFrame<Link<M>>` (its drop-obligation was consumed by
+//!   `into_raw` on push); the owner's [`LinkedListOwner::relate_region`]
+//!   ties every link to its UNIQUE region slot and pins the
+//!   `next`/`prev` pointer wiring.
+//! - `loose`: held-but-unlisted [`UniqueFrameOwner`]s — live
+//!   `UniqueFrame<Link<M>>` handles (drop-obligation present) eligible
+//!   to be pushed. `push` moves one from `loose` into a list; `pop`
+//!   moves a list's end link out into `loose`.
+//!
+//! # Roadmap
+//!
+//! Landed: the store + invariant, the front/back
+//! allocate-build-teardown suite (`new`, `push_front` / `pop_front`,
+//! `push_back` / `pop_back`), the general cursor surgery —
+//! `insert_before` / `take_current` at an *arbitrary* index
+//! ([`ListStore::step_insert_before_at`] / [`ListStore::step_take_at`]),
+//! which subsume the front/back ops — the read-only accessors
+//! ([`ListStore::step_size`] / [`ListStore::step_is_empty`]), and the
+//! full **persistent cursor** lifecycle: a cursor checks its list out of
+//! `lists` into `cursors` ([`ListStore::step_cursor_front_mut`] /
+//! `step_cursor_back_mut` / `step_cursor_mut_at`), walks it
+//! (`step_move_next` / `step_move_prev` / `step_current_meta`), mutates
+//! through it (`step_cursor_insert_before` / `step_cursor_take_current`),
+//! and checks it back in on drop ([`ListStore::step_cursor_drop`]).
+use vstd::prelude::*;
+use vstd_extra::cast_ptr::Repr;
+use vstd_extra::ownership::*;
+
+use crate::mm::Paddr;
+use crate::specs::arch::has_safe_slot;
+use crate::mm::frame::meta::mapping::frame_to_index;
+use crate::mm::frame::{AnyFrameMeta, Link};
+use crate::specs::mm::frame::linked_list::linked_list_owners::{
+    CursorOwner, LinkOwner, LinkedListOwner, MetaSlotSmall,
+};
+use crate::specs::mm::frame::meta_owners::{PageUsage, REF_COUNT_UNIQUE};
+use crate::specs::mm::frame::meta_region_owners::MetaRegionOwners;
+use crate::specs::mm::frame::unique::UniqueFrameOwner;
+
+verus! {
+
+/// Logical identifier for a held [`LinkedListOwner`] in the store.
+pub type ListId = int;
+
+/// Logical identifier for a loose (held-but-unlisted)
+/// `UniqueFrame<Link<M>>` in the store.
+pub type LooseId = int;
+
+/// Logical identifier for a live [`CursorOwner`] in the store. A cursor
+/// is keyed by the *home* [`ListId`] whose list it checked out, so a
+/// list is cursored iff its id is in `cursors` (and then absent from
+/// `lists`).
+pub type CursorId = ListId;
+
+/// The membership registry relating one (held or checked-out) list `lo`
+/// to the physical `in_list` tags in `regions`:
+///   - **forward**: every link's region slot carries `lo.list_id` (the
+///     exec `insert_before` stamps it via `store(lazy_get_id())`);
+///   - **reverse** (only for a real, non-zero id): every region slot
+///     carrying that id is one of `lo`'s links — the global
+///     `in_list`-uniqueness the id allocator guarantees (a freshly
+///     minted id is system-wide unused; ids are never reused).
+/// Together they make `in_list == list_id` an *exact* membership test,
+/// which is exactly what [`crate::mm::frame::LinkedList::contains`]
+/// computes.
+pub open spec fn list_registry_ok<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
+    regions: MetaRegionOwners,
+    lo: LinkedListOwner<M>,
+) -> bool {
+    &&& forall|i: int|
+        #![trigger lo.slot_index_at(i)]
+        0 <= i < lo.list.len() ==> regions.slot_owners[lo.slot_index_at(
+            i,
+        )].inner_perms.in_list.value() == lo.list_id
+    &&& lo.list_id != 0 ==> forall|idx: usize|
+        #![trigger regions.slot_owners[idx]]
+        regions.slot_owners.contains_key(idx)
+            && regions.slot_owners[idx].inner_perms.in_list.value() == lo.list_id ==> exists|i: int|
+
+            0 <= i < lo.list.len() && lo.slot_index_at(i) == idx
+}
+
+/// One-step-soundness store for the frame `LinkedList`. Holds the shared
+/// `regions`, the set of held lists, the pool of loose
+/// (push-eligible) `UniqueFrame<Link<M>>` handles, and the live cursors.
+///
+/// A cursor *checks out* its list: a live `CursorMut` borrows the
+/// `LinkedList` exclusively, so while a cursor exists its
+/// `LinkedListOwner` lives inside the [`CursorOwner`] (`cursors`) rather
+/// than in `lists`. Dropping the cursor returns the list to `lists`.
+pub tracked struct ListStore<M: AnyFrameMeta + Repr<MetaSlotSmall>> {
+    pub regions: MetaRegionOwners,
+    pub lists: Map<ListId, LinkedListOwner<M>>,
+    pub loose: Map<LooseId, UniqueFrameOwner<Link<M>>>,
+    pub cursors: Map<CursorId, CursorOwner<M>>,
+}
+
+impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
+    /// The store's top-level invariant.
+    pub open spec fn inv(self) -> bool {
+        &&& self.regions.inv()
+        &&& self.lists.dom().finite()
+        &&& self.loose.dom().finite()
+        // Each held list is well-formed and every link relates to its
+        // UNIQUE region slot (incl. the `next`/`prev` pointer wiring).
+        &&& forall|id: ListId| #[trigger]
+            self.lists.dom().contains(id) ==> {
+                &&& self.lists[id].inv()
+                &&& self.lists[id].relate_region(self.regions)
+            }
+            // Each loose handle is a valid live `UniqueFrame<Link<M>>`:
+            // a UNIQUE slot with a pending drop-obligation, sitting
+            // *outside* every list — `in_list == 0` and unlinked
+            // (`frame_link_inv`: no `prev`/`next`). The `in_list == 0`
+            // fact makes list-vs-loose slot disjointness derivable (a
+            // listed slot has `in_list == list_id != 0`).
+        &&& forall|lid: LooseId| #[trigger]
+            self.loose.dom().contains(lid) ==> {
+                &&& self.loose[lid].inv()
+                &&& self.loose[lid].global_inv(self.regions)
+                &&& self.loose[lid].frame_link_inv(self.regions)
+                &&& self.regions.slot_owners[self.loose[lid].slot_index].inner_perms.in_list.value()
+                    == 0
+            }
+            // Distinct lists carry distinct *nonzero* ids (`lazy_get_id`
+            // mints a globally fresh id per list — even a list emptied by
+            // pops keeps its unique id; only never-pushed lists share the
+            // placeholder `list_id == 0`). With each link's
+            // `in_list == list_id`, this makes cross-list slot
+            // disjointness derivable.
+        &&& forall|id1: ListId, id2: ListId|
+            #![trigger self.lists.dom().contains(id1), self.lists.dom().contains(id2)]
+            self.lists.dom().contains(id1) && self.lists.dom().contains(id2)
+                && self.lists[id1].list_id == self.lists[id2].list_id && self.lists[id1].list_id
+                != 0 ==> id1
+                == id2
+            // Distinct loose handles occupy distinct slots (a UNIQUE frame
+            // is held in at most one place).
+        &&& forall|lid1: LooseId, lid2: LooseId|
+            #![trigger self.loose.dom().contains(lid1), self.loose.dom().contains(lid2)]
+            self.loose.dom().contains(lid1) && self.loose.dom().contains(lid2)
+                && self.loose[lid1].slot_index == self.loose[lid2].slot_index ==> lid1 == lid2
+        &&& self.cursors.dom().finite()
+        // A cursored list is *checked out*: it lives in `cursors`
+        // (keyed by its home id), never simultaneously in `lists`. This
+        // is the borrow — a live `CursorMut` holds the list exclusively.
+        &&& self.lists.dom().disjoint(
+            self.cursors.dom(),
+        )
+        // Each live cursor's checked-out list is well-formed and every
+        // link relates to its UNIQUE region slot, exactly as for a held
+        // list; additionally the cursor index is in range
+        // (`inv_region`). `list_own.inv()` is carried so the trusted
+        // per-op other-lists frame (stated over `inv() && relate_region`)
+        // applies to a cursor's list under region-changing ops.
+        &&& forall|cid: CursorId| #[trigger]
+            self.cursors.dom().contains(cid) ==> {
+                &&& self.cursors[cid].list_own.inv()
+                &&& self.cursors[cid].inv_region(self.regions)
+            }
+            // A cursor's list shares no nonzero id with any held list —
+            // cross list/cursor slot disjointness, mirroring lists×lists.
+        &&& forall|id: ListId, cid: CursorId|
+            #![trigger self.lists.dom().contains(id), self.cursors.dom().contains(cid)]
+            self.lists.dom().contains(id) && self.cursors.dom().contains(cid)
+                && self.lists[id].list_id == self.cursors[cid].list_own.list_id
+                && self.lists[id].list_id != 0
+                ==> false
+            // Distinct cursors carry distinct *nonzero* list ids.
+        &&& forall|cid1: CursorId, cid2: CursorId|
+            #![trigger self.cursors.dom().contains(cid1), self.cursors.dom().contains(cid2)]
+            self.cursors.dom().contains(cid1) && self.cursors.dom().contains(cid2)
+                && self.cursors[cid1].list_own.list_id == self.cursors[cid2].list_own.list_id
+                && self.cursors[cid1].list_own.list_id != 0 ==> cid1
+                == cid2
+            // Membership registry: each held list's id tags exactly its own
+            // links in the region (forward + reverse — see [`list_registry_ok`]).
+            // This is what makes `contains` an exact membership test.
+        &&& forall|id: ListId| #[trigger]
+            self.lists.dom().contains(id) ==> list_registry_ok(
+                self.regions,
+                self.lists[id],
+            )
+        // Same registry for each checked-out cursor's list.
+        &&& forall|cid: CursorId| #[trigger]
+            self.cursors.dom().contains(cid) ==> list_registry_ok(
+                self.regions,
+                self.cursors[cid].list_own,
+            )
+    }
+}
+
+// =============================================================================
+// Fresh-id helpers + tracked constructors
+// =============================================================================
+/// Tracked constructor for a fresh *empty* list owner. Sound: an empty
+/// `LinkedListOwner` claims no permissions (cf.
+/// [`LinkedListOwner::tracked_destroy_empty`]), and carries
+/// `list_id == 0` — the real id is minted lazily on first push.
+pub axiom fn axiom_empty_list_owner<M: AnyFrameMeta + Repr<MetaSlotSmall>>() -> (tracked res:
+    LinkedListOwner<M>)
+    ensures
+        res.list =~= Seq::<LinkOwner>::empty(),
+        res.list_id == 0,
+;
+
+/// Fresh-id helper for the list id space. The id must avoid both held
+/// lists *and* checked-out cursors (a cursored list's home id is absent
+/// from `lists` but reserved in `cursors`).
+pub open spec fn fresh_list_id<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
+    lists: Map<ListId, LinkedListOwner<M>>,
+    cursors: Map<CursorId, CursorOwner<M>>,
+) -> ListId {
+    choose|id: ListId| !lists.dom().contains(id) && !cursors.dom().contains(id)
+}
+
+pub axiom fn axiom_fresh_list_id_not_in_dom<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
+    lists: Map<ListId, LinkedListOwner<M>>,
+    cursors: Map<CursorId, CursorOwner<M>>,
+)
+    requires
+        lists.dom().finite(),
+        cursors.dom().finite(),
+    ensures
+        !lists.dom().contains(fresh_list_id(lists, cursors)) && !cursors.dom().contains(
+            fresh_list_id(lists, cursors),
+        ),
+;
+
+/// Trusted reflection of [`crate::mm::frame::LinkedList::push_front`]'s
+/// effect on `(regions, owner, frame_own)`. The first block of `ensures`
+/// mirrors the now-verified exec `push_front` ensures verbatim
+/// (`relate_region` of the pushed owner, the list / id / `in_list`
+/// effects, `frame_obligations` consumption, and the outside-the-list
+/// slot-preservation frame). The last two add facts that *follow* from
+/// them — sound, hence safe to assert here:
+///   - **fresh minted id** (`old.list_id == 0 ==> final.list_id ∉
+///     used_ids`): the exec mints the id from a global counter, so it is
+///     fresh w.r.t. any finite in-use set; the caller passes the other
+///     lists' ids, keeping cross-list id uniqueness.
+///   - **other lists preserved**: any well-formed list `l` with a
+///     *different* id keeps its `relate_region`. The only slots the
+///     surgery touches are the loose frame's (`in_list == 0`, required
+///     below) and the old front's (`in_list == new id`); both are
+///     disjoint from `l`'s slots (which carry `in_list == l.list_id`),
+///     so by the slot-preservation frame `l` is untouched.
+pub axiom fn push_front_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
+    tracked regions: &mut MetaRegionOwners,
+    tracked owner: &mut LinkedListOwner<M>,
+    tracked frame_own: &mut UniqueFrameOwner<Link<M>>,
+    used_ids: Set<u64>,
+)
+    requires
+        old(regions).inv(),
+        old(owner).inv(),
+        old(owner).relate_region(*old(regions)),
+        old(frame_own).inv(),
+        old(frame_own).global_inv(*old(regions)),
+        old(frame_own).frame_link_inv(*old(regions)),
+        old(regions).slot_owners[old(frame_own).slot_index].inner_perms.in_list.value() == 0,
+    ensures
+        final(regions).inv(),
+        final(owner).inv(),
+        final(owner).relate_region(*final(regions)),
+        final(owner).list == old(owner).list.insert(0, final(frame_own).meta_own),
+        old(owner).list_id != 0 ==> final(owner).list_id == old(owner).list_id,
+        final(owner).list_id != 0,
+        old(owner).list_id == 0 ==> !used_ids.contains(final(owner).list_id),
+        final(frame_own).meta_own.paddr == old(frame_own).meta_own.paddr,
+        final(frame_own).meta_own.in_list == final(owner).list_id,
+        final(regions).frame_obligations =~= old(regions).frame_obligations.remove(
+            old(frame_own).slot_index,
+        ),
+        forall|k: usize|
+            #![trigger final(regions).slots[k]]
+            #![trigger final(regions).slot_owners[k]]
+            k != old(frame_own).slot_index && (old(owner).list.len() > 0 ==> k != old(
+                owner,
+            ).slot_index_at(0)) ==> final(regions).slots[k] == old(regions).slots[k]
+                && final(regions).slot_owners[k] == old(regions).slot_owners[k],
+        forall|l: LinkedListOwner<M>|
+            #![trigger l.relate_region(*old(regions))]
+            l.inv() && l.relate_region(*old(regions)) && l.list_id != final(owner).list_id
+                ==> l.relate_region(*final(regions)),
+        // Membership registry for the operated list: forward stamp of
+        // the (minted or preserved) id + reverse global uniqueness (see
+        // [`list_registry_ok`]).
+        list_registry_ok(*final(regions), *final(owner)),
+        // Every other list/cursor list keeps its registry: the only slot
+        // the surgery retags now carries `final(owner).list_id` (or 0),
+        // never another list's id — so no foreign list gains or loses a
+        // tagged slot.
+        forall|l: LinkedListOwner<M>|
+            #![trigger l.relate_region(*old(regions))]
+            l.inv() && l.relate_region(*old(regions)) && list_registry_ok(*old(regions), l)
+                && l.list_id != final(owner).list_id ==> list_registry_ok(*final(regions), l),
+        // **other loose handles preserved**: a loose frame `fo` sitting
+        // at a different `in_list == 0` slot is untouched. Sound by the
+        // same disjointness — a list slot carries `in_list == list_id
+        // != 0`, so `fo`'s slot is neither the pushed frame's nor the
+        // old front's.
+        forall|fo: UniqueFrameOwner<Link<M>>|
+            #![trigger fo.global_inv(*old(regions))]
+            fo.global_inv(*old(regions)) && fo.frame_link_inv(*old(regions)) && old(
+                regions,
+            ).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0 && fo.slot_index != old(
+                frame_own,
+            ).slot_index ==> fo.global_inv(*final(regions)) && fo.frame_link_inv(*final(regions))
+                && final(regions).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0,
+;
+
+/// Fresh-id helper for the loose-frame id space.
+pub open spec fn fresh_loose_id<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
+    m: Map<LooseId, UniqueFrameOwner<Link<M>>>,
+) -> LooseId {
+    choose|id: LooseId| !m.dom().contains(id)
+}
+
+pub axiom fn axiom_fresh_loose_id_not_in_dom<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
+    m: Map<LooseId, UniqueFrameOwner<Link<M>>>,
+)
+    ensures
+        !m.dom().contains(fresh_loose_id(m)),
+;
+
+/// Trusted reflection of the (now properly `&mut owner`-threaded and
+/// fully verified) [`crate::mm::frame::LinkedList::pop_front`]. Pops the
+/// front link off `owner`, restoring it to a loose
+/// `UniqueFrame<Link<M>>` (its drop-obligation re-minted by `from_raw`,
+/// `in_list` reset to 0, `prev`/`next` cleared). The list shrinks by one
+/// from the front with `list_id` preserved.
+///
+/// The first block of `ensures` mirrors the verified exec `pop_front`
+/// verbatim. The last two are the sound companion facts (cf.
+/// [`push_front_embedded`]): other lists and other loose frames are
+/// untouched, and — additionally — the popped slot is *distinct* from
+/// every loose slot (it was a list link, `in_list == list_id != 0`),
+/// which keeps loose-slot disjointness when the popped frame joins
+/// `loose`.
+pub axiom fn pop_front_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
+    tracked regions: &mut MetaRegionOwners,
+    tracked owner: &mut LinkedListOwner<M>,
+) -> (tracked frame_own: UniqueFrameOwner<Link<M>>)
+    requires
+        old(regions).inv(),
+        old(owner).inv(),
+        old(owner).relate_region(*old(regions)),
+        old(owner).list.len() > 0,
+    ensures
+        final(regions).inv(),
+        final(owner).inv(),
+        final(owner).relate_region(*final(regions)),
+        final(owner).list == old(owner).list.remove(0),
+        final(owner).list_id == old(owner).list_id,
+        // The popped frame is a valid loose handle at the old front slot.
+        frame_own.inv(),
+        frame_own.global_inv(*final(regions)),
+        frame_own.frame_link_inv(*final(regions)),
+        frame_own.slot_index == old(owner).slot_index_at(0),
+        final(regions).slot_owners[frame_own.slot_index].inner_perms.in_list.value() == 0,
+        // `from_raw` re-mints the drop-obligation.
+        final(regions).frame_obligations =~= old(regions).frame_obligations.insert(
+            old(owner).slot_index_at(0),
+        ),
+        // Outside-the-list slot preservation (front specialisation:
+        // popped slot + the new front at `slot_index_at(1)`).
+        forall|j: usize|
+            #![trigger final(regions).slots[j]]
+            #![trigger final(regions).slot_owners[j]]
+            j != old(owner).slot_index_at(0) && (old(owner).list.len() > 1 ==> j != old(
+                owner,
+            ).slot_index_at(1)) ==> final(regions).slots[j] == old(regions).slots[j]
+                && final(regions).slot_owners[j] == old(regions).slot_owners[j],
+        // Other lists preserved.
+        forall|l: LinkedListOwner<M>|
+            #![trigger l.relate_region(*old(regions))]
+            l.inv() && l.relate_region(*old(regions)) && l.list_id != final(owner).list_id
+                ==> l.relate_region(*final(regions)),
+        // Membership registry for the operated list: forward stamp of
+        // the (minted or preserved) id + reverse global uniqueness (see
+        // [`list_registry_ok`]).
+        list_registry_ok(*final(regions), *final(owner)),
+        // Every other list/cursor list keeps its registry: the only slot
+        // the surgery retags now carries `final(owner).list_id` (or 0),
+        // never another list's id — so no foreign list gains or loses a
+        // tagged slot.
+        forall|l: LinkedListOwner<M>|
+            #![trigger l.relate_region(*old(regions))]
+            l.inv() && l.relate_region(*old(regions)) && list_registry_ok(*old(regions), l)
+                && l.list_id != final(owner).list_id ==> list_registry_ok(*final(regions), l),
+        // Other loose frames preserved, and the popped slot is disjoint
+        // from every loose slot.
+        forall|fo: UniqueFrameOwner<Link<M>>|
+            #![trigger fo.global_inv(*old(regions))]
+            fo.global_inv(*old(regions)) && fo.frame_link_inv(*old(regions)) && old(
+                regions,
+            ).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0 ==> fo.global_inv(
+                *final(regions),
+            ) && fo.frame_link_inv(*final(regions))
+                && final(regions).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0
+                && fo.slot_index != old(owner).slot_index_at(0),
+;
+
+/// Trusted reflection of the (verified) [`crate::mm::frame::LinkedList::push_back`].
+/// Identical to [`push_front_embedded`] except the frame is spliced in
+/// at the *tail* (touching the back neighbours instead of the front).
+pub axiom fn push_back_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
+    tracked regions: &mut MetaRegionOwners,
+    tracked owner: &mut LinkedListOwner<M>,
+    tracked frame_own: &mut UniqueFrameOwner<Link<M>>,
+    used_ids: Set<u64>,
+)
+    requires
+        old(regions).inv(),
+        old(owner).inv(),
+        old(owner).relate_region(*old(regions)),
+        old(frame_own).inv(),
+        old(frame_own).global_inv(*old(regions)),
+        old(frame_own).frame_link_inv(*old(regions)),
+        old(regions).slot_owners[old(frame_own).slot_index].inner_perms.in_list.value() == 0,
+    ensures
+        final(regions).inv(),
+        final(owner).inv(),
+        final(owner).relate_region(*final(regions)),
+        old(owner).list.len() > 0 ==> final(owner).list == old(owner).list.insert(
+            old(owner).list.len() as int - 1,
+            final(frame_own).meta_own,
+        ),
+        old(owner).list.len() == 0 ==> final(owner).list == old(owner).list.insert(
+            0,
+            final(frame_own).meta_own,
+        ),
+        old(owner).list_id != 0 ==> final(owner).list_id == old(owner).list_id,
+        final(owner).list_id != 0,
+        old(owner).list_id == 0 ==> !used_ids.contains(final(owner).list_id),
+        final(frame_own).meta_own.paddr == old(frame_own).meta_own.paddr,
+        final(frame_own).meta_own.in_list == final(owner).list_id,
+        final(regions).frame_obligations =~= old(regions).frame_obligations.remove(
+            old(frame_own).slot_index,
+        ),
+        forall|k: usize|
+            #![trigger final(regions).slots[k]]
+            #![trigger final(regions).slot_owners[k]]
+            k != old(frame_own).slot_index && (old(owner).list.len() > 1 ==> k != old(
+                owner,
+            ).slot_index_at(old(owner).list.len() - 2)) && (old(owner).list.len() > 0 ==> k != old(
+                owner,
+            ).slot_index_at(old(owner).list.len() - 1)) ==> final(regions).slots[k] == old(
+                regions,
+            ).slots[k] && final(regions).slot_owners[k] == old(regions).slot_owners[k],
+        forall|l: LinkedListOwner<M>|
+            #![trigger l.relate_region(*old(regions))]
+            l.inv() && l.relate_region(*old(regions)) && l.list_id != final(owner).list_id
+                ==> l.relate_region(*final(regions)),
+        // Membership registry for the operated list: forward stamp of
+        // the (minted or preserved) id + reverse global uniqueness (see
+        // [`list_registry_ok`]).
+        list_registry_ok(*final(regions), *final(owner)),
+        // Every other list/cursor list keeps its registry: the only slot
+        // the surgery retags now carries `final(owner).list_id` (or 0),
+        // never another list's id — so no foreign list gains or loses a
+        // tagged slot.
+        forall|l: LinkedListOwner<M>|
+            #![trigger l.relate_region(*old(regions))]
+            l.inv() && l.relate_region(*old(regions)) && list_registry_ok(*old(regions), l)
+                && l.list_id != final(owner).list_id ==> list_registry_ok(*final(regions), l),
+        forall|fo: UniqueFrameOwner<Link<M>>|
+            #![trigger fo.global_inv(*old(regions))]
+            fo.global_inv(*old(regions)) && fo.frame_link_inv(*old(regions)) && old(
+                regions,
+            ).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0 && fo.slot_index != old(
+                frame_own,
+            ).slot_index ==> fo.global_inv(*final(regions)) && fo.frame_link_inv(*final(regions))
+                && final(regions).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0,
+;
+
+/// Trusted reflection of the (verified) [`crate::mm::frame::LinkedList::pop_back`].
+/// Identical to [`pop_front_embedded`] except the *last* link is popped
+/// (touching the back neighbour at `slot_index_at(len - 2)`).
+pub axiom fn pop_back_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
+    tracked regions: &mut MetaRegionOwners,
+    tracked owner: &mut LinkedListOwner<M>,
+) -> (tracked frame_own: UniqueFrameOwner<Link<M>>)
+    requires
+        old(regions).inv(),
+        old(owner).inv(),
+        old(owner).relate_region(*old(regions)),
+        old(owner).list.len() > 0,
+    ensures
+        final(regions).inv(),
+        final(owner).inv(),
+        final(owner).relate_region(*final(regions)),
+        final(owner).list == old(owner).list.remove(old(owner).list.len() - 1),
+        final(owner).list_id == old(owner).list_id,
+        frame_own.inv(),
+        frame_own.global_inv(*final(regions)),
+        frame_own.frame_link_inv(*final(regions)),
+        frame_own.slot_index == old(owner).slot_index_at(old(owner).list.len() - 1),
+        final(regions).slot_owners[frame_own.slot_index].inner_perms.in_list.value() == 0,
+        final(regions).frame_obligations =~= old(regions).frame_obligations.insert(
+            old(owner).slot_index_at(old(owner).list.len() - 1),
+        ),
+        forall|j: usize|
+            #![trigger final(regions).slots[j]]
+            #![trigger final(regions).slot_owners[j]]
+            j != old(owner).slot_index_at(old(owner).list.len() - 1) && (old(owner).list.len() > 1
+                ==> j != old(owner).slot_index_at(old(owner).list.len() - 2))
+                ==> final(regions).slots[j] == old(regions).slots[j]
+                && final(regions).slot_owners[j] == old(regions).slot_owners[j],
+        forall|l: LinkedListOwner<M>|
+            #![trigger l.relate_region(*old(regions))]
+            l.inv() && l.relate_region(*old(regions)) && l.list_id != final(owner).list_id
+                ==> l.relate_region(*final(regions)),
+        // Membership registry for the operated list: forward stamp of
+        // the (minted or preserved) id + reverse global uniqueness (see
+        // [`list_registry_ok`]).
+        list_registry_ok(*final(regions), *final(owner)),
+        // Every other list/cursor list keeps its registry: the only slot
+        // the surgery retags now carries `final(owner).list_id` (or 0),
+        // never another list's id — so no foreign list gains or loses a
+        // tagged slot.
+        forall|l: LinkedListOwner<M>|
+            #![trigger l.relate_region(*old(regions))]
+            l.inv() && l.relate_region(*old(regions)) && list_registry_ok(*old(regions), l)
+                && l.list_id != final(owner).list_id ==> list_registry_ok(*final(regions), l),
+        forall|fo: UniqueFrameOwner<Link<M>>|
+            #![trigger fo.global_inv(*old(regions))]
+            fo.global_inv(*old(regions)) && fo.frame_link_inv(*old(regions)) && old(
+                regions,
+            ).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0 ==> fo.global_inv(
+                *final(regions),
+            ) && fo.frame_link_inv(*final(regions))
+                && final(regions).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0
+                && fo.slot_index != old(owner).slot_index_at(old(owner).list.len() - 1),
+;
+
+/// Trusted reflection of [`crate::mm::frame::CursorMut::insert_before`]
+/// applied to a cursor at an arbitrary index `n` over `owner`. The
+/// general form of [`push_front_embedded`] (`n == 0`) /
+/// [`push_back_embedded`]: splices the loose frame in at position `n`
+/// (`0 <= n <= len`), touching `n`'s ≤2 link neighbours.
+pub axiom fn insert_before_at_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
+    tracked regions: &mut MetaRegionOwners,
+    tracked owner: &mut LinkedListOwner<M>,
+    tracked frame_own: &mut UniqueFrameOwner<Link<M>>,
+    n: int,
+    used_ids: Set<u64>,
+)
+    requires
+        old(regions).inv(),
+        old(owner).inv(),
+        old(owner).relate_region(*old(regions)),
+        old(frame_own).inv(),
+        old(frame_own).global_inv(*old(regions)),
+        old(frame_own).frame_link_inv(*old(regions)),
+        old(regions).slot_owners[old(frame_own).slot_index].inner_perms.in_list.value() == 0,
+        0 <= n <= old(owner).list.len(),
+    ensures
+        final(regions).inv(),
+        final(owner).inv(),
+        final(owner).relate_region(*final(regions)),
+        final(owner).list == old(owner).list.insert(n, final(frame_own).meta_own),
+        old(owner).list_id != 0 ==> final(owner).list_id == old(owner).list_id,
+        final(owner).list_id != 0,
+        old(owner).list_id == 0 ==> !used_ids.contains(final(owner).list_id),
+        final(frame_own).meta_own.paddr == old(frame_own).meta_own.paddr,
+        final(frame_own).meta_own.in_list == final(owner).list_id,
+        final(regions).frame_obligations =~= old(regions).frame_obligations.remove(
+            old(frame_own).slot_index,
+        ),
+        forall|k: usize|
+            #![trigger final(regions).slots[k]]
+            #![trigger final(regions).slot_owners[k]]
+            k != old(frame_own).slot_index && (n > 0 ==> k != old(owner).slot_index_at(n - 1)) && (n
+                < old(owner).list.len() ==> k != old(owner).slot_index_at(n))
+                ==> final(regions).slots[k] == old(regions).slots[k]
+                && final(regions).slot_owners[k] == old(regions).slot_owners[k],
+        forall|l: LinkedListOwner<M>|
+            #![trigger l.relate_region(*old(regions))]
+            l.inv() && l.relate_region(*old(regions)) && l.list_id != final(owner).list_id
+                ==> l.relate_region(*final(regions)),
+        // Membership registry for the operated list: forward stamp of
+        // the (minted or preserved) id + reverse global uniqueness (see
+        // [`list_registry_ok`]).
+        list_registry_ok(*final(regions), *final(owner)),
+        // Every other list/cursor list keeps its registry: the only slot
+        // the surgery retags now carries `final(owner).list_id` (or 0),
+        // never another list's id — so no foreign list gains or loses a
+        // tagged slot.
+        forall|l: LinkedListOwner<M>|
+            #![trigger l.relate_region(*old(regions))]
+            l.inv() && l.relate_region(*old(regions)) && list_registry_ok(*old(regions), l)
+                && l.list_id != final(owner).list_id ==> list_registry_ok(*final(regions), l),
+        forall|fo: UniqueFrameOwner<Link<M>>|
+            #![trigger fo.global_inv(*old(regions))]
+            fo.global_inv(*old(regions)) && fo.frame_link_inv(*old(regions)) && old(
+                regions,
+            ).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0 && fo.slot_index != old(
+                frame_own,
+            ).slot_index ==> fo.global_inv(*final(regions)) && fo.frame_link_inv(*final(regions))
+                && final(regions).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0,
+;
+
+/// Trusted reflection of [`crate::mm::frame::CursorMut::take_current`]
+/// at an arbitrary index `n` over `owner`. The general form of
+/// [`pop_front_embedded`] (`n == 0`) / [`pop_back_embedded`]: removes
+/// the link at position `n` (`0 <= n < len`) back into a loose handle,
+/// touching `n`'s ≤2 bridged neighbours.
+pub axiom fn take_at_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
+    tracked regions: &mut MetaRegionOwners,
+    tracked owner: &mut LinkedListOwner<M>,
+    n: int,
+) -> (tracked frame_own: UniqueFrameOwner<Link<M>>)
+    requires
+        old(regions).inv(),
+        old(owner).inv(),
+        old(owner).relate_region(*old(regions)),
+        0 <= n < old(owner).list.len(),
+    ensures
+        final(regions).inv(),
+        final(owner).inv(),
+        final(owner).relate_region(*final(regions)),
+        final(owner).list == old(owner).list.remove(n),
+        final(owner).list_id == old(owner).list_id,
+        frame_own.inv(),
+        frame_own.global_inv(*final(regions)),
+        frame_own.frame_link_inv(*final(regions)),
+        frame_own.slot_index == old(owner).slot_index_at(n),
+        final(regions).slot_owners[frame_own.slot_index].inner_perms.in_list.value() == 0,
+        final(regions).frame_obligations =~= old(regions).frame_obligations.insert(
+            old(owner).slot_index_at(n),
+        ),
+        forall|j: usize|
+            #![trigger final(regions).slots[j]]
+            #![trigger final(regions).slot_owners[j]]
+            j != old(owner).slot_index_at(n) && (n > 0 ==> j != old(owner).slot_index_at(n - 1))
+                && (n < old(owner).list.len() - 1 ==> j != old(owner).slot_index_at(n + 1))
+                ==> final(regions).slots[j] == old(regions).slots[j]
+                && final(regions).slot_owners[j] == old(regions).slot_owners[j],
+        forall|l: LinkedListOwner<M>|
+            #![trigger l.relate_region(*old(regions))]
+            l.inv() && l.relate_region(*old(regions)) && l.list_id != final(owner).list_id
+                ==> l.relate_region(*final(regions)),
+        // Membership registry for the operated list: forward stamp of
+        // the (minted or preserved) id + reverse global uniqueness (see
+        // [`list_registry_ok`]).
+        list_registry_ok(*final(regions), *final(owner)),
+        // Every other list/cursor list keeps its registry: the only slot
+        // the surgery retags now carries `final(owner).list_id` (or 0),
+        // never another list's id — so no foreign list gains or loses a
+        // tagged slot.
+        forall|l: LinkedListOwner<M>|
+            #![trigger l.relate_region(*old(regions))]
+            l.inv() && l.relate_region(*old(regions)) && list_registry_ok(*old(regions), l)
+                && l.list_id != final(owner).list_id ==> list_registry_ok(*final(regions), l),
+        forall|fo: UniqueFrameOwner<Link<M>>|
+            #![trigger fo.global_inv(*old(regions))]
+            fo.global_inv(*old(regions)) && fo.frame_link_inv(*old(regions)) && old(
+                regions,
+            ).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0 ==> fo.global_inv(
+                *final(regions),
+            ) && fo.frame_link_inv(*final(regions))
+                && final(regions).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0
+                && fo.slot_index != old(owner).slot_index_at(n),
+;
+
+/// Trusted reflection of the (now-strengthened, verified) whole-list
+/// teardown [`crate::mm::frame::LinkedList`]'s `Drop`/`TrackDrop`. The
+/// destructor pops every link via `take_current` and `UniqueFrame::drop`s
+/// the recovered frame, so each former link's slot is **freed** —
+/// `rc → REF_COUNT_UNUSED`, `in_list → 0` — not orphaned. `owner` is
+/// consumed (emptied). The per-link `frame_obligations.count == 0`
+/// precondition mirrors the exec `drop_requires` (a listed frame was
+/// forgotten via `into_raw`); `ListStore` doesn't track that accounting
+/// fact, so it is surfaced here for an accounting-aware caller to supply.
+///
+/// `ensures` mirror the verified `drop_ensures` (freed slots + full
+/// preservation of every out-of-list slot, `slots.dom()`, `inv()`) plus
+/// the sound companion frames (cf. the push/pop axioms): other lists /
+/// cursors keep `relate_region` + [`list_registry_ok`], other loose
+/// frames are untouched, and — when the list was empty — the region is
+/// unchanged outright.
+pub axiom fn list_drop_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
+    tracked regions: &mut MetaRegionOwners,
+    tracked owner: LinkedListOwner<M>,
+)
+    requires
+        old(regions).inv(),
+        owner.inv(),
+        owner.relate_region(*old(regions)),
+        forall|i: int|
+            #![trigger owner.slot_index_at(i)]
+            0 <= i < owner.list.len() ==> old(regions).frame_obligations.count(
+                owner.slot_index_at(i),
+            ) == 0,
+        // Mirrors the exec `TrackDrop for LinkedList::drop_requires`
+        // conjunct (`linked_list.rs`): each link's slot has no live PTE
+        // mapping. The destructor `UniqueFrame::drop`s each link to
+        // `REF_COUNT_UNUSED`, which is only valid for an unmapped frame
+        // (a mapping is itself a reference). Discharged in `step_list_drop`
+        // from `MetaSlotOwner::inv`'s UNIQUE branch (a UNIQUE slot — which
+        // every link is, via `relate_region`) has empty `paths_in_pt`).
+        forall|i: int|
+            #![trigger owner.slot_index_at(i)]
+            0 <= i < owner.list.len() ==> old(regions).slot_owners[owner.slot_index_at(
+                i,
+            )].paths_in_pt.is_empty(),
+    ensures
+        final(regions).inv(),
+        final(regions).slots.dom() =~= old(regions).slots.dom(),
+        // An empty list frees nothing — the region is untouched.
+        owner.list.len() == 0 ==> *final(regions) == *old(regions),
+        // Each former link is freed: its slot is UNUSED with `in_list` 0.
+        forall|i: int|
+            #![trigger owner.slot_index_at(i)]
+            0 <= i < owner.list.len() ==> {
+                let idx = owner.slot_index_at(i);
+                &&& final(regions).slot_owners[idx].inner_perms.ref_count.value()
+                    == crate::specs::mm::frame::meta_owners::REF_COUNT_UNUSED
+                &&& final(regions).slot_owners[idx].inner_perms.in_list.value() == 0
+            },
+        // Every slot outside the dropped list is fully preserved.
+        forall|idx: usize|
+            #![trigger final(regions).slot_owners[idx]]
+            (forall|i: int| 0 <= i < owner.list.len() ==> idx != owner.slot_index_at(i))
+                ==> final(regions).slot_owners[idx] == old(regions).slot_owners[idx]
+                && final(regions).slots[idx] == old(regions).slots[idx]
+                && final(regions).frame_obligations.count(idx) == old(
+                regions,
+            ).frame_obligations.count(idx),
+        // Other lists / cursors keep their `relate_region` and registry.
+        forall|l: LinkedListOwner<M>|
+            #![trigger l.relate_region(*old(regions))]
+            l.inv() && l.relate_region(*old(regions)) && l.list_id != owner.list_id
+                ==> l.relate_region(*final(regions)),
+        forall|l: LinkedListOwner<M>|
+            #![trigger l.relate_region(*old(regions))]
+            l.inv() && l.relate_region(*old(regions)) && list_registry_ok(*old(regions), l)
+                && l.list_id != owner.list_id ==> list_registry_ok(*final(regions), l),
+        // Other loose frames (at `in_list == 0` slots disjoint from the
+        // dropped list's) are untouched.
+        forall|fo: UniqueFrameOwner<Link<M>>|
+            #![trigger fo.global_inv(*old(regions))]
+            fo.global_inv(*old(regions)) && fo.frame_link_inv(*old(regions)) && old(
+                regions,
+            ).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0 ==> fo.global_inv(
+                *final(regions),
+            ) && fo.frame_link_inv(*final(regions))
+                && final(regions).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0,
+;
+
+// =============================================================================
+// Operations
+// =============================================================================
+impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
+    /// `LinkedList::size`: the number of links in list `id`. A read-only
+    /// query — the store is unchanged.
+    pub proof fn step_size(tracked &self, id: ListId) -> (res: nat)
+        requires
+            self.inv(),
+            self.lists.dom().contains(id),
+        ensures
+            res == self.lists[id].list.len(),
+    {
+        self.lists[id].list.len()
+    }
+
+    /// `LinkedList::is_empty`: whether list `id` has no links. Read-only.
+    pub proof fn step_is_empty(tracked &self, id: ListId) -> (res: bool)
+        requires
+            self.inv(),
+            self.lists.dom().contains(id),
+        ensures
+            res <==> self.lists[id].list.len() == 0,
+    {
+        self.lists[id].list.len() == 0
+    }
+
+    /// `LinkedList::contains`: whether `frame` is a link of list `id`. A
+    /// read-only query. The exec computes `in_list[frame] == list_id`;
+    /// the membership registry ([`list_registry_ok`], an `inv` clause)
+    /// turns that comparison into an *exact* membership test — `res`
+    /// holds iff `frame`'s slot is one of the list's links. The list must
+    /// have a real (non-zero) id, i.e. it has been pushed to at least
+    /// once (an empty/never-pushed list trivially contains nothing).
+    pub proof fn step_contains(tracked &self, id: ListId, frame: Paddr) -> (res: bool)
+        requires
+            self.inv(),
+            self.lists.dom().contains(id),
+            self.lists[id].list_id != 0,
+            has_safe_slot(frame),
+            self.regions.slot_owners.contains_key(frame_to_index(frame)),
+        ensures
+    // What the exec computes — the frame's slot is tagged with
+    // this list's id.
+
+            res == (self.regions.slot_owners[frame_to_index(frame)].inner_perms.in_list.value()
+                == self.lists[id].list_id),
+            // ... which, by the registry, is exactly list membership.
+            res <==> exists|i: int|
+                0 <= i < self.lists[id].list.len() && self.lists[id].slot_index_at(i)
+                    == frame_to_index(frame),
+    {
+        let idx = frame_to_index(frame);
+        // The registry for list `id` (forward + reverse) from `inv`.
+        assert(list_registry_ok(self.regions, self.lists[id]));
+        let res = self.regions.slot_owners[idx].inner_perms.in_list.value()
+            == self.lists[id].list_id;
+        if res {
+            // reverse: a slot tagged with the id is one of the links.
+            assert(exists|i: int|
+                0 <= i < self.lists[id].list.len() && self.lists[id].slot_index_at(i) == idx);
+        } else {
+            // forward: every link's slot is tagged, so an untagged slot
+            // is no link.
+            assert forall|i: int|
+                0 <= i < self.lists[id].list.len() implies self.lists[id].slot_index_at(i)
+                != idx by {
+                assert(self.regions.slot_owners[self.lists[id].slot_index_at(
+                    i,
+                )].inner_perms.in_list.value() == self.lists[id].list_id);
+            };
+        }
+        res
+    }
+
+    /// `LinkedList::new`: register a fresh *empty* list. No region
+    /// change; the new list is empty with `list_id == 0` (minted on
+    /// first push). Returns the fresh list id.
+    pub proof fn step_list_new(tracked &mut self) -> (res: ListId)
+        requires
+            old(self).inv(),
+        ensures
+            final(self).inv(),
+            final(self).regions == old(self).regions,
+            final(self).loose == old(self).loose,
+            !old(self).lists.dom().contains(res),
+            final(self).lists == old(self).lists.insert(res, final(self).lists[res]),
+            final(self).lists[res].list.len() == 0,
+    {
+        let ghost old_self = *self;
+        let ghost id = fresh_list_id(self.lists, self.cursors);
+        axiom_fresh_list_id_not_in_dom(self.lists, self.cursors);
+        let tracked empty = axiom_empty_list_owner::<M>();
+        self.lists.tracked_insert(id, empty);
+        assert(self.lists[id].list.len() == 0);
+        // The new list is empty: `inv()` (`len > 0 ==> ...` vacuous,
+        // per-link forall vacuous) and `relate_region` (both foralls
+        // vacuous over an empty `list`) hold. Every other list / loose
+        // entry is unchanged, and `regions` is untouched.
+        assert(self.lists[id].inv());
+        assert(self.lists[id].relate_region(self.regions));
+        // Cursors untouched; `id` is fresh w.r.t. `cursors` (so
+        // disjointness holds), and the new list's `list_id == 0` makes
+        // the cross list/cursor id clause vacuous for it.
+        assert(self.cursors == old_self.cursors);
+        assert(self.lists.dom().disjoint(self.cursors.dom()));
+        assert(self.lists[id].list_id == 0);
+        id
+    }
+
+    /// Drop of `LinkedList` `id`: tear the whole list down, *freeing*
+    /// every link's frame (slot → UNUSED, `in_list` → 0) and removing the
+    /// list from the store. Faithful to the verified destructor (each
+    /// link is popped and `UniqueFrame::drop`ped — no orphaning).
+    ///
+    /// The per-link `frame_obligations.count == 0` precondition mirrors
+    /// the exec `drop_requires` (listed frames are forgotten); the
+    /// accounting-free `ListStore` cannot itself supply it, so it is left
+    /// to the caller. The freed frames leave the store entirely (they
+    /// return to the allocator's UNUSED pool, tracked by nobody here).
+    pub proof fn step_list_drop(tracked &mut self, id: ListId)
+        requires
+            old(self).inv(),
+            old(self).lists.dom().contains(id),
+            forall|i: int|
+                0 <= i < old(self).lists[id].list.len() ==> old(
+                    self,
+                ).regions.frame_obligations.count(old(self).lists[id].slot_index_at(i)) == 0,
+        ensures
+            final(self).inv(),
+            !final(self).lists.dom().contains(id),
+            final(self).loose == old(self).loose,
+            final(self).cursors == old(self).cursors,
+    {
+        let ghost old_self = *self;
+        let ghost old_regions = self.regions;
+        let ghost dropped_id = self.lists[id].list_id;
+        let ghost is_empty = self.lists[id].list.len() == 0;
+        assert(self.lists[id].inv());
+        assert(self.lists[id].relate_region(self.regions));
+
+        // Discharge the axiom's unmapped-link precondition: every link's
+        // slot is a non-MMIO UNIQUE frame (via `relate_region_at`:
+        // `ref_count == REF_COUNT_UNIQUE` + `usage == Frame`), and
+        // `regions.inv()`'s UNIQUE branch (`usage != MMIO ==> empty`) then
+        // gives it an empty `paths_in_pt`.
+        assert forall|i: int|
+            #![trigger self.lists[id].slot_index_at(i)]
+            0 <= i
+                < self.lists[id].list.len() implies self.regions.slot_owners[self.lists[id].slot_index_at(
+        i)].paths_in_pt.is_empty() by {
+            let idx = self.lists[id].slot_index_at(i);
+            // Instantiate `relate_region`'s per-link forall (trigger
+            // `self.list[i]`) to get `relate_region_at(regions, i)`.
+            let _ = self.lists[id].list[i];
+            self.lists[id].relate_region_at_facts(self.regions, i);
+            assert(self.regions.slot_owners.contains_key(idx));
+            assert(self.regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
+            assert(self.regions.slot_owners[idx].usage == PageUsage::Frame);
+            assert(self.regions.slot_owners[idx].inv());
+        };
+
+        let tracked owner = self.lists.tracked_remove(id);
+        list_drop_embedded(&mut self.regions, owner);
+        assert(self.lists =~= old_self.lists.remove(id));
+        if is_empty {
+            assert(self.regions == old_regions);
+        }
+        // A non-empty dropped list has a real (non-zero) id, so every
+        // other list/cursor is separated from it by the id uniqueness;
+        // an empty drop left `regions` untouched outright.
+
+        if !is_empty {
+            assert(dropped_id != 0);
+        }
+        // --- per-list: remaining lists preserved ---
+
+        assert forall|i: ListId| #[trigger] self.lists.dom().contains(i) implies {
+            &&& self.lists[i].inv()
+            &&& self.lists[i].relate_region(self.regions)
+        } by {
+            assert(i != id);
+            assert(old_self.lists.dom().contains(i));
+            assert(old_self.lists[i] == self.lists[i]);
+            assert(old_self.lists[i].relate_region(old_regions));
+            if !is_empty {
+                assert(self.lists[i].list_id != dropped_id);
+            }
+        };
+
+        // --- per-loose preserved ---
+        assert forall|lid2: LooseId| #[trigger] self.loose.dom().contains(lid2) implies {
+            &&& self.loose[lid2].inv()
+            &&& self.loose[lid2].global_inv(self.regions)
+            &&& self.loose[lid2].frame_link_inv(self.regions)
+            &&& self.regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                == 0
+        } by {
+            assert(old_self.loose.dom().contains(lid2));
+            assert(old_self.loose[lid2].global_inv(old_regions));
+            assert(old_self.loose[lid2].frame_link_inv(old_regions));
+            assert(old_regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                == 0);
+        };
+
+        // --- per-cursor preserved (cursor lists are "other lists") ---
+        assert forall|cid: CursorId| #[trigger] self.cursors.dom().contains(cid) implies {
+            &&& self.cursors[cid].list_own.inv()
+            &&& self.cursors[cid].inv_region(self.regions)
+        } by {
+            assert(old_self.cursors.dom().contains(cid));
+            assert(old_self.cursors[cid].list_own.inv());
+            assert(old_self.cursors[cid].inv_region(old_regions));
+            assert(self.cursors[cid].list_own.relate_region(old_regions));
+            if !is_empty {
+                assert(self.cursors[cid].list_own.list_id != dropped_id);
+            }
+        };
+
+        // --- lists×lists uniqueness (subset of old) ---
+        assert forall|i1: ListId, i2: ListId|
+            self.lists.dom().contains(i1) && self.lists.dom().contains(i2) && self.lists[i1].list_id
+                == self.lists[i2].list_id && self.lists[i1].list_id != 0 implies i1 == i2 by {
+            assert(old_self.lists.dom().contains(i1));
+            assert(old_self.lists.dom().contains(i2));
+        };
+
+        // --- loose-internal disjointness (loose unchanged) ---
+        assert forall|l1: LooseId, l2: LooseId|
+            self.loose.dom().contains(l1) && self.loose.dom().contains(l2)
+                && self.loose[l1].slot_index == self.loose[l2].slot_index implies l1 == l2 by {
+            assert(old_self.loose.dom().contains(l1));
+            assert(old_self.loose.dom().contains(l2));
+        };
+
+        // --- disjointness + cross/cursor uniqueness (lists lost `id`) ---
+        assert(self.lists.dom().disjoint(self.cursors.dom()));
+        assert forall|id2: ListId, cid: CursorId|
+            self.lists.dom().contains(id2) && self.cursors.dom().contains(cid)
+                && self.lists[id2].list_id == self.cursors[cid].list_own.list_id
+                && self.lists[id2].list_id != 0 implies false by {
+            assert(old_self.lists.dom().contains(id2));
+            assert(old_self.cursors.dom().contains(cid));
+        };
+        assert forall|cid1: CursorId, cid2: CursorId|
+            self.cursors.dom().contains(cid1) && self.cursors.dom().contains(cid2)
+                && self.cursors[cid1].list_own.list_id == self.cursors[cid2].list_own.list_id
+                && self.cursors[cid1].list_own.list_id != 0 implies cid1 == cid2 by {
+            assert(old_self.cursors.dom().contains(cid1));
+            assert(old_self.cursors.dom().contains(cid2));
+        };
+
+        // --- membership registry (remaining lists & cursors) ---
+        assert forall|i: ListId| #[trigger] self.lists.dom().contains(i) implies list_registry_ok(
+            self.regions,
+            self.lists[i],
+        ) by {
+            assert(old_self.lists.dom().contains(i));
+            assert(old_self.lists[i] == self.lists[i]);
+            assert(old_self.lists[i].relate_region(old_regions));
+            if !is_empty {
+                assert(self.lists[i].list_id != dropped_id);
+            }
+        };
+        assert forall|cid: CursorId| #[trigger]
+            self.cursors.dom().contains(cid) implies list_registry_ok(
+            self.regions,
+            self.cursors[cid].list_own,
+        ) by {
+            assert(old_self.cursors.dom().contains(cid));
+            assert(old_self.cursors[cid].list_own.relate_region(old_regions));
+            if !is_empty {
+                assert(self.cursors[cid].list_own.list_id != dropped_id);
+            }
+        };
+    }
+
+    /// `LinkedList::push_front`: move the loose handle `lid` to the front
+    /// of list `id`. The frame is forgotten into the list (its
+    /// drop-obligation consumed); the `loose` entry is removed.
+    pub proof fn step_push_front(tracked &mut self, id: ListId, lid: LooseId)
+        requires
+            old(self).inv(),
+            old(self).lists.dom().contains(id),
+            old(self).loose.dom().contains(lid),
+        ensures
+            final(self).inv(),
+    {
+        let ghost old_self = *self;
+        let ghost old_regions = self.regions;
+        let ghost fidx = self.loose[lid].slot_index;
+        // The other lists' ids — the lazily-minted id must avoid these.
+        let ghost used = Set::new_assuming_finite(
+            |x: u64|
+                (exists|i: ListId| #[trigger]
+                    old_self.lists.dom().contains(i) && i != id && old_self.lists[i].list_id == x)
+                    || (exists|cid: CursorId| #[trigger]
+                    old_self.cursors.dom().contains(cid) && old_self.cursors[cid].list_own.list_id
+                        == x),
+        );
+        // Push preconditions, sourced from `inv`.
+        assert(self.lists[id].inv());
+        assert(self.lists[id].relate_region(self.regions));
+        assert(self.loose[lid].inv());
+        assert(self.loose[lid].global_inv(self.regions));
+        assert(self.loose[lid].frame_link_inv(self.regions));
+        assert(self.regions.slot_owners[fidx].inner_perms.in_list.value() == 0);
+
+        let tracked mut owner = self.lists.tracked_remove(id);
+        let tracked mut frame_own = self.loose.tracked_remove(lid);
+        push_front_embedded(&mut self.regions, &mut owner, &mut frame_own, used);
+        self.lists.tracked_insert(id, owner);
+        assert(self.loose =~= old_self.loose.remove(lid));
+        assert(self.lists =~= old_self.lists.remove(id).insert(id, owner));
+        let ghost new_id = self.lists[id].list_id;
+
+        // Other lists with a nonzero id keep it distinct from `new_id`:
+        // the pushed list either kept its (uniquely-minted) id or minted
+        // one outside `used` (which holds every other list's id).
+        assert forall|i: ListId|
+            self.lists.dom().contains(i) && i != id && self.lists[i].list_id
+                != 0 implies self.lists[i].list_id != new_id by {
+            assert(old_self.lists.dom().contains(i));
+            assert(old_self.lists[i] == self.lists[i]);
+            if old_self.lists[id].list_id != 0 {
+                // `new_id == old id`; old nonzero-id uniqueness separates `i`.
+                assert(new_id == old_self.lists[id].list_id);
+            } else {
+                assert(used.contains(self.lists[i].list_id));
+            }
+        };
+
+        // --- per-list: inv + relate_region ---
+        assert forall|i: ListId| #[trigger] self.lists.dom().contains(i) implies {
+            &&& self.lists[i].inv()
+            &&& self.lists[i].relate_region(self.regions)
+        } by {
+            if i != id {
+                assert(old_self.lists.dom().contains(i));
+                assert(old_self.lists[i] == self.lists[i]);
+                assert(old_self.lists[i].inv());
+                assert(old_self.lists[i].relate_region(old_regions));
+                if self.lists[i].list.len() > 0 {
+                    assert(self.lists[i].list_id != new_id);
+                }
+            }
+        };
+
+        // --- per-loose: a different loose frame is at a `!= fidx` slot,
+        // so the axiom's other-loose clause carries it. ---
+        assert forall|lid2: LooseId| #[trigger] self.loose.dom().contains(lid2) implies {
+            &&& self.loose[lid2].inv()
+            &&& self.loose[lid2].global_inv(self.regions)
+            &&& self.loose[lid2].frame_link_inv(self.regions)
+            &&& self.regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                == 0
+        } by {
+            assert(lid2 != lid);
+            assert(old_self.loose.dom().contains(lid2));
+            assert(old_self.loose[lid2] == self.loose[lid2]);
+            assert(old_self.loose[lid2].global_inv(old_regions));
+            assert(old_self.loose[lid2].frame_link_inv(old_regions));
+            assert(old_regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                == 0);
+            assert(self.loose[lid2].slot_index != fidx);
+        };
+
+        // --- list_id uniqueness (non-empty lists) ---
+        assert forall|i1: ListId, i2: ListId|
+            self.lists.dom().contains(i1) && self.lists.dom().contains(i2)
+                && self.lists[i1].list.len() > 0 && self.lists[i2].list.len() > 0
+                && self.lists[i1].list_id == self.lists[i2].list_id implies i1 == i2 by {
+            if i1 != id && i2 != id {
+                assert(old_self.lists[i1] == self.lists[i1]);
+                assert(old_self.lists[i2] == self.lists[i2]);
+            } else if i1 == id && i2 != id {
+                assert(self.lists[i2].list_id != new_id);
+            } else if i2 == id && i1 != id {
+                assert(self.lists[i1].list_id != new_id);
+            }
+        };
+
+        // --- loose-internal slot disjointness (subset of old) ---
+        assert forall|l1: LooseId, l2: LooseId|
+            self.loose.dom().contains(l1) && self.loose.dom().contains(l2)
+                && self.loose[l1].slot_index == self.loose[l2].slot_index implies l1 == l2 by {
+            assert(old_self.loose.dom().contains(l1));
+            assert(old_self.loose.dom().contains(l2));
+        };
+
+        // --- cursors: checked-out lists are untouched ---
+        // `cursors` is not read or written by a list op, and every
+        // cursor's list carries an id distinct from the just-minted
+        // `new_id` (other cursors' ids are in `used`, or — when the id
+        // was preserved — separated by the old list/cursor uniqueness),
+        // so the axiom's other-lists frame preserves each cursor's
+        // `relate_region`. Index bounds are unchanged.
+        assert(self.cursors == old_self.cursors);
+        assert(self.lists.dom() =~= old_self.lists.dom());
+        assert forall|cid: CursorId| #[trigger] self.cursors.dom().contains(cid) implies {
+            &&& self.cursors[cid].list_own.inv()
+            &&& self.cursors[cid].inv_region(self.regions)
+        } by {
+            assert(old_self.cursors.dom().contains(cid));
+            assert(old_self.cursors[cid].list_own.inv());
+            assert(old_self.cursors[cid].inv_region(old_regions));
+            assert(self.cursors[cid].list_own.relate_region(old_regions));
+            if old_self.lists[id].list_id != 0 {
+                assert(new_id == old_self.lists[id].list_id);
+            } else {
+                assert(used.contains(self.cursors[cid].list_own.list_id));
+            }
+            assert(self.cursors[cid].list_own.list_id != new_id);
+            assert(self.cursors[cid].list_own.relate_region(self.regions));
+        };
+        assert forall|id2: ListId, cid: CursorId|
+            self.lists.dom().contains(id2) && self.cursors.dom().contains(cid)
+                && self.lists[id2].list_id == self.cursors[cid].list_own.list_id
+                && self.lists[id2].list_id != 0 implies false by {
+            assert(old_self.cursors.dom().contains(cid));
+            if id2 == id {
+                assert(self.lists[id].list_id == new_id);
+                if old_self.lists[id].list_id != 0 {
+                    assert(new_id == old_self.lists[id].list_id);
+                } else {
+                    assert(used.contains(self.cursors[cid].list_own.list_id));
+                }
+            } else {
+                assert(old_self.lists.dom().contains(id2));
+                assert(old_self.lists[id2] == self.lists[id2]);
+            }
+        };
+        assert forall|cid1: CursorId, cid2: CursorId|
+            self.cursors.dom().contains(cid1) && self.cursors.dom().contains(cid2)
+                && self.cursors[cid1].list_own.list_id == self.cursors[cid2].list_own.list_id
+                && self.cursors[cid1].list_own.list_id != 0 implies cid1 == cid2 by {
+            assert(old_self.cursors.dom().contains(cid1));
+            assert(old_self.cursors.dom().contains(cid2));
+        };
+    }
+
+    /// `LinkedList::pop_front`: pop the front link of list `id` back into
+    /// the loose pool as a fresh `UniqueFrame<Link<M>>`. Requires the
+    /// list be non-empty. Returns the fresh loose id.
+    pub proof fn step_pop_front(tracked &mut self, id: ListId) -> (res: LooseId)
+        requires
+            old(self).inv(),
+            old(self).lists.dom().contains(id),
+            old(self).lists[id].list.len() > 0,
+        ensures
+            final(self).inv(),
+    {
+        let ghost old_self = *self;
+        let ghost old_regions = self.regions;
+        let ghost popped_idx = self.lists[id].slot_index_at(0);
+        let ghost old_list_id = self.lists[id].list_id;
+        // Pop preconditions from `inv`.
+        assert(self.lists[id].inv());
+        assert(self.lists[id].relate_region(self.regions));
+
+        let tracked mut owner = self.lists.tracked_remove(id);
+        let tracked frame_own = pop_front_embedded(&mut self.regions, &mut owner);
+        self.lists.tracked_insert(id, owner);
+        let ghost new_loose = fresh_loose_id(self.loose);
+        axiom_fresh_loose_id_not_in_dom(self.loose);
+        self.loose.tracked_insert(new_loose, frame_own);
+
+        assert(self.lists =~= old_self.lists.remove(id).insert(id, owner));
+        assert(self.loose =~= old_self.loose.insert(new_loose, frame_own));
+        assert(self.lists[id].list_id == old_list_id);
+        assert(frame_own.slot_index == popped_idx);
+
+        // --- per-list: inv + relate_region ---
+        assert forall|i: ListId| #[trigger] self.lists.dom().contains(i) implies {
+            &&& self.lists[i].inv()
+            &&& self.lists[i].relate_region(self.regions)
+        } by {
+            if i != id {
+                assert(old_self.lists.dom().contains(i));
+                assert(old_self.lists[i] == self.lists[i]);
+                assert(old_self.lists[i].inv());
+                assert(old_self.lists[i].relate_region(old_regions));
+                if self.lists[i].list.len() > 0 {
+                    // non-empty ⟹ nonzero id, distinct from `id`'s
+                    // (preserved) id by old uniqueness.
+                    assert(self.lists[i].list_id != old_list_id);
+                }
+            }
+        };
+
+        // --- per-loose: new entry from the axiom; others preserved ---
+        assert forall|lid2: LooseId| #[trigger] self.loose.dom().contains(lid2) implies {
+            &&& self.loose[lid2].inv()
+            &&& self.loose[lid2].global_inv(self.regions)
+            &&& self.loose[lid2].frame_link_inv(self.regions)
+            &&& self.regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                == 0
+        } by {
+            if lid2 != new_loose {
+                assert(old_self.loose.dom().contains(lid2));
+                assert(old_self.loose[lid2] == self.loose[lid2]);
+                assert(old_self.loose[lid2].global_inv(old_regions));
+                assert(old_self.loose[lid2].frame_link_inv(old_regions));
+                assert(old_regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                    == 0);
+            }
+        };
+
+        // --- list_id uniqueness (all ids unchanged) ---
+        assert forall|i1: ListId, i2: ListId|
+            self.lists.dom().contains(i1) && self.lists.dom().contains(i2) && self.lists[i1].list_id
+                == self.lists[i2].list_id && self.lists[i1].list_id != 0 implies i1 == i2 by {
+            assert(old_self.lists.dom().contains(i1));
+            assert(old_self.lists.dom().contains(i2));
+            assert(self.lists[i1].list_id == old_self.lists[i1].list_id);
+            assert(self.lists[i2].list_id == old_self.lists[i2].list_id);
+        };
+
+        // --- loose-internal disjointness ---
+        assert forall|l1: LooseId, l2: LooseId|
+            self.loose.dom().contains(l1) && self.loose.dom().contains(l2)
+                && self.loose[l1].slot_index == self.loose[l2].slot_index implies l1 == l2 by {
+            if l1 == new_loose && l2 != new_loose {
+                assert(old_self.loose.dom().contains(l2));
+                assert(self.loose[l2].slot_index != popped_idx);
+            } else if l2 == new_loose && l1 != new_loose {
+                assert(old_self.loose.dom().contains(l1));
+                assert(self.loose[l1].slot_index != popped_idx);
+            } else if l1 != new_loose && l2 != new_loose {
+                assert(old_self.loose.dom().contains(l1));
+                assert(old_self.loose.dom().contains(l2));
+            }
+        };
+
+        // --- cursors: checked-out lists are untouched ---
+        // `id`'s (preserved, nonzero) `old_list_id` is separated from
+        // every cursor's list id by the old list/cursor uniqueness, so
+        // the axiom's other-lists frame preserves each cursor.
+        assert(self.cursors == old_self.cursors);
+        assert(self.lists.dom() =~= old_self.lists.dom());
+        assert forall|cid: CursorId| #[trigger] self.cursors.dom().contains(cid) implies {
+            &&& self.cursors[cid].list_own.inv()
+            &&& self.cursors[cid].inv_region(self.regions)
+        } by {
+            assert(old_self.cursors.dom().contains(cid));
+            assert(old_self.cursors[cid].list_own.inv());
+            assert(old_self.cursors[cid].inv_region(old_regions));
+            assert(self.cursors[cid].list_own.relate_region(old_regions));
+            assert(old_self.lists.dom().contains(id));
+            assert(old_self.lists[id].list_id == old_list_id);
+            assert(self.cursors[cid].list_own.list_id != old_list_id);
+            assert(self.cursors[cid].list_own.relate_region(self.regions));
+        };
+        assert forall|id2: ListId, cid: CursorId|
+            self.lists.dom().contains(id2) && self.cursors.dom().contains(cid)
+                && self.lists[id2].list_id == self.cursors[cid].list_own.list_id
+                && self.lists[id2].list_id != 0 implies false by {
+            assert(old_self.cursors.dom().contains(cid));
+            assert(old_self.lists.dom().contains(id2));
+            assert(old_self.lists[id2].list_id == self.lists[id2].list_id);
+        };
+        assert forall|cid1: CursorId, cid2: CursorId|
+            self.cursors.dom().contains(cid1) && self.cursors.dom().contains(cid2)
+                && self.cursors[cid1].list_own.list_id == self.cursors[cid2].list_own.list_id
+                && self.cursors[cid1].list_own.list_id != 0 implies cid1 == cid2 by {
+            assert(old_self.cursors.dom().contains(cid1));
+            assert(old_self.cursors.dom().contains(cid2));
+        };
+        new_loose
+    }
+
+    /// `LinkedList::push_back`: move the loose handle `lid` to the back
+    /// of list `id`. Same global effect as [`Self::step_push_front`] —
+    /// only the link's position within the list differs.
+    pub proof fn step_push_back(tracked &mut self, id: ListId, lid: LooseId)
+        requires
+            old(self).inv(),
+            old(self).lists.dom().contains(id),
+            old(self).loose.dom().contains(lid),
+        ensures
+            final(self).inv(),
+    {
+        let ghost old_self = *self;
+        let ghost old_regions = self.regions;
+        let ghost fidx = self.loose[lid].slot_index;
+        let ghost used = Set::new_assuming_finite(
+            |x: u64|
+                (exists|i: ListId| #[trigger]
+                    old_self.lists.dom().contains(i) && i != id && old_self.lists[i].list_id == x)
+                    || (exists|cid: CursorId| #[trigger]
+                    old_self.cursors.dom().contains(cid) && old_self.cursors[cid].list_own.list_id
+                        == x),
+        );
+        assert(self.lists[id].inv());
+        assert(self.lists[id].relate_region(self.regions));
+        assert(self.loose[lid].inv());
+        assert(self.loose[lid].global_inv(self.regions));
+        assert(self.loose[lid].frame_link_inv(self.regions));
+        assert(self.regions.slot_owners[fidx].inner_perms.in_list.value() == 0);
+
+        let tracked mut owner = self.lists.tracked_remove(id);
+        let tracked mut frame_own = self.loose.tracked_remove(lid);
+        push_back_embedded(&mut self.regions, &mut owner, &mut frame_own, used);
+        self.lists.tracked_insert(id, owner);
+        assert(self.loose =~= old_self.loose.remove(lid));
+        assert(self.lists =~= old_self.lists.remove(id).insert(id, owner));
+        let ghost new_id = self.lists[id].list_id;
+
+        assert forall|i: ListId|
+            self.lists.dom().contains(i) && i != id && self.lists[i].list_id
+                != 0 implies self.lists[i].list_id != new_id by {
+            assert(old_self.lists.dom().contains(i));
+            assert(old_self.lists[i] == self.lists[i]);
+            if old_self.lists[id].list_id != 0 {
+                assert(new_id == old_self.lists[id].list_id);
+            } else {
+                assert(used.contains(self.lists[i].list_id));
+            }
+        };
+
+        assert forall|i: ListId| #[trigger] self.lists.dom().contains(i) implies {
+            &&& self.lists[i].inv()
+            &&& self.lists[i].relate_region(self.regions)
+        } by {
+            if i != id {
+                assert(old_self.lists.dom().contains(i));
+                assert(old_self.lists[i] == self.lists[i]);
+                assert(old_self.lists[i].inv());
+                assert(old_self.lists[i].relate_region(old_regions));
+                if self.lists[i].list.len() > 0 {
+                    assert(self.lists[i].list_id != new_id);
+                }
+            }
+        };
+
+        assert forall|lid2: LooseId| #[trigger] self.loose.dom().contains(lid2) implies {
+            &&& self.loose[lid2].inv()
+            &&& self.loose[lid2].global_inv(self.regions)
+            &&& self.loose[lid2].frame_link_inv(self.regions)
+            &&& self.regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                == 0
+        } by {
+            assert(lid2 != lid);
+            assert(old_self.loose.dom().contains(lid2));
+            assert(old_self.loose[lid2] == self.loose[lid2]);
+            assert(old_self.loose[lid2].global_inv(old_regions));
+            assert(old_self.loose[lid2].frame_link_inv(old_regions));
+            assert(old_regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                == 0);
+            assert(self.loose[lid2].slot_index != fidx);
+        };
+
+        assert forall|i1: ListId, i2: ListId|
+            self.lists.dom().contains(i1) && self.lists.dom().contains(i2)
+                && self.lists[i1].list.len() > 0 && self.lists[i2].list.len() > 0
+                && self.lists[i1].list_id == self.lists[i2].list_id implies i1 == i2 by {
+            if i1 != id && i2 != id {
+                assert(old_self.lists[i1] == self.lists[i1]);
+                assert(old_self.lists[i2] == self.lists[i2]);
+            } else if i1 == id && i2 != id {
+                assert(self.lists[i2].list_id != new_id);
+            } else if i2 == id && i1 != id {
+                assert(self.lists[i1].list_id != new_id);
+            }
+        };
+
+        assert forall|l1: LooseId, l2: LooseId|
+            self.loose.dom().contains(l1) && self.loose.dom().contains(l2)
+                && self.loose[l1].slot_index == self.loose[l2].slot_index implies l1 == l2 by {
+            assert(old_self.loose.dom().contains(l1));
+            assert(old_self.loose.dom().contains(l2));
+        };
+
+        // --- cursors: checked-out lists are untouched ---
+        // `cursors` is not read or written by a list op, and every
+        // cursor's list carries an id distinct from the just-minted
+        // `new_id` (other cursors' ids are in `used`, or — when the id
+        // was preserved — separated by the old list/cursor uniqueness),
+        // so the axiom's other-lists frame preserves each cursor's
+        // `relate_region`. Index bounds are unchanged.
+        assert(self.cursors == old_self.cursors);
+        assert(self.lists.dom() =~= old_self.lists.dom());
+        assert forall|cid: CursorId| #[trigger] self.cursors.dom().contains(cid) implies {
+            &&& self.cursors[cid].list_own.inv()
+            &&& self.cursors[cid].inv_region(self.regions)
+        } by {
+            assert(old_self.cursors.dom().contains(cid));
+            assert(old_self.cursors[cid].list_own.inv());
+            assert(old_self.cursors[cid].inv_region(old_regions));
+            assert(self.cursors[cid].list_own.relate_region(old_regions));
+            if old_self.lists[id].list_id != 0 {
+                assert(new_id == old_self.lists[id].list_id);
+            } else {
+                assert(used.contains(self.cursors[cid].list_own.list_id));
+            }
+            assert(self.cursors[cid].list_own.list_id != new_id);
+            assert(self.cursors[cid].list_own.relate_region(self.regions));
+        };
+        assert forall|id2: ListId, cid: CursorId|
+            self.lists.dom().contains(id2) && self.cursors.dom().contains(cid)
+                && self.lists[id2].list_id == self.cursors[cid].list_own.list_id
+                && self.lists[id2].list_id != 0 implies false by {
+            assert(old_self.cursors.dom().contains(cid));
+            if id2 == id {
+                assert(self.lists[id].list_id == new_id);
+                if old_self.lists[id].list_id != 0 {
+                    assert(new_id == old_self.lists[id].list_id);
+                } else {
+                    assert(used.contains(self.cursors[cid].list_own.list_id));
+                }
+            } else {
+                assert(old_self.lists.dom().contains(id2));
+                assert(old_self.lists[id2] == self.lists[id2]);
+            }
+        };
+        assert forall|cid1: CursorId, cid2: CursorId|
+            self.cursors.dom().contains(cid1) && self.cursors.dom().contains(cid2)
+                && self.cursors[cid1].list_own.list_id == self.cursors[cid2].list_own.list_id
+                && self.cursors[cid1].list_own.list_id != 0 implies cid1 == cid2 by {
+            assert(old_self.cursors.dom().contains(cid1));
+            assert(old_self.cursors.dom().contains(cid2));
+        };
+    }
+
+    /// `LinkedList::pop_back`: pop the back link of list `id` back into
+    /// the loose pool. Same global effect as [`Self::step_pop_front`] —
+    /// only which link is removed differs.
+    pub proof fn step_pop_back(tracked &mut self, id: ListId) -> (res: LooseId)
+        requires
+            old(self).inv(),
+            old(self).lists.dom().contains(id),
+            old(self).lists[id].list.len() > 0,
+        ensures
+            final(self).inv(),
+    {
+        let ghost old_self = *self;
+        let ghost old_regions = self.regions;
+        let ghost popped_idx = self.lists[id].slot_index_at(self.lists[id].list.len() - 1);
+        let ghost old_list_id = self.lists[id].list_id;
+        assert(self.lists[id].inv());
+        assert(self.lists[id].relate_region(self.regions));
+
+        let tracked mut owner = self.lists.tracked_remove(id);
+        let tracked frame_own = pop_back_embedded(&mut self.regions, &mut owner);
+        self.lists.tracked_insert(id, owner);
+        let ghost new_loose = fresh_loose_id(self.loose);
+        axiom_fresh_loose_id_not_in_dom(self.loose);
+        self.loose.tracked_insert(new_loose, frame_own);
+
+        assert(self.lists =~= old_self.lists.remove(id).insert(id, owner));
+        assert(self.loose =~= old_self.loose.insert(new_loose, frame_own));
+        assert(self.lists[id].list_id == old_list_id);
+        assert(frame_own.slot_index == popped_idx);
+
+        assert forall|i: ListId| #[trigger] self.lists.dom().contains(i) implies {
+            &&& self.lists[i].inv()
+            &&& self.lists[i].relate_region(self.regions)
+        } by {
+            if i != id {
+                assert(old_self.lists.dom().contains(i));
+                assert(old_self.lists[i] == self.lists[i]);
+                assert(old_self.lists[i].inv());
+                assert(old_self.lists[i].relate_region(old_regions));
+                if self.lists[i].list.len() > 0 {
+                    assert(self.lists[i].list_id != old_list_id);
+                }
+            }
+        };
+
+        assert forall|lid2: LooseId| #[trigger] self.loose.dom().contains(lid2) implies {
+            &&& self.loose[lid2].inv()
+            &&& self.loose[lid2].global_inv(self.regions)
+            &&& self.loose[lid2].frame_link_inv(self.regions)
+            &&& self.regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                == 0
+        } by {
+            if lid2 != new_loose {
+                assert(old_self.loose.dom().contains(lid2));
+                assert(old_self.loose[lid2] == self.loose[lid2]);
+                assert(old_self.loose[lid2].global_inv(old_regions));
+                assert(old_self.loose[lid2].frame_link_inv(old_regions));
+                assert(old_regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                    == 0);
+            }
+        };
+
+        assert forall|i1: ListId, i2: ListId|
+            self.lists.dom().contains(i1) && self.lists.dom().contains(i2) && self.lists[i1].list_id
+                == self.lists[i2].list_id && self.lists[i1].list_id != 0 implies i1 == i2 by {
+            assert(old_self.lists.dom().contains(i1));
+            assert(old_self.lists.dom().contains(i2));
+            assert(self.lists[i1].list_id == old_self.lists[i1].list_id);
+            assert(self.lists[i2].list_id == old_self.lists[i2].list_id);
+        };
+
+        assert forall|l1: LooseId, l2: LooseId|
+            self.loose.dom().contains(l1) && self.loose.dom().contains(l2)
+                && self.loose[l1].slot_index == self.loose[l2].slot_index implies l1 == l2 by {
+            if l1 == new_loose && l2 != new_loose {
+                assert(old_self.loose.dom().contains(l2));
+                assert(self.loose[l2].slot_index != popped_idx);
+            } else if l2 == new_loose && l1 != new_loose {
+                assert(old_self.loose.dom().contains(l1));
+                assert(self.loose[l1].slot_index != popped_idx);
+            } else if l1 != new_loose && l2 != new_loose {
+                assert(old_self.loose.dom().contains(l1));
+                assert(old_self.loose.dom().contains(l2));
+            }
+        };
+
+        // --- cursors: checked-out lists are untouched ---
+        // `id`'s (preserved, nonzero) `old_list_id` is separated from
+        // every cursor's list id by the old list/cursor uniqueness, so
+        // the axiom's other-lists frame preserves each cursor.
+        assert(self.cursors == old_self.cursors);
+        assert(self.lists.dom() =~= old_self.lists.dom());
+        assert forall|cid: CursorId| #[trigger] self.cursors.dom().contains(cid) implies {
+            &&& self.cursors[cid].list_own.inv()
+            &&& self.cursors[cid].inv_region(self.regions)
+        } by {
+            assert(old_self.cursors.dom().contains(cid));
+            assert(old_self.cursors[cid].list_own.inv());
+            assert(old_self.cursors[cid].inv_region(old_regions));
+            assert(self.cursors[cid].list_own.relate_region(old_regions));
+            assert(old_self.lists.dom().contains(id));
+            assert(old_self.lists[id].list_id == old_list_id);
+            assert(self.cursors[cid].list_own.list_id != old_list_id);
+            assert(self.cursors[cid].list_own.relate_region(self.regions));
+        };
+        assert forall|id2: ListId, cid: CursorId|
+            self.lists.dom().contains(id2) && self.cursors.dom().contains(cid)
+                && self.lists[id2].list_id == self.cursors[cid].list_own.list_id
+                && self.lists[id2].list_id != 0 implies false by {
+            assert(old_self.cursors.dom().contains(cid));
+            assert(old_self.lists.dom().contains(id2));
+            assert(old_self.lists[id2].list_id == self.lists[id2].list_id);
+        };
+        assert forall|cid1: CursorId, cid2: CursorId|
+            self.cursors.dom().contains(cid1) && self.cursors.dom().contains(cid2)
+                && self.cursors[cid1].list_own.list_id == self.cursors[cid2].list_own.list_id
+                && self.cursors[cid1].list_own.list_id != 0 implies cid1 == cid2 by {
+            assert(old_self.cursors.dom().contains(cid1));
+            assert(old_self.cursors.dom().contains(cid2));
+        };
+        new_loose
+    }
+
+    /// Cursor `insert_before` at an arbitrary position `n`: move the
+    /// loose handle `lid` into list `id` at index `n` (`0 <= n <= len`).
+    /// The general form of [`Self::step_push_front`] /
+    /// [`Self::step_push_back`]; same global effect.
+    pub proof fn step_insert_before_at(tracked &mut self, id: ListId, n: int, lid: LooseId)
+        requires
+            old(self).inv(),
+            old(self).lists.dom().contains(id),
+            old(self).loose.dom().contains(lid),
+            0 <= n <= old(self).lists[id].list.len(),
+        ensures
+            final(self).inv(),
+    {
+        let ghost old_self = *self;
+        let ghost old_regions = self.regions;
+        let ghost fidx = self.loose[lid].slot_index;
+        let ghost used = Set::new_assuming_finite(
+            |x: u64|
+                (exists|i: ListId| #[trigger]
+                    old_self.lists.dom().contains(i) && i != id && old_self.lists[i].list_id == x)
+                    || (exists|cid: CursorId| #[trigger]
+                    old_self.cursors.dom().contains(cid) && old_self.cursors[cid].list_own.list_id
+                        == x),
+        );
+        assert(self.lists[id].inv());
+        assert(self.lists[id].relate_region(self.regions));
+        assert(self.loose[lid].inv());
+        assert(self.loose[lid].global_inv(self.regions));
+        assert(self.loose[lid].frame_link_inv(self.regions));
+        assert(self.regions.slot_owners[fidx].inner_perms.in_list.value() == 0);
+
+        let tracked mut owner = self.lists.tracked_remove(id);
+        let tracked mut frame_own = self.loose.tracked_remove(lid);
+        insert_before_at_embedded(&mut self.regions, &mut owner, &mut frame_own, n, used);
+        self.lists.tracked_insert(id, owner);
+        assert(self.loose =~= old_self.loose.remove(lid));
+        assert(self.lists =~= old_self.lists.remove(id).insert(id, owner));
+        let ghost new_id = self.lists[id].list_id;
+
+        assert forall|i: ListId|
+            self.lists.dom().contains(i) && i != id && self.lists[i].list_id
+                != 0 implies self.lists[i].list_id != new_id by {
+            assert(old_self.lists.dom().contains(i));
+            assert(old_self.lists[i] == self.lists[i]);
+            if old_self.lists[id].list_id != 0 {
+                assert(new_id == old_self.lists[id].list_id);
+            } else {
+                assert(used.contains(self.lists[i].list_id));
+            }
+        };
+
+        assert forall|i: ListId| #[trigger] self.lists.dom().contains(i) implies {
+            &&& self.lists[i].inv()
+            &&& self.lists[i].relate_region(self.regions)
+        } by {
+            if i != id {
+                assert(old_self.lists.dom().contains(i));
+                assert(old_self.lists[i] == self.lists[i]);
+                assert(old_self.lists[i].inv());
+                assert(old_self.lists[i].relate_region(old_regions));
+                if self.lists[i].list.len() > 0 {
+                    assert(self.lists[i].list_id != new_id);
+                }
+            }
+        };
+
+        assert forall|lid2: LooseId| #[trigger] self.loose.dom().contains(lid2) implies {
+            &&& self.loose[lid2].inv()
+            &&& self.loose[lid2].global_inv(self.regions)
+            &&& self.loose[lid2].frame_link_inv(self.regions)
+            &&& self.regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                == 0
+        } by {
+            assert(lid2 != lid);
+            assert(old_self.loose.dom().contains(lid2));
+            assert(old_self.loose[lid2] == self.loose[lid2]);
+            assert(old_self.loose[lid2].global_inv(old_regions));
+            assert(old_self.loose[lid2].frame_link_inv(old_regions));
+            assert(old_regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                == 0);
+            assert(self.loose[lid2].slot_index != fidx);
+        };
+
+        assert forall|i1: ListId, i2: ListId|
+            self.lists.dom().contains(i1) && self.lists.dom().contains(i2)
+                && self.lists[i1].list.len() > 0 && self.lists[i2].list.len() > 0
+                && self.lists[i1].list_id == self.lists[i2].list_id implies i1 == i2 by {
+            if i1 != id && i2 != id {
+                assert(old_self.lists[i1] == self.lists[i1]);
+                assert(old_self.lists[i2] == self.lists[i2]);
+            } else if i1 == id && i2 != id {
+                assert(self.lists[i2].list_id != new_id);
+            } else if i2 == id && i1 != id {
+                assert(self.lists[i1].list_id != new_id);
+            }
+        };
+
+        assert forall|l1: LooseId, l2: LooseId|
+            self.loose.dom().contains(l1) && self.loose.dom().contains(l2)
+                && self.loose[l1].slot_index == self.loose[l2].slot_index implies l1 == l2 by {
+            assert(old_self.loose.dom().contains(l1));
+            assert(old_self.loose.dom().contains(l2));
+        };
+
+        // --- cursors: checked-out lists are untouched ---
+        // `cursors` is not read or written by a list op, and every
+        // cursor's list carries an id distinct from the just-minted
+        // `new_id` (other cursors' ids are in `used`, or — when the id
+        // was preserved — separated by the old list/cursor uniqueness),
+        // so the axiom's other-lists frame preserves each cursor's
+        // `relate_region`. Index bounds are unchanged.
+        assert(self.cursors == old_self.cursors);
+        assert(self.lists.dom() =~= old_self.lists.dom());
+        assert forall|cid: CursorId| #[trigger] self.cursors.dom().contains(cid) implies {
+            &&& self.cursors[cid].list_own.inv()
+            &&& self.cursors[cid].inv_region(self.regions)
+        } by {
+            assert(old_self.cursors.dom().contains(cid));
+            assert(old_self.cursors[cid].list_own.inv());
+            assert(old_self.cursors[cid].inv_region(old_regions));
+            assert(self.cursors[cid].list_own.relate_region(old_regions));
+            if old_self.lists[id].list_id != 0 {
+                assert(new_id == old_self.lists[id].list_id);
+            } else {
+                assert(used.contains(self.cursors[cid].list_own.list_id));
+            }
+            assert(self.cursors[cid].list_own.list_id != new_id);
+            assert(self.cursors[cid].list_own.relate_region(self.regions));
+        };
+        assert forall|id2: ListId, cid: CursorId|
+            self.lists.dom().contains(id2) && self.cursors.dom().contains(cid)
+                && self.lists[id2].list_id == self.cursors[cid].list_own.list_id
+                && self.lists[id2].list_id != 0 implies false by {
+            assert(old_self.cursors.dom().contains(cid));
+            if id2 == id {
+                assert(self.lists[id].list_id == new_id);
+                if old_self.lists[id].list_id != 0 {
+                    assert(new_id == old_self.lists[id].list_id);
+                } else {
+                    assert(used.contains(self.cursors[cid].list_own.list_id));
+                }
+            } else {
+                assert(old_self.lists.dom().contains(id2));
+                assert(old_self.lists[id2] == self.lists[id2]);
+            }
+        };
+        assert forall|cid1: CursorId, cid2: CursorId|
+            self.cursors.dom().contains(cid1) && self.cursors.dom().contains(cid2)
+                && self.cursors[cid1].list_own.list_id == self.cursors[cid2].list_own.list_id
+                && self.cursors[cid1].list_own.list_id != 0 implies cid1 == cid2 by {
+            assert(old_self.cursors.dom().contains(cid1));
+            assert(old_self.cursors.dom().contains(cid2));
+        };
+    }
+
+    /// Cursor `take_current` at an arbitrary position `n`: pop the link
+    /// at index `n` (`0 <= n < len`) of list `id` back into the loose
+    /// pool. The general form of [`Self::step_pop_front`] /
+    /// [`Self::step_pop_back`]; same global effect.
+    pub proof fn step_take_at(tracked &mut self, id: ListId, n: int) -> (res: LooseId)
+        requires
+            old(self).inv(),
+            old(self).lists.dom().contains(id),
+            0 <= n < old(self).lists[id].list.len(),
+        ensures
+            final(self).inv(),
+    {
+        let ghost old_self = *self;
+        let ghost old_regions = self.regions;
+        let ghost popped_idx = self.lists[id].slot_index_at(n);
+        let ghost old_list_id = self.lists[id].list_id;
+        assert(self.lists[id].inv());
+        assert(self.lists[id].relate_region(self.regions));
+
+        let tracked mut owner = self.lists.tracked_remove(id);
+        let tracked frame_own = take_at_embedded(&mut self.regions, &mut owner, n);
+        self.lists.tracked_insert(id, owner);
+        let ghost new_loose = fresh_loose_id(self.loose);
+        axiom_fresh_loose_id_not_in_dom(self.loose);
+        self.loose.tracked_insert(new_loose, frame_own);
+
+        assert(self.lists =~= old_self.lists.remove(id).insert(id, owner));
+        assert(self.loose =~= old_self.loose.insert(new_loose, frame_own));
+        assert(self.lists[id].list_id == old_list_id);
+        assert(frame_own.slot_index == popped_idx);
+
+        assert forall|i: ListId| #[trigger] self.lists.dom().contains(i) implies {
+            &&& self.lists[i].inv()
+            &&& self.lists[i].relate_region(self.regions)
+        } by {
+            if i != id {
+                assert(old_self.lists.dom().contains(i));
+                assert(old_self.lists[i] == self.lists[i]);
+                assert(old_self.lists[i].inv());
+                assert(old_self.lists[i].relate_region(old_regions));
+                if self.lists[i].list.len() > 0 {
+                    assert(self.lists[i].list_id != old_list_id);
+                }
+            }
+        };
+
+        assert forall|lid2: LooseId| #[trigger] self.loose.dom().contains(lid2) implies {
+            &&& self.loose[lid2].inv()
+            &&& self.loose[lid2].global_inv(self.regions)
+            &&& self.loose[lid2].frame_link_inv(self.regions)
+            &&& self.regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                == 0
+        } by {
+            if lid2 != new_loose {
+                assert(old_self.loose.dom().contains(lid2));
+                assert(old_self.loose[lid2] == self.loose[lid2]);
+                assert(old_self.loose[lid2].global_inv(old_regions));
+                assert(old_self.loose[lid2].frame_link_inv(old_regions));
+                assert(old_regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                    == 0);
+            }
+        };
+
+        assert forall|i1: ListId, i2: ListId|
+            self.lists.dom().contains(i1) && self.lists.dom().contains(i2) && self.lists[i1].list_id
+                == self.lists[i2].list_id && self.lists[i1].list_id != 0 implies i1 == i2 by {
+            assert(old_self.lists.dom().contains(i1));
+            assert(old_self.lists.dom().contains(i2));
+            assert(self.lists[i1].list_id == old_self.lists[i1].list_id);
+            assert(self.lists[i2].list_id == old_self.lists[i2].list_id);
+        };
+
+        assert forall|l1: LooseId, l2: LooseId|
+            self.loose.dom().contains(l1) && self.loose.dom().contains(l2)
+                && self.loose[l1].slot_index == self.loose[l2].slot_index implies l1 == l2 by {
+            if l1 == new_loose && l2 != new_loose {
+                assert(old_self.loose.dom().contains(l2));
+                assert(self.loose[l2].slot_index != popped_idx);
+            } else if l2 == new_loose && l1 != new_loose {
+                assert(old_self.loose.dom().contains(l1));
+                assert(self.loose[l1].slot_index != popped_idx);
+            } else if l1 != new_loose && l2 != new_loose {
+                assert(old_self.loose.dom().contains(l1));
+                assert(old_self.loose.dom().contains(l2));
+            }
+        };
+
+        // --- cursors: checked-out lists are untouched ---
+        // `id`'s (preserved, nonzero) `old_list_id` is separated from
+        // every cursor's list id by the old list/cursor uniqueness, so
+        // the axiom's other-lists frame preserves each cursor.
+        assert(self.cursors == old_self.cursors);
+        assert(self.lists.dom() =~= old_self.lists.dom());
+        assert forall|cid: CursorId| #[trigger] self.cursors.dom().contains(cid) implies {
+            &&& self.cursors[cid].list_own.inv()
+            &&& self.cursors[cid].inv_region(self.regions)
+        } by {
+            assert(old_self.cursors.dom().contains(cid));
+            assert(old_self.cursors[cid].list_own.inv());
+            assert(old_self.cursors[cid].inv_region(old_regions));
+            assert(self.cursors[cid].list_own.relate_region(old_regions));
+            assert(old_self.lists.dom().contains(id));
+            assert(old_self.lists[id].list_id == old_list_id);
+            assert(self.cursors[cid].list_own.list_id != old_list_id);
+            assert(self.cursors[cid].list_own.relate_region(self.regions));
+        };
+        assert forall|id2: ListId, cid: CursorId|
+            self.lists.dom().contains(id2) && self.cursors.dom().contains(cid)
+                && self.lists[id2].list_id == self.cursors[cid].list_own.list_id
+                && self.lists[id2].list_id != 0 implies false by {
+            assert(old_self.cursors.dom().contains(cid));
+            assert(old_self.lists.dom().contains(id2));
+            assert(old_self.lists[id2].list_id == self.lists[id2].list_id);
+        };
+        assert forall|cid1: CursorId, cid2: CursorId|
+            self.cursors.dom().contains(cid1) && self.cursors.dom().contains(cid2)
+                && self.cursors[cid1].list_own.list_id == self.cursors[cid2].list_own.list_id
+                && self.cursors[cid1].list_own.list_id != 0 implies cid1 == cid2 by {
+            assert(old_self.cursors.dom().contains(cid1));
+            assert(old_self.cursors.dom().contains(cid2));
+        };
+        new_loose
+    }
+
+    // -------------------------------------------------------------------
+    // Persistent cursor lifecycle
+    // -------------------------------------------------------------------
+    /// Invariant-preservation lemma for *checking a list out* into a
+    /// cursor: `lists[id]` (a held list) moves to `cursors[id]` (the
+    /// same list, now position-tracked at `index`). Region-free — only
+    /// the `lists`/`cursors` bookkeeping moves. All disjointness /
+    /// uniqueness facts transfer from the old store (a checked-out list
+    /// keeps its id, distinct by the same arguments as a held list).
+    proof fn lemma_checkout_inv(old_self: Self, new_self: Self, id: ListId, index: int)
+        requires
+            old_self.inv(),
+            old_self.lists.dom().contains(id),
+            0 <= index <= old_self.lists[id].list.len(),
+            new_self.regions == old_self.regions,
+            new_self.loose == old_self.loose,
+            new_self.lists == old_self.lists.remove(id),
+            new_self.cursors == old_self.cursors.insert(
+                id,
+                CursorOwner::cursor_mut_at_owner(old_self.lists[id], index),
+            ),
+        ensures
+            new_self.inv(),
+    {
+        assert forall|i: ListId| #[trigger] new_self.lists.dom().contains(i) implies {
+            &&& new_self.lists[i].inv()
+            &&& new_self.lists[i].relate_region(new_self.regions)
+        } by {
+            assert(i != id);
+            assert(old_self.lists.dom().contains(i));
+            assert(old_self.lists[i] == new_self.lists[i]);
+        };
+        assert forall|lid: LooseId| #[trigger] new_self.loose.dom().contains(lid) implies {
+            &&& new_self.loose[lid].inv()
+            &&& new_self.loose[lid].global_inv(new_self.regions)
+            &&& new_self.loose[lid].frame_link_inv(new_self.regions)
+            &&& new_self.regions.slot_owners[new_self.loose[lid].slot_index].inner_perms.in_list.value()
+                == 0
+        } by {
+            assert(old_self.loose.dom().contains(lid));
+        };
+        assert forall|i1: ListId, i2: ListId|
+            new_self.lists.dom().contains(i1) && new_self.lists.dom().contains(i2)
+                && new_self.lists[i1].list_id == new_self.lists[i2].list_id
+                && new_self.lists[i1].list_id != 0 implies i1 == i2 by {
+            assert(old_self.lists.dom().contains(i1));
+            assert(old_self.lists.dom().contains(i2));
+        };
+        assert forall|l1: LooseId, l2: LooseId|
+            new_self.loose.dom().contains(l1) && new_self.loose.dom().contains(l2)
+                && new_self.loose[l1].slot_index == new_self.loose[l2].slot_index implies l1
+            == l2 by {
+            assert(old_self.loose.dom().contains(l1));
+            assert(old_self.loose.dom().contains(l2));
+        };
+        assert(new_self.lists.dom().disjoint(new_self.cursors.dom()));
+        assert forall|cid: CursorId| #[trigger] new_self.cursors.dom().contains(cid) implies {
+            &&& new_self.cursors[cid].list_own.inv()
+            &&& new_self.cursors[cid].inv_region(new_self.regions)
+        } by {
+            if cid != id {
+                assert(old_self.cursors.dom().contains(cid));
+            } else {
+                assert(new_self.cursors[id].list_own == old_self.lists[id]);
+                assert(old_self.lists[id].inv());
+                assert(old_self.lists[id].relate_region(old_self.regions));
+            }
+        };
+        assert forall|id2: ListId, cid: CursorId|
+            new_self.lists.dom().contains(id2) && new_self.cursors.dom().contains(cid)
+                && new_self.lists[id2].list_id == new_self.cursors[cid].list_own.list_id
+                && new_self.lists[id2].list_id != 0 implies false by {
+            assert(id2 != id);
+            assert(old_self.lists.dom().contains(id2));
+            assert(old_self.lists[id2] == new_self.lists[id2]);
+            if cid == id {
+                assert(new_self.cursors[id].list_own == old_self.lists[id]);
+                assert(old_self.lists.dom().contains(id));
+            } else {
+                assert(old_self.cursors.dom().contains(cid));
+                assert(old_self.cursors[cid] == new_self.cursors[cid]);
+            }
+        };
+        assert forall|cid1: CursorId, cid2: CursorId|
+            new_self.cursors.dom().contains(cid1) && new_self.cursors.dom().contains(cid2)
+                && new_self.cursors[cid1].list_own.list_id
+                == new_self.cursors[cid2].list_own.list_id
+                && new_self.cursors[cid1].list_own.list_id != 0 implies cid1 == cid2 by {
+            if cid1 == id && cid2 != id {
+                assert(old_self.cursors.dom().contains(cid2));
+                assert(new_self.cursors[id].list_own == old_self.lists[id]);
+                assert(old_self.lists.dom().contains(id));
+            } else if cid2 == id && cid1 != id {
+                assert(old_self.cursors.dom().contains(cid1));
+                assert(new_self.cursors[id].list_own == old_self.lists[id]);
+                assert(old_self.lists.dom().contains(id));
+            } else if cid1 != id && cid2 != id {
+                assert(old_self.cursors.dom().contains(cid1));
+                assert(old_self.cursors.dom().contains(cid2));
+            }
+        };
+    }
+
+    /// Invariant-preservation lemma for *checking a list back in* on
+    /// cursor drop: `cursors[id]`'s list moves back to `lists[id]`. The
+    /// exact inverse of [`Self::lemma_checkout_inv`].
+    proof fn lemma_checkin_inv(old_self: Self, new_self: Self, id: CursorId)
+        requires
+            old_self.inv(),
+            old_self.cursors.dom().contains(id),
+            new_self.regions == old_self.regions,
+            new_self.loose == old_self.loose,
+            new_self.cursors == old_self.cursors.remove(id),
+            new_self.lists == old_self.lists.insert(id, old_self.cursors[id].list_own),
+        ensures
+            new_self.inv(),
+    {
+        assert(!old_self.lists.dom().contains(id));
+        assert forall|i: ListId| #[trigger] new_self.lists.dom().contains(i) implies {
+            &&& new_self.lists[i].inv()
+            &&& new_self.lists[i].relate_region(new_self.regions)
+        } by {
+            if i == id {
+                assert(new_self.lists[id] == old_self.cursors[id].list_own);
+                assert(old_self.cursors[id].list_own.inv());
+                assert(old_self.cursors[id].inv_region(old_self.regions));
+            } else {
+                assert(old_self.lists.dom().contains(i));
+                assert(old_self.lists[i] == new_self.lists[i]);
+            }
+        };
+        assert forall|lid: LooseId| #[trigger] new_self.loose.dom().contains(lid) implies {
+            &&& new_self.loose[lid].inv()
+            &&& new_self.loose[lid].global_inv(new_self.regions)
+            &&& new_self.loose[lid].frame_link_inv(new_self.regions)
+            &&& new_self.regions.slot_owners[new_self.loose[lid].slot_index].inner_perms.in_list.value()
+                == 0
+        } by {
+            assert(old_self.loose.dom().contains(lid));
+        };
+        assert forall|i1: ListId, i2: ListId|
+            new_self.lists.dom().contains(i1) && new_self.lists.dom().contains(i2)
+                && new_self.lists[i1].list_id == new_self.lists[i2].list_id
+                && new_self.lists[i1].list_id != 0 implies i1 == i2 by {
+            // The reinstated list at `id` carries the cursor's id; any
+            // other list with the same nonzero id is separated by the old
+            // cross list/cursor uniqueness.
+            if i1 == id && i2 != id {
+                assert(old_self.lists.dom().contains(i2));
+                assert(new_self.lists[id] == old_self.cursors[id].list_own);
+                assert(old_self.cursors.dom().contains(id));
+            } else if i2 == id && i1 != id {
+                assert(old_self.lists.dom().contains(i1));
+                assert(new_self.lists[id] == old_self.cursors[id].list_own);
+                assert(old_self.cursors.dom().contains(id));
+            } else if i1 != id && i2 != id {
+                assert(old_self.lists.dom().contains(i1));
+                assert(old_self.lists.dom().contains(i2));
+            }
+        };
+        assert forall|l1: LooseId, l2: LooseId|
+            new_self.loose.dom().contains(l1) && new_self.loose.dom().contains(l2)
+                && new_self.loose[l1].slot_index == new_self.loose[l2].slot_index implies l1
+            == l2 by {
+            assert(old_self.loose.dom().contains(l1));
+            assert(old_self.loose.dom().contains(l2));
+        };
+        assert(new_self.lists.dom().disjoint(new_self.cursors.dom()));
+        assert forall|cid: CursorId| #[trigger] new_self.cursors.dom().contains(cid) implies {
+            &&& new_self.cursors[cid].list_own.inv()
+            &&& new_self.cursors[cid].inv_region(new_self.regions)
+        } by {
+            assert(cid != id);
+            assert(old_self.cursors.dom().contains(cid));
+            assert(old_self.cursors[cid] == new_self.cursors[cid]);
+        };
+        assert forall|id2: ListId, cid: CursorId|
+            new_self.lists.dom().contains(id2) && new_self.cursors.dom().contains(cid)
+                && new_self.lists[id2].list_id == new_self.cursors[cid].list_own.list_id
+                && new_self.lists[id2].list_id != 0 implies false by {
+            assert(cid != id);
+            assert(old_self.cursors.dom().contains(cid));
+            assert(old_self.cursors[cid] == new_self.cursors[cid]);
+            if id2 == id {
+                assert(new_self.lists[id] == old_self.cursors[id].list_own);
+                assert(old_self.cursors.dom().contains(id));
+            } else {
+                assert(old_self.lists.dom().contains(id2));
+                assert(old_self.lists[id2] == new_self.lists[id2]);
+            }
+        };
+        assert forall|cid1: CursorId, cid2: CursorId|
+            new_self.cursors.dom().contains(cid1) && new_self.cursors.dom().contains(cid2)
+                && new_self.cursors[cid1].list_own.list_id
+                == new_self.cursors[cid2].list_own.list_id
+                && new_self.cursors[cid1].list_own.list_id != 0 implies cid1 == cid2 by {
+            assert(old_self.cursors.dom().contains(cid1));
+            assert(old_self.cursors.dom().contains(cid2));
+        };
+    }
+
+    /// Invariant-preservation lemma for *revising a cursor's position in
+    /// place*: `cursors[id]` keeps its checked-out list (same `list_own`)
+    /// but adopts a new in-range `index`. Region-free; everything else is
+    /// untouched, so every fact transfers from the old store.
+    proof fn lemma_revise_cursor_inv(old_self: Self, new_self: Self, id: CursorId)
+        requires
+            old_self.inv(),
+            old_self.cursors.dom().contains(id),
+            new_self.regions == old_self.regions,
+            new_self.lists == old_self.lists,
+            new_self.loose == old_self.loose,
+            new_self.cursors.dom() == old_self.cursors.dom(),
+            new_self.cursors[id].list_own == old_self.cursors[id].list_own,
+            0 <= new_self.cursors[id].index <= new_self.cursors[id].list_own.list.len(),
+            forall|c: CursorId| #[trigger]
+                new_self.cursors.dom().contains(c) && c != id ==> new_self.cursors[c]
+                    == old_self.cursors[c],
+        ensures
+            new_self.inv(),
+    {
+        assert forall|i: ListId| #[trigger] new_self.lists.dom().contains(i) implies {
+            &&& new_self.lists[i].inv()
+            &&& new_self.lists[i].relate_region(new_self.regions)
+        } by {
+            assert(old_self.lists.dom().contains(i));
+        };
+        assert forall|lid: LooseId| #[trigger] new_self.loose.dom().contains(lid) implies {
+            &&& new_self.loose[lid].inv()
+            &&& new_self.loose[lid].global_inv(new_self.regions)
+            &&& new_self.loose[lid].frame_link_inv(new_self.regions)
+            &&& new_self.regions.slot_owners[new_self.loose[lid].slot_index].inner_perms.in_list.value()
+                == 0
+        } by {
+            assert(old_self.loose.dom().contains(lid));
+        };
+        assert forall|i1: ListId, i2: ListId|
+            new_self.lists.dom().contains(i1) && new_self.lists.dom().contains(i2)
+                && new_self.lists[i1].list_id == new_self.lists[i2].list_id
+                && new_self.lists[i1].list_id != 0 implies i1 == i2 by {
+            assert(old_self.lists.dom().contains(i1));
+            assert(old_self.lists.dom().contains(i2));
+        };
+        assert forall|l1: LooseId, l2: LooseId|
+            new_self.loose.dom().contains(l1) && new_self.loose.dom().contains(l2)
+                && new_self.loose[l1].slot_index == new_self.loose[l2].slot_index implies l1
+            == l2 by {
+            assert(old_self.loose.dom().contains(l1));
+            assert(old_self.loose.dom().contains(l2));
+        };
+        assert(new_self.lists.dom().disjoint(new_self.cursors.dom()));
+        assert forall|cid: CursorId| #[trigger] new_self.cursors.dom().contains(cid) implies {
+            &&& new_self.cursors[cid].list_own.inv()
+            &&& new_self.cursors[cid].inv_region(new_self.regions)
+        } by {
+            assert(old_self.cursors.dom().contains(cid));
+            if cid != id {
+                assert(new_self.cursors[cid] == old_self.cursors[cid]);
+            } else {
+                assert(new_self.cursors[id].list_own == old_self.cursors[id].list_own);
+                assert(old_self.cursors[id].list_own.inv());
+                assert(old_self.cursors[id].inv_region(old_self.regions));
+            }
+        };
+        assert forall|id2: ListId, cid: CursorId|
+            new_self.lists.dom().contains(id2) && new_self.cursors.dom().contains(cid)
+                && new_self.lists[id2].list_id == new_self.cursors[cid].list_own.list_id
+                && new_self.lists[id2].list_id != 0 implies false by {
+            assert(old_self.lists.dom().contains(id2));
+            assert(old_self.cursors.dom().contains(cid));
+            assert(new_self.cursors[cid].list_own.list_id
+                == old_self.cursors[cid].list_own.list_id);
+        };
+        assert forall|cid1: CursorId, cid2: CursorId|
+            new_self.cursors.dom().contains(cid1) && new_self.cursors.dom().contains(cid2)
+                && new_self.cursors[cid1].list_own.list_id
+                == new_self.cursors[cid2].list_own.list_id
+                && new_self.cursors[cid1].list_own.list_id != 0 implies cid1 == cid2 by {
+            assert(old_self.cursors.dom().contains(cid1));
+            assert(old_self.cursors.dom().contains(cid2));
+            assert(new_self.cursors[cid1].list_own.list_id
+                == old_self.cursors[cid1].list_own.list_id);
+            assert(new_self.cursors[cid2].list_own.list_id
+                == old_self.cursors[cid2].list_own.list_id);
+        };
+    }
+
+    /// `LinkedList::cursor_front_mut`: check list `id` out into a cursor
+    /// positioned at the front (index 0). The list leaves `lists` and
+    /// enters `cursors` under the same id (its borrow).
+    pub proof fn step_cursor_front_mut(tracked &mut self, id: ListId)
+        requires
+            old(self).inv(),
+            old(self).lists.dom().contains(id),
+        ensures
+            final(self).inv(),
+            !final(self).lists.dom().contains(id),
+            final(self).cursors.dom().contains(id),
+            final(self).cursors[id] == CursorOwner::front_owner(old(self).lists[id]),
+    {
+        let ghost old_self = *self;
+        let tracked owner = self.lists.tracked_remove(id);
+        let tracked cur = CursorOwner::tracked_front_owner(owner);
+        self.cursors.tracked_insert(id, cur);
+        assert(self.lists =~= old_self.lists.remove(id));
+        assert(self.cursors =~= old_self.cursors.insert(
+            id,
+            CursorOwner::cursor_mut_at_owner(old_self.lists[id], 0),
+        ));
+        Self::lemma_checkout_inv(old_self, *self, id, 0);
+    }
+
+    /// `LinkedList::cursor_back_mut`: check list `id` out into a cursor
+    /// at the back (the last element, or the ghost slot when empty).
+    pub proof fn step_cursor_back_mut(tracked &mut self, id: ListId)
+        requires
+            old(self).inv(),
+            old(self).lists.dom().contains(id),
+        ensures
+            final(self).inv(),
+            !final(self).lists.dom().contains(id),
+            final(self).cursors.dom().contains(id),
+            final(self).cursors[id] == CursorOwner::back_owner(old(self).lists[id]),
+    {
+        let ghost old_self = *self;
+        let tracked owner = self.lists.tracked_remove(id);
+        let ghost bidx = CursorOwner::back_owner(owner).index;
+        let tracked cur = CursorOwner::tracked_back_owner(owner);
+        self.cursors.tracked_insert(id, cur);
+        assert(self.lists =~= old_self.lists.remove(id));
+        assert(self.cursors =~= old_self.cursors.insert(
+            id,
+            CursorOwner::cursor_mut_at_owner(old_self.lists[id], bidx),
+        ));
+        Self::lemma_checkout_inv(old_self, *self, id, bidx);
+    }
+
+    /// `LinkedList::cursor_mut_at`: check list `id` out into a cursor at
+    /// an explicit in-range `index` (`0 <= index <= len`).
+    pub proof fn step_cursor_mut_at(tracked &mut self, id: ListId, index: int)
+        requires
+            old(self).inv(),
+            old(self).lists.dom().contains(id),
+            0 <= index <= old(self).lists[id].list.len(),
+        ensures
+            final(self).inv(),
+            !final(self).lists.dom().contains(id),
+            final(self).cursors.dom().contains(id),
+            final(self).cursors[id] == CursorOwner::cursor_mut_at_owner(old(self).lists[id], index),
+    {
+        let ghost old_self = *self;
+        let tracked owner = self.lists.tracked_remove(id);
+        let tracked cur = CursorOwner::tracked_cursor_mut_at_owner(owner, index);
+        self.cursors.tracked_insert(id, cur);
+        assert(self.lists =~= old_self.lists.remove(id));
+        assert(self.cursors =~= old_self.cursors.insert(
+            id,
+            CursorOwner::cursor_mut_at_owner(old_self.lists[id], index),
+        ));
+        Self::lemma_checkout_inv(old_self, *self, id, index);
+    }
+
+    /// `CursorMut::move_next`: advance cursor `id` one step toward the
+    /// back (wrapping through the ghost slot). Pure position change.
+    pub proof fn step_move_next(tracked &mut self, id: CursorId)
+        requires
+            old(self).inv(),
+            old(self).cursors.dom().contains(id),
+        ensures
+            final(self).inv(),
+            final(self).regions == old(self).regions,
+            final(self).cursors[id] == old(self).cursors[id].move_next_owner_spec(),
+    {
+        let ghost old_self = *self;
+        let tracked cur = self.cursors.tracked_remove(id);
+        let ghost ni = cur.move_next_owner_spec().index;
+        let tracked CursorOwner { list_own, index: _ } = cur;
+        let tracked cur2 = CursorOwner::tracked_cursor_mut_at_owner(list_own, ni);
+        self.cursors.tracked_insert(id, cur2);
+        assert(self.cursors[id] == old_self.cursors[id].move_next_owner_spec());
+        assert(self.cursors.dom() =~= old_self.cursors.dom());
+        Self::lemma_revise_cursor_inv(old_self, *self, id);
+    }
+
+    /// `CursorMut::move_prev`: retreat cursor `id` one step toward the
+    /// front (wrapping through the ghost slot). Pure position change.
+    pub proof fn step_move_prev(tracked &mut self, id: CursorId)
+        requires
+            old(self).inv(),
+            old(self).cursors.dom().contains(id),
+        ensures
+            final(self).inv(),
+            final(self).regions == old(self).regions,
+            final(self).cursors[id] == old(self).cursors[id].move_prev_owner_spec(),
+    {
+        let ghost old_self = *self;
+        let tracked cur = self.cursors.tracked_remove(id);
+        let ghost ni = cur.move_prev_owner_spec().index;
+        let tracked CursorOwner { list_own, index: _ } = cur;
+        let tracked cur2 = CursorOwner::tracked_cursor_mut_at_owner(list_own, ni);
+        self.cursors.tracked_insert(id, cur2);
+        assert(self.cursors[id] == old_self.cursors[id].move_prev_owner_spec());
+        assert(self.cursors.dom() =~= old_self.cursors.dom());
+        Self::lemma_revise_cursor_inv(old_self, *self, id);
+    }
+
+    /// `CursorMut::current_meta`: read the link the cursor `id` is on.
+    /// A read-only query — returns the current [`LinkOwner`] (`None` at
+    /// the ghost slot); the store is unchanged.
+    pub proof fn step_current_meta(tracked &self, id: CursorId) -> (res: Option<LinkOwner>)
+        requires
+            self.inv(),
+            self.cursors.dom().contains(id),
+        ensures
+            res == self.cursors[id].current(),
+            res.is_some() <==> 0 <= self.cursors[id].index < self.cursors[id].length(),
+    {
+        self.cursors[id].current()
+    }
+
+    /// `CursorMut::as_list`: borrow the cursor's checked-out list for
+    /// reading. A pure no-op — `&self` on the store, so `regions` /
+    /// `lists` / `loose` / `cursors` are all untouched; it merely exposes
+    /// the list's contents (the model `Seq` of links). Modeled for
+    /// completeness, to demonstrate the read-only view changes nothing.
+    pub proof fn step_as_list(tracked &self, id: CursorId) -> (res: Seq<LinkOwner>)
+        requires
+            self.inv(),
+            self.cursors.dom().contains(id),
+        ensures
+            res == self.cursors[id].list_own.list,
+            res.len() == self.cursors[id].length(),
+    {
+        self.cursors[id].list_own.list
+    }
+
+    /// Drop of a `CursorMut`: check the cursor's list back into `lists`
+    /// under its home id, ending the borrow. Inverse of
+    /// [`Self::step_cursor_front_mut`] et al.
+    pub proof fn step_cursor_drop(tracked &mut self, id: CursorId)
+        requires
+            old(self).inv(),
+            old(self).cursors.dom().contains(id),
+        ensures
+            final(self).inv(),
+            !final(self).cursors.dom().contains(id),
+            final(self).lists.dom().contains(id),
+            final(self).lists[id] == old(self).cursors[id].list_own,
+    {
+        let ghost old_self = *self;
+        let tracked cur = self.cursors.tracked_remove(id);
+        let tracked CursorOwner { list_own, index: _ } = cur;
+        self.lists.tracked_insert(id, list_own);
+        assert(self.cursors =~= old_self.cursors.remove(id));
+        assert(self.lists =~= old_self.lists.insert(id, old_self.cursors[id].list_own));
+        Self::lemma_checkin_inv(old_self, *self, id);
+    }
+
+    /// `CursorMut::insert_before`: through the checked-out cursor `id`,
+    /// move the loose handle `lid` into the cursor's list at the current
+    /// position (index `n`), advancing the cursor to `n + 1`. The general
+    /// [`Self::step_insert_before_at`], but on the list parked in
+    /// `cursors` rather than `lists` — so *every* held list is an "other
+    /// list" preserved by the axiom's frame.
+    pub proof fn step_cursor_insert_before(tracked &mut self, id: CursorId, lid: LooseId)
+        requires
+            old(self).inv(),
+            old(self).cursors.dom().contains(id),
+            old(self).loose.dom().contains(lid),
+        ensures
+            final(self).inv(),
+    {
+        let ghost old_self = *self;
+        let ghost old_regions = self.regions;
+        let ghost fidx = self.loose[lid].slot_index;
+        let ghost n = self.cursors[id].index;
+        // Avoid every other list's *and* every other cursor's id.
+        let ghost used = Set::new_assuming_finite(
+            |x: u64|
+                (exists|i: ListId| #[trigger]
+                    old_self.lists.dom().contains(i) && old_self.lists[i].list_id == x) || (exists|
+                    cid: CursorId,
+                | #[trigger]
+                    old_self.cursors.dom().contains(cid) && cid != id
+                        && old_self.cursors[cid].list_own.list_id == x),
+        );
+        assert(self.cursors[id].list_own.inv());
+        assert(self.cursors[id].inv_region(self.regions));
+        assert(self.cursors[id].list_own.relate_region(self.regions));
+        assert(self.loose[lid].inv());
+        assert(self.loose[lid].global_inv(self.regions));
+        assert(self.loose[lid].frame_link_inv(self.regions));
+        assert(self.regions.slot_owners[fidx].inner_perms.in_list.value() == 0);
+        assert(0 <= n <= self.cursors[id].list_own.list.len());
+
+        let tracked cur = self.cursors.tracked_remove(id);
+        let tracked CursorOwner { list_own: mut owner, index: _ } = cur;
+        let tracked mut frame_own = self.loose.tracked_remove(lid);
+        insert_before_at_embedded(&mut self.regions, &mut owner, &mut frame_own, n, used);
+        let tracked cur2 = CursorOwner::tracked_cursor_mut_at_owner(owner, n + 1);
+        self.cursors.tracked_insert(id, cur2);
+        assert(self.loose =~= old_self.loose.remove(lid));
+        assert(self.cursors =~= old_self.cursors.remove(id).insert(id, cur2));
+        let ghost new_id = self.cursors[id].list_own.list_id;
+        assert(self.cursors[id].list_own == owner);
+
+        // `new_id` is distinct from every list id and every *other*
+        // cursor id (minted outside `used`, or — when the cursor's list
+        // already had an id — separated by the old uniqueness).
+        assert forall|i: ListId|
+            old_self.lists.dom().contains(i) && self.lists[i].list_id
+                != 0 implies self.lists[i].list_id != new_id by {
+            if old_self.cursors[id].list_own.list_id != 0 {
+                assert(new_id == old_self.cursors[id].list_own.list_id);
+                assert(old_self.cursors.dom().contains(id));
+            } else {
+                assert(used.contains(self.lists[i].list_id));
+            }
+        };
+        assert forall|cid: CursorId|
+            old_self.cursors.dom().contains(cid) && cid != id
+                && old_self.cursors[cid].list_own.list_id
+                != 0 implies old_self.cursors[cid].list_own.list_id != new_id by {
+            if old_self.cursors[id].list_own.list_id != 0 {
+                assert(new_id == old_self.cursors[id].list_own.list_id);
+            } else {
+                assert(used.contains(old_self.cursors[cid].list_own.list_id));
+            }
+        };
+
+        // --- per-list: every list is preserved (none is operating) ---
+        assert forall|i: ListId| #[trigger] self.lists.dom().contains(i) implies {
+            &&& self.lists[i].inv()
+            &&& self.lists[i].relate_region(self.regions)
+        } by {
+            assert(old_self.lists.dom().contains(i));
+            assert(old_self.lists[i] == self.lists[i]);
+            assert(old_self.lists[i].relate_region(old_regions));
+            assert(self.lists[i].list_id != new_id);
+            assert(self.lists[i].relate_region(self.regions));
+        };
+
+        // --- per-loose: `lid` removed; others at `!= fidx` preserved ---
+        assert forall|lid2: LooseId| #[trigger] self.loose.dom().contains(lid2) implies {
+            &&& self.loose[lid2].inv()
+            &&& self.loose[lid2].global_inv(self.regions)
+            &&& self.loose[lid2].frame_link_inv(self.regions)
+            &&& self.regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                == 0
+        } by {
+            assert(lid2 != lid);
+            assert(old_self.loose.dom().contains(lid2));
+            assert(old_self.loose[lid2] == self.loose[lid2]);
+            assert(old_self.loose[lid2].global_inv(old_regions));
+            assert(old_self.loose[lid2].frame_link_inv(old_regions));
+            assert(old_regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                == 0);
+            assert(self.loose[lid2].slot_index != fidx);
+        };
+
+        // --- disjointness (list/cursor domains unchanged) ---
+        assert(self.lists.dom() =~= old_self.lists.dom());
+        assert(self.cursors.dom() =~= old_self.cursors.dom());
+        assert(self.lists.dom().disjoint(self.cursors.dom()));
+
+        // --- per-cursor: operating cursor rebuilt; others preserved ---
+        assert forall|cid: CursorId| #[trigger] self.cursors.dom().contains(cid) implies {
+            &&& self.cursors[cid].list_own.inv()
+            &&& self.cursors[cid].inv_region(self.regions)
+        } by {
+            if cid == id {
+                assert(self.cursors[id].list_own == owner);
+                assert(self.cursors[id].index == n + 1);
+                assert(owner.list.len() == old_self.cursors[id].list_own.list.len() + 1);
+            } else {
+                assert(old_self.cursors.dom().contains(cid));
+                assert(old_self.cursors[cid] == self.cursors[cid]);
+                assert(old_self.cursors[cid].list_own.inv());
+                assert(old_self.cursors[cid].inv_region(old_regions));
+                assert(self.cursors[cid].list_own.relate_region(old_regions));
+                assert(self.cursors[cid].list_own.list_id != new_id);
+                assert(self.cursors[cid].list_own.relate_region(self.regions));
+            }
+        };
+
+        // --- cross list/cursor uniqueness ---
+        assert forall|id2: ListId, cid: CursorId|
+            self.lists.dom().contains(id2) && self.cursors.dom().contains(cid)
+                && self.lists[id2].list_id == self.cursors[cid].list_own.list_id
+                && self.lists[id2].list_id != 0 implies false by {
+            assert(old_self.lists.dom().contains(id2));
+            assert(old_self.lists[id2] == self.lists[id2]);
+            if cid == id {
+                assert(self.cursors[id].list_own.list_id == new_id);
+                assert(self.lists[id2].list_id != new_id);
+            } else {
+                assert(old_self.cursors.dom().contains(cid));
+                assert(old_self.cursors[cid] == self.cursors[cid]);
+            }
+        };
+
+        // --- cursor×cursor uniqueness ---
+        assert forall|cid1: CursorId, cid2: CursorId|
+            self.cursors.dom().contains(cid1) && self.cursors.dom().contains(cid2)
+                && self.cursors[cid1].list_own.list_id == self.cursors[cid2].list_own.list_id
+                && self.cursors[cid1].list_own.list_id != 0 implies cid1 == cid2 by {
+            if cid1 == id && cid2 != id {
+                assert(self.cursors[id].list_own.list_id == new_id);
+                assert(old_self.cursors.dom().contains(cid2));
+                assert(old_self.cursors[cid2] == self.cursors[cid2]);
+                assert(self.cursors[cid2].list_own.list_id != new_id);
+            } else if cid2 == id && cid1 != id {
+                assert(self.cursors[id].list_own.list_id == new_id);
+                assert(old_self.cursors.dom().contains(cid1));
+                assert(old_self.cursors[cid1] == self.cursors[cid1]);
+                assert(self.cursors[cid1].list_own.list_id != new_id);
+            } else if cid1 != id && cid2 != id {
+                assert(old_self.cursors.dom().contains(cid1));
+                assert(old_self.cursors.dom().contains(cid2));
+            }
+        };
+    }
+
+    /// `CursorMut::take_current`: through the checked-out cursor `id`,
+    /// pop the link the cursor is on (index `n`, requires the cursor be
+    /// on an element) back into the loose pool, leaving the cursor at the
+    /// same index (now on the following link). The general
+    /// [`Self::step_take_at`] on a cursored list. Returns the fresh loose
+    /// id.
+    pub proof fn step_cursor_take_current(tracked &mut self, id: CursorId) -> (res: LooseId)
+        requires
+            old(self).inv(),
+            old(self).cursors.dom().contains(id),
+            0 <= old(self).cursors[id].index < old(self).cursors[id].length(),
+        ensures
+            final(self).inv(),
+    {
+        let ghost old_self = *self;
+        let ghost old_regions = self.regions;
+        let ghost n = self.cursors[id].index;
+        let ghost old_list_id = self.cursors[id].list_own.list_id;
+        let ghost popped_idx = self.cursors[id].list_own.slot_index_at(n);
+        assert(self.cursors[id].list_own.inv());
+        assert(self.cursors[id].list_own.relate_region(self.regions));
+        assert(0 <= n < self.cursors[id].list_own.list.len());
+        // A non-empty list carries a nonzero id (`LinkedListOwner::inv`).
+        assert(old_list_id != 0);
+
+        let tracked cur = self.cursors.tracked_remove(id);
+        let tracked CursorOwner { list_own: mut owner, index: _ } = cur;
+        let tracked frame_own = take_at_embedded(&mut self.regions, &mut owner, n);
+        let tracked cur2 = CursorOwner::tracked_cursor_mut_at_owner(owner, n);
+        self.cursors.tracked_insert(id, cur2);
+        let ghost new_loose = fresh_loose_id(self.loose);
+        axiom_fresh_loose_id_not_in_dom(self.loose);
+        self.loose.tracked_insert(new_loose, frame_own);
+
+        assert(self.cursors =~= old_self.cursors.remove(id).insert(id, cur2));
+        assert(self.loose =~= old_self.loose.insert(new_loose, frame_own));
+        assert(self.cursors[id].list_own.list_id == old_list_id);
+        assert(self.cursors[id].list_own == owner);
+        assert(frame_own.slot_index == popped_idx);
+
+        // --- per-list: every list preserved (operating is a cursor) ---
+        assert forall|i: ListId| #[trigger] self.lists.dom().contains(i) implies {
+            &&& self.lists[i].inv()
+            &&& self.lists[i].relate_region(self.regions)
+        } by {
+            assert(old_self.lists.dom().contains(i));
+            assert(old_self.lists[i] == self.lists[i]);
+            assert(old_self.lists[i].relate_region(old_regions));
+            assert(old_self.cursors.dom().contains(id));
+            assert(self.lists[i].list_id != old_list_id);
+            assert(self.lists[i].relate_region(self.regions));
+        };
+
+        // --- per-loose: new entry from the axiom; others preserved;
+        // the popped slot is disjoint from every loose slot ---
+        assert forall|lid2: LooseId| #[trigger] self.loose.dom().contains(lid2) implies {
+            &&& self.loose[lid2].inv()
+            &&& self.loose[lid2].global_inv(self.regions)
+            &&& self.loose[lid2].frame_link_inv(self.regions)
+            &&& self.regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                == 0
+        } by {
+            if lid2 != new_loose {
+                assert(old_self.loose.dom().contains(lid2));
+                assert(old_self.loose[lid2] == self.loose[lid2]);
+                assert(old_self.loose[lid2].global_inv(old_regions));
+                assert(old_self.loose[lid2].frame_link_inv(old_regions));
+                assert(old_regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                    == 0);
+            }
+        };
+
+        // --- disjointness ---
+        assert(self.lists.dom() =~= old_self.lists.dom());
+        assert(self.cursors.dom() =~= old_self.cursors.dom());
+        assert(self.lists.dom().disjoint(self.cursors.dom()));
+
+        // --- per-cursor: operating cursor rebuilt; others preserved ---
+        assert forall|cid: CursorId| #[trigger] self.cursors.dom().contains(cid) implies {
+            &&& self.cursors[cid].list_own.inv()
+            &&& self.cursors[cid].inv_region(self.regions)
+        } by {
+            if cid == id {
+                assert(self.cursors[id].list_own == owner);
+                assert(self.cursors[id].index == n);
+                assert(owner.list.len() == old_self.cursors[id].list_own.list.len() - 1);
+            } else {
+                assert(old_self.cursors.dom().contains(cid));
+                assert(old_self.cursors[cid] == self.cursors[cid]);
+                assert(old_self.cursors[cid].list_own.inv());
+                assert(old_self.cursors[cid].inv_region(old_regions));
+                assert(self.cursors[cid].list_own.relate_region(old_regions));
+                assert(self.cursors[cid].list_own.list_id != old_list_id);
+                assert(self.cursors[cid].list_own.relate_region(self.regions));
+            }
+        };
+
+        // --- cross list/cursor uniqueness ---
+        assert forall|id2: ListId, cid: CursorId|
+            self.lists.dom().contains(id2) && self.cursors.dom().contains(cid)
+                && self.lists[id2].list_id == self.cursors[cid].list_own.list_id
+                && self.lists[id2].list_id != 0 implies false by {
+            assert(old_self.lists.dom().contains(id2));
+            assert(old_self.lists[id2] == self.lists[id2]);
+            if cid == id {
+                assert(self.cursors[id].list_own.list_id == old_list_id);
+                assert(self.lists[id2].list_id != old_list_id);
+            } else {
+                assert(old_self.cursors.dom().contains(cid));
+                assert(old_self.cursors[cid] == self.cursors[cid]);
+            }
+        };
+
+        // --- cursor×cursor uniqueness ---
+        assert forall|cid1: CursorId, cid2: CursorId|
+            self.cursors.dom().contains(cid1) && self.cursors.dom().contains(cid2)
+                && self.cursors[cid1].list_own.list_id == self.cursors[cid2].list_own.list_id
+                && self.cursors[cid1].list_own.list_id != 0 implies cid1 == cid2 by {
+            assert(old_self.cursors.dom().contains(cid1));
+            assert(old_self.cursors.dom().contains(cid2));
+            assert(self.cursors[cid1].list_own.list_id == old_self.cursors[cid1].list_own.list_id);
+            assert(self.cursors[cid2].list_own.list_id == old_self.cursors[cid2].list_own.list_id);
+        };
+
+        // --- loose-internal slot disjointness ---
+        assert forall|l1: LooseId, l2: LooseId|
+            self.loose.dom().contains(l1) && self.loose.dom().contains(l2)
+                && self.loose[l1].slot_index == self.loose[l2].slot_index implies l1 == l2 by {
+            if l1 == new_loose && l2 != new_loose {
+                assert(old_self.loose.dom().contains(l2));
+                assert(self.loose[l2].slot_index != popped_idx);
+            } else if l2 == new_loose && l1 != new_loose {
+                assert(old_self.loose.dom().contains(l1));
+                assert(self.loose[l1].slot_index != popped_idx);
+            } else if l1 != new_loose && l2 != new_loose {
+                assert(old_self.loose.dom().contains(l1));
+                assert(old_self.loose.dom().contains(l2));
+            }
+        };
+        new_loose
+    }
+}
+
+} // verus!

--- a/ostd/specs/mm/embedding/list_store.rs
+++ b/ostd/specs/mm/embedding/list_store.rs
@@ -59,9 +59,9 @@ use vstd_extra::cast_ptr::Repr;
 use vstd_extra::ownership::*;
 
 use crate::mm::Paddr;
-use crate::specs::arch::has_safe_slot;
 use crate::mm::frame::meta::mapping::frame_to_index;
 use crate::mm::frame::{AnyFrameMeta, Link};
+use crate::specs::arch::has_safe_slot;
 use crate::specs::mm::frame::linked_list::linked_list_owners::{
     CursorOwner, LinkOwner, LinkedListOwner, MetaSlotSmall,
 };

--- a/ostd/specs/mm/embedding/list_store.rs
+++ b/ostd/specs/mm/embedding/list_store.rs
@@ -809,51 +809,62 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
     }
 
     /// `LinkedList::contains`: whether `frame` is a link of list `id`. A
-    /// read-only query. The exec computes `in_list[frame] == list_id`;
-    /// the membership registry ([`list_registry_ok`], an `inv` clause)
-    /// turns that comparison into an *exact* membership test — `res`
-    /// holds iff `frame`'s slot is one of the list's links. The list must
-    /// have a real (non-zero) id, i.e. it has been pushed to at least
-    /// once (an empty/never-pushed list trivially contains nothing).
+    /// read-only query mirroring exec `contains(frame) -> bool`. `res`
+    /// holds iff `frame` is a safe managed slot AND one of the list's
+    /// links: for a real (non-zero) id the membership registry
+    /// ([`list_registry_ok`], an `inv` clause) makes the
+    /// `in_list[frame] == list_id` comparison an exact membership test;
+    /// an empty/never-pushed list (`list_id == 0`, hence empty) or a
+    /// `frame` that is not a safe slot (which exec's `get_slot` rejects)
+    /// contains nothing.
     pub proof fn step_contains(tracked &self, id: ListId, frame: Paddr) -> (res: bool)
         requires
             self.inv(),
             self.lists.dom().contains(id),
-            self.lists[id].list_id != 0,
-            has_safe_slot(frame),
-            self.regions.slot_owners.contains_key(frame_to_index(frame)),
         ensures
-    // What the exec computes — the frame's slot is tagged with
-    // this list's id.
-
-            res == (self.regions.slot_owners[frame_to_index(frame)].inner_perms.in_list.value()
-                == self.lists[id].list_id),
-            // ... which, by the registry, is exactly list membership.
-            res <==> exists|i: int|
+            res <==> (has_safe_slot(frame) && exists|i: int|
                 0 <= i < self.lists[id].list.len() && self.lists[id].slot_index_at(i)
-                    == frame_to_index(frame),
+                    == frame_to_index(frame)),
     {
         let idx = frame_to_index(frame);
-        // The registry for list `id` (forward + reverse) from `inv`.
-        assert(list_registry_ok(self.regions, self.lists[id]));
-        let res = self.regions.slot_owners[idx].inner_perms.in_list.value()
-            == self.lists[id].list_id;
-        if res {
-            // reverse: a slot tagged with the id is one of the links.
-            assert(exists|i: int|
-                0 <= i < self.lists[id].list.len() && self.lists[id].slot_index_at(i) == idx);
+        if has_safe_slot(frame) {
+            // A safe slot is a managed region key.
+            self.regions.inv_implies_correct_addr(frame);
+            assert(self.regions.slot_owners.contains_key(idx));
+            if self.lists[id].list_id != 0 {
+                // The registry for list `id` (forward + reverse) from `inv`.
+                assert(list_registry_ok(self.regions, self.lists[id]));
+                let res = self.regions.slot_owners[idx].inner_perms.in_list.value()
+                    == self.lists[id].list_id;
+                if res {
+                    // reverse: a slot tagged with the id is one of the links.
+                    assert(exists|i: int|
+                        0 <= i < self.lists[id].list.len() && self.lists[id].slot_index_at(i)
+                            == idx);
+                } else {
+                    // forward: every link's slot is tagged, so an untagged
+                    // slot is no link.
+                    assert forall|i: int|
+                        0 <= i < self.lists[id].list.len() implies self.lists[id].slot_index_at(i)
+                        != idx by {
+                        assert(self.regions.slot_owners[self.lists[id].slot_index_at(
+                            i,
+                        )].inner_perms.in_list.value() == self.lists[id].list_id);
+                    };
+                }
+                res
+            } else {
+                // `list_id == 0` ⟹ the list is empty (`LinkedListOwner::inv`:
+                // `len > 0 ==> list_id != 0`), so it has no links.
+                assert(self.lists[id].inv());
+                assert(self.lists[id].list.len() == 0);
+                false
+            }
         } else {
-            // forward: every link's slot is tagged, so an untagged slot
-            // is no link.
-            assert forall|i: int|
-                0 <= i < self.lists[id].list.len() implies self.lists[id].slot_index_at(i)
-                != idx by {
-                assert(self.regions.slot_owners[self.lists[id].slot_index_at(
-                    i,
-                )].inner_perms.in_list.value() == self.lists[id].list_id);
-            };
+            // `!has_safe_slot(frame)`: exec `get_slot` rejects it, so the
+            // guarded membership is vacuously false.
+            false
         }
-        res
     }
 
     /// `LinkedList::new`: register a fresh *empty* list. No region
@@ -1225,131 +1236,139 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
     /// `LinkedList::pop_front`: pop the front link of list `id` back into
     /// the loose pool as a fresh `UniqueFrame<Link<M>>`. Requires the
     /// list be non-empty. Returns the fresh loose id.
-    pub proof fn step_pop_front(tracked &mut self, id: ListId) -> (res: LooseId)
+    pub proof fn step_pop_front(tracked &mut self, id: ListId) -> (res: Option<LooseId>)
         requires
             old(self).inv(),
             old(self).lists.dom().contains(id),
-            old(self).lists[id].list.len() > 0,
         ensures
             final(self).inv(),
+            old(self).lists[id].list.len() == 0 ==> res is None && *final(self) == *old(self),
+            old(self).lists[id].list.len() > 0 ==> res is Some,
     {
-        let ghost old_self = *self;
-        let ghost old_regions = self.regions;
-        let ghost popped_idx = self.lists[id].slot_index_at(0);
-        let ghost old_list_id = self.lists[id].list_id;
-        // Pop preconditions from `inv`.
-        assert(self.lists[id].inv());
-        assert(self.lists[id].relate_region(self.regions));
+        if self.lists[id].list.len() == 0 {
+            // Exec `LinkedList::pop_front` returns `None` on an empty
+            // list; the store is unchanged.
+            Option::None
+        } else {
+            let ghost old_self = *self;
+            let ghost old_regions = self.regions;
+            let ghost popped_idx = self.lists[id].slot_index_at(0);
+            let ghost old_list_id = self.lists[id].list_id;
+            // Pop preconditions from `inv`.
+            assert(self.lists[id].inv());
+            assert(self.lists[id].relate_region(self.regions));
 
-        let tracked mut owner = self.lists.tracked_remove(id);
-        let tracked frame_own = pop_front_embedded(&mut self.regions, &mut owner);
-        self.lists.tracked_insert(id, owner);
-        let ghost new_loose = fresh_loose_id(self.loose);
-        axiom_fresh_loose_id_not_in_dom(self.loose);
-        self.loose.tracked_insert(new_loose, frame_own);
+            let tracked mut owner = self.lists.tracked_remove(id);
+            let tracked frame_own = pop_front_embedded(&mut self.regions, &mut owner);
+            self.lists.tracked_insert(id, owner);
+            let ghost new_loose = fresh_loose_id(self.loose);
+            axiom_fresh_loose_id_not_in_dom(self.loose);
+            self.loose.tracked_insert(new_loose, frame_own);
 
-        assert(self.lists =~= old_self.lists.remove(id).insert(id, owner));
-        assert(self.loose =~= old_self.loose.insert(new_loose, frame_own));
-        assert(self.lists[id].list_id == old_list_id);
-        assert(frame_own.slot_index == popped_idx);
+            assert(self.lists =~= old_self.lists.remove(id).insert(id, owner));
+            assert(self.loose =~= old_self.loose.insert(new_loose, frame_own));
+            assert(self.lists[id].list_id == old_list_id);
+            assert(frame_own.slot_index == popped_idx);
 
-        // --- per-list: inv + relate_region ---
-        assert forall|i: ListId| #[trigger] self.lists.dom().contains(i) implies {
-            &&& self.lists[i].inv()
-            &&& self.lists[i].relate_region(self.regions)
-        } by {
-            if i != id {
-                assert(old_self.lists.dom().contains(i));
-                assert(old_self.lists[i] == self.lists[i]);
-                assert(old_self.lists[i].inv());
-                assert(old_self.lists[i].relate_region(old_regions));
-                if self.lists[i].list.len() > 0 {
-                    // non-empty ⟹ nonzero id, distinct from `id`'s
-                    // (preserved) id by old uniqueness.
-                    assert(self.lists[i].list_id != old_list_id);
+            // --- per-list: inv + relate_region ---
+            assert forall|i: ListId| #[trigger] self.lists.dom().contains(i) implies {
+                &&& self.lists[i].inv()
+                &&& self.lists[i].relate_region(self.regions)
+            } by {
+                if i != id {
+                    assert(old_self.lists.dom().contains(i));
+                    assert(old_self.lists[i] == self.lists[i]);
+                    assert(old_self.lists[i].inv());
+                    assert(old_self.lists[i].relate_region(old_regions));
+                    if self.lists[i].list.len() > 0 {
+                        // non-empty ⟹ nonzero id, distinct from `id`'s
+                        // (preserved) id by old uniqueness.
+                        assert(self.lists[i].list_id != old_list_id);
+                    }
                 }
-            }
-        };
+            };
 
-        // --- per-loose: new entry from the axiom; others preserved ---
-        assert forall|lid2: LooseId| #[trigger] self.loose.dom().contains(lid2) implies {
-            &&& self.loose[lid2].inv()
-            &&& self.loose[lid2].global_inv(self.regions)
-            &&& self.loose[lid2].frame_link_inv(self.regions)
-            &&& self.regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
-                == 0
-        } by {
-            if lid2 != new_loose {
-                assert(old_self.loose.dom().contains(lid2));
-                assert(old_self.loose[lid2] == self.loose[lid2]);
-                assert(old_self.loose[lid2].global_inv(old_regions));
-                assert(old_self.loose[lid2].frame_link_inv(old_regions));
-                assert(old_regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
-                    == 0);
-            }
-        };
+            // --- per-loose: new entry from the axiom; others preserved ---
+            assert forall|lid2: LooseId| #[trigger] self.loose.dom().contains(lid2) implies {
+                &&& self.loose[lid2].inv()
+                &&& self.loose[lid2].global_inv(self.regions)
+                &&& self.loose[lid2].frame_link_inv(self.regions)
+                &&& self.regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                    == 0
+            } by {
+                if lid2 != new_loose {
+                    assert(old_self.loose.dom().contains(lid2));
+                    assert(old_self.loose[lid2] == self.loose[lid2]);
+                    assert(old_self.loose[lid2].global_inv(old_regions));
+                    assert(old_self.loose[lid2].frame_link_inv(old_regions));
+                    assert(old_regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                        == 0);
+                }
+            };
 
-        // --- list_id uniqueness (all ids unchanged) ---
-        assert forall|i1: ListId, i2: ListId|
-            self.lists.dom().contains(i1) && self.lists.dom().contains(i2) && self.lists[i1].list_id
-                == self.lists[i2].list_id && self.lists[i1].list_id != 0 implies i1 == i2 by {
-            assert(old_self.lists.dom().contains(i1));
-            assert(old_self.lists.dom().contains(i2));
-            assert(self.lists[i1].list_id == old_self.lists[i1].list_id);
-            assert(self.lists[i2].list_id == old_self.lists[i2].list_id);
-        };
+            // --- list_id uniqueness (all ids unchanged) ---
+            assert forall|i1: ListId, i2: ListId|
+                self.lists.dom().contains(i1) && self.lists.dom().contains(i2)
+                    && self.lists[i1].list_id == self.lists[i2].list_id && self.lists[i1].list_id
+                    != 0 implies i1 == i2 by {
+                assert(old_self.lists.dom().contains(i1));
+                assert(old_self.lists.dom().contains(i2));
+                assert(self.lists[i1].list_id == old_self.lists[i1].list_id);
+                assert(self.lists[i2].list_id == old_self.lists[i2].list_id);
+            };
 
-        // --- loose-internal disjointness ---
-        assert forall|l1: LooseId, l2: LooseId|
-            self.loose.dom().contains(l1) && self.loose.dom().contains(l2)
-                && self.loose[l1].slot_index == self.loose[l2].slot_index implies l1 == l2 by {
-            if l1 == new_loose && l2 != new_loose {
-                assert(old_self.loose.dom().contains(l2));
-                assert(self.loose[l2].slot_index != popped_idx);
-            } else if l2 == new_loose && l1 != new_loose {
-                assert(old_self.loose.dom().contains(l1));
-                assert(self.loose[l1].slot_index != popped_idx);
-            } else if l1 != new_loose && l2 != new_loose {
-                assert(old_self.loose.dom().contains(l1));
-                assert(old_self.loose.dom().contains(l2));
-            }
-        };
+            // --- loose-internal disjointness ---
+            assert forall|l1: LooseId, l2: LooseId|
+                self.loose.dom().contains(l1) && self.loose.dom().contains(l2)
+                    && self.loose[l1].slot_index == self.loose[l2].slot_index implies l1 == l2 by {
+                if l1 == new_loose && l2 != new_loose {
+                    assert(old_self.loose.dom().contains(l2));
+                    assert(self.loose[l2].slot_index != popped_idx);
+                } else if l2 == new_loose && l1 != new_loose {
+                    assert(old_self.loose.dom().contains(l1));
+                    assert(self.loose[l1].slot_index != popped_idx);
+                } else if l1 != new_loose && l2 != new_loose {
+                    assert(old_self.loose.dom().contains(l1));
+                    assert(old_self.loose.dom().contains(l2));
+                }
+            };
 
-        // --- cursors: checked-out lists are untouched ---
-        // `id`'s (preserved, nonzero) `old_list_id` is separated from
-        // every cursor's list id by the old list/cursor uniqueness, so
-        // the axiom's other-lists frame preserves each cursor.
-        assert(self.cursors == old_self.cursors);
-        assert(self.lists.dom() =~= old_self.lists.dom());
-        assert forall|cid: CursorId| #[trigger] self.cursors.dom().contains(cid) implies {
-            &&& self.cursors[cid].list_own.inv()
-            &&& self.cursors[cid].inv_region(self.regions)
-        } by {
-            assert(old_self.cursors.dom().contains(cid));
-            assert(old_self.cursors[cid].list_own.inv());
-            assert(old_self.cursors[cid].inv_region(old_regions));
-            assert(self.cursors[cid].list_own.relate_region(old_regions));
-            assert(old_self.lists.dom().contains(id));
-            assert(old_self.lists[id].list_id == old_list_id);
-            assert(self.cursors[cid].list_own.list_id != old_list_id);
-            assert(self.cursors[cid].list_own.relate_region(self.regions));
-        };
-        assert forall|id2: ListId, cid: CursorId|
-            self.lists.dom().contains(id2) && self.cursors.dom().contains(cid)
-                && self.lists[id2].list_id == self.cursors[cid].list_own.list_id
-                && self.lists[id2].list_id != 0 implies false by {
-            assert(old_self.cursors.dom().contains(cid));
-            assert(old_self.lists.dom().contains(id2));
-            assert(old_self.lists[id2].list_id == self.lists[id2].list_id);
-        };
-        assert forall|cid1: CursorId, cid2: CursorId|
-            self.cursors.dom().contains(cid1) && self.cursors.dom().contains(cid2)
-                && self.cursors[cid1].list_own.list_id == self.cursors[cid2].list_own.list_id
-                && self.cursors[cid1].list_own.list_id != 0 implies cid1 == cid2 by {
-            assert(old_self.cursors.dom().contains(cid1));
-            assert(old_self.cursors.dom().contains(cid2));
-        };
-        new_loose
+            // --- cursors: checked-out lists are untouched ---
+            // `id`'s (preserved, nonzero) `old_list_id` is separated from
+            // every cursor's list id by the old list/cursor uniqueness, so
+            // the axiom's other-lists frame preserves each cursor.
+            assert(self.cursors == old_self.cursors);
+            assert(self.lists.dom() =~= old_self.lists.dom());
+            assert forall|cid: CursorId| #[trigger] self.cursors.dom().contains(cid) implies {
+                &&& self.cursors[cid].list_own.inv()
+                &&& self.cursors[cid].inv_region(self.regions)
+            } by {
+                assert(old_self.cursors.dom().contains(cid));
+                assert(old_self.cursors[cid].list_own.inv());
+                assert(old_self.cursors[cid].inv_region(old_regions));
+                assert(self.cursors[cid].list_own.relate_region(old_regions));
+                assert(old_self.lists.dom().contains(id));
+                assert(old_self.lists[id].list_id == old_list_id);
+                assert(self.cursors[cid].list_own.list_id != old_list_id);
+                assert(self.cursors[cid].list_own.relate_region(self.regions));
+            };
+            assert forall|id2: ListId, cid: CursorId|
+                self.lists.dom().contains(id2) && self.cursors.dom().contains(cid)
+                    && self.lists[id2].list_id == self.cursors[cid].list_own.list_id
+                    && self.lists[id2].list_id != 0 implies false by {
+                assert(old_self.cursors.dom().contains(cid));
+                assert(old_self.lists.dom().contains(id2));
+                assert(old_self.lists[id2].list_id == self.lists[id2].list_id);
+            };
+            assert forall|cid1: CursorId, cid2: CursorId|
+                self.cursors.dom().contains(cid1) && self.cursors.dom().contains(cid2)
+                    && self.cursors[cid1].list_own.list_id == self.cursors[cid2].list_own.list_id
+                    && self.cursors[cid1].list_own.list_id != 0 implies cid1 == cid2 by {
+                assert(old_self.cursors.dom().contains(cid1));
+                assert(old_self.cursors.dom().contains(cid2));
+            };
+            Option::Some(new_loose)
+        }
     }
 
     /// `LinkedList::push_back`: move the loose handle `lid` to the back
@@ -1508,124 +1527,132 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
     /// `LinkedList::pop_back`: pop the back link of list `id` back into
     /// the loose pool. Same global effect as [`Self::step_pop_front`] —
     /// only which link is removed differs.
-    pub proof fn step_pop_back(tracked &mut self, id: ListId) -> (res: LooseId)
+    pub proof fn step_pop_back(tracked &mut self, id: ListId) -> (res: Option<LooseId>)
         requires
             old(self).inv(),
             old(self).lists.dom().contains(id),
-            old(self).lists[id].list.len() > 0,
         ensures
             final(self).inv(),
+            old(self).lists[id].list.len() == 0 ==> res is None && *final(self) == *old(self),
+            old(self).lists[id].list.len() > 0 ==> res is Some,
     {
-        let ghost old_self = *self;
-        let ghost old_regions = self.regions;
-        let ghost popped_idx = self.lists[id].slot_index_at(self.lists[id].list.len() - 1);
-        let ghost old_list_id = self.lists[id].list_id;
-        assert(self.lists[id].inv());
-        assert(self.lists[id].relate_region(self.regions));
+        if self.lists[id].list.len() == 0 {
+            // Exec `LinkedList::pop_back` returns `None` on an empty list;
+            // the store is unchanged.
+            Option::None
+        } else {
+            let ghost old_self = *self;
+            let ghost old_regions = self.regions;
+            let ghost popped_idx = self.lists[id].slot_index_at(self.lists[id].list.len() - 1);
+            let ghost old_list_id = self.lists[id].list_id;
+            assert(self.lists[id].inv());
+            assert(self.lists[id].relate_region(self.regions));
 
-        let tracked mut owner = self.lists.tracked_remove(id);
-        let tracked frame_own = pop_back_embedded(&mut self.regions, &mut owner);
-        self.lists.tracked_insert(id, owner);
-        let ghost new_loose = fresh_loose_id(self.loose);
-        axiom_fresh_loose_id_not_in_dom(self.loose);
-        self.loose.tracked_insert(new_loose, frame_own);
+            let tracked mut owner = self.lists.tracked_remove(id);
+            let tracked frame_own = pop_back_embedded(&mut self.regions, &mut owner);
+            self.lists.tracked_insert(id, owner);
+            let ghost new_loose = fresh_loose_id(self.loose);
+            axiom_fresh_loose_id_not_in_dom(self.loose);
+            self.loose.tracked_insert(new_loose, frame_own);
 
-        assert(self.lists =~= old_self.lists.remove(id).insert(id, owner));
-        assert(self.loose =~= old_self.loose.insert(new_loose, frame_own));
-        assert(self.lists[id].list_id == old_list_id);
-        assert(frame_own.slot_index == popped_idx);
+            assert(self.lists =~= old_self.lists.remove(id).insert(id, owner));
+            assert(self.loose =~= old_self.loose.insert(new_loose, frame_own));
+            assert(self.lists[id].list_id == old_list_id);
+            assert(frame_own.slot_index == popped_idx);
 
-        assert forall|i: ListId| #[trigger] self.lists.dom().contains(i) implies {
-            &&& self.lists[i].inv()
-            &&& self.lists[i].relate_region(self.regions)
-        } by {
-            if i != id {
-                assert(old_self.lists.dom().contains(i));
-                assert(old_self.lists[i] == self.lists[i]);
-                assert(old_self.lists[i].inv());
-                assert(old_self.lists[i].relate_region(old_regions));
-                if self.lists[i].list.len() > 0 {
-                    assert(self.lists[i].list_id != old_list_id);
+            assert forall|i: ListId| #[trigger] self.lists.dom().contains(i) implies {
+                &&& self.lists[i].inv()
+                &&& self.lists[i].relate_region(self.regions)
+            } by {
+                if i != id {
+                    assert(old_self.lists.dom().contains(i));
+                    assert(old_self.lists[i] == self.lists[i]);
+                    assert(old_self.lists[i].inv());
+                    assert(old_self.lists[i].relate_region(old_regions));
+                    if self.lists[i].list.len() > 0 {
+                        assert(self.lists[i].list_id != old_list_id);
+                    }
                 }
-            }
-        };
+            };
 
-        assert forall|lid2: LooseId| #[trigger] self.loose.dom().contains(lid2) implies {
-            &&& self.loose[lid2].inv()
-            &&& self.loose[lid2].global_inv(self.regions)
-            &&& self.loose[lid2].frame_link_inv(self.regions)
-            &&& self.regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
-                == 0
-        } by {
-            if lid2 != new_loose {
-                assert(old_self.loose.dom().contains(lid2));
-                assert(old_self.loose[lid2] == self.loose[lid2]);
-                assert(old_self.loose[lid2].global_inv(old_regions));
-                assert(old_self.loose[lid2].frame_link_inv(old_regions));
-                assert(old_regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
-                    == 0);
-            }
-        };
+            assert forall|lid2: LooseId| #[trigger] self.loose.dom().contains(lid2) implies {
+                &&& self.loose[lid2].inv()
+                &&& self.loose[lid2].global_inv(self.regions)
+                &&& self.loose[lid2].frame_link_inv(self.regions)
+                &&& self.regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                    == 0
+            } by {
+                if lid2 != new_loose {
+                    assert(old_self.loose.dom().contains(lid2));
+                    assert(old_self.loose[lid2] == self.loose[lid2]);
+                    assert(old_self.loose[lid2].global_inv(old_regions));
+                    assert(old_self.loose[lid2].frame_link_inv(old_regions));
+                    assert(old_regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                        == 0);
+                }
+            };
 
-        assert forall|i1: ListId, i2: ListId|
-            self.lists.dom().contains(i1) && self.lists.dom().contains(i2) && self.lists[i1].list_id
-                == self.lists[i2].list_id && self.lists[i1].list_id != 0 implies i1 == i2 by {
-            assert(old_self.lists.dom().contains(i1));
-            assert(old_self.lists.dom().contains(i2));
-            assert(self.lists[i1].list_id == old_self.lists[i1].list_id);
-            assert(self.lists[i2].list_id == old_self.lists[i2].list_id);
-        };
+            assert forall|i1: ListId, i2: ListId|
+                self.lists.dom().contains(i1) && self.lists.dom().contains(i2)
+                    && self.lists[i1].list_id == self.lists[i2].list_id && self.lists[i1].list_id
+                    != 0 implies i1 == i2 by {
+                assert(old_self.lists.dom().contains(i1));
+                assert(old_self.lists.dom().contains(i2));
+                assert(self.lists[i1].list_id == old_self.lists[i1].list_id);
+                assert(self.lists[i2].list_id == old_self.lists[i2].list_id);
+            };
 
-        assert forall|l1: LooseId, l2: LooseId|
-            self.loose.dom().contains(l1) && self.loose.dom().contains(l2)
-                && self.loose[l1].slot_index == self.loose[l2].slot_index implies l1 == l2 by {
-            if l1 == new_loose && l2 != new_loose {
-                assert(old_self.loose.dom().contains(l2));
-                assert(self.loose[l2].slot_index != popped_idx);
-            } else if l2 == new_loose && l1 != new_loose {
-                assert(old_self.loose.dom().contains(l1));
-                assert(self.loose[l1].slot_index != popped_idx);
-            } else if l1 != new_loose && l2 != new_loose {
-                assert(old_self.loose.dom().contains(l1));
-                assert(old_self.loose.dom().contains(l2));
-            }
-        };
+            assert forall|l1: LooseId, l2: LooseId|
+                self.loose.dom().contains(l1) && self.loose.dom().contains(l2)
+                    && self.loose[l1].slot_index == self.loose[l2].slot_index implies l1 == l2 by {
+                if l1 == new_loose && l2 != new_loose {
+                    assert(old_self.loose.dom().contains(l2));
+                    assert(self.loose[l2].slot_index != popped_idx);
+                } else if l2 == new_loose && l1 != new_loose {
+                    assert(old_self.loose.dom().contains(l1));
+                    assert(self.loose[l1].slot_index != popped_idx);
+                } else if l1 != new_loose && l2 != new_loose {
+                    assert(old_self.loose.dom().contains(l1));
+                    assert(old_self.loose.dom().contains(l2));
+                }
+            };
 
-        // --- cursors: checked-out lists are untouched ---
-        // `id`'s (preserved, nonzero) `old_list_id` is separated from
-        // every cursor's list id by the old list/cursor uniqueness, so
-        // the axiom's other-lists frame preserves each cursor.
-        assert(self.cursors == old_self.cursors);
-        assert(self.lists.dom() =~= old_self.lists.dom());
-        assert forall|cid: CursorId| #[trigger] self.cursors.dom().contains(cid) implies {
-            &&& self.cursors[cid].list_own.inv()
-            &&& self.cursors[cid].inv_region(self.regions)
-        } by {
-            assert(old_self.cursors.dom().contains(cid));
-            assert(old_self.cursors[cid].list_own.inv());
-            assert(old_self.cursors[cid].inv_region(old_regions));
-            assert(self.cursors[cid].list_own.relate_region(old_regions));
-            assert(old_self.lists.dom().contains(id));
-            assert(old_self.lists[id].list_id == old_list_id);
-            assert(self.cursors[cid].list_own.list_id != old_list_id);
-            assert(self.cursors[cid].list_own.relate_region(self.regions));
-        };
-        assert forall|id2: ListId, cid: CursorId|
-            self.lists.dom().contains(id2) && self.cursors.dom().contains(cid)
-                && self.lists[id2].list_id == self.cursors[cid].list_own.list_id
-                && self.lists[id2].list_id != 0 implies false by {
-            assert(old_self.cursors.dom().contains(cid));
-            assert(old_self.lists.dom().contains(id2));
-            assert(old_self.lists[id2].list_id == self.lists[id2].list_id);
-        };
-        assert forall|cid1: CursorId, cid2: CursorId|
-            self.cursors.dom().contains(cid1) && self.cursors.dom().contains(cid2)
-                && self.cursors[cid1].list_own.list_id == self.cursors[cid2].list_own.list_id
-                && self.cursors[cid1].list_own.list_id != 0 implies cid1 == cid2 by {
-            assert(old_self.cursors.dom().contains(cid1));
-            assert(old_self.cursors.dom().contains(cid2));
-        };
-        new_loose
+            // --- cursors: checked-out lists are untouched ---
+            // `id`'s (preserved, nonzero) `old_list_id` is separated from
+            // every cursor's list id by the old list/cursor uniqueness, so
+            // the axiom's other-lists frame preserves each cursor.
+            assert(self.cursors == old_self.cursors);
+            assert(self.lists.dom() =~= old_self.lists.dom());
+            assert forall|cid: CursorId| #[trigger] self.cursors.dom().contains(cid) implies {
+                &&& self.cursors[cid].list_own.inv()
+                &&& self.cursors[cid].inv_region(self.regions)
+            } by {
+                assert(old_self.cursors.dom().contains(cid));
+                assert(old_self.cursors[cid].list_own.inv());
+                assert(old_self.cursors[cid].inv_region(old_regions));
+                assert(self.cursors[cid].list_own.relate_region(old_regions));
+                assert(old_self.lists.dom().contains(id));
+                assert(old_self.lists[id].list_id == old_list_id);
+                assert(self.cursors[cid].list_own.list_id != old_list_id);
+                assert(self.cursors[cid].list_own.relate_region(self.regions));
+            };
+            assert forall|id2: ListId, cid: CursorId|
+                self.lists.dom().contains(id2) && self.cursors.dom().contains(cid)
+                    && self.lists[id2].list_id == self.cursors[cid].list_own.list_id
+                    && self.lists[id2].list_id != 0 implies false by {
+                assert(old_self.cursors.dom().contains(cid));
+                assert(old_self.lists.dom().contains(id2));
+                assert(old_self.lists[id2].list_id == self.lists[id2].list_id);
+            };
+            assert forall|cid1: CursorId, cid2: CursorId|
+                self.cursors.dom().contains(cid1) && self.cursors.dom().contains(cid2)
+                    && self.cursors[cid1].list_own.list_id == self.cursors[cid2].list_own.list_id
+                    && self.cursors[cid1].list_own.list_id != 0 implies cid1 == cid2 by {
+                assert(old_self.cursors.dom().contains(cid1));
+                assert(old_self.cursors.dom().contains(cid2));
+            };
+            Option::Some(new_loose)
+        }
     }
 
     /// Cursor `insert_before` at an arbitrary position `n`: move the
@@ -1787,124 +1814,134 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
     /// at index `n` (`0 <= n < len`) of list `id` back into the loose
     /// pool. The general form of [`Self::step_pop_front`] /
     /// [`Self::step_pop_back`]; same global effect.
-    pub proof fn step_take_at(tracked &mut self, id: ListId, n: int) -> (res: LooseId)
+    pub proof fn step_take_at(tracked &mut self, id: ListId, n: int) -> (res: Option<LooseId>)
         requires
             old(self).inv(),
             old(self).lists.dom().contains(id),
-            0 <= n < old(self).lists[id].list.len(),
         ensures
             final(self).inv(),
+            !(0 <= n < old(self).lists[id].list.len()) ==> res is None && *final(self) == *old(
+                self,
+            ),
+            0 <= n < old(self).lists[id].list.len() ==> res is Some,
     {
-        let ghost old_self = *self;
-        let ghost old_regions = self.regions;
-        let ghost popped_idx = self.lists[id].slot_index_at(n);
-        let ghost old_list_id = self.lists[id].list_id;
-        assert(self.lists[id].inv());
-        assert(self.lists[id].relate_region(self.regions));
+        if !(0 <= n < self.lists[id].list.len()) {
+            // Exec take-at-position returns `None` when `n` is out of
+            // range; the store is unchanged.
+            Option::None
+        } else {
+            let ghost old_self = *self;
+            let ghost old_regions = self.regions;
+            let ghost popped_idx = self.lists[id].slot_index_at(n);
+            let ghost old_list_id = self.lists[id].list_id;
+            assert(self.lists[id].inv());
+            assert(self.lists[id].relate_region(self.regions));
 
-        let tracked mut owner = self.lists.tracked_remove(id);
-        let tracked frame_own = take_at_embedded(&mut self.regions, &mut owner, n);
-        self.lists.tracked_insert(id, owner);
-        let ghost new_loose = fresh_loose_id(self.loose);
-        axiom_fresh_loose_id_not_in_dom(self.loose);
-        self.loose.tracked_insert(new_loose, frame_own);
+            let tracked mut owner = self.lists.tracked_remove(id);
+            let tracked frame_own = take_at_embedded(&mut self.regions, &mut owner, n);
+            self.lists.tracked_insert(id, owner);
+            let ghost new_loose = fresh_loose_id(self.loose);
+            axiom_fresh_loose_id_not_in_dom(self.loose);
+            self.loose.tracked_insert(new_loose, frame_own);
 
-        assert(self.lists =~= old_self.lists.remove(id).insert(id, owner));
-        assert(self.loose =~= old_self.loose.insert(new_loose, frame_own));
-        assert(self.lists[id].list_id == old_list_id);
-        assert(frame_own.slot_index == popped_idx);
+            assert(self.lists =~= old_self.lists.remove(id).insert(id, owner));
+            assert(self.loose =~= old_self.loose.insert(new_loose, frame_own));
+            assert(self.lists[id].list_id == old_list_id);
+            assert(frame_own.slot_index == popped_idx);
 
-        assert forall|i: ListId| #[trigger] self.lists.dom().contains(i) implies {
-            &&& self.lists[i].inv()
-            &&& self.lists[i].relate_region(self.regions)
-        } by {
-            if i != id {
-                assert(old_self.lists.dom().contains(i));
-                assert(old_self.lists[i] == self.lists[i]);
-                assert(old_self.lists[i].inv());
-                assert(old_self.lists[i].relate_region(old_regions));
-                if self.lists[i].list.len() > 0 {
-                    assert(self.lists[i].list_id != old_list_id);
+            assert forall|i: ListId| #[trigger] self.lists.dom().contains(i) implies {
+                &&& self.lists[i].inv()
+                &&& self.lists[i].relate_region(self.regions)
+            } by {
+                if i != id {
+                    assert(old_self.lists.dom().contains(i));
+                    assert(old_self.lists[i] == self.lists[i]);
+                    assert(old_self.lists[i].inv());
+                    assert(old_self.lists[i].relate_region(old_regions));
+                    if self.lists[i].list.len() > 0 {
+                        assert(self.lists[i].list_id != old_list_id);
+                    }
                 }
-            }
-        };
+            };
 
-        assert forall|lid2: LooseId| #[trigger] self.loose.dom().contains(lid2) implies {
-            &&& self.loose[lid2].inv()
-            &&& self.loose[lid2].global_inv(self.regions)
-            &&& self.loose[lid2].frame_link_inv(self.regions)
-            &&& self.regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
-                == 0
-        } by {
-            if lid2 != new_loose {
-                assert(old_self.loose.dom().contains(lid2));
-                assert(old_self.loose[lid2] == self.loose[lid2]);
-                assert(old_self.loose[lid2].global_inv(old_regions));
-                assert(old_self.loose[lid2].frame_link_inv(old_regions));
-                assert(old_regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
-                    == 0);
-            }
-        };
+            assert forall|lid2: LooseId| #[trigger] self.loose.dom().contains(lid2) implies {
+                &&& self.loose[lid2].inv()
+                &&& self.loose[lid2].global_inv(self.regions)
+                &&& self.loose[lid2].frame_link_inv(self.regions)
+                &&& self.regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                    == 0
+            } by {
+                if lid2 != new_loose {
+                    assert(old_self.loose.dom().contains(lid2));
+                    assert(old_self.loose[lid2] == self.loose[lid2]);
+                    assert(old_self.loose[lid2].global_inv(old_regions));
+                    assert(old_self.loose[lid2].frame_link_inv(old_regions));
+                    assert(old_regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                        == 0);
+                }
+            };
 
-        assert forall|i1: ListId, i2: ListId|
-            self.lists.dom().contains(i1) && self.lists.dom().contains(i2) && self.lists[i1].list_id
-                == self.lists[i2].list_id && self.lists[i1].list_id != 0 implies i1 == i2 by {
-            assert(old_self.lists.dom().contains(i1));
-            assert(old_self.lists.dom().contains(i2));
-            assert(self.lists[i1].list_id == old_self.lists[i1].list_id);
-            assert(self.lists[i2].list_id == old_self.lists[i2].list_id);
-        };
+            assert forall|i1: ListId, i2: ListId|
+                self.lists.dom().contains(i1) && self.lists.dom().contains(i2)
+                    && self.lists[i1].list_id == self.lists[i2].list_id && self.lists[i1].list_id
+                    != 0 implies i1 == i2 by {
+                assert(old_self.lists.dom().contains(i1));
+                assert(old_self.lists.dom().contains(i2));
+                assert(self.lists[i1].list_id == old_self.lists[i1].list_id);
+                assert(self.lists[i2].list_id == old_self.lists[i2].list_id);
+            };
 
-        assert forall|l1: LooseId, l2: LooseId|
-            self.loose.dom().contains(l1) && self.loose.dom().contains(l2)
-                && self.loose[l1].slot_index == self.loose[l2].slot_index implies l1 == l2 by {
-            if l1 == new_loose && l2 != new_loose {
-                assert(old_self.loose.dom().contains(l2));
-                assert(self.loose[l2].slot_index != popped_idx);
-            } else if l2 == new_loose && l1 != new_loose {
-                assert(old_self.loose.dom().contains(l1));
-                assert(self.loose[l1].slot_index != popped_idx);
-            } else if l1 != new_loose && l2 != new_loose {
-                assert(old_self.loose.dom().contains(l1));
-                assert(old_self.loose.dom().contains(l2));
-            }
-        };
+            assert forall|l1: LooseId, l2: LooseId|
+                self.loose.dom().contains(l1) && self.loose.dom().contains(l2)
+                    && self.loose[l1].slot_index == self.loose[l2].slot_index implies l1 == l2 by {
+                if l1 == new_loose && l2 != new_loose {
+                    assert(old_self.loose.dom().contains(l2));
+                    assert(self.loose[l2].slot_index != popped_idx);
+                } else if l2 == new_loose && l1 != new_loose {
+                    assert(old_self.loose.dom().contains(l1));
+                    assert(self.loose[l1].slot_index != popped_idx);
+                } else if l1 != new_loose && l2 != new_loose {
+                    assert(old_self.loose.dom().contains(l1));
+                    assert(old_self.loose.dom().contains(l2));
+                }
+            };
 
-        // --- cursors: checked-out lists are untouched ---
-        // `id`'s (preserved, nonzero) `old_list_id` is separated from
-        // every cursor's list id by the old list/cursor uniqueness, so
-        // the axiom's other-lists frame preserves each cursor.
-        assert(self.cursors == old_self.cursors);
-        assert(self.lists.dom() =~= old_self.lists.dom());
-        assert forall|cid: CursorId| #[trigger] self.cursors.dom().contains(cid) implies {
-            &&& self.cursors[cid].list_own.inv()
-            &&& self.cursors[cid].inv_region(self.regions)
-        } by {
-            assert(old_self.cursors.dom().contains(cid));
-            assert(old_self.cursors[cid].list_own.inv());
-            assert(old_self.cursors[cid].inv_region(old_regions));
-            assert(self.cursors[cid].list_own.relate_region(old_regions));
-            assert(old_self.lists.dom().contains(id));
-            assert(old_self.lists[id].list_id == old_list_id);
-            assert(self.cursors[cid].list_own.list_id != old_list_id);
-            assert(self.cursors[cid].list_own.relate_region(self.regions));
-        };
-        assert forall|id2: ListId, cid: CursorId|
-            self.lists.dom().contains(id2) && self.cursors.dom().contains(cid)
-                && self.lists[id2].list_id == self.cursors[cid].list_own.list_id
-                && self.lists[id2].list_id != 0 implies false by {
-            assert(old_self.cursors.dom().contains(cid));
-            assert(old_self.lists.dom().contains(id2));
-            assert(old_self.lists[id2].list_id == self.lists[id2].list_id);
-        };
-        assert forall|cid1: CursorId, cid2: CursorId|
-            self.cursors.dom().contains(cid1) && self.cursors.dom().contains(cid2)
-                && self.cursors[cid1].list_own.list_id == self.cursors[cid2].list_own.list_id
-                && self.cursors[cid1].list_own.list_id != 0 implies cid1 == cid2 by {
-            assert(old_self.cursors.dom().contains(cid1));
-            assert(old_self.cursors.dom().contains(cid2));
-        };
-        new_loose
+            // --- cursors: checked-out lists are untouched ---
+            // `id`'s (preserved, nonzero) `old_list_id` is separated from
+            // every cursor's list id by the old list/cursor uniqueness, so
+            // the axiom's other-lists frame preserves each cursor.
+            assert(self.cursors == old_self.cursors);
+            assert(self.lists.dom() =~= old_self.lists.dom());
+            assert forall|cid: CursorId| #[trigger] self.cursors.dom().contains(cid) implies {
+                &&& self.cursors[cid].list_own.inv()
+                &&& self.cursors[cid].inv_region(self.regions)
+            } by {
+                assert(old_self.cursors.dom().contains(cid));
+                assert(old_self.cursors[cid].list_own.inv());
+                assert(old_self.cursors[cid].inv_region(old_regions));
+                assert(self.cursors[cid].list_own.relate_region(old_regions));
+                assert(old_self.lists.dom().contains(id));
+                assert(old_self.lists[id].list_id == old_list_id);
+                assert(self.cursors[cid].list_own.list_id != old_list_id);
+                assert(self.cursors[cid].list_own.relate_region(self.regions));
+            };
+            assert forall|id2: ListId, cid: CursorId|
+                self.lists.dom().contains(id2) && self.cursors.dom().contains(cid)
+                    && self.lists[id2].list_id == self.cursors[cid].list_own.list_id
+                    && self.lists[id2].list_id != 0 implies false by {
+                assert(old_self.cursors.dom().contains(cid));
+                assert(old_self.lists.dom().contains(id2));
+                assert(old_self.lists[id2].list_id == self.lists[id2].list_id);
+            };
+            assert forall|cid1: CursorId, cid2: CursorId|
+                self.cursors.dom().contains(cid1) && self.cursors.dom().contains(cid2)
+                    && self.cursors[cid1].list_own.list_id == self.cursors[cid2].list_own.list_id
+                    && self.cursors[cid1].list_own.list_id != 0 implies cid1 == cid2 by {
+                assert(old_self.cursors.dom().contains(cid1));
+                assert(old_self.cursors.dom().contains(cid2));
+            };
+            Option::Some(new_loose)
+        }
     }
 
     // -------------------------------------------------------------------
@@ -2244,29 +2281,53 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
         Self::lemma_checkout_inv(old_self, *self, id, bidx);
     }
 
-    /// `LinkedList::cursor_mut_at`: check list `id` out into a cursor at
-    /// an explicit in-range `index` (`0 <= index <= len`).
-    pub proof fn step_cursor_mut_at(tracked &mut self, id: ListId, index: int)
+    /// `LinkedList::cursor_mut_at`: search list `id` for `frame` and, if
+    /// it is one of the list's links, check the list out into a cursor
+    /// positioned at that link; otherwise (the frame is absent — or not a
+    /// safe managed slot, which can never be a link) leave the store
+    /// unchanged. Mirrors exec `cursor_mut_at(frame) -> Option<CursorMut>`
+    /// (the `Some`/`None` outcome is returned as `res`).
+    pub proof fn step_cursor_mut_at(tracked &mut self, id: ListId, frame: Paddr) -> (res: bool)
         requires
             old(self).inv(),
             old(self).lists.dom().contains(id),
-            0 <= index <= old(self).lists[id].list.len(),
         ensures
             final(self).inv(),
-            !final(self).lists.dom().contains(id),
-            final(self).cursors.dom().contains(id),
-            final(self).cursors[id] == CursorOwner::cursor_mut_at_owner(old(self).lists[id], index),
+            // `res` is exactly list membership of `frame`.
+            res == (exists|i: int|
+                0 <= i < old(self).lists[id].list.len() && old(self).lists[id].slot_index_at(i)
+                    == frame_to_index(frame)),
+            // On a hit: the list is checked out into a cursor positioned
+            // at the matching link.
+            res ==> !final(self).lists.dom().contains(id) && final(self).cursors.dom().contains(id)
+                && exists|i: int|
+                0 <= i < old(self).lists[id].list.len() && old(self).lists[id].slot_index_at(i)
+                    == frame_to_index(frame) && final(self).cursors[id]
+                    == CursorOwner::cursor_mut_at_owner(old(self).lists[id], i),
+            // On a miss: no checkout, the store is unchanged.
+            !res ==> *final(self) == *old(self),
     {
-        let ghost old_self = *self;
-        let tracked owner = self.lists.tracked_remove(id);
-        let tracked cur = CursorOwner::tracked_cursor_mut_at_owner(owner, index);
-        self.cursors.tracked_insert(id, cur);
-        assert(self.lists =~= old_self.lists.remove(id));
-        assert(self.cursors =~= old_self.cursors.insert(
-            id,
-            CursorOwner::cursor_mut_at_owner(old_self.lists[id], index),
-        ));
-        Self::lemma_checkout_inv(old_self, *self, id, index);
+        if exists|i: int|
+            0 <= i < self.lists[id].list.len() && self.lists[id].slot_index_at(i) == frame_to_index(
+                frame,
+            ) {
+            let ghost index = choose|i: int|
+                0 <= i < self.lists[id].list.len() && self.lists[id].slot_index_at(i)
+                    == frame_to_index(frame);
+            let ghost old_self = *self;
+            let tracked owner = self.lists.tracked_remove(id);
+            let tracked cur = CursorOwner::tracked_cursor_mut_at_owner(owner, index);
+            self.cursors.tracked_insert(id, cur);
+            assert(self.lists =~= old_self.lists.remove(id));
+            assert(self.cursors =~= old_self.cursors.insert(
+                id,
+                CursorOwner::cursor_mut_at_owner(old_self.lists[id], index),
+            ));
+            Self::lemma_checkout_inv(old_self, *self, id, index);
+            true
+        } else {
+            false
+        }
     }
 
     /// `CursorMut::move_next`: advance cursor `id` one step toward the
@@ -2536,140 +2597,150 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
     /// same index (now on the following link). The general
     /// [`Self::step_take_at`] on a cursored list. Returns the fresh loose
     /// id.
-    pub proof fn step_cursor_take_current(tracked &mut self, id: CursorId) -> (res: LooseId)
+    pub proof fn step_cursor_take_current(tracked &mut self, id: CursorId) -> (res: Option<LooseId>)
         requires
             old(self).inv(),
             old(self).cursors.dom().contains(id),
-            0 <= old(self).cursors[id].index < old(self).cursors[id].length(),
         ensures
             final(self).inv(),
+            !(0 <= old(self).cursors[id].index < old(self).cursors[id].length()) ==> res is None
+                && *final(self) == *old(self),
+            0 <= old(self).cursors[id].index < old(self).cursors[id].length() ==> res is Some,
     {
-        let ghost old_self = *self;
-        let ghost old_regions = self.regions;
-        let ghost n = self.cursors[id].index;
-        let ghost old_list_id = self.cursors[id].list_own.list_id;
-        let ghost popped_idx = self.cursors[id].list_own.slot_index_at(n);
-        assert(self.cursors[id].list_own.inv());
-        assert(self.cursors[id].list_own.relate_region(self.regions));
-        assert(0 <= n < self.cursors[id].list_own.list.len());
-        // A non-empty list carries a nonzero id (`LinkedListOwner::inv`).
-        assert(old_list_id != 0);
+        if !(0 <= self.cursors[id].index < self.cursors[id].length()) {
+            // Exec `CursorMut::take_current` returns `None` when the
+            // cursor is not on an element; the store is unchanged.
+            Option::None
+        } else {
+            let ghost old_self = *self;
+            let ghost old_regions = self.regions;
+            let ghost n = self.cursors[id].index;
+            let ghost old_list_id = self.cursors[id].list_own.list_id;
+            let ghost popped_idx = self.cursors[id].list_own.slot_index_at(n);
+            assert(self.cursors[id].list_own.inv());
+            assert(self.cursors[id].list_own.relate_region(self.regions));
+            assert(0 <= n < self.cursors[id].list_own.list.len());
+            // A non-empty list carries a nonzero id (`LinkedListOwner::inv`).
+            assert(old_list_id != 0);
 
-        let tracked cur = self.cursors.tracked_remove(id);
-        let tracked CursorOwner { list_own: mut owner, index: _ } = cur;
-        let tracked frame_own = take_at_embedded(&mut self.regions, &mut owner, n);
-        let tracked cur2 = CursorOwner::tracked_cursor_mut_at_owner(owner, n);
-        self.cursors.tracked_insert(id, cur2);
-        let ghost new_loose = fresh_loose_id(self.loose);
-        axiom_fresh_loose_id_not_in_dom(self.loose);
-        self.loose.tracked_insert(new_loose, frame_own);
+            let tracked cur = self.cursors.tracked_remove(id);
+            let tracked CursorOwner { list_own: mut owner, index: _ } = cur;
+            let tracked frame_own = take_at_embedded(&mut self.regions, &mut owner, n);
+            let tracked cur2 = CursorOwner::tracked_cursor_mut_at_owner(owner, n);
+            self.cursors.tracked_insert(id, cur2);
+            let ghost new_loose = fresh_loose_id(self.loose);
+            axiom_fresh_loose_id_not_in_dom(self.loose);
+            self.loose.tracked_insert(new_loose, frame_own);
 
-        assert(self.cursors =~= old_self.cursors.remove(id).insert(id, cur2));
-        assert(self.loose =~= old_self.loose.insert(new_loose, frame_own));
-        assert(self.cursors[id].list_own.list_id == old_list_id);
-        assert(self.cursors[id].list_own == owner);
-        assert(frame_own.slot_index == popped_idx);
+            assert(self.cursors =~= old_self.cursors.remove(id).insert(id, cur2));
+            assert(self.loose =~= old_self.loose.insert(new_loose, frame_own));
+            assert(self.cursors[id].list_own.list_id == old_list_id);
+            assert(self.cursors[id].list_own == owner);
+            assert(frame_own.slot_index == popped_idx);
 
-        // --- per-list: every list preserved (operating is a cursor) ---
-        assert forall|i: ListId| #[trigger] self.lists.dom().contains(i) implies {
-            &&& self.lists[i].inv()
-            &&& self.lists[i].relate_region(self.regions)
-        } by {
-            assert(old_self.lists.dom().contains(i));
-            assert(old_self.lists[i] == self.lists[i]);
-            assert(old_self.lists[i].relate_region(old_regions));
-            assert(old_self.cursors.dom().contains(id));
-            assert(self.lists[i].list_id != old_list_id);
-            assert(self.lists[i].relate_region(self.regions));
-        };
+            // --- per-list: every list preserved (operating is a cursor) ---
+            assert forall|i: ListId| #[trigger] self.lists.dom().contains(i) implies {
+                &&& self.lists[i].inv()
+                &&& self.lists[i].relate_region(self.regions)
+            } by {
+                assert(old_self.lists.dom().contains(i));
+                assert(old_self.lists[i] == self.lists[i]);
+                assert(old_self.lists[i].relate_region(old_regions));
+                assert(old_self.cursors.dom().contains(id));
+                assert(self.lists[i].list_id != old_list_id);
+                assert(self.lists[i].relate_region(self.regions));
+            };
 
-        // --- per-loose: new entry from the axiom; others preserved;
-        // the popped slot is disjoint from every loose slot ---
-        assert forall|lid2: LooseId| #[trigger] self.loose.dom().contains(lid2) implies {
-            &&& self.loose[lid2].inv()
-            &&& self.loose[lid2].global_inv(self.regions)
-            &&& self.loose[lid2].frame_link_inv(self.regions)
-            &&& self.regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
-                == 0
-        } by {
-            if lid2 != new_loose {
-                assert(old_self.loose.dom().contains(lid2));
-                assert(old_self.loose[lid2] == self.loose[lid2]);
-                assert(old_self.loose[lid2].global_inv(old_regions));
-                assert(old_self.loose[lid2].frame_link_inv(old_regions));
-                assert(old_regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
-                    == 0);
-            }
-        };
+            // --- per-loose: new entry from the axiom; others preserved;
+            // the popped slot is disjoint from every loose slot ---
+            assert forall|lid2: LooseId| #[trigger] self.loose.dom().contains(lid2) implies {
+                &&& self.loose[lid2].inv()
+                &&& self.loose[lid2].global_inv(self.regions)
+                &&& self.loose[lid2].frame_link_inv(self.regions)
+                &&& self.regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                    == 0
+            } by {
+                if lid2 != new_loose {
+                    assert(old_self.loose.dom().contains(lid2));
+                    assert(old_self.loose[lid2] == self.loose[lid2]);
+                    assert(old_self.loose[lid2].global_inv(old_regions));
+                    assert(old_self.loose[lid2].frame_link_inv(old_regions));
+                    assert(old_regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                        == 0);
+                }
+            };
 
-        // --- disjointness ---
-        assert(self.lists.dom() =~= old_self.lists.dom());
-        assert(self.cursors.dom() =~= old_self.cursors.dom());
-        assert(self.lists.dom().disjoint(self.cursors.dom()));
+            // --- disjointness ---
+            assert(self.lists.dom() =~= old_self.lists.dom());
+            assert(self.cursors.dom() =~= old_self.cursors.dom());
+            assert(self.lists.dom().disjoint(self.cursors.dom()));
 
-        // --- per-cursor: operating cursor rebuilt; others preserved ---
-        assert forall|cid: CursorId| #[trigger] self.cursors.dom().contains(cid) implies {
-            &&& self.cursors[cid].list_own.inv()
-            &&& self.cursors[cid].inv_region(self.regions)
-        } by {
-            if cid == id {
-                assert(self.cursors[id].list_own == owner);
-                assert(self.cursors[id].index == n);
-                assert(owner.list.len() == old_self.cursors[id].list_own.list.len() - 1);
-            } else {
-                assert(old_self.cursors.dom().contains(cid));
-                assert(old_self.cursors[cid] == self.cursors[cid]);
-                assert(old_self.cursors[cid].list_own.inv());
-                assert(old_self.cursors[cid].inv_region(old_regions));
-                assert(self.cursors[cid].list_own.relate_region(old_regions));
-                assert(self.cursors[cid].list_own.list_id != old_list_id);
-                assert(self.cursors[cid].list_own.relate_region(self.regions));
-            }
-        };
+            // --- per-cursor: operating cursor rebuilt; others preserved ---
+            assert forall|cid: CursorId| #[trigger] self.cursors.dom().contains(cid) implies {
+                &&& self.cursors[cid].list_own.inv()
+                &&& self.cursors[cid].inv_region(self.regions)
+            } by {
+                if cid == id {
+                    assert(self.cursors[id].list_own == owner);
+                    assert(self.cursors[id].index == n);
+                    assert(owner.list.len() == old_self.cursors[id].list_own.list.len() - 1);
+                } else {
+                    assert(old_self.cursors.dom().contains(cid));
+                    assert(old_self.cursors[cid] == self.cursors[cid]);
+                    assert(old_self.cursors[cid].list_own.inv());
+                    assert(old_self.cursors[cid].inv_region(old_regions));
+                    assert(self.cursors[cid].list_own.relate_region(old_regions));
+                    assert(self.cursors[cid].list_own.list_id != old_list_id);
+                    assert(self.cursors[cid].list_own.relate_region(self.regions));
+                }
+            };
 
-        // --- cross list/cursor uniqueness ---
-        assert forall|id2: ListId, cid: CursorId|
-            self.lists.dom().contains(id2) && self.cursors.dom().contains(cid)
-                && self.lists[id2].list_id == self.cursors[cid].list_own.list_id
-                && self.lists[id2].list_id != 0 implies false by {
-            assert(old_self.lists.dom().contains(id2));
-            assert(old_self.lists[id2] == self.lists[id2]);
-            if cid == id {
-                assert(self.cursors[id].list_own.list_id == old_list_id);
-                assert(self.lists[id2].list_id != old_list_id);
-            } else {
-                assert(old_self.cursors.dom().contains(cid));
-                assert(old_self.cursors[cid] == self.cursors[cid]);
-            }
-        };
+            // --- cross list/cursor uniqueness ---
+            assert forall|id2: ListId, cid: CursorId|
+                self.lists.dom().contains(id2) && self.cursors.dom().contains(cid)
+                    && self.lists[id2].list_id == self.cursors[cid].list_own.list_id
+                    && self.lists[id2].list_id != 0 implies false by {
+                assert(old_self.lists.dom().contains(id2));
+                assert(old_self.lists[id2] == self.lists[id2]);
+                if cid == id {
+                    assert(self.cursors[id].list_own.list_id == old_list_id);
+                    assert(self.lists[id2].list_id != old_list_id);
+                } else {
+                    assert(old_self.cursors.dom().contains(cid));
+                    assert(old_self.cursors[cid] == self.cursors[cid]);
+                }
+            };
 
-        // --- cursor×cursor uniqueness ---
-        assert forall|cid1: CursorId, cid2: CursorId|
-            self.cursors.dom().contains(cid1) && self.cursors.dom().contains(cid2)
-                && self.cursors[cid1].list_own.list_id == self.cursors[cid2].list_own.list_id
-                && self.cursors[cid1].list_own.list_id != 0 implies cid1 == cid2 by {
-            assert(old_self.cursors.dom().contains(cid1));
-            assert(old_self.cursors.dom().contains(cid2));
-            assert(self.cursors[cid1].list_own.list_id == old_self.cursors[cid1].list_own.list_id);
-            assert(self.cursors[cid2].list_own.list_id == old_self.cursors[cid2].list_own.list_id);
-        };
+            // --- cursor×cursor uniqueness ---
+            assert forall|cid1: CursorId, cid2: CursorId|
+                self.cursors.dom().contains(cid1) && self.cursors.dom().contains(cid2)
+                    && self.cursors[cid1].list_own.list_id == self.cursors[cid2].list_own.list_id
+                    && self.cursors[cid1].list_own.list_id != 0 implies cid1 == cid2 by {
+                assert(old_self.cursors.dom().contains(cid1));
+                assert(old_self.cursors.dom().contains(cid2));
+                assert(self.cursors[cid1].list_own.list_id
+                    == old_self.cursors[cid1].list_own.list_id);
+                assert(self.cursors[cid2].list_own.list_id
+                    == old_self.cursors[cid2].list_own.list_id);
+            };
 
-        // --- loose-internal slot disjointness ---
-        assert forall|l1: LooseId, l2: LooseId|
-            self.loose.dom().contains(l1) && self.loose.dom().contains(l2)
-                && self.loose[l1].slot_index == self.loose[l2].slot_index implies l1 == l2 by {
-            if l1 == new_loose && l2 != new_loose {
-                assert(old_self.loose.dom().contains(l2));
-                assert(self.loose[l2].slot_index != popped_idx);
-            } else if l2 == new_loose && l1 != new_loose {
-                assert(old_self.loose.dom().contains(l1));
-                assert(self.loose[l1].slot_index != popped_idx);
-            } else if l1 != new_loose && l2 != new_loose {
-                assert(old_self.loose.dom().contains(l1));
-                assert(old_self.loose.dom().contains(l2));
-            }
-        };
-        new_loose
+            // --- loose-internal slot disjointness ---
+            assert forall|l1: LooseId, l2: LooseId|
+                self.loose.dom().contains(l1) && self.loose.dom().contains(l2)
+                    && self.loose[l1].slot_index == self.loose[l2].slot_index implies l1 == l2 by {
+                if l1 == new_loose && l2 != new_loose {
+                    assert(old_self.loose.dom().contains(l2));
+                    assert(self.loose[l2].slot_index != popped_idx);
+                } else if l2 == new_loose && l1 != new_loose {
+                    assert(old_self.loose.dom().contains(l1));
+                    assert(self.loose[l1].slot_index != popped_idx);
+                } else if l1 != new_loose && l2 != new_loose {
+                    assert(old_self.loose.dom().contains(l1));
+                    assert(old_self.loose.dom().contains(l2));
+                }
+            };
+            Option::Some(new_loose)
+        }
     }
 }
 

--- a/ostd/specs/mm/embedding/mod.rs
+++ b/ostd/specs/mm/embedding/mod.rs
@@ -1101,19 +1101,13 @@ pub open spec fn op_pre<'rcu>(s: VmStore<'rcu>, op: Op) -> bool {
             s.segments,
             s.frames[fid].paddr,
         ) == 0,
-        // `Segment::from_unused`: aligned, in-bound, non-empty range;
-        // every frame in `range` is currently UNUSED (so we can
-        // allocate fresh references). The UNUSED condition is what
-        // `accounting_inv` clause 1 ⟹ no users gives us at the slot
-        // level; combined with `structural_inv`'s slot-perm coverage,
-        // it discharges the `segment_from_unused_embedded` axiom's
-        // requires verbatim.
-        Op::SegmentFromUnused { range } => range.start % PAGE_SIZE == 0 && range.end % PAGE_SIZE
-            == 0 && range.start < range.end && range.end <= MAX_PADDR && forall|paddr: Paddr|
-            #![trigger frame_to_index(paddr)]
-            (range.start <= paddr < range.end && paddr % PAGE_SIZE == 0)
-                ==> s.regions.slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
-                == REF_COUNT_UNUSED,
+        // `Segment::from_unused`: no precondition. The exec returns `Err`
+        // (NotAligned/OutOfBound) or rolls back a partial allocation when
+        // a frame in `range` is not free, leaving `regions` unchanged in
+        // every failure case; `step_segment_from_unused` branches
+        // internally on success (aligned + in-bound + non-empty +
+        // every covered slot UNUSED) and is a no-op otherwise.
+        Op::SegmentFromUnused { range: _ } => true,
         // `Segment` drop: id-existence + range well-formedness is
         // satisfied by every registered `SegmentEntry`; the per-slot
         // SHARED+Frame conditions are derived inside `step_segment_drop`
@@ -1148,17 +1142,13 @@ pub open spec fn op_pre<'rcu>(s: VmStore<'rcu>, op: Op) -> bool {
             (sub_range.start <= paddr < sub_range.end && paddr % PAGE_SIZE == 0)
                 ==> s.regions.slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() + 1
                 < REF_COUNT_MAX,
-        // `UniqueFrame::from_unused`: the target slot is in-bound,
-        // managed, and genuinely free — `usage is Unused` (the exec
-        // precondition) AND `rc == REF_COUNT_UNUSED` (which delivers the
-        // accounting "no users" facts needed to re-establish clause 0 at
-        // the freshly-UNIQUE slot). A fresh allocator frame satisfies
-        // both.
-        Op::UniqueFromUnused { paddr } => has_safe_slot(paddr) && s.regions.slots.contains_key(
-            frame_to_index(paddr),
-        ) && s.regions.slot_owners[frame_to_index(paddr)].usage is Unused
-            && s.regions.slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
-            == REF_COUNT_UNUSED,
+        // `UniqueFrame::from_unused`: no precondition (mirrors
+        // `FrameFromUnused`). The exec returns `Err` and leaves the slot
+        // untouched unless the target is genuinely a free frame slot;
+        // `step_unique_from_unused` branches internally on that condition
+        // (`has_safe_slot` + slot managed + `usage is Unused` +
+        // `rc == REF_COUNT_UNUSED`) and both outcomes preserve `s.inv()`.
+        Op::UniqueFromUnused { paddr: _ } => true,
         // `UniqueFrame` drop: id-existence. The per-slot UNIQUE / in_list
         // / storage / paths-empty teardown preconditions are derived
         // inside `step_unique_drop` from `s.inv()` (the structural
@@ -2856,192 +2846,198 @@ proof fn step_frame_drop<'rcu>(tracked s: &mut VmStore<'rcu>, fid: FrameId)
 proof fn step_segment_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, range: Range<Paddr>)
     requires
         old(s).inv(),
-        range.start % PAGE_SIZE == 0,
-        range.end % PAGE_SIZE == 0,
-        range.start < range.end,
-        range.end <= MAX_PADDR,
-        forall|paddr: Paddr|
-            #![trigger frame_to_index(paddr)]
-            (range.start <= paddr < range.end && paddr % PAGE_SIZE == 0) ==> old(
-                s,
-            ).regions.slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
-                == REF_COUNT_UNUSED,
     ensures
         final(s).inv(),
 {
-    let ghost old_regions = s.regions;
-    let ghost old_frames = s.frames;
-    let ghost old_segments = s.segments;
-    // Slot-perm coverage in `range` follows from structural_inv (every
-    // `idx < max_meta_slots()` has `slots.contains_key(idx)`).
-    assert forall|paddr: Paddr|
+    // Exec `Segment::from_unused` returns `Err` (NotAligned/OutOfBound)
+    // or rolls back its partial allocation (when some frame in `range`
+    // is not free), leaving `regions` unchanged in every failure case.
+    // Only an aligned, in-bound, non-empty range whose every covered
+    // slot is genuinely UNUSED produces a fresh segment; the step
+    // branches on that condition and is a no-op otherwise.
+    if range.start % PAGE_SIZE == 0 && range.end % PAGE_SIZE == 0 && range.start < range.end
+        && range.end <= MAX_PADDR && (forall|paddr: Paddr|
         #![trigger frame_to_index(paddr)]
-        (range.start <= paddr < range.end && paddr % PAGE_SIZE
-            == 0) implies s.regions.slots.contains_key(frame_to_index(paddr)) by {
-        s.regions.inv_implies_correct_addr(paddr);
-    };
-    let tracked res = segment::from_unused_step(&mut s.regions, range);
-    match res {
-        Option::Some(entry) => {
-            let ghost id = fresh_segment_id(s.segments);
-            lemma_fresh_segment_id_not_in_dom(s.segments);
-            s.insert_segment(id, entry);
-            // Discharge accounting_inv on the post-state.
-            // Per-slot reasoning:
-            //   - Slot in `range`: pre rc=UNUSED ⟹ pre H=0, pre cover=0
-            //     (pre clause 1). Post rc=1, post H=0 (frames unchanged),
-            //     post cover=1 (one new segment covers this paddr).
-            //     Equation: post rc == post H + post paths + post cover
-            //                == 0 + 0 + 1 == 1. ✓
-            //   - Slot outside `range`: fully preserved (axiom); segments
-            //     gained one entry whose range doesn't cover this paddr,
-            //     so cover unchanged. Accounting carries from pre.
-            assert forall|idx: usize|
-                #![trigger s.regions.slot_owners[idx]]
-                idx < max_meta_slots() && s.regions.slot_owners[idx].inner_perms.ref_count.value()
-                    == REF_COUNT_UNUSED implies handle_count(s.frames, idx) == 0
-                && s.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
-                s.segments,
-                index_to_frame(idx),
-            ) == 0 by {
-                let paddr = index_to_frame(idx);
-                // Round-trip: idx < max ⟹ paddr aligned, in-bound.
-                assert(paddr == (idx * PAGE_SIZE) as usize);
-                assert(paddr % PAGE_SIZE == 0);
-                assert(frame_to_index(paddr) == idx);
-                if range.start <= paddr < range.end {
-                    // Slot in range: post rc=1 ≠ UNUSED — contradiction.
-                    assert(false);
-                } else {
-                    // Slot outside range: fully preserved by axiom.
-                    assert(s.regions.slot_owners[idx] == old_regions.slot_owners[idx]);
-                    // segments gained one entry; cover at this paddr is
-                    // the same as before (entry's range doesn't cover paddr).
-                    assert(!(entry.range.start <= paddr < entry.range.end));
-                    lemma_segment_cover_insert_outside(old_segments, id, entry, paddr);
-                }
-            };
-            assert forall|idx: usize|
-                #![trigger s.regions.slot_owners[idx]]
-                idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
-                    && s.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-                    && s.regions.slot_owners[idx].inner_perms.ref_count.value()
-                    != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
-                || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
-                s.segments,
-                index_to_frame(idx),
-            ) > 0 by {
-                let paddr = index_to_frame(idx);
-                assert(paddr == (idx * PAGE_SIZE) as usize);
-                assert(paddr % PAGE_SIZE == 0);
-                assert(frame_to_index(paddr) == idx);
-                if range.start <= paddr < range.end {
-                    assert(entry.range == range);
-                    lemma_segment_cover_insert_inside(old_segments, id, entry, paddr);
-                } else {
-                    assert(s.regions.slot_owners[idx] == old_regions.slot_owners[idx]);
-                    assert(!(entry.range.start <= paddr < entry.range.end));
-                    lemma_segment_cover_insert_outside(old_segments, id, entry, paddr);
-                }
-            };
-            assert forall|idx: usize|
-                #![trigger s.regions.slot_owners[idx]]
-                idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame && (
-                handle_count(s.frames, idx) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0
-                    || segment_cover_count(s.segments, index_to_frame(idx)) > 0) implies {
-                let so = s.regions.slot_owners[idx];
-                let rc = so.inner_perms.ref_count.value();
-                &&& rc != REF_COUNT_UNUSED
-                &&& rc != REF_COUNT_UNIQUE
-                &&& rc == handle_count(s.frames, idx) + so.paths_in_pt.len() + segment_cover_count(
+        (range.start <= paddr < range.end && paddr % PAGE_SIZE == 0)
+            ==> s.regions.slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
+            == REF_COUNT_UNUSED) {
+        let ghost old_regions = s.regions;
+        let ghost old_frames = s.frames;
+        let ghost old_segments = s.segments;
+        // Slot-perm coverage in `range` follows from structural_inv (every
+        // `idx < max_meta_slots()` has `slots.contains_key(idx)`).
+        assert forall|paddr: Paddr|
+            #![trigger frame_to_index(paddr)]
+            (range.start <= paddr < range.end && paddr % PAGE_SIZE
+                == 0) implies s.regions.slots.contains_key(frame_to_index(paddr)) by {
+            s.regions.inv_implies_correct_addr(paddr);
+        };
+        let tracked res = segment::from_unused_step(&mut s.regions, range);
+        match res {
+            Option::Some(entry) => {
+                let ghost id = fresh_segment_id(s.segments);
+                lemma_fresh_segment_id_not_in_dom(s.segments);
+                s.insert_segment(id, entry);
+                // Discharge accounting_inv on the post-state.
+                // Per-slot reasoning:
+                //   - Slot in `range`: pre rc=UNUSED ⟹ pre H=0, pre cover=0
+                //     (pre clause 1). Post rc=1, post H=0 (frames unchanged),
+                //     post cover=1 (one new segment covers this paddr).
+                //     Equation: post rc == post H + post paths + post cover
+                //                == 0 + 0 + 1 == 1. ✓
+                //   - Slot outside `range`: fully preserved (axiom); segments
+                //     gained one entry whose range doesn't cover this paddr,
+                //     so cover unchanged. Accounting carries from pre.
+                assert forall|idx: usize|
+                    #![trigger s.regions.slot_owners[idx]]
+                    idx < max_meta_slots()
+                        && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+                        == REF_COUNT_UNUSED implies handle_count(s.frames, idx) == 0
+                    && s.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
                     s.segments,
                     index_to_frame(idx),
-                )
-                &&& so.inner_perms.storage.is_init()
-            } by {
-                let paddr = index_to_frame(idx);
-                assert(paddr == (idx * PAGE_SIZE) as usize);
-                assert(paddr % PAGE_SIZE == 0);
-                assert(frame_to_index(paddr) == idx);
-                if range.start <= paddr < range.end {
-                    assert(entry.range == range);
-                    lemma_segment_cover_insert_inside(old_segments, id, entry, paddr);
-                    // H == 0 at idx because pre UNUSED ⟹ pre H == 0
-                    // (pre clause 1) and frames unchanged.
-                    assert(handle_count(s.frames, idx) == 0);
-                } else {
-                    assert(s.regions.slot_owners[idx] == old_regions.slot_owners[idx]);
-                    assert(!(entry.range.start <= paddr < entry.range.end));
-                    lemma_segment_cover_insert_outside(old_segments, id, entry, paddr);
-                }
-            };
-            // Discharge structural_inv's `in_list == 0` clause.
-            assert forall|idx: usize|
-                idx
-                    < max_meta_slots() implies #[trigger] s.regions.slot_owners[idx].inner_perms.in_list.value()
-                == 0 by {
-                let paddr = index_to_frame(idx);
-                assert(paddr == (idx * PAGE_SIZE) as usize);
-                assert(paddr % PAGE_SIZE == 0);
-                assert(frame_to_index(paddr) == idx);
-                if range.start <= paddr < range.end {
-                    // Axiom: in_list == 0 post for in-range slots.
-                } else {
-                    // Outside: fully preserved.
-                    assert(s.regions.slot_owners[idx] == old_regions.slot_owners[idx]);
-                }
-            };
-            // structural FrameId⟹Frame-usage: every existing fid's
-            // slot's usage preserved. Frame-usage slots are non-UNUSED
-            // pre (clause 4), so they're outside `range` (which is all
-            // UNUSED pre). Axiom fully preserves outside-range slots.
-            assert forall|fid_other: FrameId| #[trigger]
-                s.frames.dom().contains(fid_other) implies s.regions.slot_owners[frame_to_index(
-                s.frames[fid_other].paddr,
-            )].usage == PageUsage::Frame by {
-                let other_idx = frame_to_index(s.frames[fid_other].paddr);
-                let other_paddr = index_to_frame(other_idx);
-                // pre fid_other's slot usage == Frame from old structural.
-                assert(old_regions.slot_owners[other_idx].usage == PageUsage::Frame);
-                // pre rc != UNUSED at fid_other's slot (clause 4 + H>=1).
-                assert(old_frames.dom().filter(
-                    |gid: FrameId| frame_to_index(old_frames[gid].paddr) == other_idx,
-                ).contains(fid_other));
-                assert(handle_count(old_frames, other_idx) >= 1);
-                assert(old_regions.slot_owners[other_idx].inner_perms.ref_count.value()
-                    != REF_COUNT_UNUSED);
-                // pre rc != UNUSED ⟹ paddr not in `range` (range slots are
-                // all UNUSED).
-                // ⟹ axiom preserves the slot fully.
-                assert(s.regions.slot_owners[other_idx] == old_regions.slot_owners[other_idx]);
-            };
-            // Discharge the structural unique-entry validity clause. A
-            // UNIQUE slot is `usage == Frame` at `rc == REF_COUNT_UNIQUE`
-            // (`!= UNUSED`), so it is not in the freshly-allocated `range`
-            // (all-UNUSED) and the axiom preserves it fully.
-            assert(s.unique_frames == old(s).unique_frames);
-            assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
-                let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
-                &&& so.usage == PageUsage::Frame
-                &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
-                &&& so.inner_perms.in_list.value() == 0
-                &&& so.paths_in_pt.is_empty()
-            } by {
-                let u_idx = frame_to_index(s.unique_frames[u].paddr);
-                assert(old(s).unique_frames.dom().contains(u));
-                // Old UNIQUE validity at `u`.
-                assert(old_regions.slot_owners[u_idx].inner_perms.ref_count.value()
-                    == REF_COUNT_UNIQUE);
-                assert(old_regions.slot_owners[u_idx].inner_perms.ref_count.value()
-                    != REF_COUNT_UNUSED);
-                // rc != UNUSED ⟹ not in `range` ⟹ slot preserved.
-                assert(s.regions.slot_owners[u_idx] == old_regions.slot_owners[u_idx]);
-            };
-        },
-        Option::None => {
-            assert(s.regions == old_regions);
-            assert(s.segments == old_segments);
-        },
+                ) == 0 by {
+                    let paddr = index_to_frame(idx);
+                    // Round-trip: idx < max ⟹ paddr aligned, in-bound.
+                    assert(paddr == (idx * PAGE_SIZE) as usize);
+                    assert(paddr % PAGE_SIZE == 0);
+                    assert(frame_to_index(paddr) == idx);
+                    if range.start <= paddr < range.end {
+                        // Slot in range: post rc=1 ≠ UNUSED — contradiction.
+                        assert(false);
+                    } else {
+                        // Slot outside range: fully preserved by axiom.
+                        assert(s.regions.slot_owners[idx] == old_regions.slot_owners[idx]);
+                        // segments gained one entry; cover at this paddr is
+                        // the same as before (entry's range doesn't cover paddr).
+                        assert(!(entry.range.start <= paddr < entry.range.end));
+                        lemma_segment_cover_insert_outside(old_segments, id, entry, paddr);
+                    }
+                };
+                assert forall|idx: usize|
+                    #![trigger s.regions.slot_owners[idx]]
+                    idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
+                        && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+                        != REF_COUNT_UNUSED
+                        && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+                        != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
+                    || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
+                    s.segments,
+                    index_to_frame(idx),
+                ) > 0 by {
+                    let paddr = index_to_frame(idx);
+                    assert(paddr == (idx * PAGE_SIZE) as usize);
+                    assert(paddr % PAGE_SIZE == 0);
+                    assert(frame_to_index(paddr) == idx);
+                    if range.start <= paddr < range.end {
+                        assert(entry.range == range);
+                        lemma_segment_cover_insert_inside(old_segments, id, entry, paddr);
+                    } else {
+                        assert(s.regions.slot_owners[idx] == old_regions.slot_owners[idx]);
+                        assert(!(entry.range.start <= paddr < entry.range.end));
+                        lemma_segment_cover_insert_outside(old_segments, id, entry, paddr);
+                    }
+                };
+                assert forall|idx: usize|
+                    #![trigger s.regions.slot_owners[idx]]
+                    idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
+                        && (handle_count(s.frames, idx) > 0
+                        || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
+                        s.segments,
+                        index_to_frame(idx),
+                    ) > 0) implies {
+                    let so = s.regions.slot_owners[idx];
+                    let rc = so.inner_perms.ref_count.value();
+                    &&& rc != REF_COUNT_UNUSED
+                    &&& rc != REF_COUNT_UNIQUE
+                    &&& rc == handle_count(s.frames, idx) + so.paths_in_pt.len()
+                        + segment_cover_count(s.segments, index_to_frame(idx))
+                    &&& so.inner_perms.storage.is_init()
+                } by {
+                    let paddr = index_to_frame(idx);
+                    assert(paddr == (idx * PAGE_SIZE) as usize);
+                    assert(paddr % PAGE_SIZE == 0);
+                    assert(frame_to_index(paddr) == idx);
+                    if range.start <= paddr < range.end {
+                        assert(entry.range == range);
+                        lemma_segment_cover_insert_inside(old_segments, id, entry, paddr);
+                        // H == 0 at idx because pre UNUSED ⟹ pre H == 0
+                        // (pre clause 1) and frames unchanged.
+                        assert(handle_count(s.frames, idx) == 0);
+                    } else {
+                        assert(s.regions.slot_owners[idx] == old_regions.slot_owners[idx]);
+                        assert(!(entry.range.start <= paddr < entry.range.end));
+                        lemma_segment_cover_insert_outside(old_segments, id, entry, paddr);
+                    }
+                };
+                // Discharge structural_inv's `in_list == 0` clause.
+                assert forall|idx: usize|
+                    idx
+                        < max_meta_slots() implies #[trigger] s.regions.slot_owners[idx].inner_perms.in_list.value()
+                    == 0 by {
+                    let paddr = index_to_frame(idx);
+                    assert(paddr == (idx * PAGE_SIZE) as usize);
+                    assert(paddr % PAGE_SIZE == 0);
+                    assert(frame_to_index(paddr) == idx);
+                    if range.start <= paddr < range.end {
+                        // Axiom: in_list == 0 post for in-range slots.
+                    } else {
+                        // Outside: fully preserved.
+                        assert(s.regions.slot_owners[idx] == old_regions.slot_owners[idx]);
+                    }
+                };
+                // structural FrameId⟹Frame-usage: every existing fid's
+                // slot's usage preserved. Frame-usage slots are non-UNUSED
+                // pre (clause 4), so they're outside `range` (which is all
+                // UNUSED pre). Axiom fully preserves outside-range slots.
+                assert forall|fid_other: FrameId| #[trigger]
+                    s.frames.dom().contains(fid_other) implies s.regions.slot_owners[frame_to_index(
+                    s.frames[fid_other].paddr,
+                )].usage == PageUsage::Frame by {
+                    let other_idx = frame_to_index(s.frames[fid_other].paddr);
+                    let other_paddr = index_to_frame(other_idx);
+                    // pre fid_other's slot usage == Frame from old structural.
+                    assert(old_regions.slot_owners[other_idx].usage == PageUsage::Frame);
+                    // pre rc != UNUSED at fid_other's slot (clause 4 + H>=1).
+                    assert(old_frames.dom().filter(
+                        |gid: FrameId| frame_to_index(old_frames[gid].paddr) == other_idx,
+                    ).contains(fid_other));
+                    assert(handle_count(old_frames, other_idx) >= 1);
+                    assert(old_regions.slot_owners[other_idx].inner_perms.ref_count.value()
+                        != REF_COUNT_UNUSED);
+                    // pre rc != UNUSED ⟹ paddr not in `range` (range slots are
+                    // all UNUSED).
+                    // ⟹ axiom preserves the slot fully.
+                    assert(s.regions.slot_owners[other_idx] == old_regions.slot_owners[other_idx]);
+                };
+                // Discharge the structural unique-entry validity clause. A
+                // UNIQUE slot is `usage == Frame` at `rc == REF_COUNT_UNIQUE`
+                // (`!= UNUSED`), so it is not in the freshly-allocated `range`
+                // (all-UNUSED) and the axiom preserves it fully.
+                assert(s.unique_frames == old(s).unique_frames);
+                assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
+                    let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
+                    &&& so.usage == PageUsage::Frame
+                    &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+                    &&& so.inner_perms.in_list.value() == 0
+                    &&& so.paths_in_pt.is_empty()
+                } by {
+                    let u_idx = frame_to_index(s.unique_frames[u].paddr);
+                    assert(old(s).unique_frames.dom().contains(u));
+                    // Old UNIQUE validity at `u`.
+                    assert(old_regions.slot_owners[u_idx].inner_perms.ref_count.value()
+                        == REF_COUNT_UNIQUE);
+                    assert(old_regions.slot_owners[u_idx].inner_perms.ref_count.value()
+                        != REF_COUNT_UNUSED);
+                    // rc != UNUSED ⟹ not in `range` ⟹ slot preserved.
+                    assert(s.regions.slot_owners[u_idx] == old_regions.slot_owners[u_idx]);
+                };
+            },
+            Option::None => {
+                assert(s.regions == old_regions);
+                assert(s.segments == old_segments);
+            },
+        }
     }
 }
 
@@ -4084,194 +4080,195 @@ proof fn step_segment_slice<'rcu>(
 proof fn step_unique_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, paddr: Paddr)
     requires
         old(s).inv(),
-        has_safe_slot(paddr),
-        old(s).regions.slots.contains_key(frame_to_index(paddr)),
-        old(s).regions.slot_owners[frame_to_index(paddr)].usage is Unused,
-        old(s).regions.slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
-            == REF_COUNT_UNUSED,
     ensures
         final(s).inv(),
 {
-    let ghost old_regions = s.regions;
-    let ghost old_frames = s.frames;
-    let ghost old_segments = s.segments;
-    let ghost old_unique = s.unique_frames;
-    let ghost idx = frame_to_index(paddr);
+    // Exec `UniqueFrame::from_unused` returns `Err(GetFrameError)` and
+    // leaves the slot untouched unless the target is genuinely an unused
+    // frame slot; only the success branch mutates the store.
+    if has_safe_slot(paddr) && s.regions.slots.contains_key(frame_to_index(paddr))
+        && s.regions.slot_owners[frame_to_index(paddr)].usage is Unused
+        && s.regions.slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
+        == REF_COUNT_UNUSED {
+        let ghost old_regions = s.regions;
+        let ghost old_frames = s.frames;
+        let ghost old_segments = s.segments;
+        let ghost old_unique = s.unique_frames;
+        let ghost idx = frame_to_index(paddr);
 
-    // `idx` in range; `paddr` is its page base.
-    s.regions.inv_implies_correct_addr(paddr);
-    assert(s.regions.slot_owners.contains_key(idx));
-    assert(idx < max_meta_slots());
-    assert(index_to_frame(idx) == paddr);
+        // `idx` in range; `paddr` is its page base.
+        s.regions.inv_implies_correct_addr(paddr);
+        assert(s.regions.slot_owners.contains_key(idx));
+        assert(idx < max_meta_slots());
+        assert(index_to_frame(idx) == paddr);
 
-    // Pre "no users" facts at the UNUSED slot (accounting clause 1).
-    assert(handle_count(old_frames, idx) == 0);
-    assert(old_regions.slot_owners[idx].paths_in_pt.is_empty());
-    assert(segment_cover_count(old_segments, index_to_frame(idx)) == 0);
+        // Pre "no users" facts at the UNUSED slot (accounting clause 1).
+        assert(handle_count(old_frames, idx) == 0);
+        assert(old_regions.slot_owners[idx].paths_in_pt.is_empty());
+        assert(segment_cover_count(old_segments, index_to_frame(idx)) == 0);
 
-    // Transition the slot UNUSED → UNIQUE.
-    unique::unique_from_unused_embedded(&mut s.regions, paddr);
+        // Transition the slot UNUSED → UNIQUE.
+        unique::unique_from_unused_embedded(&mut s.regions, paddr);
 
-    // Register the fresh UniqueEntry at a fresh id.
-    let ghost uid = fresh_unique_id(s.unique_frames);
-    lemma_fresh_unique_id_not_in_dom(s.unique_frames);
-    let tracked entry = axiom_unique_entry_new(paddr);
-    s.insert_unique(uid, entry);
-    assert(s.unique_frames =~= old_unique.insert(uid, UniqueEntry { paddr }));
-    assert(s.frames == old_frames);
-    assert(s.segments == old_segments);
+        // Register the fresh UniqueEntry at a fresh id.
+        let ghost uid = fresh_unique_id(s.unique_frames);
+        lemma_fresh_unique_id_not_in_dom(s.unique_frames);
+        let tracked entry = axiom_unique_entry_new(paddr);
+        s.insert_unique(uid, entry);
+        assert(s.unique_frames =~= old_unique.insert(uid, UniqueEntry { paddr }));
+        assert(s.frames == old_frames);
+        assert(s.segments == old_segments);
 
-    // --- structural: in_list == 0 everywhere ---
-    assert forall|i: usize|
-        i < max_meta_slots() implies #[trigger] s.regions.slot_owners[i].inner_perms.in_list.value()
-        == 0 by {
-        if i != idx {
-            assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
-        }
-    };
-    // --- structural: FrameId ⟹ Frame-usage ---
-    assert forall|fid: FrameId| #[trigger]
-        s.frames.dom().contains(fid) implies s.regions.slot_owners[frame_to_index(
-        s.frames[fid].paddr,
-    )].usage == PageUsage::Frame by {
-        let other_idx = frame_to_index(s.frames[fid].paddr);
-        assert(old_frames.dom().contains(fid));
-        assert(old_regions.slot_owners[other_idx].usage == PageUsage::Frame);
-        if other_idx == idx {
-            // Pre `idx` was `Unused`-usage — no `FrameEntry` maps there.
-            assert(false);
-        }
-    };
-    // --- structural: segment-covered ⟹ Frame-usage ---
-    assert forall|sid: SegmentId, paddr_c: Paddr|
-        #![trigger s.segments.dom().contains(sid), frame_to_index(paddr_c)]
-        s.segments.dom().contains(sid) && s.segments[sid].range.start <= paddr_c
-            < s.segments[sid].range.end && paddr_c % PAGE_SIZE
-            == 0 implies s.regions.slot_owners[frame_to_index(paddr_c)].usage
-        == PageUsage::Frame by {
-        let cov_idx = frame_to_index(paddr_c);
-        assert(old_segments.dom().contains(sid));
-        assert(old_regions.slot_owners[cov_idx].usage == PageUsage::Frame);
-        if cov_idx == idx {
-            assert(false);
-        }
-    };
-    // --- structural: unique-entry validity ---
-    assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
-        let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
-        &&& so.usage == PageUsage::Frame
-        &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
-        &&& so.inner_perms.in_list.value() == 0
-        &&& so.paths_in_pt.is_empty()
-    } by {
-        let u_idx = frame_to_index(s.unique_frames[u].paddr);
-        if u == uid {
-            assert(s.unique_frames[u].paddr == paddr);
-            assert(u_idx == idx);
-        } else {
-            assert(old_unique.dom().contains(u));
-            assert(s.unique_frames[u] == old_unique[u]);
-            assert(old_regions.slot_owners[u_idx].inner_perms.ref_count.value()
-                == REF_COUNT_UNIQUE);
-            assert(u_idx != idx);
-            assert(s.regions.slot_owners[u_idx] == old_regions.slot_owners[u_idx]);
-        }
-    };
-    // --- structural: unique has_safe_slot ---
-    assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies has_safe_slot(
-        s.unique_frames[u].paddr,
-    ) by {
-        if u != uid {
-            assert(old_unique.dom().contains(u));
-        }
-    };
-    // --- structural: unique injectivity ---
-    assert forall|u1: UniqueId, u2: UniqueId|
-        #![trigger s.unique_frames.dom().contains(u1), s.unique_frames.dom().contains(u2)]
-        s.unique_frames.dom().contains(u1) && s.unique_frames.dom().contains(u2)
-            && s.unique_frames[u1].paddr == s.unique_frames[u2].paddr implies u1 == u2 by {
-        if u1 == uid && u2 != uid {
-            assert(old_unique.dom().contains(u2));
-            assert(s.unique_frames[u2].paddr == paddr);
-            assert(frame_to_index(s.unique_frames[u2].paddr) == idx);
-            assert(old_regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
-            assert(false);
-        } else if u2 == uid && u1 != uid {
-            assert(old_unique.dom().contains(u1));
-            assert(s.unique_frames[u1].paddr == paddr);
-            assert(frame_to_index(s.unique_frames[u1].paddr) == idx);
-            assert(old_regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
-            assert(false);
-        } else if u1 != uid && u2 != uid {
-            assert(old_unique.dom().contains(u1));
-            assert(old_unique.dom().contains(u2));
-        }
-    };
+        // --- structural: in_list == 0 everywhere ---
+        assert forall|i: usize|
+            i
+                < max_meta_slots() implies #[trigger] s.regions.slot_owners[i].inner_perms.in_list.value()
+            == 0 by {
+            if i != idx {
+                assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
+            }
+        };
+        // --- structural: FrameId ⟹ Frame-usage ---
+        assert forall|fid: FrameId| #[trigger]
+            s.frames.dom().contains(fid) implies s.regions.slot_owners[frame_to_index(
+            s.frames[fid].paddr,
+        )].usage == PageUsage::Frame by {
+            let other_idx = frame_to_index(s.frames[fid].paddr);
+            assert(old_frames.dom().contains(fid));
+            assert(old_regions.slot_owners[other_idx].usage == PageUsage::Frame);
+            if other_idx == idx {
+                // Pre `idx` was `Unused`-usage — no `FrameEntry` maps there.
+                assert(false);
+            }
+        };
+        // --- structural: segment-covered ⟹ Frame-usage ---
+        assert forall|sid: SegmentId, paddr_c: Paddr|
+            #![trigger s.segments.dom().contains(sid), frame_to_index(paddr_c)]
+            s.segments.dom().contains(sid) && s.segments[sid].range.start <= paddr_c
+                < s.segments[sid].range.end && paddr_c % PAGE_SIZE
+                == 0 implies s.regions.slot_owners[frame_to_index(paddr_c)].usage
+            == PageUsage::Frame by {
+            let cov_idx = frame_to_index(paddr_c);
+            assert(old_segments.dom().contains(sid));
+            assert(old_regions.slot_owners[cov_idx].usage == PageUsage::Frame);
+            if cov_idx == idx {
+                assert(false);
+            }
+        };
+        // --- structural: unique-entry validity ---
+        assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
+            let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
+            &&& so.usage == PageUsage::Frame
+            &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+            &&& so.inner_perms.in_list.value() == 0
+            &&& so.paths_in_pt.is_empty()
+        } by {
+            let u_idx = frame_to_index(s.unique_frames[u].paddr);
+            if u == uid {
+                assert(s.unique_frames[u].paddr == paddr);
+                assert(u_idx == idx);
+            } else {
+                assert(old_unique.dom().contains(u));
+                assert(s.unique_frames[u] == old_unique[u]);
+                assert(old_regions.slot_owners[u_idx].inner_perms.ref_count.value()
+                    == REF_COUNT_UNIQUE);
+                assert(u_idx != idx);
+                assert(s.regions.slot_owners[u_idx] == old_regions.slot_owners[u_idx]);
+            }
+        };
+        // --- structural: unique has_safe_slot ---
+        assert forall|u: UniqueId| #[trigger]
+            s.unique_frames.dom().contains(u) implies has_safe_slot(s.unique_frames[u].paddr) by {
+            if u != uid {
+                assert(old_unique.dom().contains(u));
+            }
+        };
+        // --- structural: unique injectivity ---
+        assert forall|u1: UniqueId, u2: UniqueId|
+            #![trigger s.unique_frames.dom().contains(u1), s.unique_frames.dom().contains(u2)]
+            s.unique_frames.dom().contains(u1) && s.unique_frames.dom().contains(u2)
+                && s.unique_frames[u1].paddr == s.unique_frames[u2].paddr implies u1 == u2 by {
+            if u1 == uid && u2 != uid {
+                assert(old_unique.dom().contains(u2));
+                assert(s.unique_frames[u2].paddr == paddr);
+                assert(frame_to_index(s.unique_frames[u2].paddr) == idx);
+                assert(old_regions.slot_owners[idx].inner_perms.ref_count.value()
+                    == REF_COUNT_UNIQUE);
+                assert(false);
+            } else if u2 == uid && u1 != uid {
+                assert(old_unique.dom().contains(u1));
+                assert(s.unique_frames[u1].paddr == paddr);
+                assert(frame_to_index(s.unique_frames[u1].paddr) == idx);
+                assert(old_regions.slot_owners[idx].inner_perms.ref_count.value()
+                    == REF_COUNT_UNIQUE);
+                assert(false);
+            } else if u1 != uid && u2 != uid {
+                assert(old_unique.dom().contains(u1));
+                assert(old_unique.dom().contains(u2));
+            }
+        };
 
-    // --- accounting clause 1: UNUSED ⟹ no users ---
-    assert forall|i: usize|
-        #![trigger s.regions.slot_owners[i]]
-        i < max_meta_slots() && s.regions.slot_owners[i].inner_perms.ref_count.value()
-            == REF_COUNT_UNUSED implies handle_count(s.frames, i) == 0
-        && s.regions.slot_owners[i].paths_in_pt.is_empty() && segment_cover_count(
-        s.segments,
-        index_to_frame(i),
-    ) == 0 by {
-        if i == idx {
-            // post rc at `idx` is UNIQUE, not UNUSED — antecedent false.
-            assert(false);
-        } else {
-            assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
-        }
-    };
-    // --- accounting clause 2: valid rc ⟹ active head ---
-    assert forall|i: usize|
-        #![trigger s.regions.slot_owners[i]]
-        i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame
-            && s.regions.slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-            && s.regions.slot_owners[i].inner_perms.ref_count.value()
-            != REF_COUNT_UNIQUE implies handle_count(s.frames, i) > 0
-        || s.regions.slot_owners[i].paths_in_pt.len() > 0 || segment_cover_count(
-        s.segments,
-        index_to_frame(i),
-    ) > 0 by {
-        if i == idx {
-            // post rc at `idx` is UNIQUE — antecedent false.
-            assert(false);
-        } else {
-            assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
-        }
-    };
-    // --- accounting clause 3: the rc equation ---
-    assert forall|i: usize|
-        #![trigger s.regions.slot_owners[i]]
-        i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame && (handle_count(
-            s.frames,
-            i,
-        ) > 0 || s.regions.slot_owners[i].paths_in_pt.len() > 0 || segment_cover_count(
+        // --- accounting clause 1: UNUSED ⟹ no users ---
+        assert forall|i: usize|
+            #![trigger s.regions.slot_owners[i]]
+            i < max_meta_slots() && s.regions.slot_owners[i].inner_perms.ref_count.value()
+                == REF_COUNT_UNUSED implies handle_count(s.frames, i) == 0
+            && s.regions.slot_owners[i].paths_in_pt.is_empty() && segment_cover_count(
             s.segments,
             index_to_frame(i),
-        ) > 0) implies {
-        let so = s.regions.slot_owners[i];
-        let rc = so.inner_perms.ref_count.value();
-        &&& rc != REF_COUNT_UNUSED
-        &&& rc != REF_COUNT_UNIQUE
-        &&& rc == handle_count(s.frames, i) + so.paths_in_pt.len() + segment_cover_count(
+        ) == 0 by {
+            if i == idx {
+                // post rc at `idx` is UNIQUE, not UNUSED — antecedent false.
+                assert(false);
+            } else {
+                assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
+            }
+        };
+        // --- accounting clause 2: valid rc ⟹ active head ---
+        assert forall|i: usize|
+            #![trigger s.regions.slot_owners[i]]
+            i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame
+                && s.regions.slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
+                && s.regions.slot_owners[i].inner_perms.ref_count.value()
+                != REF_COUNT_UNIQUE implies handle_count(s.frames, i) > 0
+            || s.regions.slot_owners[i].paths_in_pt.len() > 0 || segment_cover_count(
             s.segments,
             index_to_frame(i),
-        )
-        &&& so.inner_perms.storage.is_init()
-    } by {
-        if i == idx {
-            // `idx` is now UNIQUE with no users (H=P=cover=0) — the
-            // active-head antecedent is false, so this is vacuous.
-            assert(handle_count(s.frames, idx) == 0);
-            assert(s.regions.slot_owners[idx].paths_in_pt.is_empty());
-            assert(segment_cover_count(s.segments, index_to_frame(idx)) == 0);
-        } else {
-            assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
-        }
-    };
+        ) > 0 by {
+            if i == idx {
+                // post rc at `idx` is UNIQUE — antecedent false.
+                assert(false);
+            } else {
+                assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
+            }
+        };
+        // --- accounting clause 3: the rc equation ---
+        assert forall|i: usize|
+            #![trigger s.regions.slot_owners[i]]
+            i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame && (
+            handle_count(s.frames, i) > 0 || s.regions.slot_owners[i].paths_in_pt.len() > 0
+                || segment_cover_count(s.segments, index_to_frame(i)) > 0) implies {
+            let so = s.regions.slot_owners[i];
+            let rc = so.inner_perms.ref_count.value();
+            &&& rc != REF_COUNT_UNUSED
+            &&& rc != REF_COUNT_UNIQUE
+            &&& rc == handle_count(s.frames, i) + so.paths_in_pt.len() + segment_cover_count(
+                s.segments,
+                index_to_frame(i),
+            )
+            &&& so.inner_perms.storage.is_init()
+        } by {
+            if i == idx {
+                // `idx` is now UNIQUE with no users (H=P=cover=0) — the
+                // active-head antecedent is false, so this is vacuous.
+                assert(handle_count(s.frames, idx) == 0);
+                assert(s.regions.slot_owners[idx].paths_in_pt.is_empty());
+                assert(segment_cover_count(s.segments, index_to_frame(idx)) == 0);
+            } else {
+                assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
+            }
+        };
+    }
 }
 
 /// `Op::UniqueDrop` step. Tears down the exclusive handle `uid`: the

--- a/ostd/specs/mm/embedding/mod.rs
+++ b/ostd/specs/mm/embedding/mod.rs
@@ -131,17 +131,9 @@
 //!      `cover_count` is invariant under the partition.
 //!      [`lemma_segment_cover_split`] proves the per-paddr
 //!      invariance.
-//!    - **`clone`** — NOT modeled, pending exec fix. Today exec
-//!      `Segment::clone` bumps `rc` but not `raw_count` and doesn't
-//!      produce a new `SegmentOwner`, so the clone is un-droppable
-//!      from verified code. Planned fix (separate session):
-//!      generalise `Frame::from_raw` to `raw_count >= 1` + decrement;
-//!      weaken `SegmentOwner::relate_regions` to `raw_count >= 1`;
-//!      replace `RCClone for Segment` with an inherent `clone` that
-//!      returns `(Self, Tracked<SegmentOwner<M>>)` and per-frame
-//!      `from_in_use + ManuallyDrop::new`. Once it ships, the
-//!      embedding adds `Op::SegmentClone { sid }` that inserts a
-//!      fresh `SegmentEntry` mirroring `sid`'s range.
+//!    - **`clone`** — DONE. Produce a second handle covering the same
+//!      range as `sid`; per covered paddr `cover_count += 1` and
+//!      `rc += 1` (`H` unchanged), so the accounting equation chains.
 //!    - **`next`** — DONE. The conversion bridge between
 //!      segment-held forgotten references and user-held `Frame<M>`
 //!      handles. Per-paddr at the popped slot: `raw_count -= 1`,
@@ -150,42 +142,16 @@
 //!      lockstep because H and cover decrement/increment together;
 //!      structural `raw_count == cover_count` chains via
 //!      [`lemma_segment_cover_shrink_front`].
-//!    - **`slice`** — NOT modeled, deferred for the same reason as
-//!      `clone` (and probably HARDER, despite initial appearances).
-//!      Both APIs produce an un-droppable handle (no `SegmentOwner`
-//!      returned) and don't bump `raw_count`. A faithful fix
-//!      requires generalising `Frame::from_raw`'s precondition from
-//!      `raw_count <= 1` to `raw_count >= 1` (with decrement-not-
-//!      zero body) so that sliced/cloned segments — which produce
-//!      multiple forgotten refs at the same slot — can each be
-//!      drop-reclaimed. **An attempted exec fix in this session
-//!      revealed unanticipated cascade**: `borrow` / `borrow_paddr`
-//!      bridge through `lemma_from_raw_manuallydrop_general` which
-//!      assumes the single-forgotten-ref case, and the PT-node
-//!      `child_perms_embedding` invariant carries `raw_count <= 1`
-//!      without supplying a `>= 1` companion. Tightening one half
-//!      breaks the other. Properly resolving this requires either:
-//!      (a) per-handle ghost certificates (the `FrameCert` route
-//!          documented in the Item 2 future-work note above), or
-//!      (b) splitting `from_raw` into two variants — one for the
-//!          single-forgotten case (existing) and one for
-//!          multi-forgotten (new) — and threading the
-//!          discriminator through `SegmentOwner` so `drop` can pick
-//!          the right one.
-//!      Either path is half-day to multi-day work. `slice` and
-//!      `clone` should be tackled together when that engineering
-//!      effort is funded; the embedding side is ready to receive
-//!      a `cover_count + 1` / `raw_count + 1` Op as soon as the
-//!      exec ships the API.
+//!    - **`slice`** — DONE. Like `clone` but over a sub-range: insert a
+//!      fresh `SegmentEntry` covering `sub_range` and bump `cover_count`
+//!      / `rc` for each frame inside it. `clone` is the special case
+//!      `sub_range == sid`'s range.
 //!    - **`into_raw` / `from_raw`** — `pub(crate)` only in exec, so
 //!      the embedding can ignore them.
 pub mod cursor;
 pub mod frame;
 pub mod io;
 pub mod kvirt_store;
-// list_store deferred: depends on a 118-line-diverged linked_list_owners layer
-// (its `LinkedListOwner::inv` differs between main and upstream) — needs that
-// linked-list embedding reconciliation before it verifies.
 pub mod list_store;
 pub mod segment;
 pub mod trace;
@@ -992,16 +958,6 @@ pub enum Op {
     /// exactly one half). Removes `sid` from `s.segments`, inserts
     /// two fresh `SegmentEntry`s.
     SegmentSplit { sid: SegmentId, offset: usize },
-    // **Op::SegmentNext is NOT modeled.** It would be the
-    // conversion bridge between segment-held forgotten references
-    // and user-held Frame handles — at the popped paddr:
-    // `raw_count -= 1`, `cover_count -= 1`, `H += 1`, `rc` unchanged.
-    // The model is laid out in [`segment::segment_next_embedded`]
-    // (axiom present, proof-discharge scaffolded but ends in
-    // `assume(false)`); reaching a real `s.inv()` discharge needs
-    // SMT-chaining cleanup at the per-paddr assert-forall sites
-    // that this pass didn't finish. Tracked as future work alongside
-    // `SegmentSlice`.
     /// `Segment::next`: pop the front frame off `sid`'s range,
     /// producing a fresh `Frame<M>` handle (a new `FrameEntry`
     /// registered in `s.frames`). The segment's range shrinks by one
@@ -1026,56 +982,6 @@ pub enum Op {
     /// `sub_range` by 1. Clone is the special case `sub_range == sid`'s
     /// range.
     SegmentSlice { sid: SegmentId, sub_range: Range<Paddr> },
-    // **Op::SegmentSlice is NOT modeled — same exec gap as
-    // `SegmentClone`, plus weaker ensures.**
-    //
-    // Exec [`crate::mm::frame::Segment::slice`] does
-    // `inc_frame_ref_count` per frame in the sub-range (bumps `rc`
-    // only, not `raw_count`) and returns just `Self` — no
-    // `SegmentOwner`, so the sliced segment is un-droppable from
-    // verified code. Compounding this, its `ensures` only commits to
-    // `slots`/`slot_owners.dom()` preservation; the per-frame `rc`
-    // bumps aren't surfaced. A faithful embedding axiom would need
-    // both:
-    //   1. The same exec fix as `SegmentClone`
-    //      (`Frame::from_raw` precondition relaxation, weakened
-    //      `relate_regions`, owner-producing API).
-    //   2. Stronger exec ensures pinning the per-frame `rc`/
-    //      `raw_count` deltas at sliced paddrs.
-    //
-    // Once both ship, the embedding can add `Op::SegmentSlice {
-    // sid, sub_range }` that inserts a fresh `SegmentEntry` with the
-    // sub-range (per-paddr `cover_count += 1` inside sub-range,
-    // unchanged outside) and discharges accounting via the same
-    // shrink-from-front machinery used by `next`.
-    // **Op::SegmentClone is NOT modeled — pending exec fix.**
-    //
-    // Exec [`crate::mm::frame::Segment::clone`] today bumps `rc` per
-    // frame (via `inc_frame_ref_count`) but doesn't bump `raw_count`
-    // and doesn't produce a new `SegmentOwner`. The cloned `Segment`
-    // is therefore un-droppable from verified code: `Segment::drop`
-    // requires a `SegmentOwner` with `relate_regions` (currently
-    // pinning `raw_count == 1` per covered slot), and the clone path
-    // produces neither the owner nor the matching `raw_count` bump.
-    //
-    // The planned exec fix (own branch / session):
-    //   1. `Frame::from_raw`: generalise `raw_count <= 1` precondition
-    //      to `raw_count >= 1` and decrement (not zero) on call.
-    //   2. `SegmentOwner::relate_regions`: weaken `raw_count == 1`
-    //      to `raw_count >= 1`.
-    //   3. Remove `RCClone for Segment`; add inherent
-    //      `Segment::clone(&self, …) -> (Self, Tracked<SegmentOwner<M>>)`
-    //      whose body per-frame is `from_in_use + ManuallyDrop::new`
-    //      (bumping both `rc` and `raw_count`).
-    //   4. Rework `Segment::drop` / `Segment::next` loop invariants
-    //      for the `raw_count >= 1` form.
-    //
-    // Once the exec ships those, the embedding can add an `Op` variant
-    // that inserts a fresh `SegmentEntry` with the same range as `sid`
-    // and bumps the per-paddr `rc`/`raw_count` to match — the
-    // `accounting_inv` equation `rc == H + P + cover_count` chains
-    // naturally because both `rc` and `cover_count` increment together
-    // at each covered paddr.
     /// `UniqueFrame::from_unused`: allocate a fresh *exclusive* handle on
     /// a previously-unused slot. The slot transitions
     /// `usage == Unused, rc == UNUSED` → `usage == Frame, rc == UNIQUE`.

--- a/ostd/specs/mm/embedding/mod.rs
+++ b/ostd/specs/mm/embedding/mod.rs
@@ -1013,6 +1013,19 @@ pub enum Op {
     SegmentNext {
         sid: SegmentId,
     },
+    /// `Segment::clone`: produce a second handle covering the *same*
+    /// range as `sid`. Inserts a fresh `SegmentEntry` mirroring `sid`'s
+    /// range and bumps every covered frame's `rc` by 1 (Arc-style, via
+    /// `inc_frame_ref_count`). Per covered paddr: `cover_count += 1`,
+    /// `rc += 1`, `H` unchanged — the `accounting_inv` equation chains.
+    SegmentClone { sid: SegmentId },
+    /// `Segment::slice`: produce a handle covering the sub-range
+    /// `sub_range` (an absolute, page-aligned physical range contained
+    /// in `sid`'s range). Inserts a fresh `SegmentEntry` covering
+    /// `sub_range` and bumps the `rc` of every frame *inside*
+    /// `sub_range` by 1. Clone is the special case `sub_range == sid`'s
+    /// range.
+    SegmentSlice { sid: SegmentId, sub_range: Range<Paddr> },
     // **Op::SegmentSlice is NOT modeled — same exec gap as
     // `SegmentClone`, plus weaker ensures.**
     //
@@ -1212,6 +1225,24 @@ pub open spec fn op_pre<'rcu>(s: VmStore<'rcu>, op: Op) -> bool {
         // `Segment::next`: id-existence. Range well-formedness from
         // `structural_inv` (range.start < range.end + page-aligned).
         Op::SegmentNext { sid } => s.segments.dom().contains(sid),
+        Op::SegmentClone { sid } => s.segments.dom().contains(sid) && forall|paddr: Paddr|
+            #![trigger frame_to_index(paddr)]
+            (s.segments[sid].range.start <= paddr < s.segments[sid].range.end && paddr % PAGE_SIZE
+                == 0) ==> s.regions.slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
+                + 1 < REF_COUNT_MAX,
+        // `Segment::slice`: id-existence + the sub-range is a
+        // page-aligned, non-empty, absolute physical range contained in
+        // `sid`'s range (mirroring exec `slice`'s `assert!`s on the
+        // offset range), plus the same per-frame saturation freedom as
+        // clone over the sub-range.
+        Op::SegmentSlice { sid, sub_range } => s.segments.dom().contains(sid) && sub_range.start
+            % PAGE_SIZE == 0 && sub_range.end % PAGE_SIZE == 0 && s.segments[sid].range.start
+            <= sub_range.start && sub_range.start < sub_range.end && sub_range.end
+            <= s.segments[sid].range.end && forall|paddr: Paddr|
+            #![trigger frame_to_index(paddr)]
+            (sub_range.start <= paddr < sub_range.end && paddr % PAGE_SIZE == 0)
+                ==> s.regions.slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() + 1
+                < REF_COUNT_MAX,
         // `UniqueFrame::from_unused`: the target slot is in-bound,
         // managed, and genuinely free — `usage is Unused` (the exec
         // precondition) AND `rc == REF_COUNT_UNUSED` (which delivers the
@@ -1602,6 +1633,8 @@ pub proof fn step<'rcu>(tracked s: &mut VmStore<'rcu>, op: Op)
         Op::SegmentDrop { sid } => step_segment_drop(s, sid),
         Op::SegmentSplit { sid, offset } => step_segment_split(s, sid, offset),
         Op::SegmentNext { sid } => step_segment_next(s, sid),
+        Op::SegmentClone { sid } => step_segment_clone(s, sid),
+        Op::SegmentSlice { sid, sub_range } => step_segment_slice(s, sid, sub_range),
         Op::UniqueFromUnused { paddr } => step_unique_from_unused(s, paddr),
         Op::UniqueDrop { uid } => step_unique_drop(s, uid),
         Op::FromUnique { uid } => step_from_unique(s, uid),
@@ -3833,6 +3866,314 @@ proof fn step_segment_next<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
         };
         assert(s.regions.slot_owners[u_idx] == old_regions.slot_owners[u_idx]);
     };
+}
+
+proof fn step_segment_clone_range<'rcu>(
+    tracked s: &mut VmStore<'rcu>,
+    sid: SegmentId,
+    sub_range: Range<Paddr>,
+)
+    requires
+        old(s).inv(),
+        old(s).segments.dom().contains(sid),
+        sub_range.start % PAGE_SIZE == 0,
+        sub_range.end % PAGE_SIZE == 0,
+        old(s).segments[sid].range.start <= sub_range.start,
+        sub_range.start < sub_range.end,
+        sub_range.end <= old(s).segments[sid].range.end,
+        forall|paddr: Paddr|
+            #![trigger frame_to_index(paddr)]
+            (sub_range.start <= paddr < sub_range.end && paddr % PAGE_SIZE == 0) ==> old(
+                s,
+            ).regions.slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() + 1
+                < REF_COUNT_MAX,
+    ensures
+        final(s).inv(),
+{
+    let ghost old_regions = s.regions;
+    let ghost old_frames = s.frames;
+    let ghost old_segments = s.segments;
+    let ghost sid_range = s.segments[sid].range;
+    let ghost new_entry_ghost = SegmentEntry { range: sub_range };
+
+    // `sub_range ⊆ sid`'s range, and `sid`'s range is in-bound, so the
+    // new entry's range is well-formed (aligned / non-empty / bound).
+    assert(sid_range.end <= MAX_PADDR);
+    assert(sub_range.end <= MAX_PADDR);
+    assert(old_segments.dom().finite());
+
+    // Derive the clone axiom's per-frame preconditions from `s.inv()`:
+    // every paddr in `sub_range` is covered by `sid`, hence
+    // `usage == Frame` (structural covered⟹Frame) and `rc >= 1`
+    // (accounting active head: `cover_count >= 1`). The non-saturation
+    // `rc + 1 < REF_COUNT_MAX` comes from this fn's `requires`.
+    assert forall|paddr: Paddr|
+        #![trigger frame_to_index(paddr)]
+        (sub_range.start <= paddr < sub_range.end && paddr % PAGE_SIZE == 0) implies {
+        let so = old_regions.slot_owners[frame_to_index(paddr)];
+        &&& so.usage == PageUsage::Frame
+        &&& so.inner_perms.ref_count.value() >= 1
+        &&& so.inner_perms.ref_count.value() + 1 < REF_COUNT_MAX
+    } by {
+        // `paddr` is covered by `sid` (sub_range ⊆ sid's range).
+        assert(old_segments.dom().contains(sid));
+        assert(sid_range.start <= paddr < sid_range.end);
+        lemma_segment_cover_contains(old_segments, sid, paddr);
+        assert(segment_cover_count(old_segments, paddr) >= 1);
+        // Active head (cover > 0) ⟹ accounting equation gives rc >= cover >= 1.
+    };
+
+    // Bump `rc` at every frame in `sub_range`.
+    segment::segment_clone_embedded(&mut s.regions, sub_range);
+
+    // Insert the fresh covering entry at a fresh id.
+    let ghost sid2 = fresh_segment_id(s.segments);
+    lemma_fresh_segment_id_not_in_dom(s.segments);
+    assert(sid2 != sid);
+    let tracked new_entry = axiom_segment_entry_new(sub_range);
+    s.insert_segment(sid2, new_entry);
+    assert(new_entry =~= new_entry_ghost);
+    assert(s.segments =~= old_segments.insert(sid2, new_entry_ghost));
+    assert(s.frames == old_frames);
+
+    // --- per-paddr cover delta: +1 inside sub_range, unchanged outside ---
+    assert forall|paddr_c: Paddr|
+        paddr_c % PAGE_SIZE == 0 && sub_range.start <= paddr_c
+            < sub_range.end implies #[trigger] segment_cover_count(s.segments, paddr_c)
+        == segment_cover_count(old_segments, paddr_c) + 1 by {
+        lemma_segment_cover_insert_inside(old_segments, sid2, new_entry_ghost, paddr_c);
+    };
+    assert forall|paddr_c: Paddr|
+        paddr_c % PAGE_SIZE == 0 && !(sub_range.start <= paddr_c
+            < sub_range.end) implies #[trigger] segment_cover_count(s.segments, paddr_c)
+        == segment_cover_count(old_segments, paddr_c) by {
+        lemma_segment_cover_insert_outside(old_segments, sid2, new_entry_ghost, paddr_c);
+    };
+
+    // --- per-slot regions delta: usage / in_list preserved everywhere ---
+    // `usage` is preserved at every slot (inside: usage clause of the
+    // axiom; outside: full slot preservation).
+    assert forall|idx: usize|
+        idx < max_meta_slots() implies #[trigger] s.regions.slot_owners[idx].usage
+        == old_regions.slot_owners[idx].usage by {
+        let aligned = index_to_frame(idx);
+        assert(aligned == (idx * PAGE_SIZE) as usize);
+        assert(frame_to_index(aligned) == idx);
+        if sub_range.start <= aligned < sub_range.end {
+            // inside: axiom preserves usage at `aligned`.
+        } else {
+            assert(s.regions.slot_owners[idx] == old_regions.slot_owners[idx]);
+        }
+    };
+    // `in_list == 0` at every slot (preserved by the axiom both ways).
+    assert forall|idx: usize|
+        idx
+            < max_meta_slots() implies #[trigger] s.regions.slot_owners[idx].inner_perms.in_list.value()
+        == 0 by {
+        let aligned = index_to_frame(idx);
+        assert(aligned == (idx * PAGE_SIZE) as usize);
+        assert(frame_to_index(aligned) == idx);
+        if sub_range.start <= aligned < sub_range.end {
+            // inside: axiom preserves in_list at `aligned`.
+        } else {
+            assert(s.regions.slot_owners[idx] == old_regions.slot_owners[idx]);
+        }
+    };
+
+    // --- structural: segment-covered ⟹ Frame-usage ---
+    assert forall|sid_other: SegmentId, paddr_c: Paddr|
+        #![trigger
+            s.segments.dom().contains(sid_other),
+            frame_to_index(paddr_c)]
+        s.segments.dom().contains(sid_other) && s.segments[sid_other].range.start <= paddr_c
+            < s.segments[sid_other].range.end && paddr_c % PAGE_SIZE
+            == 0 implies s.regions.slot_owners[frame_to_index(paddr_c)].usage
+        == PageUsage::Frame by {
+        let cov_idx = frame_to_index(paddr_c);
+        if sid_other == sid2 {
+            // Covered by the new entry ⟹ in sub_range ⊆ sid's range.
+            assert(s.segments[sid2].range == sub_range);
+            assert(old_segments.dom().contains(sid));
+            assert(sid_range.start <= paddr_c < sid_range.end);
+            assert(old_regions.slot_owners[cov_idx].usage == PageUsage::Frame);
+            assert(paddr_c < sid_range.end);
+        } else {
+            assert(old_segments.dom().contains(sid_other));
+            assert(old_segments[sid_other] == s.segments[sid_other]);
+            assert(old_regions.slot_owners[cov_idx].usage == PageUsage::Frame);
+            assert(paddr_c < s.segments[sid_other].range.end);
+        }
+        // `cov_idx < max_meta_slots()` via `inv_implies_correct_addr`
+        // (`slot_owners.contains_key`) + `MetaRegionOwners::inv`'s
+        // biimplication. Then the universal usage-preservation above
+        // gives `s.regions` usage == old usage == Frame at cov_idx.
+        assert(has_safe_slot(paddr_c));
+        s.regions.inv_implies_correct_addr(paddr_c);
+        assert(s.regions.slot_owners.contains_key(cov_idx));
+    };
+
+    // --- structural: FrameId ⟹ Frame-usage (frames unchanged) ---
+    assert forall|fid_other: FrameId| #[trigger]
+        s.frames.dom().contains(fid_other) implies s.regions.slot_owners[frame_to_index(
+        s.frames[fid_other].paddr,
+    )].usage == PageUsage::Frame by {
+        let other_idx = frame_to_index(s.frames[fid_other].paddr);
+        assert(old_frames.dom().contains(fid_other));
+        assert(old_regions.slot_owners[other_idx].usage == PageUsage::Frame);
+        assert(has_safe_slot(s.frames[fid_other].paddr));
+        s.regions.inv_implies_correct_addr(s.frames[fid_other].paddr);
+        assert(s.regions.slot_owners.contains_key(other_idx));
+        // `other_idx < max_meta_slots()` (biimplication) ⟹ universal
+        // usage-preservation above gives Frame-usage at other_idx.
+    };
+
+    // --- accounting clause 1: UNUSED ⟹ no users ---
+    assert forall|idx: usize|
+        #![trigger s.regions.slot_owners[idx]]
+        idx < max_meta_slots() && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+            == REF_COUNT_UNUSED implies handle_count(s.frames, idx) == 0
+        && s.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
+        s.segments,
+        index_to_frame(idx),
+    ) == 0 by {
+        let aligned = index_to_frame(idx);
+        assert(aligned == (idx * PAGE_SIZE) as usize);
+        assert(frame_to_index(aligned) == idx);
+        if sub_range.start <= aligned < sub_range.end {
+            // post rc == pre rc + 1 < REF_COUNT_MAX < UNUSED. Antecedent false.
+            assert(false);
+        } else {
+            assert(s.regions.slot_owners[idx] == old_regions.slot_owners[idx]);
+        }
+    };
+    // --- accounting clause 2: valid rc ⟹ active head ---
+    assert forall|idx: usize|
+        #![trigger s.regions.slot_owners[idx]]
+        idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
+            && s.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
+            && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+            != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
+        || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
+        s.segments,
+        index_to_frame(idx),
+    ) > 0 by {
+        let aligned = index_to_frame(idx);
+        assert(aligned == (idx * PAGE_SIZE) as usize);
+        assert(frame_to_index(aligned) == idx);
+        if sub_range.start <= aligned < sub_range.end {
+            // cover_post >= cover_pre + 1 >= 1 > 0 ⟹ third disjunct.
+        } else {
+            assert(s.regions.slot_owners[idx] == old_regions.slot_owners[idx]);
+        }
+    };
+    // --- accounting clause 3: the rc equation ---
+    assert forall|idx: usize|
+        #![trigger s.regions.slot_owners[idx]]
+        idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame && (
+        handle_count(s.frames, idx) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0
+            || segment_cover_count(s.segments, index_to_frame(idx)) > 0) implies {
+        let so = s.regions.slot_owners[idx];
+        let rc = so.inner_perms.ref_count.value();
+        &&& rc != REF_COUNT_UNUSED
+        &&& rc != REF_COUNT_UNIQUE
+        &&& rc == handle_count(s.frames, idx) + so.paths_in_pt.len() + segment_cover_count(
+            s.segments,
+            index_to_frame(idx),
+        )
+        &&& so.inner_perms.storage.is_init()
+    } by {
+        let aligned = index_to_frame(idx);
+        assert(aligned == (idx * PAGE_SIZE) as usize);
+        assert(frame_to_index(aligned) == idx);
+        if sub_range.start <= aligned < sub_range.end {
+            // covered: rc += 1, cover += 1, H & P preserved. Pre was an
+            // active head (cover_pre >= 1), so the old equation applies.
+        } else {
+            assert(s.regions.slot_owners[idx] == old_regions.slot_owners[idx]);
+        }
+    };
+    // Discharge the structural unique-entry validity clause. A UNIQUE
+    // slot is `rc == REF_COUNT_UNIQUE` ⟹ uncovered (accounting:
+    // `cover_count > 0 ⟹ rc != UNIQUE`) ⟹ not in `sub_range` (⊆ `sid`'s
+    // range), so `segment_clone_embedded` preserves it fully.
+    assert(s.unique_frames == old(s).unique_frames);
+    assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
+        let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
+        &&& so.usage == PageUsage::Frame
+        &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+        &&& so.inner_perms.in_list.value() == 0
+        &&& so.paths_in_pt.is_empty()
+    } by {
+        let u_paddr = s.unique_frames[u].paddr;
+        let u_idx = frame_to_index(u_paddr);
+        assert(old(s).unique_frames.dom().contains(u));
+        assert(has_safe_slot(u_paddr));
+        s.regions.inv_implies_correct_addr(u_paddr);
+        assert(old_regions.slot_owners[u_idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
+        assert(old_regions.slot_owners[u_idx].usage == PageUsage::Frame);
+        assert(!(sub_range.start <= u_paddr < sub_range.end)) by {
+            if sub_range.start <= u_paddr < sub_range.end {
+                // u_paddr ∈ sub_range ⊆ sid_range ⟹ sid covers u_paddr.
+                assert(sid_range.start <= u_paddr < sid_range.end);
+                lemma_segment_cover_contains(old_segments, sid, u_paddr);
+            }
+        };
+        assert(s.regions.slot_owners[u_idx] == old_regions.slot_owners[u_idx]);
+    };
+}
+
+/// `Op::SegmentClone` step. Produces a second handle covering the same
+/// range as `sid` (a fresh `SegmentEntry` mirroring `sid`'s range, with
+/// every covered frame's `rc` bumped by 1).
+proof fn step_segment_clone<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
+    requires
+        old(s).inv(),
+        old(s).segments.dom().contains(sid),
+        forall|paddr: Paddr|
+            #![trigger frame_to_index(paddr)]
+            (old(s).segments[sid].range.start <= paddr < old(s).segments[sid].range.end && paddr
+                % PAGE_SIZE == 0) ==> old(s).regions.slot_owners[frame_to_index(
+                paddr,
+            )].inner_perms.ref_count.value() + 1 < REF_COUNT_MAX,
+    ensures
+        final(s).inv(),
+{
+    // Clone is `step_segment_clone_range` over `sid`'s whole range. The
+    // range's well-formedness (aligned / non-empty / in-bound) comes
+    // from `structural_inv`'s per-segment range clause.
+    let ghost r = s.segments[sid].range;
+    assert(r.start % PAGE_SIZE == 0);
+    assert(r.end % PAGE_SIZE == 0);
+    assert(r.start < r.end);
+    assert(r.end <= MAX_PADDR);
+    step_segment_clone_range(s, sid, r);
+}
+
+/// `Op::SegmentSlice` step. Produces a handle covering `sub_range`
+/// (⊆ `sid`'s range), bumping the `rc` of every frame inside it.
+proof fn step_segment_slice<'rcu>(
+    tracked s: &mut VmStore<'rcu>,
+    sid: SegmentId,
+    sub_range: Range<Paddr>,
+)
+    requires
+        old(s).inv(),
+        old(s).segments.dom().contains(sid),
+        sub_range.start % PAGE_SIZE == 0,
+        sub_range.end % PAGE_SIZE == 0,
+        old(s).segments[sid].range.start <= sub_range.start,
+        sub_range.start < sub_range.end,
+        sub_range.end <= old(s).segments[sid].range.end,
+        forall|paddr: Paddr|
+            #![trigger frame_to_index(paddr)]
+            (sub_range.start <= paddr < sub_range.end && paddr % PAGE_SIZE == 0) ==> old(
+                s,
+            ).regions.slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() + 1
+                < REF_COUNT_MAX,
+    ensures
+        final(s).inv(),
+{
+    step_segment_clone_range(s, sid, sub_range);
 }
 
 proof fn step_unique_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, paddr: Paddr)

--- a/ostd/specs/mm/embedding/mod.rs
+++ b/ostd/specs/mm/embedding/mod.rs
@@ -186,7 +186,7 @@ pub mod kvirt_store;
 // list_store deferred: depends on a 118-line-diverged linked_list_owners layer
 // (its `LinkedListOwner::inv` differs between main and upstream) — needs that
 // linked-list embedding reconciliation before it verifies.
-// pub mod list_store;
+pub mod list_store;
 pub mod segment;
 pub mod trace;
 pub mod unique;

--- a/ostd/specs/mm/embedding/mod.rs
+++ b/ostd/specs/mm/embedding/mod.rs
@@ -1128,7 +1128,7 @@ pub open spec fn op_pre<'rcu>(s: VmStore<'rcu>, op: Op) -> bool {
             #![trigger frame_to_index(paddr)]
             (s.segments[sid].range.start <= paddr < s.segments[sid].range.end && paddr % PAGE_SIZE
                 == 0) ==> s.regions.slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
-                + 1 < REF_COUNT_MAX,
+                + 1 <= REF_COUNT_MAX,
         // `Segment::slice`: id-existence + the sub-range is a
         // page-aligned, non-empty, absolute physical range contained in
         // `sid`'s range (mirroring exec `slice`'s `assert!`s on the
@@ -1141,7 +1141,7 @@ pub open spec fn op_pre<'rcu>(s: VmStore<'rcu>, op: Op) -> bool {
             #![trigger frame_to_index(paddr)]
             (sub_range.start <= paddr < sub_range.end && paddr % PAGE_SIZE == 0)
                 ==> s.regions.slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() + 1
-                < REF_COUNT_MAX,
+                <= REF_COUNT_MAX,
         // `UniqueFrame::from_unused`: no precondition (mirrors
         // `FrameFromUnused`). The exec returns `Err` and leaves the slot
         // untouched unless the target is genuinely a free frame slot;
@@ -3787,7 +3787,7 @@ proof fn step_segment_clone_range<'rcu>(
             (sub_range.start <= paddr < sub_range.end && paddr % PAGE_SIZE == 0) ==> old(
                 s,
             ).regions.slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() + 1
-                < REF_COUNT_MAX,
+                <= REF_COUNT_MAX,
     ensures
         final(s).inv(),
 {
@@ -3807,14 +3807,16 @@ proof fn step_segment_clone_range<'rcu>(
     // every paddr in `sub_range` is covered by `sid`, hence
     // `usage == Frame` (structural covered⟹Frame) and `rc >= 1`
     // (accounting active head: `cover_count >= 1`). The non-saturation
-    // `rc + 1 < REF_COUNT_MAX` comes from this fn's `requires`.
+    // `rc + 1 <= REF_COUNT_MAX` (i.e. `rc < REF_COUNT_MAX`, matching the
+    // exec `inc_frame_ref_count` saturation guard) comes from this fn's
+    // `requires`.
     assert forall|paddr: Paddr|
         #![trigger frame_to_index(paddr)]
         (sub_range.start <= paddr < sub_range.end && paddr % PAGE_SIZE == 0) implies {
         let so = old_regions.slot_owners[frame_to_index(paddr)];
         &&& so.usage == PageUsage::Frame
         &&& so.inner_perms.ref_count.value() >= 1
-        &&& so.inner_perms.ref_count.value() + 1 < REF_COUNT_MAX
+        &&& so.inner_perms.ref_count.value() + 1 <= REF_COUNT_MAX
     } by {
         // `paddr` is covered by `sid` (sub_range ⊆ sid's range).
         assert(old_segments.dom().contains(sid));
@@ -3941,7 +3943,7 @@ proof fn step_segment_clone_range<'rcu>(
         assert(aligned == (idx * PAGE_SIZE) as usize);
         assert(frame_to_index(aligned) == idx);
         if sub_range.start <= aligned < sub_range.end {
-            // post rc == pre rc + 1 < REF_COUNT_MAX < UNUSED. Antecedent false.
+            // post rc == pre rc + 1 <= REF_COUNT_MAX < UNUSED. Antecedent false.
             assert(false);
         } else {
             assert(s.regions.slot_owners[idx] == old_regions.slot_owners[idx]);
@@ -4035,7 +4037,7 @@ proof fn step_segment_clone<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
             (old(s).segments[sid].range.start <= paddr < old(s).segments[sid].range.end && paddr
                 % PAGE_SIZE == 0) ==> old(s).regions.slot_owners[frame_to_index(
                 paddr,
-            )].inner_perms.ref_count.value() + 1 < REF_COUNT_MAX,
+            )].inner_perms.ref_count.value() + 1 <= REF_COUNT_MAX,
     ensures
         final(s).inv(),
 {
@@ -4070,7 +4072,7 @@ proof fn step_segment_slice<'rcu>(
             (sub_range.start <= paddr < sub_range.end && paddr % PAGE_SIZE == 0) ==> old(
                 s,
             ).regions.slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() + 1
-                < REF_COUNT_MAX,
+                <= REF_COUNT_MAX,
     ensures
         final(s).inv(),
 {

--- a/ostd/specs/mm/embedding/mod.rs
+++ b/ostd/specs/mm/embedding/mod.rs
@@ -235,6 +235,10 @@ pub type FrameId = int;
 /// the store.
 pub type SegmentId = int;
 
+/// Logical identifier for a held [`crate::mm::frame::UniqueFrame`]
+/// handle in the store.
+pub type UniqueId = int;
+
 /// Per-Frame entry in the store. Represents one outstanding handle to
 /// the slot at `paddr` — i.e., one unit of refcount in
 /// `regions.slot_owners[frame_to_index(paddr)]`.
@@ -264,6 +268,17 @@ pub tracked struct FrameEntry {
 /// [`SegmentOwner::relate_regions`]: crate::specs::mm::frame::segment::SegmentOwner::relate_regions
 pub tracked struct SegmentEntry {
     pub range: Range<Paddr>,
+}
+
+/// Per-`UniqueFrame` entry in the store. Represents the sole exclusive
+/// handle to the slot at `paddr` — i.e., the slot is held at the
+/// `REF_COUNT_UNIQUE` sentinel with no shared users (no `FrameEntry`,
+/// no `SegmentEntry` coverage, no live PTE). At most one `UniqueEntry`
+/// exists per slot (enforced by [`VmStore::structural_inv`]'s
+/// injectivity clause), mirroring the exec exclusivity of
+/// `UniqueFrame<M>`.
+pub tracked struct UniqueEntry {
+    pub paddr: Paddr,
 }
 
 /// Number of outstanding `Segment` handles covering the frame slot
@@ -629,6 +644,7 @@ pub tracked struct VmStore<'rcu> {
     pub vm_ios: Map<VmIoId, VmIoEntry>,
     pub frames: Map<FrameId, FrameEntry>,
     pub segments: Map<SegmentId, SegmentEntry>,
+    pub unique_frames: Map<UniqueId, UniqueEntry>,
 }
 
 impl<'a, 'rcu> VmStore<'rcu> {
@@ -755,6 +771,36 @@ impl<'a, 'rcu> VmStore<'rcu> {
             self.segments.dom().contains(sid) && self.segments[sid].range.start <= paddr
                 < self.segments[sid].range.end && paddr % PAGE_SIZE == 0
                 ==> self.regions.slot_owners[frame_to_index(paddr)].usage == PageUsage::Frame
+        // `unique_frames.dom()` is finite (built by finitely many
+        // `insert_unique`), needed wherever the embedding reasons
+        // about the unique-handle set as a whole.
+        &&& self.unique_frames.dom().finite()
+        // Every registered `UniqueEntry`'s paddr is in-bound.
+        &&& forall|uid: UniqueId| #[trigger]
+            self.unique_frames.dom().contains(uid) ==> has_safe_slot(
+                self.unique_frames[uid].paddr,
+            )
+        // Every `UniqueEntry`'s slot is held exclusively: a `Frame`-usage
+        // slot at the `REF_COUNT_UNIQUE` sentinel, off the free-list
+        // (`in_list == 0`) and with no PTE mappings. (Storage-init is
+        // recovered on demand from `MetaSlotOwner::inv`'s UNIQUE branch.)
+        &&& forall|uid: UniqueId| #[trigger]
+            self.unique_frames.dom().contains(uid) ==> {
+                let so = self.regions.slot_owners[frame_to_index(self.unique_frames[uid].paddr)];
+                &&& so.usage == PageUsage::Frame
+                &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+                &&& so.inner_perms.in_list.value() == 0
+                &&& so.paths_in_pt.is_empty()
+            }
+            // At most one `UniqueEntry` per slot — the exclusivity of
+            // `UniqueFrame<M>`. Keeps `Op::UniqueDrop` well-defined: tearing
+            // down a unique slot cannot leave a second entry dangling at it.
+        &&& forall|uid1: UniqueId, uid2: UniqueId|
+            #![trigger
+                self.unique_frames.dom().contains(uid1),
+                self.unique_frames.dom().contains(uid2)]
+            self.unique_frames.dom().contains(uid1) && self.unique_frames.dom().contains(uid2)
+                && self.unique_frames[uid1].paddr == self.unique_frames[uid2].paddr ==> uid1 == uid2
     }
 
     /// Stage 5 / full #4 — EXACT reference-count accounting.
@@ -1017,6 +1063,26 @@ pub enum Op {
     // `accounting_inv` equation `rc == H + P + cover_count` chains
     // naturally because both `rc` and `cover_count` increment together
     // at each covered paddr.
+    /// `UniqueFrame::from_unused`: allocate a fresh *exclusive* handle on
+    /// a previously-unused slot. The slot transitions
+    /// `usage == Unused, rc == UNUSED` → `usage == Frame, rc == UNIQUE`.
+    /// Registers a [`UniqueEntry`] on success.
+    UniqueFromUnused { paddr: Paddr },
+    /// Drop a `UniqueFrame` handle. Tears the exclusive slot down
+    /// (`rc == UNIQUE` → `rc == UNUSED`), uninitialising its metadata
+    /// storage. Removes `uid` from `s.unique_frames`.
+    UniqueDrop { uid: UniqueId },
+    /// `Frame::from_unique`: convert the exclusive handle `uid` into a
+    /// shared `Frame`. The slot's `rc` drops `UNIQUE → 1`; the
+    /// `UniqueEntry` is consumed and a fresh `FrameEntry` registered
+    /// (`H: 0 → 1`).
+    FromUnique { uid: UniqueId },
+    /// `UniqueFrame::try_from_shared`: try to convert the shared handle
+    /// `fid` back into an exclusive one. Succeeds only when `fid` is the
+    /// sole reference (`rc == 1`): then `rc` rises `1 → UNIQUE`, the
+    /// `FrameEntry` is consumed and a fresh `UniqueEntry` registered.
+    /// Otherwise (`rc != 1`) the CAS fails and the store is unchanged.
+    TryFromShared { fid: FrameId },
 }
 
 /// Per-op precondition — the conjunction of facts about the store that
@@ -1146,6 +1212,29 @@ pub open spec fn op_pre<'rcu>(s: VmStore<'rcu>, op: Op) -> bool {
         // `Segment::next`: id-existence. Range well-formedness from
         // `structural_inv` (range.start < range.end + page-aligned).
         Op::SegmentNext { sid } => s.segments.dom().contains(sid),
+        // `UniqueFrame::from_unused`: the target slot is in-bound,
+        // managed, and genuinely free — `usage is Unused` (the exec
+        // precondition) AND `rc == REF_COUNT_UNUSED` (which delivers the
+        // accounting "no users" facts needed to re-establish clause 0 at
+        // the freshly-UNIQUE slot). A fresh allocator frame satisfies
+        // both.
+        Op::UniqueFromUnused { paddr } => has_safe_slot(paddr) && s.regions.slots.contains_key(
+            frame_to_index(paddr),
+        ) && s.regions.slot_owners[frame_to_index(paddr)].usage is Unused
+            && s.regions.slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
+            == REF_COUNT_UNUSED,
+        // `UniqueFrame` drop: id-existence. The per-slot UNIQUE / in_list
+        // / storage / paths-empty teardown preconditions are derived
+        // inside `step_unique_drop` from `s.inv()` (the structural
+        // unique-entry clause + `MetaSlotOwner::inv`'s UNIQUE branch).
+        Op::UniqueDrop { uid } => s.unique_frames.dom().contains(uid),
+        // `Frame::from_unique`: id-existence. The UNIQUE-slot facts are
+        // derived inside `step_from_unique` from `s.inv()`.
+        Op::FromUnique { uid } => s.unique_frames.dom().contains(uid),
+        // `UniqueFrame::try_from_shared`: id-existence. The step branches
+        // internally on whether `fid`'s slot is the sole reference
+        // (`rc == 1`); both outcomes preserve `s.inv()`.
+        Op::TryFromShared { fid } => s.frames.dom().contains(fid),
     }
 }
 
@@ -1174,6 +1263,7 @@ impl<'rcu> VmStore<'rcu> {
             final(self).vm_ios == old(self).vm_ios,
             final(self).frames == old(self).frames,
             final(self).segments == old(self).segments,
+            final(self).unique_frames == old(self).unique_frames,
             res == old(self).vm_spaces[vs],
             final(self).inv(),
     {
@@ -1195,6 +1285,7 @@ impl<'rcu> VmStore<'rcu> {
             final(self).vm_ios == old(self).vm_ios,
             final(self).frames == old(self).frames,
             final(self).segments == old(self).segments,
+            final(self).unique_frames == old(self).unique_frames,
             final(self).inv(),
     {
         self.vm_spaces.tracked_insert(vs, owner);
@@ -1213,6 +1304,7 @@ impl<'rcu> VmStore<'rcu> {
             final(self).vm_ios == old(self).vm_ios,
             final(self).frames == old(self).frames,
             final(self).segments == old(self).segments,
+            final(self).unique_frames == old(self).unique_frames,
             res == old(self).cursors[c],
             final(self).inv(),
     {
@@ -1238,6 +1330,7 @@ impl<'rcu> VmStore<'rcu> {
             final(self).vm_ios == old(self).vm_ios,
             final(self).frames == old(self).frames,
             final(self).segments == old(self).segments,
+            final(self).unique_frames == old(self).unique_frames,
             final(self).inv(),
     {
         self.cursors.tracked_insert(c, entry);
@@ -1256,6 +1349,7 @@ impl<'rcu> VmStore<'rcu> {
             final(self).vm_ios == old(self).vm_ios.remove(vio),
             final(self).frames == old(self).frames,
             final(self).segments == old(self).segments,
+            final(self).unique_frames == old(self).unique_frames,
             res == old(self).vm_ios[vio],
             final(self).inv(),
     {
@@ -1285,6 +1379,7 @@ impl<'rcu> VmStore<'rcu> {
             final(self).vm_ios == old(self).vm_ios.insert(vio, entry),
             final(self).frames == old(self).frames,
             final(self).segments == old(self).segments,
+            final(self).unique_frames == old(self).unique_frames,
             final(self).inv(),
     {
         self.vm_ios.tracked_insert(vio, entry);
@@ -1310,6 +1405,7 @@ impl<'rcu> VmStore<'rcu> {
             final(self).vm_ios == old(self).vm_ios,
             final(self).frames == old(self).frames.remove(fid),
             final(self).segments == old(self).segments,
+            final(self).unique_frames == old(self).unique_frames,
             res == old(self).frames[fid],
             final(self).structural_inv(),
     {
@@ -1342,9 +1438,52 @@ impl<'rcu> VmStore<'rcu> {
             final(self).vm_ios == old(self).vm_ios,
             final(self).frames == old(self).frames.insert(fid, entry),
             final(self).segments == old(self).segments,
+            final(self).unique_frames == old(self).unique_frames,
             final(self).structural_inv(),
     {
         self.frames.tracked_insert(fid, entry);
+    }
+
+    /// Removes the UniqueEntry at `uid` from the store. **Does NOT**
+    /// ensure `structural_inv` — the caller must pair this with the
+    /// regions UNIQUE→UNUSED teardown before observing `s.inv()`.
+    pub proof fn extract_unique(tracked &mut self, uid: UniqueId) -> (tracked res: UniqueEntry)
+        requires
+            old(self).unique_frames.dom().contains(uid),
+            old(self).unique_frames.dom().finite(),
+        ensures
+            final(self).regions == old(self).regions,
+            final(self).tlb_model == old(self).tlb_model,
+            final(self).vm_spaces == old(self).vm_spaces,
+            final(self).cursors == old(self).cursors,
+            final(self).vm_ios == old(self).vm_ios,
+            final(self).frames == old(self).frames,
+            final(self).segments == old(self).segments,
+            final(self).unique_frames == old(self).unique_frames.remove(uid),
+            res == old(self).unique_frames[uid],
+    {
+        self.unique_frames.tracked_remove(uid)
+    }
+
+    /// Inserts a UniqueEntry at a fresh id. **Does NOT** ensure
+    /// `structural_inv` — the caller must pair this with the regions
+    /// UNUSED→UNIQUE transition (via
+    /// [`unique::unique_from_unused_embedded`]) before observing
+    /// `s.inv()`.
+    pub proof fn insert_unique(tracked &mut self, uid: UniqueId, tracked entry: UniqueEntry)
+        requires
+            !old(self).unique_frames.dom().contains(uid),
+        ensures
+            final(self).regions == old(self).regions,
+            final(self).tlb_model == old(self).tlb_model,
+            final(self).vm_spaces == old(self).vm_spaces,
+            final(self).cursors == old(self).cursors,
+            final(self).vm_ios == old(self).vm_ios,
+            final(self).frames == old(self).frames,
+            final(self).segments == old(self).segments,
+            final(self).unique_frames == old(self).unique_frames.insert(uid, entry),
+    {
+        self.unique_frames.tracked_insert(uid, entry);
     }
 
     /// Removes the SegmentEntry at `sid` from the store. **Does NOT**
@@ -1364,6 +1503,7 @@ impl<'rcu> VmStore<'rcu> {
             final(self).vm_ios == old(self).vm_ios,
             final(self).frames == old(self).frames,
             final(self).segments == old(self).segments.remove(sid),
+            final(self).unique_frames == old(self).unique_frames,
             res == old(self).segments[sid],
     {
         self.segments.tracked_remove(sid)
@@ -1384,6 +1524,7 @@ impl<'rcu> VmStore<'rcu> {
             final(self).vm_ios == old(self).vm_ios,
             final(self).frames == old(self).frames,
             final(self).segments == old(self).segments.insert(sid, entry),
+            final(self).unique_frames == old(self).unique_frames,
     {
         self.segments.tracked_insert(sid, entry);
     }
@@ -1461,6 +1602,10 @@ pub proof fn step<'rcu>(tracked s: &mut VmStore<'rcu>, op: Op)
         Op::SegmentDrop { sid } => step_segment_drop(s, sid),
         Op::SegmentSplit { sid, offset } => step_segment_split(s, sid, offset),
         Op::SegmentNext { sid } => step_segment_next(s, sid),
+        Op::UniqueFromUnused { paddr } => step_unique_from_unused(s, paddr),
+        Op::UniqueDrop { uid } => step_unique_drop(s, uid),
+        Op::FromUnique { uid } => step_from_unique(s, uid),
+        Op::TryFromShared { fid } => step_try_from_shared(s, fid),
     }
 }
 
@@ -2261,6 +2406,45 @@ proof fn step_unmap<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId, len: usize
         let other_idx = frame_to_index(s.frames[fid_other].paddr);
         assert(s.regions.slot_owners[other_idx].usage == old_regions.slot_owners[other_idx].usage);
     };
+    // Discharge the structural unique-entry validity clause. Unmap never
+    // touches a UNIQUE slot: such a slot is `usage == Frame` with empty
+    // `paths_in_pt`, so the Frame rc-paths invariant (`post rc - post
+    // paths.len == pre rc - pre paths.len`, paths monotonically
+    // non-increasing) forces post `paths` empty and post `rc == pre rc
+    // == UNIQUE`; `usage` / `in_list` are preserved universally.
+    assert(s.unique_frames == old(s).unique_frames);
+    assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
+        let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
+        &&& so.usage == PageUsage::Frame
+        &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+        &&& so.inner_perms.in_list.value() == 0
+        &&& so.paths_in_pt.is_empty()
+    } by {
+        let u_idx = frame_to_index(s.unique_frames[u].paddr);
+        assert(old(s).unique_frames.dom().contains(u));
+        // Old validity at `u`.
+        assert(old_regions.slot_owners[u_idx].usage == PageUsage::Frame);
+        assert(old_regions.slot_owners[u_idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
+        assert(old_regions.slot_owners[u_idx].paths_in_pt.is_empty());
+        assert(old_regions.slot_owners[u_idx].inner_perms.in_list.value() == 0);
+        // `u_idx` is a managed slot.
+        assert(has_safe_slot(s.unique_frames[u].paddr));
+        s.regions.inv_implies_correct_addr(s.unique_frames[u].paddr);
+        assert(s.regions.slot_owners.contains_key(u_idx));
+        assert(u_idx < max_meta_slots());
+        assert(s.regions.slot_owners[u_idx].inv());
+        // usage / in_list preserved universally by the unmap axiom.
+        assert(s.regions.slot_owners[u_idx].usage == old_regions.slot_owners[u_idx].usage);
+        assert(s.regions.slot_owners[u_idx].inner_perms.in_list
+            == old_regions.slot_owners[u_idx].inner_perms.in_list);
+        // Frame rc-paths invariant: pre paths empty ⟹ post paths empty,
+        // post rc == pre rc == UNIQUE.
+        assert(s.regions.slot_owners[u_idx].paths_in_pt.len()
+            <= old_regions.slot_owners[u_idx].paths_in_pt.len());
+        assert(old_regions.slot_owners[u_idx].paths_in_pt.len() == 0);
+        assert(s.regions.slot_owners[u_idx].paths_in_pt =~= Set::empty());
+        assert(s.regions.slot_owners[u_idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
+    };
     s.insert_cursor(c, entry);
 }
 
@@ -2893,6 +3077,28 @@ proof fn step_segment_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, range: Ra
                 // ⟹ axiom preserves the slot fully.
                 assert(s.regions.slot_owners[other_idx] == old_regions.slot_owners[other_idx]);
             };
+            // Discharge the structural unique-entry validity clause. A
+            // UNIQUE slot is `usage == Frame` at `rc == REF_COUNT_UNIQUE`
+            // (`!= UNUSED`), so it is not in the freshly-allocated `range`
+            // (all-UNUSED) and the axiom preserves it fully.
+            assert(s.unique_frames == old(s).unique_frames);
+            assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
+                let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
+                &&& so.usage == PageUsage::Frame
+                &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+                &&& so.inner_perms.in_list.value() == 0
+                &&& so.paths_in_pt.is_empty()
+            } by {
+                let u_idx = frame_to_index(s.unique_frames[u].paddr);
+                assert(old(s).unique_frames.dom().contains(u));
+                // Old UNIQUE validity at `u`.
+                assert(old_regions.slot_owners[u_idx].inner_perms.ref_count.value()
+                    == REF_COUNT_UNIQUE);
+                assert(old_regions.slot_owners[u_idx].inner_perms.ref_count.value()
+                    != REF_COUNT_UNUSED);
+                // rc != UNUSED ⟹ not in `range` ⟹ slot preserved.
+                assert(s.regions.slot_owners[u_idx] == old_regions.slot_owners[u_idx]);
+            };
         },
         Option::None => {
             assert(s.regions == old_regions);
@@ -3154,6 +3360,35 @@ proof fn step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
         assert(old_regions.slot_owners[cov_idx].usage == PageUsage::Frame);
         // Axiom preserves usage universally.
     };
+    // Discharge the structural unique-entry validity clause. A UNIQUE
+    // slot is `rc == REF_COUNT_UNIQUE`, so by the accounting equation
+    // (`cover_count > 0 ⟹ rc != UNIQUE`) it is uncovered; hence outside
+    // the dropped segment's range, and the teardown axiom preserves it.
+    assert(s.unique_frames == old(s).unique_frames);
+    assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
+        let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
+        &&& so.usage == PageUsage::Frame
+        &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+        &&& so.inner_perms.in_list.value() == 0
+        &&& so.paths_in_pt.is_empty()
+    } by {
+        let u_paddr = s.unique_frames[u].paddr;
+        let u_idx = frame_to_index(u_paddr);
+        assert(old(s).unique_frames.dom().contains(u));
+        assert(has_safe_slot(u_paddr));
+        s.regions.inv_implies_correct_addr(u_paddr);
+        // Old UNIQUE validity at `u`.
+        assert(old_regions.slot_owners[u_idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
+        assert(old_regions.slot_owners[u_idx].usage == PageUsage::Frame);
+        // UNIQUE ⟹ uncovered ⟹ not in the dropped segment's range.
+        assert(!(range.start <= u_paddr < range.end)) by {
+            if range.start <= u_paddr < range.end {
+                lemma_segment_cover_contains(old_segments, sid, u_paddr);
+            }
+        };
+        // Outside range ⟹ teardown axiom preserves the slot fully.
+        assert(s.regions.slot_owners[u_idx] == old_regions.slot_owners[u_idx]);
+    };
 }
 
 /// `Op::SegmentSplit` step. Replaces `sid` with two fresh segment
@@ -3324,6 +3559,9 @@ proof fn step_segment_split<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId,
             paddr,
         );
     };
+    // `regions` is unchanged by split, so the structural unique-entry
+    // validity clause is preserved verbatim from `old(s).inv()`.
+    assert(s.unique_frames == old(s).unique_frames);
 }
 
 /// `Op::SegmentNext` step. Pops the front frame off `sid`'s range,
@@ -3571,6 +3809,829 @@ proof fn step_segment_next<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
             assert(s.regions.slot_owners[idx] == old_regions.slot_owners[idx]);
         }
     };
+    // Discharge the structural unique-entry validity clause. A UNIQUE
+    // slot is `rc == REF_COUNT_UNIQUE` ⟹ uncovered ⟹ not the popped
+    // (covered) front slot `target_idx`, so the pop axiom preserves it.
+    assert(s.unique_frames == old(s).unique_frames);
+    assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
+        let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
+        &&& so.usage == PageUsage::Frame
+        &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+        &&& so.inner_perms.in_list.value() == 0
+        &&& so.paths_in_pt.is_empty()
+    } by {
+        let u_paddr = s.unique_frames[u].paddr;
+        let u_idx = frame_to_index(u_paddr);
+        assert(old(s).unique_frames.dom().contains(u));
+        assert(has_safe_slot(u_paddr));
+        s.regions.inv_implies_correct_addr(u_paddr);
+        assert(old_regions.slot_owners[u_idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
+        assert(old_regions.slot_owners[u_idx].usage == PageUsage::Frame);
+        // The popped front slot is covered ⟹ rc != UNIQUE ⟹ != u_idx.
+        assert(u_idx != target_idx) by {
+            lemma_segment_cover_contains(old_segments, sid, paddr);
+        };
+        assert(s.regions.slot_owners[u_idx] == old_regions.slot_owners[u_idx]);
+    };
+}
+
+proof fn step_unique_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, paddr: Paddr)
+    requires
+        old(s).inv(),
+        has_safe_slot(paddr),
+        old(s).regions.slots.contains_key(frame_to_index(paddr)),
+        old(s).regions.slot_owners[frame_to_index(paddr)].usage is Unused,
+        old(s).regions.slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
+            == REF_COUNT_UNUSED,
+    ensures
+        final(s).inv(),
+{
+    let ghost old_regions = s.regions;
+    let ghost old_frames = s.frames;
+    let ghost old_segments = s.segments;
+    let ghost old_unique = s.unique_frames;
+    let ghost idx = frame_to_index(paddr);
+
+    // `idx` in range; `paddr` is its page base.
+    s.regions.inv_implies_correct_addr(paddr);
+    assert(s.regions.slot_owners.contains_key(idx));
+    assert(idx < max_meta_slots());
+    assert(index_to_frame(idx) == paddr);
+
+    // Pre "no users" facts at the UNUSED slot (accounting clause 1).
+    assert(handle_count(old_frames, idx) == 0);
+    assert(old_regions.slot_owners[idx].paths_in_pt.is_empty());
+    assert(segment_cover_count(old_segments, index_to_frame(idx)) == 0);
+
+    // Transition the slot UNUSED → UNIQUE.
+    unique::unique_from_unused_embedded(&mut s.regions, paddr);
+
+    // Register the fresh UniqueEntry at a fresh id.
+    let ghost uid = fresh_unique_id(s.unique_frames);
+    lemma_fresh_unique_id_not_in_dom(s.unique_frames);
+    let tracked entry = axiom_unique_entry_new(paddr);
+    s.insert_unique(uid, entry);
+    assert(s.unique_frames =~= old_unique.insert(uid, UniqueEntry { paddr }));
+    assert(s.frames == old_frames);
+    assert(s.segments == old_segments);
+
+    // --- structural: in_list == 0 everywhere ---
+    assert forall|i: usize|
+        i < max_meta_slots() implies #[trigger] s.regions.slot_owners[i].inner_perms.in_list.value()
+        == 0 by {
+        if i != idx {
+            assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
+        }
+    };
+    // --- structural: FrameId ⟹ Frame-usage ---
+    assert forall|fid: FrameId| #[trigger]
+        s.frames.dom().contains(fid) implies s.regions.slot_owners[frame_to_index(
+        s.frames[fid].paddr,
+    )].usage == PageUsage::Frame by {
+        let other_idx = frame_to_index(s.frames[fid].paddr);
+        assert(old_frames.dom().contains(fid));
+        assert(old_regions.slot_owners[other_idx].usage == PageUsage::Frame);
+        if other_idx == idx {
+            // Pre `idx` was `Unused`-usage — no `FrameEntry` maps there.
+            assert(false);
+        }
+    };
+    // --- structural: segment-covered ⟹ Frame-usage ---
+    assert forall|sid: SegmentId, paddr_c: Paddr|
+        #![trigger s.segments.dom().contains(sid), frame_to_index(paddr_c)]
+        s.segments.dom().contains(sid) && s.segments[sid].range.start <= paddr_c
+            < s.segments[sid].range.end && paddr_c % PAGE_SIZE
+            == 0 implies s.regions.slot_owners[frame_to_index(paddr_c)].usage
+        == PageUsage::Frame by {
+        let cov_idx = frame_to_index(paddr_c);
+        assert(old_segments.dom().contains(sid));
+        assert(old_regions.slot_owners[cov_idx].usage == PageUsage::Frame);
+        if cov_idx == idx {
+            assert(false);
+        }
+    };
+    // --- structural: unique-entry validity ---
+    assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
+        let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
+        &&& so.usage == PageUsage::Frame
+        &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+        &&& so.inner_perms.in_list.value() == 0
+        &&& so.paths_in_pt.is_empty()
+    } by {
+        let u_idx = frame_to_index(s.unique_frames[u].paddr);
+        if u == uid {
+            assert(s.unique_frames[u].paddr == paddr);
+            assert(u_idx == idx);
+        } else {
+            assert(old_unique.dom().contains(u));
+            assert(s.unique_frames[u] == old_unique[u]);
+            assert(old_regions.slot_owners[u_idx].inner_perms.ref_count.value()
+                == REF_COUNT_UNIQUE);
+            assert(u_idx != idx);
+            assert(s.regions.slot_owners[u_idx] == old_regions.slot_owners[u_idx]);
+        }
+    };
+    // --- structural: unique has_safe_slot ---
+    assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies has_safe_slot(
+        s.unique_frames[u].paddr,
+    ) by {
+        if u != uid {
+            assert(old_unique.dom().contains(u));
+        }
+    };
+    // --- structural: unique injectivity ---
+    assert forall|u1: UniqueId, u2: UniqueId|
+        #![trigger s.unique_frames.dom().contains(u1), s.unique_frames.dom().contains(u2)]
+        s.unique_frames.dom().contains(u1) && s.unique_frames.dom().contains(u2)
+            && s.unique_frames[u1].paddr == s.unique_frames[u2].paddr implies u1 == u2 by {
+        if u1 == uid && u2 != uid {
+            assert(old_unique.dom().contains(u2));
+            assert(s.unique_frames[u2].paddr == paddr);
+            assert(frame_to_index(s.unique_frames[u2].paddr) == idx);
+            assert(old_regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
+            assert(false);
+        } else if u2 == uid && u1 != uid {
+            assert(old_unique.dom().contains(u1));
+            assert(s.unique_frames[u1].paddr == paddr);
+            assert(frame_to_index(s.unique_frames[u1].paddr) == idx);
+            assert(old_regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
+            assert(false);
+        } else if u1 != uid && u2 != uid {
+            assert(old_unique.dom().contains(u1));
+            assert(old_unique.dom().contains(u2));
+        }
+    };
+
+    // --- accounting clause 1: UNUSED ⟹ no users ---
+    assert forall|i: usize|
+        #![trigger s.regions.slot_owners[i]]
+        i < max_meta_slots() && s.regions.slot_owners[i].inner_perms.ref_count.value()
+            == REF_COUNT_UNUSED implies handle_count(s.frames, i) == 0
+        && s.regions.slot_owners[i].paths_in_pt.is_empty() && segment_cover_count(
+        s.segments,
+        index_to_frame(i),
+    ) == 0 by {
+        if i == idx {
+            // post rc at `idx` is UNIQUE, not UNUSED — antecedent false.
+            assert(false);
+        } else {
+            assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
+        }
+    };
+    // --- accounting clause 2: valid rc ⟹ active head ---
+    assert forall|i: usize|
+        #![trigger s.regions.slot_owners[i]]
+        i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame
+            && s.regions.slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
+            && s.regions.slot_owners[i].inner_perms.ref_count.value()
+            != REF_COUNT_UNIQUE implies handle_count(s.frames, i) > 0
+        || s.regions.slot_owners[i].paths_in_pt.len() > 0 || segment_cover_count(
+        s.segments,
+        index_to_frame(i),
+    ) > 0 by {
+        if i == idx {
+            // post rc at `idx` is UNIQUE — antecedent false.
+            assert(false);
+        } else {
+            assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
+        }
+    };
+    // --- accounting clause 3: the rc equation ---
+    assert forall|i: usize|
+        #![trigger s.regions.slot_owners[i]]
+        i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame && (handle_count(
+            s.frames,
+            i,
+        ) > 0 || s.regions.slot_owners[i].paths_in_pt.len() > 0 || segment_cover_count(
+            s.segments,
+            index_to_frame(i),
+        ) > 0) implies {
+        let so = s.regions.slot_owners[i];
+        let rc = so.inner_perms.ref_count.value();
+        &&& rc != REF_COUNT_UNUSED
+        &&& rc != REF_COUNT_UNIQUE
+        &&& rc == handle_count(s.frames, i) + so.paths_in_pt.len() + segment_cover_count(
+            s.segments,
+            index_to_frame(i),
+        )
+        &&& so.inner_perms.storage.is_init()
+    } by {
+        if i == idx {
+            // `idx` is now UNIQUE with no users (H=P=cover=0) — the
+            // active-head antecedent is false, so this is vacuous.
+            assert(handle_count(s.frames, idx) == 0);
+            assert(s.regions.slot_owners[idx].paths_in_pt.is_empty());
+            assert(segment_cover_count(s.segments, index_to_frame(idx)) == 0);
+        } else {
+            assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
+        }
+    };
+}
+
+/// `Op::UniqueDrop` step. Tears down the exclusive handle `uid`: the
+/// slot transitions `UNIQUE → UNUSED` (uninitialising storage), with
+/// `usage` (Frame) / `paths_in_pt` (empty) / `in_list` (0) preserved.
+/// `frames` / `segments` untouched. The torn-down slot satisfies
+/// accounting clause 1 (UNUSED ⟹ no users) because the UNIQUE slot had
+/// none (clause 0); the remaining unique entries stay valid because
+/// injectivity put none of them at `idx`.
+proof fn step_unique_drop<'rcu>(tracked s: &mut VmStore<'rcu>, uid: UniqueId)
+    requires
+        old(s).inv(),
+        old(s).unique_frames.dom().contains(uid),
+    ensures
+        final(s).inv(),
+{
+    let ghost old_regions = s.regions;
+    let ghost old_frames = s.frames;
+    let ghost old_segments = s.segments;
+    let ghost old_unique = s.unique_frames;
+    let ghost paddr = s.unique_frames[uid].paddr;
+    let ghost idx = frame_to_index(paddr);
+
+    // Slot facts from the structural unique-entry clause + the UNIQUE
+    // branch of `MetaSlotOwner::inv`.
+    assert(has_safe_slot(paddr));
+    s.regions.inv_implies_correct_addr(paddr);
+    assert(s.regions.slot_owners.contains_key(idx));
+    assert(idx < max_meta_slots());
+    assert(index_to_frame(idx) == paddr);
+    assert(s.regions.slot_owners[idx].usage == PageUsage::Frame);
+    assert(s.regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
+    assert(s.regions.slot_owners[idx].inner_perms.in_list.value() == 0);
+    assert(s.regions.slot_owners[idx].paths_in_pt.is_empty());
+    assert(s.regions.slot_owners[idx].inv());
+    assert(s.regions.slot_owners[idx].inner_perms.storage.is_init());
+
+    // Pre "no users" facts at the UNIQUE slot, *derived* from the
+    // equation clause: a user (H>0 / cover>0) at a `usage == Frame` slot
+    // forces `rc != REF_COUNT_UNIQUE`, contradicting the unique slot.
+    assert(handle_count(old_frames, idx) == 0) by {
+        if handle_count(old_frames, idx) > 0 {
+            assert(old_regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNIQUE);
+            assert(false);
+        }
+    };
+    assert(segment_cover_count(old_segments, index_to_frame(idx)) == 0) by {
+        if segment_cover_count(old_segments, index_to_frame(idx)) > 0 {
+            assert(old_regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNIQUE);
+            assert(false);
+        }
+    };
+
+    // Remove the entry, then tear the slot down.
+    let tracked _entry = s.extract_unique(uid);
+    unique::unique_drop_embedded(&mut s.regions, paddr);
+    assert(s.unique_frames =~= old_unique.remove(uid));
+    assert(s.frames == old_frames);
+    assert(s.segments == old_segments);
+
+    // --- structural: in_list == 0 everywhere ---
+    assert forall|i: usize|
+        i < max_meta_slots() implies #[trigger] s.regions.slot_owners[i].inner_perms.in_list.value()
+        == 0 by {
+        if i != idx {
+            assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
+        }
+    };
+    // --- structural: FrameId ⟹ Frame-usage (usage preserved at idx) ---
+    assert forall|fid: FrameId| #[trigger]
+        s.frames.dom().contains(fid) implies s.regions.slot_owners[frame_to_index(
+        s.frames[fid].paddr,
+    )].usage == PageUsage::Frame by {
+        let other_idx = frame_to_index(s.frames[fid].paddr);
+        assert(old_frames.dom().contains(fid));
+        assert(old_regions.slot_owners[other_idx].usage == PageUsage::Frame);
+        if other_idx != idx {
+            assert(s.regions.slot_owners[other_idx] == old_regions.slot_owners[other_idx]);
+        }
+    };
+    // --- structural: segment-covered ⟹ Frame-usage ---
+    assert forall|sid: SegmentId, paddr_c: Paddr|
+        #![trigger s.segments.dom().contains(sid), frame_to_index(paddr_c)]
+        s.segments.dom().contains(sid) && s.segments[sid].range.start <= paddr_c
+            < s.segments[sid].range.end && paddr_c % PAGE_SIZE
+            == 0 implies s.regions.slot_owners[frame_to_index(paddr_c)].usage
+        == PageUsage::Frame by {
+        let cov_idx = frame_to_index(paddr_c);
+        assert(old_segments.dom().contains(sid));
+        assert(old_regions.slot_owners[cov_idx].usage == PageUsage::Frame);
+        if cov_idx != idx {
+            assert(s.regions.slot_owners[cov_idx] == old_regions.slot_owners[cov_idx]);
+        }
+    };
+    // --- structural: unique-entry validity (remaining entries) ---
+    assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
+        let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
+        &&& so.usage == PageUsage::Frame
+        &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+        &&& so.inner_perms.in_list.value() == 0
+        &&& so.paths_in_pt.is_empty()
+    } by {
+        let u_idx = frame_to_index(s.unique_frames[u].paddr);
+        assert(old_unique.dom().contains(u));
+        assert(u != uid);
+        // Injectivity (old): only `uid` sat at `paddr`/`idx`, so u_idx != idx.
+        if u_idx == idx {
+            assert(s.unique_frames[u].paddr == paddr) by {
+                assert(old_unique[u].paddr == s.unique_frames[u].paddr);
+            };
+            assert(u == uid);
+            assert(false);
+        }
+        assert(s.regions.slot_owners[u_idx] == old_regions.slot_owners[u_idx]);
+    };
+    // --- structural: unique has_safe_slot / injectivity (subset of old) ---
+    assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies has_safe_slot(
+        s.unique_frames[u].paddr,
+    ) by {
+        assert(old_unique.dom().contains(u));
+    };
+    assert forall|u1: UniqueId, u2: UniqueId|
+        #![trigger s.unique_frames.dom().contains(u1), s.unique_frames.dom().contains(u2)]
+        s.unique_frames.dom().contains(u1) && s.unique_frames.dom().contains(u2)
+            && s.unique_frames[u1].paddr == s.unique_frames[u2].paddr implies u1 == u2 by {
+        assert(old_unique.dom().contains(u1));
+        assert(old_unique.dom().contains(u2));
+    };
+
+    // --- accounting clause 1: UNUSED ⟹ no users ---
+    assert forall|i: usize|
+        #![trigger s.regions.slot_owners[i]]
+        i < max_meta_slots() && s.regions.slot_owners[i].inner_perms.ref_count.value()
+            == REF_COUNT_UNUSED implies handle_count(s.frames, i) == 0
+        && s.regions.slot_owners[i].paths_in_pt.is_empty() && segment_cover_count(
+        s.segments,
+        index_to_frame(i),
+    ) == 0 by {
+        if i == idx {
+            // post: H(idx)==0 (frames fixed; derived pre), paths empty
+            // (preserved), cover==0 (segments fixed; derived pre).
+            assert(handle_count(s.frames, idx) == 0);
+            assert(s.regions.slot_owners[idx].paths_in_pt.is_empty());
+            assert(segment_cover_count(s.segments, index_to_frame(idx)) == 0);
+        } else {
+            assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
+        }
+    };
+    // --- accounting clause 2: valid rc ⟹ active head ---
+    assert forall|i: usize|
+        #![trigger s.regions.slot_owners[i]]
+        i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame
+            && s.regions.slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
+            && s.regions.slot_owners[i].inner_perms.ref_count.value()
+            != REF_COUNT_UNIQUE implies handle_count(s.frames, i) > 0
+        || s.regions.slot_owners[i].paths_in_pt.len() > 0 || segment_cover_count(
+        s.segments,
+        index_to_frame(i),
+    ) > 0 by {
+        if i == idx {
+            // post rc at `idx` is UNUSED — antecedent false.
+            assert(false);
+        } else {
+            assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
+        }
+    };
+    // --- accounting clause 3: the rc equation ---
+    assert forall|i: usize|
+        #![trigger s.regions.slot_owners[i]]
+        i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame && (handle_count(
+            s.frames,
+            i,
+        ) > 0 || s.regions.slot_owners[i].paths_in_pt.len() > 0 || segment_cover_count(
+            s.segments,
+            index_to_frame(i),
+        ) > 0) implies {
+        let so = s.regions.slot_owners[i];
+        let rc = so.inner_perms.ref_count.value();
+        &&& rc != REF_COUNT_UNUSED
+        &&& rc != REF_COUNT_UNIQUE
+        &&& rc == handle_count(s.frames, i) + so.paths_in_pt.len() + segment_cover_count(
+            s.segments,
+            index_to_frame(i),
+        )
+        &&& so.inner_perms.storage.is_init()
+    } by {
+        if i == idx {
+            // `idx` is now UNUSED with no users — antecedent false.
+            assert(handle_count(s.frames, idx) == 0);
+            assert(s.regions.slot_owners[idx].paths_in_pt.is_empty());
+            assert(segment_cover_count(s.segments, index_to_frame(idx)) == 0);
+        } else {
+            assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
+        }
+    };
+}
+
+/// `Op::FromUnique` step. Converts the exclusive handle `uid` to a
+/// shared one: `rc` drops `UNIQUE → 1`, the `UniqueEntry` is consumed,
+/// and a fresh `FrameEntry` registered (`H: 0 → 1`). The slot becomes a
+/// SHARED active head with `rc == 1 == H + P + cover` (`P == cover == 0`
+/// derived from the pre-UNIQUE no-users facts).
+proof fn step_from_unique<'rcu>(tracked s: &mut VmStore<'rcu>, uid: UniqueId)
+    requires
+        old(s).inv(),
+        old(s).unique_frames.dom().contains(uid),
+    ensures
+        final(s).inv(),
+{
+    let ghost old_regions = s.regions;
+    let ghost old_frames = s.frames;
+    let ghost old_segments = s.segments;
+    let ghost old_unique = s.unique_frames;
+    let ghost paddr = s.unique_frames[uid].paddr;
+    let ghost idx = frame_to_index(paddr);
+
+    // Slot facts from the structural unique-entry clause + UNIQUE branch.
+    assert(has_safe_slot(paddr));
+    s.regions.inv_implies_correct_addr(paddr);
+    assert(s.regions.slot_owners.contains_key(idx));
+    assert(idx < max_meta_slots());
+    assert(index_to_frame(idx) == paddr);
+    assert(s.regions.slot_owners[idx].usage == PageUsage::Frame);
+    assert(s.regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
+    assert(s.regions.slot_owners[idx].paths_in_pt.is_empty());
+    assert(s.regions.slot_owners[idx].inv());
+    assert(s.regions.slot_owners[idx].inner_perms.storage.is_init());
+
+    // Pre "no users" at the UNIQUE slot (a user forces rc != UNIQUE).
+    assert(handle_count(old_frames, idx) == 0) by {
+        if handle_count(old_frames, idx) > 0 {
+            assert(old_regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNIQUE);
+            assert(false);
+        }
+    };
+    assert(segment_cover_count(old_segments, index_to_frame(idx)) == 0) by {
+        if segment_cover_count(old_segments, index_to_frame(idx)) > 0 {
+            assert(old_regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNIQUE);
+            assert(false);
+        }
+    };
+
+    // Consume the unique handle, transition rc UNIQUE → 1.
+    let tracked _ue = s.extract_unique(uid);
+    unique::from_unique_embedded(&mut s.regions, paddr);
+
+    // Register the fresh shared FrameEntry.
+    let ghost fid = fresh_frame_id(s.frames);
+    lemma_fresh_frame_id_not_in_dom(s.frames);
+    let tracked fe = axiom_frame_entry_new(paddr);
+    s.insert_frame(fid, fe);
+    assert(s.frames =~= old_frames.insert(fid, FrameEntry { paddr }));
+    assert(s.unique_frames =~= old_unique.remove(uid));
+    assert(s.segments == old_segments);
+    assert(s.frames[fid].paddr == paddr);
+
+    // --- structural: in_list == 0 everywhere ---
+    assert forall|i: usize|
+        i < max_meta_slots() implies #[trigger] s.regions.slot_owners[i].inner_perms.in_list.value()
+        == 0 by {
+        if i != idx {
+            assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
+        }
+    };
+    // --- structural: FrameId ⟹ Frame-usage ---
+    assert forall|fid_other: FrameId| #[trigger]
+        s.frames.dom().contains(fid_other) implies s.regions.slot_owners[frame_to_index(
+        s.frames[fid_other].paddr,
+    )].usage == PageUsage::Frame by {
+        let other_idx = frame_to_index(s.frames[fid_other].paddr);
+        if fid_other == fid {
+            assert(s.frames[fid_other].paddr == paddr);
+            assert(other_idx == idx);
+        } else {
+            assert(old_frames.dom().contains(fid_other));
+            assert(s.frames[fid_other] == old_frames[fid_other]);
+            assert(old_regions.slot_owners[other_idx].usage == PageUsage::Frame);
+            if other_idx != idx {
+                assert(s.regions.slot_owners[other_idx] == old_regions.slot_owners[other_idx]);
+            }
+        }
+    };
+    // --- structural: segment-covered ⟹ Frame-usage ---
+    assert forall|sid: SegmentId, paddr_c: Paddr|
+        #![trigger s.segments.dom().contains(sid), frame_to_index(paddr_c)]
+        s.segments.dom().contains(sid) && s.segments[sid].range.start <= paddr_c
+            < s.segments[sid].range.end && paddr_c % PAGE_SIZE
+            == 0 implies s.regions.slot_owners[frame_to_index(paddr_c)].usage
+        == PageUsage::Frame by {
+        let cov_idx = frame_to_index(paddr_c);
+        assert(old_segments.dom().contains(sid));
+        assert(old_regions.slot_owners[cov_idx].usage == PageUsage::Frame);
+        if cov_idx != idx {
+            assert(s.regions.slot_owners[cov_idx] == old_regions.slot_owners[cov_idx]);
+        }
+    };
+    // --- structural: unique-entry validity (remaining entries) ---
+    assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
+        let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
+        &&& so.usage == PageUsage::Frame
+        &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+        &&& so.inner_perms.in_list.value() == 0
+        &&& so.paths_in_pt.is_empty()
+    } by {
+        let u_idx = frame_to_index(s.unique_frames[u].paddr);
+        assert(old_unique.dom().contains(u));
+        assert(u != uid);
+        if u_idx == idx {
+            assert(old_unique[u].paddr == s.unique_frames[u].paddr);
+            assert(u == uid);
+            assert(false);
+        }
+        assert(s.regions.slot_owners[u_idx] == old_regions.slot_owners[u_idx]);
+    };
+    assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies has_safe_slot(
+        s.unique_frames[u].paddr,
+    ) by {
+        assert(old_unique.dom().contains(u));
+    };
+    assert forall|u1: UniqueId, u2: UniqueId|
+        #![trigger s.unique_frames.dom().contains(u1), s.unique_frames.dom().contains(u2)]
+        s.unique_frames.dom().contains(u1) && s.unique_frames.dom().contains(u2)
+            && s.unique_frames[u1].paddr == s.unique_frames[u2].paddr implies u1 == u2 by {
+        assert(old_unique.dom().contains(u1));
+        assert(old_unique.dom().contains(u2));
+    };
+
+    // --- accounting clause 1: UNUSED ⟹ no users ---
+    assert forall|i: usize|
+        #![trigger s.regions.slot_owners[i]]
+        i < max_meta_slots() && s.regions.slot_owners[i].inner_perms.ref_count.value()
+            == REF_COUNT_UNUSED implies handle_count(s.frames, i) == 0
+        && s.regions.slot_owners[i].paths_in_pt.is_empty() && segment_cover_count(
+        s.segments,
+        index_to_frame(i),
+    ) == 0 by {
+        lemma_handle_count_insert_fresh(old_frames, fid, fe, i);
+        if i == idx {
+            assert(false);
+        } else {
+            assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
+        }
+    };
+    // --- accounting clause 2: valid rc ⟹ active head ---
+    assert forall|i: usize|
+        #![trigger s.regions.slot_owners[i]]
+        i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame
+            && s.regions.slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
+            && s.regions.slot_owners[i].inner_perms.ref_count.value()
+            != REF_COUNT_UNIQUE implies handle_count(s.frames, i) > 0
+        || s.regions.slot_owners[i].paths_in_pt.len() > 0 || segment_cover_count(
+        s.segments,
+        index_to_frame(i),
+    ) > 0 by {
+        lemma_handle_count_insert_fresh(old_frames, fid, fe, i);
+        if i == idx {
+            assert(handle_count(s.frames, idx) == 1);
+        } else {
+            assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
+        }
+    };
+    // --- accounting clause 3: the rc equation ---
+    assert forall|i: usize|
+        #![trigger s.regions.slot_owners[i]]
+        i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame && (handle_count(
+            s.frames,
+            i,
+        ) > 0 || s.regions.slot_owners[i].paths_in_pt.len() > 0 || segment_cover_count(
+            s.segments,
+            index_to_frame(i),
+        ) > 0) implies {
+        let so = s.regions.slot_owners[i];
+        let rc = so.inner_perms.ref_count.value();
+        &&& rc != REF_COUNT_UNUSED
+        &&& rc != REF_COUNT_UNIQUE
+        &&& rc == handle_count(s.frames, i) + so.paths_in_pt.len() + segment_cover_count(
+            s.segments,
+            index_to_frame(i),
+        )
+        &&& so.inner_perms.storage.is_init()
+    } by {
+        lemma_handle_count_insert_fresh(old_frames, fid, fe, i);
+        if i == idx {
+            // post rc==1, H==1, P==0 (paths empty preserved), cover==0;
+            // storage preserved (was init at the UNIQUE slot).
+            assert(handle_count(s.frames, idx) == 1);
+            assert(s.regions.slot_owners[idx].paths_in_pt.is_empty());
+            assert(segment_cover_count(s.segments, index_to_frame(idx)) == 0);
+        } else {
+            assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
+        }
+    };
+}
+
+/// `Op::TryFromShared` step. Tries to convert the shared handle `fid`
+/// back into an exclusive one. The CAS succeeds only when `fid` is the
+/// *sole* reference (`rc == 1`, hence `H == 1 ∧ P == 0 ∧ cover == 0`):
+/// then the slot rises `1 → UNIQUE`, the `FrameEntry` is consumed and a
+/// fresh `UniqueEntry` registered. Otherwise the CAS fails and the
+/// store is unchanged.
+proof fn step_try_from_shared<'rcu>(tracked s: &mut VmStore<'rcu>, fid: FrameId)
+    requires
+        old(s).inv(),
+        old(s).frames.dom().contains(fid),
+    ensures
+        final(s).inv(),
+{
+    let ghost paddr = s.frames[fid].paddr;
+    let ghost idx = frame_to_index(paddr);
+    // `fid` registered ⟹ in-bound, `usage == Frame`, and it contributes
+    // to `handle_count` (so the slot is an active head).
+    assert(has_safe_slot(paddr));
+    s.regions.inv_implies_correct_addr(paddr);
+    assert(s.regions.slot_owners.contains_key(idx));
+    assert(idx < max_meta_slots());
+    assert(index_to_frame(idx) == paddr);
+    assert(s.regions.slot_owners[idx].usage == PageUsage::Frame);
+    assert(s.frames.dom().filter(
+        |gid: FrameId| frame_to_index(s.frames[gid].paddr) == idx,
+    ).contains(fid));
+    assert(handle_count(s.frames, idx) >= 1);
+
+    if s.regions.slot_owners[idx].inner_perms.ref_count.value() == 1 {
+        let ghost old_regions = s.regions;
+        let ghost old_frames = s.frames;
+        let ghost old_segments = s.segments;
+        let ghost old_unique = s.unique_frames;
+
+        // rc==1 ∧ active head ⟹ equation: rc == H + P + cover == 1, and
+        // H >= 1, so H == 1, P == 0, cover == 0 (sole reference).
+        assert(handle_count(old_frames, idx) == 1);
+        assert(s.regions.slot_owners[idx].paths_in_pt.len() == 0);
+        assert(segment_cover_count(old_segments, index_to_frame(idx)) == 0);
+        assert(s.regions.slot_owners[idx].inv());
+        assert(s.regions.slot_owners[idx].paths_in_pt =~= Set::empty());
+
+        // Consume the sole FrameEntry, transition rc 1 → UNIQUE.
+        let tracked _fe = s.extract_frame(fid);
+        assert(s.frames =~= old_frames.remove(fid));
+        unique::try_from_shared_embedded(&mut s.regions, paddr);
+
+        // Register the fresh exclusive UniqueEntry.
+        let ghost uid = fresh_unique_id(s.unique_frames);
+        lemma_fresh_unique_id_not_in_dom(s.unique_frames);
+        let tracked ue = axiom_unique_entry_new(paddr);
+        s.insert_unique(uid, ue);
+        assert(s.unique_frames =~= old_unique.insert(uid, UniqueEntry { paddr }));
+        assert(s.segments == old_segments);
+        // `idx` now has no shared handle (the sole `fid` was removed).
+        assert(handle_count(s.frames, idx) == 0) by {
+            lemma_handle_count_remove(old_frames, fid, idx);
+        };
+
+        // --- structural: in_list == 0 everywhere ---
+        assert forall|i: usize|
+            i
+                < max_meta_slots() implies #[trigger] s.regions.slot_owners[i].inner_perms.in_list.value()
+            == 0 by {
+            if i != idx {
+                assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
+            }
+        };
+        // --- structural: FrameId ⟹ Frame-usage ---
+        // The converted slot keeps `usage == Frame`; all other slots are
+        // unchanged. (No remaining `FrameEntry` sits at `idx`: `H == 0`.)
+        assert forall|fid_other: FrameId| #[trigger]
+            s.frames.dom().contains(fid_other) implies s.regions.slot_owners[frame_to_index(
+            s.frames[fid_other].paddr,
+        )].usage == PageUsage::Frame by {
+            let other_idx = frame_to_index(s.frames[fid_other].paddr);
+            assert(old_frames.dom().contains(fid_other));
+            assert(old_regions.slot_owners[other_idx].usage == PageUsage::Frame);
+            if other_idx != idx {
+                assert(s.regions.slot_owners[other_idx] == old_regions.slot_owners[other_idx]);
+            }
+        };
+        // --- structural: segment-covered ⟹ Frame-usage ---
+        assert forall|sid: SegmentId, paddr_c: Paddr|
+            #![trigger s.segments.dom().contains(sid), frame_to_index(paddr_c)]
+            s.segments.dom().contains(sid) && s.segments[sid].range.start <= paddr_c
+                < s.segments[sid].range.end && paddr_c % PAGE_SIZE
+                == 0 implies s.regions.slot_owners[frame_to_index(paddr_c)].usage
+            == PageUsage::Frame by {
+            let cov_idx = frame_to_index(paddr_c);
+            assert(old_segments.dom().contains(sid));
+            assert(old_regions.slot_owners[cov_idx].usage == PageUsage::Frame);
+            if cov_idx != idx {
+                assert(s.regions.slot_owners[cov_idx] == old_regions.slot_owners[cov_idx]);
+            }
+        };
+        // --- structural: unique-entry validity ---
+        assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
+            let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
+            &&& so.usage == PageUsage::Frame
+            &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+            &&& so.inner_perms.in_list.value() == 0
+            &&& so.paths_in_pt.is_empty()
+        } by {
+            let u_idx = frame_to_index(s.unique_frames[u].paddr);
+            if u == uid {
+                assert(s.unique_frames[u].paddr == paddr);
+                assert(u_idx == idx);
+            } else {
+                assert(old_unique.dom().contains(u));
+                assert(s.unique_frames[u] == old_unique[u]);
+                // old entry's slot was UNIQUE (≠ idx, which was rc==1).
+                assert(old_regions.slot_owners[u_idx].inner_perms.ref_count.value()
+                    == REF_COUNT_UNIQUE);
+                assert(u_idx != idx);
+                assert(s.regions.slot_owners[u_idx] == old_regions.slot_owners[u_idx]);
+            }
+        };
+        assert forall|u: UniqueId| #[trigger]
+            s.unique_frames.dom().contains(u) implies has_safe_slot(s.unique_frames[u].paddr) by {
+            if u != uid {
+                assert(old_unique.dom().contains(u));
+            }
+        };
+        assert forall|u1: UniqueId, u2: UniqueId|
+            #![trigger s.unique_frames.dom().contains(u1), s.unique_frames.dom().contains(u2)]
+            s.unique_frames.dom().contains(u1) && s.unique_frames.dom().contains(u2)
+                && s.unique_frames[u1].paddr == s.unique_frames[u2].paddr implies u1 == u2 by {
+            if u1 == uid && u2 != uid {
+                assert(old_unique.dom().contains(u2));
+                assert(s.unique_frames[u2].paddr == paddr);
+                assert(frame_to_index(s.unique_frames[u2].paddr) == idx);
+                assert(old_regions.slot_owners[idx].inner_perms.ref_count.value()
+                    == REF_COUNT_UNIQUE);
+                assert(false);
+            } else if u2 == uid && u1 != uid {
+                assert(old_unique.dom().contains(u1));
+                assert(s.unique_frames[u1].paddr == paddr);
+                assert(frame_to_index(s.unique_frames[u1].paddr) == idx);
+                assert(old_regions.slot_owners[idx].inner_perms.ref_count.value()
+                    == REF_COUNT_UNIQUE);
+                assert(false);
+            } else if u1 != uid && u2 != uid {
+                assert(old_unique.dom().contains(u1));
+                assert(old_unique.dom().contains(u2));
+            }
+        };
+
+        // --- accounting clause 1: UNUSED ⟹ no users ---
+        assert forall|i: usize|
+            #![trigger s.regions.slot_owners[i]]
+            i < max_meta_slots() && s.regions.slot_owners[i].inner_perms.ref_count.value()
+                == REF_COUNT_UNUSED implies handle_count(s.frames, i) == 0
+            && s.regions.slot_owners[i].paths_in_pt.is_empty() && segment_cover_count(
+            s.segments,
+            index_to_frame(i),
+        ) == 0 by {
+            lemma_handle_count_remove(old_frames, fid, i);
+            if i == idx {
+                // post `idx` is UNIQUE, not UNUSED — antecedent false.
+                assert(false);
+            } else {
+                assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
+            }
+        };
+        // --- accounting clause 2: valid rc ⟹ active head ---
+        assert forall|i: usize|
+            #![trigger s.regions.slot_owners[i]]
+            i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame
+                && s.regions.slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
+                && s.regions.slot_owners[i].inner_perms.ref_count.value()
+                != REF_COUNT_UNIQUE implies handle_count(s.frames, i) > 0
+            || s.regions.slot_owners[i].paths_in_pt.len() > 0 || segment_cover_count(
+            s.segments,
+            index_to_frame(i),
+        ) > 0 by {
+            lemma_handle_count_remove(old_frames, fid, i);
+            if i == idx {
+                // post `idx` is UNIQUE — antecedent false.
+                assert(false);
+            } else {
+                assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
+            }
+        };
+        // --- accounting clause 3: the rc equation ---
+        assert forall|i: usize|
+            #![trigger s.regions.slot_owners[i]]
+            i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame && (
+            handle_count(s.frames, i) > 0 || s.regions.slot_owners[i].paths_in_pt.len() > 0
+                || segment_cover_count(s.segments, index_to_frame(i)) > 0) implies {
+            let so = s.regions.slot_owners[i];
+            let rc = so.inner_perms.ref_count.value();
+            &&& rc != REF_COUNT_UNUSED
+            &&& rc != REF_COUNT_UNIQUE
+            &&& rc == handle_count(s.frames, i) + so.paths_in_pt.len() + segment_cover_count(
+                s.segments,
+                index_to_frame(i),
+            )
+            &&& so.inner_perms.storage.is_init()
+        } by {
+            lemma_handle_count_remove(old_frames, fid, i);
+            if i == idx {
+                // post `idx` is UNIQUE with no users (H=P=cover=0) — the
+                // active-head antecedent is false, so this is vacuous.
+                assert(handle_count(s.frames, idx) == 0);
+                assert(s.regions.slot_owners[idx].paths_in_pt.is_empty());
+                assert(segment_cover_count(s.segments, index_to_frame(idx)) == 0);
+            } else {
+                assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
+            }
+        };
+    }
 }
 
 /// Inserting a fresh segment whose range DOES cover `paddr` bumps
@@ -4090,6 +5151,24 @@ pub open spec fn fresh_segment_id(m: Map<SegmentId, SegmentEntry>) -> SegmentId 
 pub proof fn lemma_fresh_segment_id_not_in_dom(m: Map<SegmentId, SegmentEntry>)
     ensures
         !m.dom().contains(fresh_segment_id(m)),
+{
+    lemma_finite_int_set_has_unused(m.dom());
+}
+
+/// Tracked constructor for [`UniqueEntry`].
+pub axiom fn axiom_unique_entry_new(paddr: Paddr) -> (tracked res: UniqueEntry)
+    ensures
+        res.paddr == paddr,
+;
+
+/// Picks a [`UniqueId`] not currently in `m.dom()`.
+pub open spec fn fresh_unique_id(m: Map<UniqueId, UniqueEntry>) -> UniqueId {
+    choose|id: UniqueId| !m.dom().contains(id)
+}
+
+pub proof fn lemma_fresh_unique_id_not_in_dom(m: Map<UniqueId, UniqueEntry>)
+    ensures
+        !m.dom().contains(fresh_unique_id(m)),
 {
     lemma_finite_int_set_has_unused(m.dom());
 }

--- a/ostd/specs/mm/embedding/mod.rs
+++ b/ostd/specs/mm/embedding/mod.rs
@@ -182,8 +182,14 @@
 pub mod cursor;
 pub mod frame;
 pub mod io;
+pub mod kvirt_store;
+// list_store deferred: depends on a 118-line-diverged linked_list_owners layer
+// (its `LinkedListOwner::inv` differs between main and upstream) — needs that
+// linked-list embedding reconciliation before it verifies.
+// pub mod list_store;
 pub mod segment;
 pub mod trace;
+pub mod unique;
 pub mod vm_space;
 
 use core::ops::Range;

--- a/ostd/specs/mm/embedding/mod.rs
+++ b/ostd/specs/mm/embedding/mod.rs
@@ -736,10 +736,11 @@ impl<'a, 'rcu> VmStore<'rcu> {
                     frame_to_index(paddr)]
             self.segments.dom().contains(sid) && self.segments[sid].range.start <= paddr
                 < self.segments[sid].range.end && paddr % PAGE_SIZE == 0
-                ==> self.regions.slot_owners[frame_to_index(paddr)].usage == PageUsage::Frame
-        // `unique_frames.dom()` is finite (built by finitely many
-        // `insert_unique`), needed wherever the embedding reasons
-        // about the unique-handle set as a whole.
+                ==> self.regions.slot_owners[frame_to_index(paddr)].usage
+                == PageUsage::Frame
+            // `unique_frames.dom()` is finite (built by finitely many
+            // `insert_unique`), needed wherever the embedding reasons
+            // about the unique-handle set as a whole.
         &&& self.unique_frames.dom().finite()
         // Every registered `UniqueEntry`'s paddr is in-bound.
         &&& forall|uid: UniqueId| #[trigger]
@@ -966,9 +967,7 @@ pub enum Op {
     /// forgotten references and user-held Frame handles: at the
     /// popped paddr `raw_count -= 1`, `cover_count -= 1`, `H += 1`,
     /// `rc` unchanged.
-    SegmentNext {
-        sid: SegmentId,
-    },
+    SegmentNext { sid: SegmentId },
     /// `Segment::clone`: produce a second handle covering the *same*
     /// range as `sid`. Inserts a fresh `SegmentEntry` mirroring `sid`'s
     /// range and bumps every covered frame's `rc` by 1 (Arc-style, via

--- a/ostd/specs/mm/embedding/segment.rs
+++ b/ostd/specs/mm/embedding/segment.rs
@@ -384,7 +384,7 @@ pub axiom fn segment_clone_embedded(
                     let so = old(regions).slot_owners[frame_to_index(paddr)];
                     &&& so.usage == PageUsage::Frame
                     &&& so.inner_perms.ref_count.value() >= 1
-                    &&& so.inner_perms.ref_count.value() + 1 < REF_COUNT_MAX
+                    &&& so.inner_perms.ref_count.value() + 1 <= REF_COUNT_MAX
                 },
     ensures
         final(regions).inv(),

--- a/ostd/specs/mm/embedding/segment.rs
+++ b/ostd/specs/mm/embedding/segment.rs
@@ -38,7 +38,7 @@ use crate::mm::vm_space::UserPtConfig;
 use crate::mm::Paddr;
 use crate::specs::arch::*;
 use crate::specs::mm::frame::mapping::frame_to_index;
-use crate::specs::mm::frame::meta_owners::{PageUsage, REF_COUNT_UNUSED};
+use crate::specs::mm::frame::meta_owners::{PageUsage, REF_COUNT_MAX, REF_COUNT_UNUSED};
 use crate::specs::mm::frame::meta_region_owners::MetaRegionOwners;
 use crate::specs::mm::page_table::cursor::owners::CursorOwner;
 
@@ -363,5 +363,58 @@ pub(super) proof fn drop_step(
 {
     segment_drop_embedded(regions, entry.range);
 }
+
+
+pub axiom fn segment_clone_embedded(
+    tracked regions: &mut MetaRegionOwners,
+    range: Range<Paddr>,
+)
+    requires
+        old(regions).inv(),
+        range.start % PAGE_SIZE == 0,
+        range.end % PAGE_SIZE == 0,
+        range.start < range.end,
+        range.end <= MAX_PADDR,
+        // Every covered slot is a live SHARED Frame slot with headroom
+        // for one more reference (no saturation).
+        forall|paddr: Paddr|
+            #![trigger frame_to_index(paddr)]
+            (range.start <= paddr < range.end && paddr % PAGE_SIZE == 0)
+                ==> {
+                    let so = old(regions).slot_owners[frame_to_index(paddr)];
+                    &&& so.usage == PageUsage::Frame
+                    &&& so.inner_perms.ref_count.value() >= 1
+                    &&& so.inner_perms.ref_count.value() + 1 < REF_COUNT_MAX
+                },
+    ensures
+        final(regions).inv(),
+        final(regions).slots =~= old(regions).slots,
+        // At each covered slot: rc += 1, every other field preserved.
+        forall|paddr: Paddr|
+            #![trigger frame_to_index(paddr)]
+            (range.start <= paddr < range.end && paddr % PAGE_SIZE == 0)
+                ==> {
+                    let idx = frame_to_index(paddr);
+                    let so_old = old(regions).slot_owners[idx];
+                    let so_new = final(regions).slot_owners[idx];
+                    &&& so_new.inner_perms.ref_count.value()
+                            == (so_old.inner_perms.ref_count.value() + 1) as u64
+                    &&& so_new.usage == so_old.usage
+                    &&& so_new.self_addr == so_old.self_addr
+                    &&& so_new.paths_in_pt == so_old.paths_in_pt
+                    &&& so_new.inner_perms.in_list == so_old.inner_perms.in_list
+                    &&& so_new.inner_perms.storage == so_old.inner_perms.storage
+                    &&& so_new.inner_perms.vtable_ptr == so_old.inner_perms.vtable_ptr
+                },
+        // Slots OUTSIDE the range are fully preserved.
+        forall|i: usize|
+            #![trigger final(regions).slot_owners[i]]
+            i < crate::specs::mm::frame::mapping::max_meta_slots()
+            && !(range.start <= crate::specs::mm::frame::mapping::index_to_frame(i)
+                    < range.end)
+                ==> final(regions).slot_owners[i] == old(regions).slot_owners[i],
+        forall|c: CursorOwner<'_, UserPtConfig>| #![auto]
+            c.metaregion_sound(*old(regions)) ==> c.metaregion_sound(*final(regions)),
+;
 
 } // verus!

--- a/ostd/specs/mm/embedding/unique.rs
+++ b/ostd/specs/mm/embedding/unique.rs
@@ -1,0 +1,227 @@
+//! Embedding of `UniqueFrame` lifecycle operations: allocate
+//! ([`unique_from_unused_embedded`]) and drop
+//! ([`unique_drop_embedded`]).
+//!
+//! A `UniqueFrame` handle in the embedding is a `paddr`-bearing
+//! [`super::UniqueEntry`] in [`super::VmStore::unique_frames`]. Unlike a
+//! shared [`super::FrameEntry`], a unique handle drives its slot's
+//! `ref_count` to the `REF_COUNT_UNIQUE` sentinel (`u64::MAX - 1`),
+//! which is *not* a participant in the `rc == H + P + cover_count`
+//! accounting equation. Exclusivity (`rc == REF_COUNT_UNIQUE ⟹ no
+//! shared users`: `handle_count == 0`, `paths_in_pt` empty,
+//! `segment_cover_count == 0`) needs **no** dedicated invariant clause:
+//! it is *implied* by the equation itself — a user at a `usage == Frame`
+//! slot fires the equation's antecedent and demands `rc != UNIQUE`,
+//! contradicting `rc == UNIQUE`. So [`unique_drop_embedded`]'s caller
+//! recovers the "no users" facts by deriving that contradiction.
+//!
+//! # Methods modeled
+//!
+//! - `UniqueFrame::from_unused`: allocate a fresh exclusive handle on a
+//!   previously-unused slot. The slot transitions
+//!   `usage == Unused, rc == UNUSED` → `usage == Frame, rc == UNIQUE`.
+//! - `UniqueFrame` drop: tear down the exclusive handle. The slot
+//!   transitions `rc == UNIQUE` → `rc == UNUSED` (last-ref teardown,
+//!   uninitialising storage), with `usage` / `paths_in_pt`
+//!   (empty) / `in_list` preserved — the same shape as `Frame`'s
+//!   last-ref teardown.
+//! - `Frame::from_unique` ([`from_unique_embedded`]): convert the
+//!   exclusive handle to a shared one — `rc` drops `UNIQUE → 1`,
+//!   consuming the [`super::UniqueEntry`] and minting a
+//!   [`super::FrameEntry`] (`H: 0 → 1`).
+//! - `UniqueFrame::try_from_shared` ([`try_from_shared_embedded`]):
+//!   convert a *sole-reference* shared handle (`rc == 1`) back to an
+//!   exclusive one — `rc` rises `1 → UNIQUE`, consuming the
+//!   `FrameEntry` and minting a `UniqueEntry`. Fallible: if the slot is
+//!   not the sole reference (`rc != 1`) the CAS fails and the step is a
+//!   no-op (the shared handle is returned unchanged).
+//!
+//! # Model gaps
+//!
+//! - **`into_raw` / `from_raw`** (`pub(crate)`-only) and the accessors
+//!   (`meta` / `meta_mut` / `repurpose` / `transmute` /
+//!   `start_paddr`): no embedding state change / not surfaced.
+use vstd::prelude::*;
+use vstd_extra::ownership::*;
+
+use crate::specs::arch::has_safe_slot;
+use crate::mm::vm_space::UserPtConfig;
+use crate::mm::Paddr;
+use crate::specs::mm::frame::mapping::frame_to_index;
+use crate::specs::mm::frame::meta_owners::{PageUsage, REF_COUNT_UNIQUE, REF_COUNT_UNUSED};
+use crate::specs::mm::frame::meta_region_owners::MetaRegionOwners;
+use crate::specs::mm::page_table::cursor::owners::CursorOwner;
+
+verus! {
+
+// =============================================================================
+// _embedded axioms
+// =============================================================================
+/// Mirror of [`crate::mm::frame::UniqueFrame::from_unused`]. The slot at
+/// `paddr` transitions from a free slot (`usage == Unused`,
+/// `rc == REF_COUNT_UNUSED`) to an exclusively-held one
+/// (`usage == Frame`, `rc == REF_COUNT_UNIQUE`), with its metadata
+/// storage initialised, `in_list == 0`, and `paths_in_pt` preserved
+/// (it was empty — a free slot has no mappings). The slot perm is
+/// re-parked in `regions.slots` (Design B; the exec
+/// `slots.tracked_insert` at unique.rs:100), so the `slots` domain is
+/// preserved.
+///
+/// **Preconditions** mirror the exec contract (`usage is Unused`) plus
+/// the embedding-natural `rc == REF_COUNT_UNUSED` (which delivers, via
+/// [`super::accounting_inv`] clause 1, the "no users" facts needed to
+/// re-establish clause 0 at the freshly-UNIQUE slot).
+pub axiom fn unique_from_unused_embedded(tracked regions: &mut MetaRegionOwners, paddr: Paddr)
+    requires
+        old(regions).inv(),
+        has_safe_slot(paddr),
+        old(regions).slots.contains_key(frame_to_index(paddr)),
+        old(regions).slot_owners[frame_to_index(paddr)].usage is Unused,
+        old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
+            == REF_COUNT_UNUSED,
+    ensures
+        final(regions).inv(),
+        // Design-B re-park: `slots` domain preserved.
+        final(regions).slots =~= old(regions).slots,
+        // At `paddr`: UNUSED slot becomes a UNIQUE Frame slot.
+        {
+            let idx = frame_to_index(paddr);
+            let so_old = old(regions).slot_owners[idx];
+            let so_new = final(regions).slot_owners[idx];
+            &&& so_new.usage == PageUsage::Frame
+            &&& so_new.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+            &&& so_new.inner_perms.in_list.value() == 0
+            &&& so_new.inner_perms.storage.is_init()
+            &&& so_new.paths_in_pt == so_old.paths_in_pt
+            &&& so_new.self_addr == so_old.self_addr
+        },
+        // All other slots fully preserved.
+        forall|i: usize|
+            #![trigger final(regions).slot_owners[i]]
+            i != frame_to_index(paddr) ==> final(regions).slot_owners[i] == old(
+                regions,
+            ).slot_owners[i],
+        forall|c: CursorOwner<'_, UserPtConfig>| #![auto]
+            c.metaregion_sound(*old(regions)) ==> c.metaregion_sound(*final(regions)),
+;
+
+/// Mirror of [`crate::mm::frame::UniqueFrame`]'s `drop`. The sole
+/// exclusive handle is released: the slot transitions
+/// `rc == REF_COUNT_UNIQUE` → `rc == REF_COUNT_UNUSED` (last-ref
+/// teardown via `drop_last_in_place`, uninitialising storage), with
+/// `usage`, `paths_in_pt` (empty), `in_list` (0), and `self_addr`
+/// preserved.
+///
+/// **Preconditions** mirror `UniqueFrame::inv_with_regions` (the parts
+/// expressible at the `regions` level): the slot is UNIQUE with
+/// `in_list == 0`, initialised storage, and no PTE mappings
+/// (`paths_in_pt.is_empty()`).
+pub axiom fn unique_drop_embedded(tracked regions: &mut MetaRegionOwners, paddr: Paddr)
+    requires
+        old(regions).inv(),
+        old(regions).slots.contains_key(frame_to_index(paddr)),
+        old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
+            == REF_COUNT_UNIQUE,
+        old(regions).slot_owners[frame_to_index(paddr)].inner_perms.in_list.value() == 0,
+        old(regions).slot_owners[frame_to_index(paddr)].inner_perms.storage.is_init(),
+        old(regions).slot_owners[frame_to_index(paddr)].paths_in_pt.is_empty(),
+    ensures
+        final(regions).inv(),
+        final(regions).slots =~= old(regions).slots,
+        // At `paddr`: UNIQUE → UNUSED teardown; usage / paths / in_list
+        // / self_addr preserved.
+        {
+            let idx = frame_to_index(paddr);
+            let so_old = old(regions).slot_owners[idx];
+            let so_new = final(regions).slot_owners[idx];
+            &&& so_new.inner_perms.ref_count.value() == REF_COUNT_UNUSED
+            &&& so_new.usage == so_old.usage
+            &&& so_new.paths_in_pt == so_old.paths_in_pt
+            &&& so_new.inner_perms.in_list == so_old.inner_perms.in_list
+            &&& so_new.self_addr == so_old.self_addr
+        },
+        // All other slots fully preserved.
+        forall|i: usize|
+            #![trigger final(regions).slot_owners[i]]
+            i != frame_to_index(paddr) ==> final(regions).slot_owners[i] == old(
+                regions,
+            ).slot_owners[i],
+        forall|c: CursorOwner<'_, UserPtConfig>| #![auto]
+            c.metaregion_sound(*old(regions)) ==> c.metaregion_sound(*final(regions)),
+;
+
+/// Mirror of [`crate::mm::frame::Frame::from_unique`]. Converts the
+/// exclusive handle at `paddr` into a shared one: `rc` drops from the
+/// `REF_COUNT_UNIQUE` sentinel to 1, with `usage` (Frame),
+/// `paths_in_pt` (empty), `in_list` (0), `storage`, `vtable_ptr`, and
+/// `self_addr` preserved (only the count `store` runs). `metaregion_sound`
+/// is preserved: a UNIQUE slot has no live PTE (a mapping is a
+/// reference), so no cursor's `OwnerSubtree` maps it, and dropping the
+/// count to 1 keeps it referenced.
+pub axiom fn from_unique_embedded(tracked regions: &mut MetaRegionOwners, paddr: Paddr)
+    requires
+        old(regions).inv(),
+        old(regions).slots.contains_key(frame_to_index(paddr)),
+        old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
+            == REF_COUNT_UNIQUE,
+    ensures
+        final(regions).inv(),
+        final(regions).slots =~= old(regions).slots,
+        {
+            let idx = frame_to_index(paddr);
+            let so_old = old(regions).slot_owners[idx];
+            let so_new = final(regions).slot_owners[idx];
+            &&& so_new.inner_perms.ref_count.value() == 1
+            &&& so_new.usage == so_old.usage
+            &&& so_new.paths_in_pt == so_old.paths_in_pt
+            &&& so_new.inner_perms.in_list == so_old.inner_perms.in_list
+            &&& so_new.inner_perms.storage == so_old.inner_perms.storage
+            &&& so_new.self_addr == so_old.self_addr
+        },
+        forall|i: usize|
+            #![trigger final(regions).slot_owners[i]]
+            i != frame_to_index(paddr) ==> final(regions).slot_owners[i] == old(
+                regions,
+            ).slot_owners[i],
+        forall|c: CursorOwner<'_, UserPtConfig>| #![auto]
+            c.metaregion_sound(*old(regions)) ==> c.metaregion_sound(*final(regions)),
+;
+
+/// Mirror of [`crate::mm::frame::UniqueFrame::try_from_shared`]'s
+/// *success* path (the CAS `1 → REF_COUNT_UNIQUE` succeeded). The slot
+/// transitions from a sole-reference shared frame (`rc == 1`,
+/// `usage == Frame`, no PTE) to an exclusive UNIQUE one, with `usage`,
+/// `paths_in_pt` (empty), `in_list` (0), `storage`, `vtable_ptr`, and
+/// `self_addr` preserved. (The failure path — `rc != 1` — leaves
+/// `regions` untouched and is modeled in the step as a no-op.)
+pub axiom fn try_from_shared_embedded(tracked regions: &mut MetaRegionOwners, paddr: Paddr)
+    requires
+        old(regions).inv(),
+        old(regions).slots.contains_key(frame_to_index(paddr)),
+        old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() == 1,
+        old(regions).slot_owners[frame_to_index(paddr)].usage == PageUsage::Frame,
+        old(regions).slot_owners[frame_to_index(paddr)].paths_in_pt.is_empty(),
+    ensures
+        final(regions).inv(),
+        final(regions).slots =~= old(regions).slots,
+        {
+            let idx = frame_to_index(paddr);
+            let so_old = old(regions).slot_owners[idx];
+            let so_new = final(regions).slot_owners[idx];
+            &&& so_new.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+            &&& so_new.usage == so_old.usage
+            &&& so_new.paths_in_pt == so_old.paths_in_pt
+            &&& so_new.inner_perms.in_list == so_old.inner_perms.in_list
+            &&& so_new.inner_perms.storage == so_old.inner_perms.storage
+            &&& so_new.self_addr == so_old.self_addr
+        },
+        forall|i: usize|
+            #![trigger final(regions).slot_owners[i]]
+            i != frame_to_index(paddr) ==> final(regions).slot_owners[i] == old(
+                regions,
+            ).slot_owners[i],
+        forall|c: CursorOwner<'_, UserPtConfig>| #![auto]
+            c.metaregion_sound(*old(regions)) ==> c.metaregion_sound(*final(regions)),
+;
+
+} // verus!

--- a/ostd/specs/mm/embedding/unique.rs
+++ b/ostd/specs/mm/embedding/unique.rs
@@ -44,9 +44,9 @@
 use vstd::prelude::*;
 use vstd_extra::ownership::*;
 
-use crate::specs::arch::has_safe_slot;
 use crate::mm::vm_space::UserPtConfig;
 use crate::mm::Paddr;
+use crate::specs::arch::has_safe_slot;
 use crate::specs::mm::frame::mapping::frame_to_index;
 use crate::specs::mm::frame::meta_owners::{PageUsage, REF_COUNT_UNIQUE, REF_COUNT_UNUSED};
 use crate::specs::mm::frame::meta_region_owners::MetaRegionOwners;

--- a/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
+++ b/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
@@ -234,7 +234,10 @@ pub tracked struct LinkedListOwner<M: AnyFrameMeta + Repr<MetaSlotSmall>> {
 
 impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> Inv for LinkedListOwner<M> {
     open spec fn inv(self) -> bool {
-        &&& self.list_id != 0
+        // Weakened (our change): an EMPTY list may carry `list_id == 0` (the
+        // lazily-minted-id convention used by the list-store embedding); the
+        // id is only constrained non-zero once the list is non-empty.
+        &&& self.list.len() > 0 ==> self.list_id != 0
         &&& forall|i: int| 0 <= i < self.list.len() ==> self.inv_at(i)
     }
 }
@@ -284,6 +287,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
         &&& perm.addr() == self.list[i].paddr
         &&& perm.points_to.addr() == self.list[i].paddr
         &&& perm.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+        &&& regions.slot_owners[idx].usage == PageUsage::Frame
         &&& perm.wf(&perm.inner_perms)
         &&& perm.addr() % META_SLOT_SIZE == 0
         &&& FRAME_METADATA_RANGE.start <= perm.addr() < FRAME_METADATA_RANGE.start + MAX_NR_PAGES
@@ -398,6 +402,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
                 &&& perm.addr() == self.list[i].paddr
                 &&& perm.points_to.addr() == self.list[i].paddr
                 &&& perm.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+                &&& regions.slot_owners[idx].usage == PageUsage::Frame
                 &&& perm.wf(&perm.inner_perms)
                 &&& perm.addr() % META_SLOT_SIZE == 0
                 &&& FRAME_METADATA_RANGE.start <= perm.addr() < FRAME_METADATA_RANGE.start
@@ -449,6 +454,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
                 &&& perm.addr() == self.list[i].paddr
                 &&& perm.points_to.addr() == self.list[i].paddr
                 &&& perm.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+                &&& regions.slot_owners[idx].usage == PageUsage::Frame
                 &&& perm.wf(&perm.inner_perms)
                 &&& perm.addr() % META_SLOT_SIZE == 0
                 &&& FRAME_METADATA_RANGE.start <= perm.addr() < FRAME_METADATA_RANGE.start
@@ -567,6 +573,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
                     &&& fp.points_to.addr() == old.list[p].paddr
                     &&& fp.points_to.pptr() == r0.slots[i].pptr()
                     &&& fp.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+                    &&& fr.slot_owners[i].usage == PageUsage::Frame
                     &&& fp.wf(&fp.inner_perms)
                     &&& fp.addr() % META_SLOT_SIZE == 0
                     &&& FRAME_METADATA_RANGE.start <= fp.addr() < FRAME_METADATA_RANGE.start
@@ -724,6 +731,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
                 &&& fpn.addr() == link.paddr
                 &&& fpn.points_to.addr() == link.paddr
                 &&& fpn.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+                &&& fr.slot_owners[ins].usage == PageUsage::Frame
                 &&& fpn.wf(&fpn.inner_perms)
                 &&& fpn.addr() % META_SLOT_SIZE == 0
                 &&& FRAME_METADATA_RANGE.start <= fpn.addr() < FRAME_METADATA_RANGE.start
@@ -759,6 +767,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
                     &&& fp.points_to.addr() == old.list[p].paddr
                     &&& fp.points_to.pptr() == r0.slots[i].pptr()
                     &&& fp.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+                    &&& fr.slot_owners[i].usage == PageUsage::Frame
                     &&& fp.wf(&fp.inner_perms)
                     &&& fp.addr() % META_SLOT_SIZE == 0
                     &&& FRAME_METADATA_RANGE.start <= fp.addr() < FRAME_METADATA_RANGE.start

--- a/ostd/specs/mm/frame/meta_owners.rs
+++ b/ostd/specs/mm/frame/meta_owners.rs
@@ -272,6 +272,11 @@ impl Inv for MetaSlotOwner {
         &&& self.inner_perms.ref_count.value() == REF_COUNT_UNIQUE ==> {
             &&& self.inner_perms.vtable_ptr.is_init()
             &&& self.inner_perms.storage.is_init()
+            // A UNIQUE non-MMIO slot has no live PTE mapping (same rationale as
+            // the UNUSED branch): a mapping would be a reference keeping the
+            // count above the unique sentinel. Lets the list-store embedding
+            // discharge `paths_in_pt.is_empty()` for linked-list frames.
+            &&& (self.usage != PageUsage::MMIO ==> self.paths_in_pt.is_empty())
         }
         // A SHARED slot (`0 < rc <= REF_COUNT_MAX`) is genuinely in use:
         // metadata storage is written, `vtable_ptr` resolves the

--- a/ostd/specs/mm/frame/meta_region_owners.rs
+++ b/ostd/specs/mm/frame/meta_region_owners.rs
@@ -259,19 +259,6 @@ impl MetaRegionOwners {
         assert((frame_to_index(paddr)) < max_meta_slots() as usize);
     }
 
-    pub axiom fn copy_perm<M: AnyFrameMeta + Repr<MetaSlotStorage>>(
-        tracked &mut self,
-        index: usize,
-    ) -> (tracked perm: MetaPerm<M>)
-        requires
-            old(self).slots.contains_key(index),
-        ensures
-            perm.points_to == old(self).slots[index],
-            final(self).slots == old(self).slots.remove(index),
-            final(self).slot_owners == old(self).slot_owners,
-            final(self).frame_obligations == old(self).frame_obligations,
-    ;
-
     /// Move a slot pointer permission *into* `slots[index]` from caller-supplied storage.
     /// Used by `Frame::from_raw` after the migration to typed slot perms — the perm being
     /// returned to `regions.slots` has no `inner_perms` baggage; the inner-perms live in

--- a/ostd/specs/mm/frame/meta_specs.rs
+++ b/ostd/specs/mm/frame/meta_specs.rs
@@ -96,6 +96,35 @@ impl MetaSlot {
         }
     }
 
+    /// Variant of [`get_from_unused_spec`] for allocating a page-table *node*
+    /// (always non-unique). Identical except the claimed slot becomes
+    /// `PageUsage::PageTable` rather than `PageUsage::Frame`: a page-table
+    /// node is tracked with `PageTable` usage, which gives a clean
+    /// usage-based discriminator between node slots and data-frame slots
+    /// (the latter are `Frame`/MMIO). Used by the node allocators
+    /// (`PageTableNode::alloc`, `PageTable::empty_with_owner`).
+    pub open spec fn get_node_from_unused_spec(
+        paddr: Paddr,
+        pre: MetaRegionOwners,
+        post: MetaRegionOwners,
+    ) -> bool
+        recommends
+            paddr % PAGE_SIZE == 0,
+            paddr < MAX_PADDR,
+            pre.inv(),
+    {
+        let idx = frame_to_index(paddr);
+        {
+            &&& post.slot_owners.dom() =~= pre.slot_owners.dom()
+            &&& MetaSlot::get_from_unused_inner_perms_spec(false, post.slot_owners[idx].inner_perms)
+            &&& post.slot_owners[idx].usage == PageUsage::PageTable
+            &&& post.slot_owners[idx].self_addr == pre.slot_owners[idx].self_addr
+            &&& post.slot_owners[idx].paths_in_pt == pre.slot_owners[idx].paths_in_pt
+            &&& forall|i: usize| i != idx ==> (#[trigger] post.slot_owners[i] == pre.slot_owners[i])
+            &&& pre.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNUSED
+        }
+    }
+
     /// Permission-location clause: the slot perm was *extracted* (handed back to
     /// the caller via an out-param), so `regions.slots` loses it. Pairs with
     /// [`get_from_unused_spec`] to describe [`crate::mm::frame::MetaSlot::get_from_unused`].

--- a/ostd/specs/mm/frame/unique.rs
+++ b/ostd/specs/mm/frame/unique.rs
@@ -102,6 +102,11 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrameOwner<M> {
         &&& perm.value().metadata.wf(self.meta_own)
         &&& regions.slot_owners[self.slot_index].self_addr == meta_addr(self.slot_index)
         &&& regions.slot_owners[self.slot_index].inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+        // Data-frame node-repark discriminator (our change): a unique frame's
+        // slot is tracked with `Frame` usage, distinguishing it from page-table
+        // node slots (`PageTable`) and letting linked-list/list-store consumers
+        // derive `usage == Frame` (e.g. for the empty-`paths_in_pt` argument).
+        &&& regions.slot_owners[self.slot_index].usage == PageUsage::Frame
         &&& regions.frame_obligations.count(self.slot_index) > 0
     }
 

--- a/ostd/specs/mm/frame/unique.rs
+++ b/ostd/specs/mm/frame/unique.rs
@@ -133,7 +133,8 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrameOwner<M> {
         &&& perm.addr() == perm.points_to.addr()
         &&& perm.value().metadata.wf(self.meta_own)
         &&& regions.slot_owners[self.slot_index].self_addr == meta_addr(self.slot_index)
-        &&& regions.slot_owners[self.slot_index].inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+        &&& regions.slot_owners[self.slot_index].inner_perms.ref_count.value()
+            == REF_COUNT_UNIQUE
         // Data-frame node-repark discriminator (our change): a unique frame's
         // slot is tracked with `Frame` usage, distinguishing it from page-table
         // node slots (`PageTable`) and letting linked-list/list-store consumers

--- a/ostd/specs/mm/frame/unique.rs
+++ b/ostd/specs/mm/frame/unique.rs
@@ -62,6 +62,38 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> ModelOf for UniqueFrame<
 
 }
 
+impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrame<M> {
+    /// Cross-object validity of a live UNIQUE handle against the region map —
+    /// the [`UniqueFrame`] analog of [`Frame::inv_with_regions`] (which covers
+    /// the SHARED state). Bundles the structural `wf` / `owner.inv` /
+    /// `regions.inv` facts with the UNIQUE-state slot facts so a consumer (e.g.
+    /// [`UniqueFrame::drop`]) can state a single invariant instead of re-listing
+    /// each conjunct.
+    ///
+    /// The slot's `slot_owners.contains_key(idx)`, `self_addr == meta_addr(idx)`,
+    /// `storage.is_init()`, and `vtable_ptr.is_init()` are **derived**, not
+    /// required: `regions.inv()` (with `owner.inv()`'s `idx < max_meta_slots`)
+    /// delivers the first two and `slot_owners[idx].inv()`; the latter's UNIQUE
+    /// branch (under `rc == REF_COUNT_UNIQUE`) gives the storage/vtable init.
+    /// The genuinely-extra conjuncts are the UNIQUE state itself plus
+    /// `in_list == 0` and `paths_in_pt.is_empty()` (a sole owner is neither on
+    /// the free list nor mapped into any page table).
+    pub open spec fn inv_with_regions(
+        self,
+        owner: UniqueFrameOwner<M>,
+        s: MetaRegionOwners,
+    ) -> bool {
+        let idx = owner.slot_index;
+        let so = s.slot_owners[idx];
+        &&& self.wf(owner)
+        &&& owner.inv()
+        &&& s.inv()
+        &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+        &&& so.inner_perms.in_list.value() == 0
+        &&& so.paths_in_pt.is_empty()
+    }
+}
+
 impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrameOwner<M> {
     /// The typed permission for this frame, reconstructed from the region: the
     /// outer pointer-perm `regions.slots[slot_index]` paired with the inner

--- a/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
@@ -43,6 +43,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         requires
             self.inv(),
             self.in_locked_range(),
+            !self.popped_too_high,
             self.metaregion_sound(regions),
             self.cur_entry_owner().is_frame(),
             other.cur_entry_owner().is_frame(),
@@ -135,6 +136,16 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
     pub proof fn map_branch_none_inv_holds(self, owner0: Self)
         requires
             owner0.inv(),
+            // The map happens in the locked range and changes only the current
+            // continuation's slot at `idx` (a real, in-range slot). With this +
+            // "higher continuations unchanged", the root continuation's
+            // isolation clauses are preserved.
+            self.in_locked_range(),
+            !self.popped_too_high,
+            forall|j: int|
+                0 <= j < NR_ENTRIES && j != owner0.continuations[owner0.level - 1].idx as int
+                    ==> (#[trigger] self.continuations[self.level - 1].children[j])
+                    == owner0.continuations[owner0.level - 1].children[j],
             self.level == owner0.level,
             self.va == owner0.va,
             self.guard_level == owner0.guard_level,
@@ -164,6 +175,31 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         let L = self.level as int;
         assert(self.continuations[L - 1].level() == self.level);
         assert(self.continuations.contains_key(L - 1));
+        // Isolation clauses for the root continuation (NR_LEVELS-1).
+        if self.level < NR_LEVELS {
+            // Root is above the current level ⟹ unchanged (higher-unchanged), so
+            // both clauses carry verbatim from `owner0.inv()`.
+            assert(self.continuations[NR_LEVELS - 1] == owner0.continuations[NR_LEVELS - 1]);
+        } else {
+            // Root IS the current continuation. The idx clause is vacuous
+            // (level == NR_LEVELS). For the outside-(borrowed||absent) clause:
+            // the map changed only the in-range slot `idx`, so every outside
+            // child keeps `owner0`'s value; `idx` is in-range (top index in
+            // [start, end), and `in_locked_range` rules out the sentinel).
+            owner0.in_locked_range_top_index_lt_top_end();
+            assert(self.continuations[NR_LEVELS - 1].idx == self.va.index[NR_LEVELS - 1]);
+            assert(self.continuations[NR_LEVELS - 1].idx
+                == owner0.continuations[owner0.level - 1].idx);
+            assert(C::TOP_LEVEL_INDEX_RANGE_spec().start
+                <= owner0.continuations[owner0.level - 1].idx
+                < C::TOP_LEVEL_INDEX_RANGE_spec().end);
+            assert(forall|j: int|
+                0 <= j < NR_ENTRIES && !(C::TOP_LEVEL_INDEX_RANGE_spec().start <= j
+                    < C::TOP_LEVEL_INDEX_RANGE_spec().end)
+                    ==> (#[trigger] self.continuations[NR_LEVELS - 1].children[j]) is Some
+                    ==> (self.continuations[NR_LEVELS - 1].children[j].unwrap().value.is_borrowed()
+                    || self.continuations[NR_LEVELS - 1].children[j].unwrap().value.is_absent()));
+        }
     }
 
     /// After alloc_if_none (absent->node), `view_mappings` is unchanged (both contribute zero mappings).

--- a/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
@@ -143,8 +143,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.in_locked_range(),
             !self.popped_too_high,
             forall|j: int|
-                0 <= j < NR_ENTRIES && j != owner0.continuations[owner0.level - 1].idx as int
-                    ==> (#[trigger] self.continuations[self.level - 1].children[j])
+                0 <= j < NR_ENTRIES && j != owner0.continuations[owner0.level - 1].idx as int ==> (
+                #[trigger] self.continuations[self.level - 1].children[j])
                     == owner0.continuations[owner0.level - 1].children[j],
             self.level == owner0.level,
             self.va == owner0.va,
@@ -188,16 +188,15 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             // [start, end), and `in_locked_range` rules out the sentinel).
             owner0.in_locked_range_top_index_lt_top_end();
             assert(self.continuations[NR_LEVELS - 1].idx == self.va.index[NR_LEVELS - 1]);
-            assert(self.continuations[NR_LEVELS - 1].idx
-                == owner0.continuations[owner0.level - 1].idx);
-            assert(C::TOP_LEVEL_INDEX_RANGE_spec().start
-                <= owner0.continuations[owner0.level - 1].idx
-                < C::TOP_LEVEL_INDEX_RANGE_spec().end);
+            assert(self.continuations[NR_LEVELS - 1].idx == owner0.continuations[owner0.level
+                - 1].idx);
+            assert(C::TOP_LEVEL_INDEX_RANGE_spec().start <= owner0.continuations[owner0.level
+                - 1].idx < C::TOP_LEVEL_INDEX_RANGE_spec().end);
             assert(forall|j: int|
                 0 <= j < NR_ENTRIES && !(C::TOP_LEVEL_INDEX_RANGE_spec().start <= j
-                    < C::TOP_LEVEL_INDEX_RANGE_spec().end)
-                    ==> (#[trigger] self.continuations[NR_LEVELS - 1].children[j]) is Some
-                    ==> (self.continuations[NR_LEVELS - 1].children[j].unwrap().value.is_borrowed()
+                    < C::TOP_LEVEL_INDEX_RANGE_spec().end) ==> (
+                #[trigger] self.continuations[NR_LEVELS - 1].children[j]) is Some ==> (
+                self.continuations[NR_LEVELS - 1].children[j].unwrap().value.is_borrowed()
                     || self.continuations[NR_LEVELS - 1].children[j].unwrap().value.is_absent()));
         }
     }

--- a/ostd/specs/mm/page_table/cursor/cursor_fn_specs.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_fn_specs.rs
@@ -164,6 +164,12 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         // Tracked items hold a refcount; untracked (MMIO) don't.
         &&& C::tracked(item) ==> regions.slot_owners[idx].inner_perms.ref_count.value()
             > 0
+        // A tracked (mapped) item is a SHARED frame, never the UNIQUE sentinel:
+        // `rc <= MAX < REF_COUNT_UNIQUE`. Carries the bound into the mapped
+        // slot's `metaregion_sound`, keeping the UNIQUE-branch `paths_in_pt`
+        // inv clause vacuous.
+        &&& C::tracked(item) ==> regions.slot_owners[idx].inner_perms.ref_count.value()
+            <= REF_COUNT_MAX
         // Sub-page slot existence for huge frames (unconditional). Rc parts gated on tracked.
         &&& level > 1 ==> {
             forall|j: usize|
@@ -176,6 +182,11 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         != REF_COUNT_UNUSED
                     &&& C::tracked(item)
                         ==> regions.slot_owners[sub_idx].inner_perms.ref_count.value() > 0
+                    // SHARED upper bound for tracked sub-pages — carries `rc <= MAX`
+                    // into the mapped huge frame's `frame_sub_pages_valid`.
+                    &&& C::tracked(item)
+                        ==> regions.slot_owners[sub_idx].inner_perms.ref_count.value()
+                        <= REF_COUNT_MAX
                 }
         }
     }

--- a/ostd/specs/mm/page_table/cursor/cursor_fn_specs.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_fn_specs.rs
@@ -181,7 +181,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         ==> regions.slot_owners[sub_idx].inner_perms.ref_count.value()
                         != REF_COUNT_UNUSED
                     &&& C::tracked(item)
-                        ==> regions.slot_owners[sub_idx].inner_perms.ref_count.value() > 0
+                        ==> regions.slot_owners[sub_idx].inner_perms.ref_count.value()
+                        > 0
                     // SHARED upper bound for tracked sub-pages — carries `rc <= MAX`
                     // into the mapped huge frame's `frame_sub_pages_valid`.
                     &&& C::tracked(item)

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -568,7 +568,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 0 <= j < NR_ENTRIES && #[trigger] child.children[j] is Some implies {
                 &&& child.children[j].unwrap().value.parent_level == child.level()
                 &&& child.children[j].unwrap().level == child.tree_level + 1
-                &&& !child.children[j].unwrap().value.in_scope
                 &&& <EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
                     child.entry_own,
                     j,
@@ -647,7 +646,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 0 <= i < NR_ENTRIES && #[trigger] modified_cont.children[i] is Some implies {
                 &&& modified_cont.children[i].unwrap().value.parent_level == modified_cont.level()
                 &&& modified_cont.children[i].unwrap().level == modified_cont.tree_level + 1
-                &&& !modified_cont.children[i].unwrap().value.in_scope
                 &&& <EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
                     modified_cont.entry_own,
                     i,
@@ -1368,7 +1366,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 0 <= i < NR_ENTRIES && #[trigger] new_cont.children[i] is Some implies {
                 &&& new_cont.children[i].unwrap().value.parent_level == new_cont.level()
                 &&& new_cont.children[i].unwrap().level == new_cont.tree_level + 1
-                &&& !new_cont.children[i].unwrap().value.in_scope
                 &&& <EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
                     new_cont.entry_own,
                     i,
@@ -1380,7 +1377,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             } by {
                 if i == cont.idx as int {
                     assert(new_cont.children[i].unwrap() == child_node);
-                    assert(!child.entry_own.in_scope);
                 } else {
                     assert(new_cont.children[i] == cont.children[i]);
                     cont.inv_children_rel_unroll(i);

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -680,6 +680,25 @@ impl<'rcu, C: PageTableConfig> Inv for CursorOwner<'rcu, C> {
             self.level <= i < NR_LEVELS ==> {
                 (#[trigger] self.continuations[i]).all_but_index_some()
             }
+        // Root-continuation top-level index stays within the config range, and
+        //  (b) its top-level children OUTSIDE the config range are `borrowed`
+        //      OR `absent` — they share another config's sub-tree (user PT's
+        //      kernel half = borrowed) or are unmapped (kernel PT's user half =
+        //      absent), and either way contribute NOTHING to `view_rec`.
+        //      Preserved across cursor ops; makes both the user
+        //      (`lemma_view_in_vaddr_range_user`) and kernel
+        //      (`lemma_view_in_vaddr_range_kernel`) view bounds provable.
+        &&& self.level <= NR_LEVELS - 1 ==> {
+            &&& C::TOP_LEVEL_INDEX_RANGE_spec().start <= self.continuations[NR_LEVELS - 1].idx
+            &&& self.continuations[NR_LEVELS - 1].idx < C::TOP_LEVEL_INDEX_RANGE_spec().end
+        }
+        &&& forall|j: int|
+            #![trigger self.continuations[NR_LEVELS - 1].children[j]]
+            0 <= j < NR_ENTRIES && !(C::TOP_LEVEL_INDEX_RANGE_spec().start <= j
+                < C::TOP_LEVEL_INDEX_RANGE_spec().end)
+                ==> self.continuations[NR_LEVELS - 1].children[j] is Some
+                ==> (self.continuations[NR_LEVELS - 1].children[j].unwrap().value.is_borrowed()
+                || self.continuations[NR_LEVELS - 1].children[j].unwrap().value.is_absent())
         &&& self.prefix.inv()
         &&& self.prefix.offset == 0
         &&& forall|i: int|

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -680,14 +680,14 @@ impl<'rcu, C: PageTableConfig> Inv for CursorOwner<'rcu, C> {
             self.level <= i < NR_LEVELS ==> {
                 (#[trigger] self.continuations[i]).all_but_index_some()
             }
-        // Root-continuation top-level index stays within the config range, and
-        //  (b) its top-level children OUTSIDE the config range are `borrowed`
-        //      OR `absent` — they share another config's sub-tree (user PT's
-        //      kernel half = borrowed) or are unmapped (kernel PT's user half =
-        //      absent), and either way contribute NOTHING to `view_rec`.
-        //      Preserved across cursor ops; makes both the user
-        //      (`lemma_view_in_vaddr_range_user`) and kernel
-        //      (`lemma_view_in_vaddr_range_kernel`) view bounds provable.
+            // Root-continuation top-level index stays within the config range, and
+            //  (b) its top-level children OUTSIDE the config range are `borrowed`
+            //      OR `absent` — they share another config's sub-tree (user PT's
+            //      kernel half = borrowed) or are unmapped (kernel PT's user half =
+            //      absent), and either way contribute NOTHING to `view_rec`.
+            //      Preserved across cursor ops; makes both the user
+            //      (`lemma_view_in_vaddr_range_user`) and kernel
+            //      (`lemma_view_in_vaddr_range_kernel`) view bounds provable.
         &&& self.level <= NR_LEVELS - 1 ==> {
             &&& C::TOP_LEVEL_INDEX_RANGE_spec().start <= self.continuations[NR_LEVELS - 1].idx
             &&& self.continuations[NR_LEVELS - 1].idx < C::TOP_LEVEL_INDEX_RANGE_spec().end
@@ -695,10 +695,10 @@ impl<'rcu, C: PageTableConfig> Inv for CursorOwner<'rcu, C> {
         &&& forall|j: int|
             #![trigger self.continuations[NR_LEVELS - 1].children[j]]
             0 <= j < NR_ENTRIES && !(C::TOP_LEVEL_INDEX_RANGE_spec().start <= j
-                < C::TOP_LEVEL_INDEX_RANGE_spec().end)
-                ==> self.continuations[NR_LEVELS - 1].children[j] is Some
-                ==> (self.continuations[NR_LEVELS - 1].children[j].unwrap().value.is_borrowed()
-                || self.continuations[NR_LEVELS - 1].children[j].unwrap().value.is_absent())
+                < C::TOP_LEVEL_INDEX_RANGE_spec().end) ==> self.continuations[NR_LEVELS
+                - 1].children[j] is Some ==> (self.continuations[NR_LEVELS
+                - 1].children[j].unwrap().value.is_borrowed() || self.continuations[NR_LEVELS
+                - 1].children[j].unwrap().value.is_absent())
         &&& self.prefix.inv()
         &&& self.prefix.offset == 0
         &&& forall|i: int|
@@ -2926,15 +2926,17 @@ pub proof fn lemma_view_in_vaddr_range_user<'rcu>(
     let end = crate::mm::vm_space::UserPtConfig::TOP_LEVEL_INDEX_RANGE_spec().end as int;
     assert(end == 256);
     assert(end * 0x80_0000_0000int == 0x8000_0000_0000int) by (nonlinear_arith)
-        requires end == 256;
+        requires
+            end == 256,
+    ;
     assert forall|m: Mapping| owner.view_mappings().contains(m) implies {
         &&& 0 <= m.va_range.start
         &&& m.va_range.end <= 0x8000_0000_0000int
     } by {
         owner.lemma_view_mappings_contains();
         let i = choose|i: int|
-            owner.level - 1 <= i < NR_LEVELS && (#[trigger] owner.continuations[i]).view_mappings()
-                .contains(m);
+            owner.level - 1 <= i < NR_LEVELS && (
+            #[trigger] owner.continuations[i]).view_mappings().contains(m);
         owner.inv_continuation(i);
         let cont = owner.continuations[i];
         cont.lemma_view_mappings_contains();
@@ -3006,8 +3008,9 @@ pub proof fn lemma_view_in_vaddr_range_kernel<'rcu>(
             owner.view_mappings().contains(m) ==> {
                 &&& vaddr_range_bounds_spec::<crate::mm::kspace::KernelPtConfig>().0
                     <= m.va_range.start
-                &&& m.va_range.end
-                    <= vaddr_range_bounds_spec::<crate::mm::kspace::KernelPtConfig>().1 + 1
+                &&& m.va_range.end <= vaddr_range_bounds_spec::<
+                    crate::mm::kspace::KernelPtConfig,
+                >().1 + 1
             },
 {
     crate::mm::page_table::lemma_vaddr_range_bounds_spec_kernel();
@@ -3021,18 +3024,24 @@ pub proof fn lemma_view_in_vaddr_range_kernel<'rcu>(
     //       == (0xFFFF_8000_0000_0000, 0xFFFF_FFFF_FFFF_FFFF).
     assert(start * 0x80_0000_0000int + lb * 0x1_0000_0000_0000int == 0xFFFF_8000_0000_0000int)
         by (nonlinear_arith)
-        requires start == 256, lb == 0xffff;
+        requires
+            start == 256,
+            lb == 0xffff,
+    ;
     assert(end * 0x80_0000_0000int + lb * 0x1_0000_0000_0000int == 0x1_0000_0000_0000_0000int)
         by (nonlinear_arith)
-        requires end == 512, lb == 0xffff;
+        requires
+            end == 512,
+            lb == 0xffff,
+    ;
     assert forall|m: Mapping| owner.view_mappings().contains(m) implies {
         &&& vaddr_range_bounds_spec::<crate::mm::kspace::KernelPtConfig>().0 <= m.va_range.start
         &&& m.va_range.end <= vaddr_range_bounds_spec::<crate::mm::kspace::KernelPtConfig>().1 + 1
     } by {
         owner.lemma_view_mappings_contains();
         let i = choose|i: int|
-            owner.level - 1 <= i < NR_LEVELS && (#[trigger] owner.continuations[i]).view_mappings()
-                .contains(m);
+            owner.level - 1 <= i < NR_LEVELS && (
+            #[trigger] owner.continuations[i]).view_mappings().contains(m);
         owner.inv_continuation(i);
         let cont = owner.continuations[i];
         cont.lemma_view_mappings_contains();
@@ -3087,7 +3096,9 @@ pub proof fn lemma_view_in_vaddr_range_kernel<'rcu>(
         // m.start ≥ index(0)·2^39 + lb·2^48 ≥ start·2^39 + lb·2^48 = bound.0.
         assert((p.index(0) as int) * 0x80_0000_0000int + lb * 0x1_0000_0000_0000int >= start
             * 0x80_0000_0000int + lb * 0x1_0000_0000_0000int) by (nonlinear_arith)
-            requires start <= p.index(0) as int;
+            requires
+                start <= p.index(0) as int,
+        ;
     }
 }
 

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -238,7 +238,6 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
                 child is Some ==> {
                     &&& child->0.value.parent_level == self.level()
                     &&& child->0.level == self.tree_level + 1
-                    &&& !child->0.value.in_scope
                     &&& child->0.value.path.len() == self.entry_own.node().tree_level + 1
                     &&& child->0.value.match_pte(
                         self.entry_own.node().children_perm.value()[i],
@@ -280,7 +279,6 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         ensures
             self.children[i]->0.value.parent_level == self.level(),
             self.children[i]->0.level == self.tree_level + 1,
-            !self.children[i]->0.value.in_scope,
             self.children[i]->0.value.path.len() == self.entry_own.node().tree_level + 1,
             self.children[i]->0.value.match_pte(
                 self.entry_own.node().children_perm.value()[i],
@@ -299,7 +297,6 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         &&& self.pt_inv_children()
         &&& self.entry_own.is_node()
         &&& self.entry_own.inv()
-        &&& !self.entry_own.in_scope
         &&& self.entry_own.node().relate_guard(self.guard)
         &&& self.tree_level == INC_LEVELS - self.level() - 1
         &&& self.tree_level < INC_LEVELS - 1
@@ -493,7 +490,6 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             // entry_own changed only by the Node payload and otherwise keeps
             // the surrounding owner metadata.
             self.entry_own.is_absent() == cont_old.entry_own.is_absent(),
-            self.entry_own.in_scope == cont_old.entry_own.in_scope,
             self.entry_own.path == cont_old.entry_own.path,
             self.entry_own.parent_level == cont_old.entry_own.parent_level,
             // entry_own's new parent is well-formed and structurally matches the old
@@ -532,7 +528,6 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
                 self.entry_own.node().children_perm.value()[self.idx as int],
                 self.entry_own.node().level,
             ),
-            !self.children[self.idx as int]->0.value.in_scope,
             // The new child satisfies the PT-specific tree invariant. This is
             // operation-specific (alloc_if_none/protect/split_if_mapped_huge/
             // replace each establish it differently) so it's lifted to a
@@ -598,8 +593,6 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
                 }
             };
         };
-
-        assert(!self.entry_own.in_scope);
     }
 
     pub proof fn new_child(
@@ -628,7 +621,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
                 self.level(),
                 prop,
                 is_tracked,
-            ).set_in_scope(false),
+            ),
             res.inv(),
             res.level == self.tree_level + 1,
             res == OwnerSubtree::new_val(res.value, res.level as nat),
@@ -640,7 +633,6 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             prop,
             is_tracked,
         );
-        owner.in_scope = false;
         OwnerSubtree::new_val_tracked(owner, self.tree_level + 1)
     }
 
@@ -2636,7 +2628,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
     }
 
     /// Transfers `metaregion_sound` when `raw_count` changed from 0 to 1 at one index.
-    /// Uses `map_implies_and` with `not_in_scope_pred` since tree entries have `!in_scope`.
+    /// Uses `map_implies_and` with the trivial `not_in_scope_pred`.
     pub proof fn metaregion_borrow_slot(
         self,
         regions0: MetaRegionOwners,

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -2991,6 +2991,106 @@ pub proof fn lemma_view_in_vaddr_range_user<'rcu>(
     }
 }
 
+/// KERNEL isolation theorem (proven, per-config): every mapping a
+/// `KernelPtConfig` cursor exposes lives in the kernel high half. Mirror of
+/// `lemma_view_in_vaddr_range_user` with `TOP_LEVEL_INDEX_RANGE == 256..512` and
+/// `LEADING_BITS == 0xffff` (canonical high-half base).
+pub proof fn lemma_view_in_vaddr_range_kernel<'rcu>(
+    owner: &CursorOwner<'rcu, crate::mm::kspace::KernelPtConfig>,
+)
+    requires
+        owner.inv(),
+    ensures
+        forall|m: Mapping|
+            #![auto]
+            owner.view_mappings().contains(m) ==> {
+                &&& vaddr_range_bounds_spec::<crate::mm::kspace::KernelPtConfig>().0
+                    <= m.va_range.start
+                &&& m.va_range.end
+                    <= vaddr_range_bounds_spec::<crate::mm::kspace::KernelPtConfig>().1 + 1
+            },
+{
+    crate::mm::page_table::lemma_vaddr_range_bounds_spec_kernel();
+    let start = crate::mm::kspace::KernelPtConfig::TOP_LEVEL_INDEX_RANGE_spec().start as int;
+    let end = crate::mm::kspace::KernelPtConfig::TOP_LEVEL_INDEX_RANGE_spec().end as int;
+    let lb = crate::mm::kspace::KernelPtConfig::LEADING_BITS_spec() as int;
+    assert(start == 256);
+    assert(end == 512);
+    assert(lb == 0xffff);
+    // bound == (256·2^39 + 0xffff·2^48, 512·2^39 + 0xffff·2^48 - 1)
+    //       == (0xFFFF_8000_0000_0000, 0xFFFF_FFFF_FFFF_FFFF).
+    assert(start * 0x80_0000_0000int + lb * 0x1_0000_0000_0000int == 0xFFFF_8000_0000_0000int)
+        by (nonlinear_arith)
+        requires start == 256, lb == 0xffff;
+    assert(end * 0x80_0000_0000int + lb * 0x1_0000_0000_0000int == 0x1_0000_0000_0000_0000int)
+        by (nonlinear_arith)
+        requires end == 512, lb == 0xffff;
+    assert forall|m: Mapping| owner.view_mappings().contains(m) implies {
+        &&& vaddr_range_bounds_spec::<crate::mm::kspace::KernelPtConfig>().0 <= m.va_range.start
+        &&& m.va_range.end <= vaddr_range_bounds_spec::<crate::mm::kspace::KernelPtConfig>().1 + 1
+    } by {
+        owner.lemma_view_mappings_contains();
+        let i = choose|i: int|
+            owner.level - 1 <= i < NR_LEVELS && (#[trigger] owner.continuations[i]).view_mappings()
+                .contains(m);
+        owner.inv_continuation(i);
+        let cont = owner.continuations[i];
+        cont.lemma_view_mappings_contains();
+        let j = choose|j: int|
+            0 <= j < cont.children.len() && cont.children[j] is Some && PageTableOwner(
+                cont.children[j].unwrap(),
+            ).view_rec(cont.path().push_tail(j as usize)).contains(m);
+        cont.pt_inv_children_unroll(j);
+        cont.inv_children_rel_unroll(j);
+        let child = PageTableOwner(cont.children[j].unwrap());
+        let p = cont.path().push_tail(j as usize);
+        cont.path().push_tail_property_index(j as usize);
+        assert(start <= (p.index(0) as int) < end) by {
+            if i == NR_LEVELS - 1 {
+                // Root: `p == [j]`. A contributing child is a frame/node (not
+                // borrowed/absent, else empty `view_rec`); the cursor-inv
+                // top-level clause then forces `j ∈ [256, 512)`.
+                assert(cont.path().len() == 0);
+                assert(p.index(0) == j);
+                assert(child.0.value.is_frame() || child.0.value.is_node());
+                assert(!child.0.value.is_borrowed());
+                assert(!child.0.value.is_absent());
+                assert(start <= j < end);
+            } else {
+                // Non-root: `p.index(0) == cont.path().index(0) == root.idx ∈
+                // [256, 512)` (path chain + cursor-inv idx clause).
+                assert(cont.path().len() > 0);
+                assert(p.index(0) == cont.path().index(0));
+                assert(cont.path().index(0) == owner.continuations[NR_LEVELS - 1].idx) by {
+                    owner.inv_continuation(NR_LEVELS - 1);
+                    owner.continuations[NR_LEVELS - 1].path().push_tail_property_index(
+                        owner.continuations[NR_LEVELS - 1].idx,
+                    );
+                    if i == 2 {
+                    } else if i == 1 {
+                        owner.continuations[2].path().push_tail_property_index(
+                            owner.continuations[2].idx,
+                        );
+                    } else {
+                        owner.continuations[2].path().push_tail_property_index(
+                            owner.continuations[2].idx,
+                        );
+                        owner.continuations[1].path().push_tail_property_index(
+                            owner.continuations[1].idx,
+                        );
+                    }
+                }
+                assert(start <= owner.continuations[NR_LEVELS - 1].idx < end);
+            }
+        }
+        child.view_rec_top_index_va_bound(p, m, end);
+        // m.start ≥ index(0)·2^39 + lb·2^48 ≥ start·2^39 + lb·2^48 = bound.0.
+        assert((p.index(0) as int) * 0x80_0000_0000int + lb * 0x1_0000_0000_0000int >= start
+            * 0x80_0000_0000int + lb * 0x1_0000_0000_0000int) by (nonlinear_arith)
+            requires start <= p.index(0) as int;
+    }
+}
+
 impl<'rcu, C: PageTableConfig> InvView for CursorOwner<'rcu, C> {
     proof fn view_preserves_inv(self) {
         // (1) Non-overlapping: tree collapse + view_rec_disjoint_vaddrs.

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -2902,6 +2902,95 @@ pub axiom fn axiom_view_in_vaddr_range<'rcu, C: PageTableConfig>(owner: &CursorO
             },
 ;
 
+/// USER isolation theorem (proven, per-config): every mapping a `UserPtConfig`
+/// cursor exposes lives strictly in the user low half `[0, 2^47)`. Discharges
+/// the generic `axiom_view_in_vaddr_range` obligation for `UserPtConfig` without
+/// the axiom. The nested `view_mappings → continuations → view_rec` decomposition
+/// is exposed via `lemma_view_mappings_contains` (cursor + continuation forms)
+/// before each `choose`; a contributing (frame/node) root child is neither
+/// borrowed nor absent, so the cursor-inv top-level clause forces it in-range,
+/// and `view_rec_top_index_va_bound` gives the per-mapping VA bound.
+pub proof fn lemma_view_in_vaddr_range_user<'rcu>(
+    owner: &CursorOwner<'rcu, crate::mm::vm_space::UserPtConfig>,
+)
+    requires
+        owner.inv(),
+    ensures
+        forall|m: Mapping|
+            #![auto]
+            owner.view_mappings().contains(m) ==> {
+                &&& 0 <= m.va_range.start
+                &&& m.va_range.end <= 0x8000_0000_0000int
+            },
+{
+    let end = crate::mm::vm_space::UserPtConfig::TOP_LEVEL_INDEX_RANGE_spec().end as int;
+    assert(end == 256);
+    assert(end * 0x80_0000_0000int == 0x8000_0000_0000int) by (nonlinear_arith)
+        requires end == 256;
+    assert forall|m: Mapping| owner.view_mappings().contains(m) implies {
+        &&& 0 <= m.va_range.start
+        &&& m.va_range.end <= 0x8000_0000_0000int
+    } by {
+        owner.lemma_view_mappings_contains();
+        let i = choose|i: int|
+            owner.level - 1 <= i < NR_LEVELS && (#[trigger] owner.continuations[i]).view_mappings()
+                .contains(m);
+        owner.inv_continuation(i);
+        let cont = owner.continuations[i];
+        cont.lemma_view_mappings_contains();
+        let j = choose|j: int|
+            0 <= j < cont.children.len() && cont.children[j] is Some && PageTableOwner(
+                cont.children[j].unwrap(),
+            ).view_rec(cont.path().push_tail(j as usize)).contains(m);
+        cont.pt_inv_children_unroll(j);
+        cont.inv_children_rel_unroll(j);
+        let child = PageTableOwner(cont.children[j].unwrap());
+        let p = cont.path().push_tail(j as usize);
+        cont.path().push_tail_property_index(j as usize);
+        assert(0 <= (p.index(0) as int) < end) by {
+            if i == NR_LEVELS - 1 {
+                // Root continuation: `p == [j]`. A contributing child is a
+                // frame/node (borrowed/absent give an empty `view_rec`), hence
+                // neither borrowed nor absent; the cursor-inv top-level clause
+                // then forces `j ∈ [0, 256)`.
+                assert(cont.path().len() == 0);
+                assert(p.index(0) == j);
+                assert(child.0.value.is_frame() || child.0.value.is_node());
+                assert(!child.0.value.is_borrowed());
+                assert(!child.0.value.is_absent());
+                assert(0 <= j < end);
+            } else {
+                // Non-root continuation: `p.index(0) == cont.path().index(0)`,
+                // which (via the inv path chain) equals the root continuation's
+                // descended index, in `[0, 256)` by the cursor-inv idx clause.
+                assert(cont.path().len() > 0);
+                assert(p.index(0) == cont.path().index(0));
+                assert(cont.path().index(0) == owner.continuations[NR_LEVELS - 1].idx) by {
+                    owner.inv_continuation(NR_LEVELS - 1);
+                    owner.continuations[NR_LEVELS - 1].path().push_tail_property_index(
+                        owner.continuations[NR_LEVELS - 1].idx,
+                    );
+                    if i == 2 {
+                    } else if i == 1 {
+                        owner.continuations[2].path().push_tail_property_index(
+                            owner.continuations[2].idx,
+                        );
+                    } else {
+                        owner.continuations[2].path().push_tail_property_index(
+                            owner.continuations[2].idx,
+                        );
+                        owner.continuations[1].path().push_tail_property_index(
+                            owner.continuations[1].idx,
+                        );
+                    }
+                }
+                assert(0 <= owner.continuations[NR_LEVELS - 1].idx < end);
+            }
+        }
+        child.view_rec_top_index_va_bound(p, m, end);
+    }
+}
+
 impl<'rcu, C: PageTableConfig> InvView for CursorOwner<'rcu, C> {
     proof fn view_preserves_inv(self) {
         // (1) Non-overlapping: tree collapse + view_rec_disjoint_vaddrs.

--- a/ostd/specs/mm/page_table/cursor/tree_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/tree_lemmas.rs
@@ -234,7 +234,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         let nsp = PageTableOwner::<C>::not_in_scope_pred();
         assert(OwnerSubtree::implies(nsp, g)) by {
             assert forall|entry: EntryOwner<C>, path: TreePath<NR_ENTRIES>|
-                entry.inv() && !entry.in_scope implies #[trigger] g(entry, path) by {};
+                entry.inv() && nsp(entry, path) implies #[trigger] g(entry, path) by {};
         };
         assert forall|i: int|
             #![trigger self.continuations[i]]

--- a/ostd/specs/mm/page_table/cursor/va_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/va_lemmas.rs
@@ -376,20 +376,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
     }
 
     // ─── Axioms: VA mutation ─────────────────────────────────────────────
-    pub axiom fn tracked_set_va(tracked &mut self, new_va: AbstractVaddr)
-        requires
-            forall|i: int|
-                #![auto]
-                old(self).level - 1 <= i < NR_LEVELS ==> new_va.index[i] == old(self).va.index[i],
-            forall|i: int|
-                #![auto]
-                old(self).guard_level - 1 <= i < NR_LEVELS ==> new_va.index[i] == old(
-                    self,
-                ).prefix.index[i],
-        ensures
-            *final(self) == old(self).set_va(new_va),
-    ;
-
     /// When jumping within the same page-table node, only indices at levels
     /// >= level are guaranteed to match. The entry-within-node index (level - 1)
     /// may change, so we update continuations[level-1].idx along with va.

--- a/ostd/specs/mm/page_table/node/child.rs
+++ b/ostd/specs/mm/page_table/node/child.rs
@@ -104,7 +104,6 @@ impl<C: PageTableConfig> Child<C> {
         &&& regions.inv()
         &&& self.wf(owner)
         &&& owner.metaregion_sound(regions)
-        &&& owner.in_scope
     }
 }
 
@@ -114,7 +113,6 @@ impl<C: PageTableConfig> ChildRef<'_, C> {
         &&& regions.inv()
         &&& self.wf(owner)
         &&& owner.metaregion_sound(regions)
-        &&& !owner.in_scope
     }
 }
 
@@ -137,8 +135,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
             // Canonical model: forgetting a live PT-node into a PTE CONSUMES
             // its pending-Drop obligation (the body's `MD::new` redeems one
             // entry at the node's slot), mirroring `Frame::into_raw`. `slots`
-            // / `slot_owners` are untouched; the owner's `in_scope = false`
-            // records the ownership transfer. Balances the `+1` minted by
+            // / `slot_owners` are untouched. Balances the `+1` minted by
             // `from_pte` (`from_pte_regions_spec`) / `PageTableNode::alloc`.
             MetaRegionOwners {
                 frame_obligations: regions.frame_obligations.remove(index),
@@ -152,11 +149,11 @@ impl<C: PageTableConfig> EntryOwner<C> {
     }
 
     pub open spec fn into_pte_owner_spec(self) -> EntryOwner<C> {
-        EntryOwner { in_scope: false, ..self }
+        self
     }
 
     pub open spec fn from_pte_owner_spec(self) -> EntryOwner<C> {
-        EntryOwner { in_scope: true, ..self }
+        self
     }
 
     /// This is equivalent to the other `invariants` relations, combining the `inv` predicates for each
@@ -166,7 +163,6 @@ impl<C: PageTableConfig> EntryOwner<C> {
         &&& regions.inv()
         &&& self.match_pte(pte, self.parent_level)
         &&& self.metaregion_sound(regions)
-        &&& !self.in_scope
     }
 }
 

--- a/ostd/specs/mm/page_table/node/entry.rs
+++ b/ostd/specs/mm/page_table/node/entry.rs
@@ -156,7 +156,6 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
     ) -> bool {
         &&& old_owner.path == new_owner.path
         &&& old_owner.parent_level == new_owner.parent_level
-        &&& new_owner.in_scope
         &&& new_owner.is_node() ==> {
             &&& regions.slots.contains_key(frame_to_index(new_owner.meta_slot_paddr()->0))
             &&& regions.slot_owners[frame_to_index(

--- a/ostd/specs/mm/page_table/node/entry_owners.rs
+++ b/ostd/specs/mm/page_table/node/entry_owners.rs
@@ -52,7 +52,6 @@ pub tracked enum EntryOwnerKind<C: PageTableConfig> {
 
 pub tracked struct EntryOwner<C: PageTableConfig> {
     pub kind: EntryOwnerKind<C>,
-    pub ghost in_scope: bool,
     pub ghost path: TreePath<NR_ENTRIES>,
     pub ghost parent_level: PagingLevel,
 }
@@ -100,7 +99,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
     }
 
     pub open spec fn new_absent(path: TreePath<NR_ENTRIES>, parent_level: PagingLevel) -> Self {
-        EntryOwner { kind: EntryOwnerKind::Absent, in_scope: true, path, parent_level }
+        EntryOwner { kind: EntryOwnerKind::Absent, path, parent_level }
     }
 
     pub open spec fn new_frame(
@@ -119,7 +118,6 @@ impl<C: PageTableConfig> EntryOwner<C> {
                     is_tracked,
                 },
             ),
-            in_scope: true,
             path,
             parent_level,
         }
@@ -128,7 +126,6 @@ impl<C: PageTableConfig> EntryOwner<C> {
     pub open spec fn new_node(node: NodeOwner<C>, path: TreePath<NR_ENTRIES>) -> Self {
         EntryOwner {
             kind: EntryOwnerKind::Node(node),
-            in_scope: true,
             path,
             parent_level: (node.level + 1) as PagingLevel,
         }
@@ -141,7 +138,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
         parent_level: PagingLevel,
         mappings: Set<Mapping>,
     ) -> Self {
-        EntryOwner { kind: EntryOwnerKind::Borrowed(mappings), in_scope: true, path, parent_level }
+        EntryOwner { kind: EntryOwnerKind::Borrowed(mappings), path, parent_level }
     }
 
     pub proof fn tracked_new_borrowed(
@@ -152,7 +149,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
         returns
             Self::new_borrowed(path, parent_level, mappings),
     {
-        Self { kind: EntryOwnerKind::Borrowed(mappings), in_scope: true, path, parent_level }
+        Self { kind: EntryOwnerKind::Borrowed(mappings), path, parent_level }
     }
 
     pub proof fn tracked_new_absent(
@@ -162,7 +159,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
         returns
             Self::new_absent(path, parent_level),
     {
-        Self { kind: EntryOwnerKind::Absent, in_scope: true, path, parent_level }
+        Self { kind: EntryOwnerKind::Absent, path, parent_level }
     }
 
     pub proof fn tracked_take_node(tracked &mut self) -> (tracked res: NodeOwner<C>)
@@ -323,7 +320,6 @@ impl<C: PageTableConfig> EntryOwner<C> {
         Self {
             parent_level: (node.level + 1) as PagingLevel,
             kind: EntryOwnerKind::Node(node),
-            in_scope: true,
             path,
         }
     }
@@ -353,7 +349,6 @@ impl<C: PageTableConfig> EntryOwner<C> {
             res.frame().is_tracked == false,
             res.parent_level == parent_level,
             res.path.inv(),
-            res.in_scope,
             res.inv_base(),
             crate::mm::page_table::Child::<C>::Frame(paddr, parent_level, prop).wf(res),
     ;
@@ -988,8 +983,8 @@ impl<C: PageTableConfig> EntryOwner<C> {
 }
 
 impl<C: PageTableConfig> EntryOwner<C> {
-    /// Structural invariant without `!in_scope`. Used by `Child::invariants`
-    /// for entries that have been taken out of the tree (`in_scope == true`).
+    /// Structural invariant of an entry owner. This is the whole of `inv()`,
+    /// and is also used directly by `Child::invariants`.
     pub open spec fn inv_base(self) -> bool {
         &&& self.is_node() ==> {
             &&& self.node().inv()
@@ -1011,16 +1006,11 @@ impl<C: PageTableConfig> EntryOwner<C> {
         &&& self.is_borrowed() ==> { true }
         &&& self.path.inv()
     }
-
-    pub open spec fn set_in_scope(self, in_scope: bool) -> Self {
-        EntryOwner { in_scope, ..self }
-    }
 }
 
 impl<C: PageTableConfig> Inv for EntryOwner<C> {
     open spec fn inv(self) -> bool {
-        &&& !self.in_scope
-        &&& self.inv_base()
+        self.inv_base()
     }
 }
 

--- a/ostd/specs/mm/page_table/node/entry_owners.rs
+++ b/ostd/specs/mm/page_table/node/entry_owners.rs
@@ -869,6 +869,9 @@ impl<C: PageTableConfig> EntryOwner<C> {
                     == r0.slot_owners[idx].inner_perms.in_list
                 &&& r1.slot_owners[idx].self_addr == r0.slot_owners[idx].self_addr
                 &&& r1.slot_owners[idx].paths_in_pt == r0.slot_owners[idx].paths_in_pt
+                // `usage` is part of `metaregion_sound_node` (node-repark
+                // discriminator), so it must be preserved to carry soundness.
+                &&& r1.slot_owners[idx].usage == r0.slot_owners[idx].usage
             }),
             // All other slot_owners unchanged: preserves sub-page validity for huge frames.
             forall|i: usize|

--- a/ostd/specs/mm/page_table/node/entry_owners.rs
+++ b/ostd/specs/mm/page_table/node/entry_owners.rs
@@ -523,6 +523,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
                     != crate::specs::mm::frame::meta_owners::PageUsage::MMIO ==> {
                     &&& r1.slot_owners[sub_idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
                     &&& r1.slot_owners[sub_idx].inner_perms.ref_count.value() > 0
+                    &&& r1.slot_owners[sub_idx].inner_perms.ref_count.value() <= REF_COUNT_MAX
                 }
             } by {
                 let sub_idx = frame_to_index((pa + j * PAGE_SIZE) as usize);
@@ -593,6 +594,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
                         &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value()
                             != REF_COUNT_UNUSED
                         &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value() > 0
+                        &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value() <= REF_COUNT_MAX
                     }
                 }
         }
@@ -623,6 +625,11 @@ impl<C: PageTableConfig> EntryOwner<C> {
                 != crate::specs::mm::frame::meta_owners::PageUsage::MMIO ==> {
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value() > 0
+                // A mapped (tracked) frame is SHARED, never the UNIQUE sentinel
+                // (`rc <= MAX < REF_COUNT_UNIQUE`). Lets the UNIQUE-branch
+                // `paths_in_pt`-empty inv clause hold vacuously for mapped
+                // frames whose `paths_in_pt` is non-empty.
+                &&& regions.slot_owners[idx].inner_perms.ref_count.value() <= REF_COUNT_MAX
             }
             &&& regions.slot_owners[idx].paths_in_pt.contains(self.path)
             &&& self.frame_sub_pages_valid(regions)
@@ -720,7 +727,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
                         r1.slots.contains_key(sub_idx)
                             && r1.slot_owners[sub_idx].inner_perms.ref_count.value()
                             != REF_COUNT_UNUSED
-                            && r1.slot_owners[sub_idx].inner_perms.ref_count.value() > 0)
+                            && r1.slot_owners[sub_idx].inner_perms.ref_count.value() > 0 && r1.slot_owners[sub_idx].inner_perms.ref_count.value() <= REF_COUNT_MAX)
                     }
             },
         ensures
@@ -808,6 +815,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
                             &&& r1.slot_owners[sub_idx].inner_perms.ref_count.value()
                                 != REF_COUNT_UNUSED
                             &&& r1.slot_owners[sub_idx].inner_perms.ref_count.value() > 0
+                            &&& r1.slot_owners[sub_idx].inner_perms.ref_count.value() <= REF_COUNT_MAX
                         }
                     } by {
                         let sub_idx = frame_to_index((pa + j * PAGE_SIZE) as usize);

--- a/ostd/specs/mm/page_table/node/entry_owners.rs
+++ b/ostd/specs/mm/page_table/node/entry_owners.rs
@@ -594,7 +594,8 @@ impl<C: PageTableConfig> EntryOwner<C> {
                         &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value()
                             != REF_COUNT_UNUSED
                         &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value() > 0
-                        &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value() <= REF_COUNT_MAX
+                        &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value()
+                            <= REF_COUNT_MAX
                     }
                 }
         }
@@ -624,7 +625,8 @@ impl<C: PageTableConfig> EntryOwner<C> {
             &&& regions.slot_owners[idx].usage
                 != crate::specs::mm::frame::meta_owners::PageUsage::MMIO ==> {
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-                &&& regions.slot_owners[idx].inner_perms.ref_count.value() > 0
+                &&& regions.slot_owners[idx].inner_perms.ref_count.value()
+                    > 0
                 // A mapped (tracked) frame is SHARED, never the UNIQUE sentinel
                 // (`rc <= MAX < REF_COUNT_UNIQUE`). Lets the UNIQUE-branch
                 // `paths_in_pt`-empty inv clause hold vacuously for mapped
@@ -727,7 +729,9 @@ impl<C: PageTableConfig> EntryOwner<C> {
                         r1.slots.contains_key(sub_idx)
                             && r1.slot_owners[sub_idx].inner_perms.ref_count.value()
                             != REF_COUNT_UNUSED
-                            && r1.slot_owners[sub_idx].inner_perms.ref_count.value() > 0 && r1.slot_owners[sub_idx].inner_perms.ref_count.value() <= REF_COUNT_MAX)
+                            && r1.slot_owners[sub_idx].inner_perms.ref_count.value() > 0
+                            && r1.slot_owners[sub_idx].inner_perms.ref_count.value()
+                            <= REF_COUNT_MAX)
                     }
             },
         ensures
@@ -815,7 +819,8 @@ impl<C: PageTableConfig> EntryOwner<C> {
                             &&& r1.slot_owners[sub_idx].inner_perms.ref_count.value()
                                 != REF_COUNT_UNUSED
                             &&& r1.slot_owners[sub_idx].inner_perms.ref_count.value() > 0
-                            &&& r1.slot_owners[sub_idx].inner_perms.ref_count.value() <= REF_COUNT_MAX
+                            &&& r1.slot_owners[sub_idx].inner_perms.ref_count.value()
+                                <= REF_COUNT_MAX
                         }
                     } by {
                         let sub_idx = frame_to_index((pa + j * PAGE_SIZE) as usize);
@@ -876,7 +881,8 @@ impl<C: PageTableConfig> EntryOwner<C> {
                 &&& r1.slot_owners[idx].inner_perms.in_list
                     == r0.slot_owners[idx].inner_perms.in_list
                 &&& r1.slot_owners[idx].self_addr == r0.slot_owners[idx].self_addr
-                &&& r1.slot_owners[idx].paths_in_pt == r0.slot_owners[idx].paths_in_pt
+                &&& r1.slot_owners[idx].paths_in_pt
+                    == r0.slot_owners[idx].paths_in_pt
                 // `usage` is part of `metaregion_sound_node` (node-repark
                 // discriminator), so it must be preserved to carry soundness.
                 &&& r1.slot_owners[idx].usage == r0.slot_owners[idx].usage

--- a/ostd/specs/mm/page_table/node/entry_owners.rs
+++ b/ostd/specs/mm/page_table/node/entry_owners.rs
@@ -278,10 +278,10 @@ impl<C: PageTableConfig> EntryOwner<C> {
     /// gives back the original `item`. So `C::tracked` of the reconstructed item
     /// equals the recorded `is_tracked`.
     ///
-    /// Encoded as an axiom (rather than an `EntryOwner::inv_base` clause) because
-    /// adding it to `inv_base` would require discharging this connection at every
-    /// `new_frame` call site — a wide cascading refactor (attempted, abandoned in
-    /// the FrameEntryOwner is_tracked refactor session).
+    /// Currently an axiom. The proper encoding discharges this connection
+    /// through the `PageTableConfig` trait impls — establishing
+    /// `is_tracked == C::tracked(item)` at each `new_frame` construction site
+    /// (e.g. as an `EntryOwner::inv_base` clause) — rather than axiomatizing it.
     pub axiom fn axiom_frame_is_tracked_matches_item(entry: Self)
         requires
             entry.is_frame(),

--- a/ostd/specs/mm/page_table/node/owners.rs
+++ b/ostd/specs/mm/page_table/node/owners.rs
@@ -279,7 +279,8 @@ impl<C: PageTableConfig> NodeOwner<C> {
         // freshly-allocated node (whose slot was `UNUSED`) can't collide with an
         // existing live node — giving `alloc_if_none`/`split` the parent≠child
         // slot distinctness without a PointsTo-linearity axiom.
-        &&& regions.slot_owners[self.slot_index].usage == PageUsage::PageTable
+        &&& regions.slot_owners[self.slot_index].usage
+            == PageUsage::PageTable
         // `nr_children` counts the present PTEs in `children_perm`. A settled-node
         // invariant (it is momentarily broken mid-`replace`/`alloc_if_none`, between
         // the PTE write and the counter update, which is why it lives here rather

--- a/ostd/specs/mm/page_table/node/owners.rs
+++ b/ostd/specs/mm/page_table/node/owners.rs
@@ -26,6 +26,144 @@ use vstd_extra::ownership::*;
 
 verus! {
 
+// ─── Present-PTE counting ──────────────────────────────────────────────────────
+// The intended meaning of `nr_children`: the number of *present* PTEs in the
+// node's `children_perm` array. `metaregion_sound_node` ties `nr_children` to
+// `count_present(children_perm.value())` (a settled-node invariant), which lets
+// the `nr_children_*_slot_bound` boundary facts be proven rather than axiomatized.
+/// Number of present PTEs among the first `n` entries of `s`.
+pub open spec fn count_present_upto<E: PageTableEntryTrait>(s: Seq<E>, n: int) -> int
+    decreases n,
+{
+    if n <= 0 {
+        0
+    } else {
+        count_present_upto(s, n - 1) + if s[n - 1].is_present() {
+            1int
+        } else {
+            0int
+        }
+    }
+}
+
+/// Number of present PTEs in `s`.
+pub open spec fn count_present<E: PageTableEntryTrait>(s: Seq<E>) -> int {
+    count_present_upto(s, s.len() as int)
+}
+
+/// `count_present_upto` is between `0` and `n`.
+pub proof fn lemma_count_present_upto_bound<E: PageTableEntryTrait>(s: Seq<E>, n: int)
+    requires
+        0 <= n,
+    ensures
+        0 <= count_present_upto(s, n) <= n,
+    decreases n,
+{
+    if n > 0 {
+        lemma_count_present_upto_bound(s, n - 1);
+    }
+}
+
+/// An absent slot below `n` makes the count strictly less than `n`.
+pub proof fn lemma_count_present_upto_absent<E: PageTableEntryTrait>(s: Seq<E>, n: int, idx: int)
+    requires
+        0 <= idx < n,
+        !s[idx].is_present(),
+    ensures
+        count_present_upto(s, n) < n,
+    decreases n,
+{
+    lemma_count_present_upto_bound(s, n - 1);
+    if idx < n - 1 {
+        lemma_count_present_upto_absent(s, n - 1, idx);
+    }
+}
+
+/// A present slot below `n` makes the count at least `1`.
+pub proof fn lemma_count_present_upto_present<E: PageTableEntryTrait>(s: Seq<E>, n: int, idx: int)
+    requires
+        0 <= idx < n,
+        s[idx].is_present(),
+    ensures
+        count_present_upto(s, n) >= 1,
+    decreases n,
+{
+    lemma_count_present_upto_bound(s, n - 1);
+    if idx < n - 1 {
+        lemma_count_present_upto_present(s, n - 1, idx);
+    }
+}
+
+/// Updating slot `idx` (with `idx < n`) shifts the count by the change in that
+/// slot's present-indicator.
+pub proof fn lemma_count_present_upto_update<E: PageTableEntryTrait>(
+    s: Seq<E>,
+    n: int,
+    idx: int,
+    pte: E,
+)
+    requires
+        0 <= idx < n <= s.len(),
+    ensures
+        count_present_upto(s.update(idx, pte), n) == count_present_upto(s, n) - (
+        if s[idx].is_present() {
+            1int
+        } else {
+            0int
+        }) + (if pte.is_present() {
+            1int
+        } else {
+            0int
+        }),
+    decreases n,
+{
+    let s2 = s.update(idx, pte);
+    if n - 1 == idx {
+        // The first `idx` entries are unchanged.
+        assert(count_present_upto(s2, n - 1) == count_present_upto(s, n - 1)) by {
+            lemma_count_present_upto_unchanged(s, s2, n - 1, idx);
+        }
+        assert(s2[n - 1] == pte);
+    } else {
+        lemma_count_present_upto_update(s, n - 1, idx, pte);
+        assert(s2[n - 1] == s[n - 1]);
+    }
+}
+
+/// A zero present-count up to `n` means every slot below `n` is absent.
+pub proof fn lemma_count_present_upto_zero_all_absent<E: PageTableEntryTrait>(s: Seq<E>, n: int)
+    requires
+        count_present_upto(s, n) == 0,
+        0 <= n,
+    ensures
+        forall|k: int| 0 <= k < n ==> !s[k].is_present(),
+    decreases n,
+{
+    if n > 0 {
+        lemma_count_present_upto_bound(s, n - 1);
+        lemma_count_present_upto_zero_all_absent(s, n - 1);
+    }
+}
+
+/// If two sequences agree on `[0, n)`, their counts up to `n` are equal.
+pub proof fn lemma_count_present_upto_unchanged<E: PageTableEntryTrait>(
+    s: Seq<E>,
+    s2: Seq<E>,
+    n: int,
+    idx: int,
+)
+    requires
+        0 <= n <= idx,
+        forall|k: int| 0 <= k < n ==> s[k] == s2[k],
+    ensures
+        count_present_upto(s2, n) == count_present_upto(s, n),
+    decreases n,
+{
+    if n > 0 {
+        lemma_count_present_upto_unchanged(s, s2, n - 1, idx);
+    }
+}
+
 pub tracked struct PageMetaOwner {
     pub nr_children: pcell_maybe_uninit::PointsTo<u16>,
     pub stray: pcell_maybe_uninit::PointsTo<bool>,
@@ -135,6 +273,17 @@ impl<C: PageTableConfig> NodeOwner<C> {
         &&& self.meta_own.nr_children.id() == self.meta_perm_of(
             regions,
         ).value().metadata.nr_children.id()
+        // `nr_children` counts the present PTEs in `children_perm`. A settled-node
+        // invariant (it is momentarily broken mid-`replace`/`alloc_if_none`, between
+        // the PTE write and the counter update, which is why it lives here rather
+        // than in `inv()`). Lets `nr_children_*_slot_bound` be proven, not axiomatized.
+        &&& self.count_consistent()
+    }
+
+    /// `nr_children` equals the number of present PTEs in `children_perm`.
+    /// Held by a settled node (see `metaregion_sound_node`'s use site).
+    pub open spec fn count_consistent(self) -> bool {
+        self.meta_own.nr_children.value() == count_present(self.children_perm.value())
     }
 }
 
@@ -159,36 +308,38 @@ impl<C: PageTableConfig> NodeOwner<C> {
                 == self.children_perm.value().update(idx as int, pte),
     ;
 
-    /// If any slot in `children_perm` holds a non-present PTE, then
-    /// `nr_children < NR_ENTRIES`.
-    ///
-    /// Axiomatizes the intended meaning of `nr_children`: it counts the
-    /// number of *present* PTEs in the node. When at least one slot is
-    /// absent, the count must be strictly less than the maximum. This
-    /// sidesteps a full `nr_children == count(present PTEs)` invariant
-    /// (which would thread through every PTE mutation); the axiom instead
-    /// exposes the single boundary fact that `Entry::replace` needs when
-    /// incrementing the counter.
-    pub axiom fn nr_children_absent_slot_bound(self, idx: usize)
+    /// If a slot in `children_perm` holds a non-present PTE, then
+    /// `nr_children < NR_ENTRIES`. Proven (no longer axiomatized) from the
+    /// `count_consistent` invariant: `nr_children` counts present PTEs, and an
+    /// absent slot means not all `NR_ENTRIES` slots are present.
+    pub proof fn nr_children_absent_slot_bound(self, idx: usize)
         requires
             self.inv(),
+            self.count_consistent(),
+            self.children_perm.value().len() == NR_ENTRIES,
             idx < NR_ENTRIES,
             !self.children_perm.value()[idx as int].is_present(),
         ensures
             self.meta_own.nr_children.value() < NR_ENTRIES,
-    ;
+    {
+        lemma_count_present_upto_absent(self.children_perm.value(), NR_ENTRIES as int, idx as int);
+    }
 
-    /// If any slot in `children_perm` holds a present PTE, then
-    /// `nr_children > 0`. Dual of [`Self::nr_children_absent_slot_bound`];
-    /// used by `Entry::replace` when decrementing the counter.
-    pub axiom fn nr_children_present_slot_bound(self, idx: usize)
+    /// If a slot in `children_perm` holds a present PTE, then `nr_children > 0`.
+    /// Dual of [`Self::nr_children_absent_slot_bound`]; proven from
+    /// `count_consistent`.
+    pub proof fn nr_children_present_slot_bound(self, idx: usize)
         requires
             self.inv(),
+            self.count_consistent(),
+            self.children_perm.value().len() == NR_ENTRIES,
             idx < NR_ENTRIES,
             self.children_perm.value()[idx as int].is_present(),
         ensures
             self.meta_own.nr_children.value() > 0,
-    ;
+    {
+        lemma_count_present_upto_present(self.children_perm.value(), NR_ENTRIES as int, idx as int);
+    }
 }
 
 impl<'rcu, C: PageTableConfig> NodeOwner<C> {

--- a/ostd/specs/mm/page_table/node/owners.rs
+++ b/ostd/specs/mm/page_table/node/owners.rs
@@ -273,6 +273,13 @@ impl<C: PageTableConfig> NodeOwner<C> {
         &&& self.meta_own.nr_children.id() == self.meta_perm_of(
             regions,
         ).value().metadata.nr_children.id()
+        // A page-table node's slot is tracked with `PageTable` usage (set at
+        // allocation via `get_node_from_unused_spec`). This discriminates node
+        // slots from data-frame slots (`Frame`/MMIO) by `usage` alone, so a
+        // freshly-allocated node (whose slot was `UNUSED`) can't collide with an
+        // existing live node — giving `alloc_if_none`/`split` the parent≠child
+        // slot distinctness without a PointsTo-linearity axiom.
+        &&& regions.slot_owners[self.slot_index].usage == PageUsage::PageTable
         // `nr_children` counts the present PTEs in `children_perm`. A settled-node
         // invariant (it is momentarily broken mid-`replace`/`alloc_if_none`, between
         // the PTE write and the counter update, which is why it lives here rather

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -317,7 +317,6 @@ impl<C: PageTableConfig, const L: usize> TreeNodeValue<L> for EntryOwner<C> {
     open spec fn default(lv: nat) -> Self {
         Self {
             kind: EntryOwnerKind::Absent,
-            in_scope: false,
             path: TreePath::new(Seq::empty()),
             parent_level: (INC_LEVELS - lv) as PagingLevel,
         }
@@ -370,11 +369,6 @@ pub open spec fn allocated_empty_node_owner<C: PageTableConfig>(
 ) -> bool {
     &&& owner.inv()
     &&& owner.value.is_node()
-    // The freshly-allocated node is in scope (just minted via
-    // `EntryOwner::tracked_new_absent`, whose ensures pins `in_scope`).
-    // Exposed so `alloc_if_none` can discharge `into_pte`'s `in_scope`
-    // precondition on the new node.
-    &&& owner.value.in_scope
     &&& owner.value.path == TreePath::<NR_ENTRIES>::new(Seq::empty())
     &&& owner.value.parent_level == (level + 1) as PagingLevel
     &&& owner.value.node().level == level
@@ -385,7 +379,6 @@ pub open spec fn allocated_empty_node_owner<C: PageTableConfig>(
         0 <= i < NR_ENTRIES ==> {
             &&& owner.children[i] is Some
             &&& owner.children[i]->0.value.is_absent()
-            &&& !owner.children[i]->0.value.in_scope
             &&& owner.children[i]->0.value.inv()
             &&& owner.children[i]->0.value.path == owner.value.path.push_tail(i as usize)
         }
@@ -501,6 +494,49 @@ pub proof fn rebase_freshly_allocated_children<C: PageTableConfig>(
             },
 {
     rebase_freshly_allocated_children_at(owner, new_path, 0);
+}
+
+/// `tree_predicate_map` for a freshly-allocated node grafted into the cursor:
+/// every child is a `new_val`-shaped node (all grandchildren `None`), so each
+/// child's `tree_predicate_map` reduces to `f` at that child
+/// (`new_val_tree_predicate_map`). Combined with `f` at the root node, this
+/// discharges the whole one-level subtree. Used by `alloc_if_none` for the
+/// `node_unlocked_except` / `metaregion_sound_pred` / `path_tracked_pred`
+/// predicates over the fresh node (all of which hold trivially at the absent
+/// children).
+pub proof fn fresh_node_tree_predicate_map<C: PageTableConfig>(
+    node: OwnerSubtree<C>,
+    path: TreePath<NR_ENTRIES>,
+    f: spec_fn(EntryOwner<C>, TreePath<NR_ENTRIES>) -> bool,
+)
+    requires
+        node.inv(),
+        node.level < INC_LEVELS - 1,
+        f(node.value, path),
+        forall|i: int| 0 <= i < NR_ENTRIES ==> #[trigger] node.children[i] is Some,
+        forall|i: int, j: int|
+            0 <= i < NR_ENTRIES && 0 <= j < NR_ENTRIES
+                ==> #[trigger] node.children[i].unwrap().children[j] is None,
+        forall|i: int|
+            0 <= i < NR_ENTRIES ==> #[trigger] f(
+                node.children[i].unwrap().value,
+                path.push_tail(i as usize),
+            ),
+    ensures
+        node.tree_predicate_map(path, f),
+{
+    assert forall|i: int|
+        0 <= i < node.children.len() && #[trigger] node.children[i] is Some implies node.children[i]->0.tree_predicate_map(
+        path.push_tail(i as usize),
+        f,
+    ) by {
+        // Each child has all-`None` grandchildren, so its `tree_predicate_map`
+        // unfolds to `f` at the child (the grandchild forall is vacuous).
+        node.child_some_properties(i as usize);
+        let child = node.children[i]->0;
+        assert(child.children.len() == NR_ENTRIES);
+        assert(forall|j: int| 0 <= j < child.children.len() ==> #[trigger] child.children[j] is None);
+    };
 }
 
 pub tracked struct PageTableOwner<C: PageTableConfig>(pub OwnerSubtree<C>);
@@ -1780,11 +1816,10 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     }
 
     pub open spec fn not_in_scope_pred() -> spec_fn(EntryOwner<C>, TreePath<NR_ENTRIES>) -> bool {
-        |entry: EntryOwner<C>, _path: TreePath<NR_ENTRIES>| !entry.in_scope
+        |entry: EntryOwner<C>, _path: TreePath<NR_ENTRIES>| true
     }
 
-    /// Every entry in an OwnerSubtree has `!in_scope`.
-    /// Follows from `EntryOwner::inv()` including `!in_scope`, propagated through the tree.
+    /// `tree_predicate_map` for the trivial `not_in_scope_pred`.
     pub proof fn tree_not_in_scope(subtree: OwnerSubtree<C>, path: TreePath<NR_ENTRIES>)
         requires
             subtree.inv(),
@@ -1792,7 +1827,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             subtree.tree_predicate_map(path, Self::not_in_scope_pred()),
         decreases INC_LEVELS - subtree.level,
     {
-        // subtree.inv() => inv_node() => value.inv() => !value.in_scope
+        // `not_in_scope_pred` is trivially `true`; recurse to discharge it.
         if subtree.level < INC_LEVELS - 1 {
             assert forall|i: int|
                 0 <= i < subtree.children.len() && (

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -372,6 +372,11 @@ pub open spec fn allocated_empty_node_owner<C: PageTableConfig>(
     &&& owner.value.path == TreePath::<NR_ENTRIES>::new(Seq::empty())
     &&& owner.value.parent_level == (level + 1) as PagingLevel
     &&& owner.value.node().level == level
+    // The fresh subtree's ghost-tree depth. Lets `alloc_if_none` discharge
+    // `final(owner).inv()`'s `child.level == self.level + 1`: the grafted
+    // children sit at `new_node.level + 1`, which must match the cursor entry's
+    // depth + 1.
+    &&& owner.level == (INC_LEVELS - level - 1) as nat
     &&& owner.value.node().inv()
     &&& !owner.value.node().children_perm.value().all(|child: C::E| child.is_present())
     &&& forall|i: int|

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -482,7 +482,8 @@ pub open spec fn allocated_empty_node_owner<C: PageTableConfig>(
     &&& owner.value.is_node()
     &&& owner.value.path == TreePath::<NR_ENTRIES>::new(Seq::empty())
     &&& owner.value.parent_level == (level + 1) as PagingLevel
-    &&& owner.value.node().level == level
+    &&& owner.value.node().level
+        == level
     // The fresh subtree's ghost-tree depth. Lets `alloc_if_none` discharge
     // `final(owner).inv()`'s `child.level == self.level + 1`: the grafted
     // children sit at `new_node.level + 1`, which must match the cursor entry's
@@ -642,7 +643,8 @@ pub proof fn fresh_node_tree_predicate_map<C: PageTableConfig>(
         node.tree_predicate_map(path, f),
 {
     assert forall|i: int|
-        0 <= i < node.children.len() && #[trigger] node.children[i] is Some implies node.children[i]->0.tree_predicate_map(
+        0 <= i < node.children.len()
+            && #[trigger] node.children[i] is Some implies node.children[i]->0.tree_predicate_map(
         path.push_tail(i as usize),
         f,
     ) by {
@@ -651,7 +653,8 @@ pub proof fn fresh_node_tree_predicate_map<C: PageTableConfig>(
         node.child_some_properties(i as usize);
         let child = node.children[i]->0;
         assert(child.children.len() == NR_ENTRIES);
-        assert(forall|j: int| 0 <= j < child.children.len() ==> #[trigger] child.children[j] is None);
+        assert(forall|j: int|
+            0 <= j < child.children.len() ==> #[trigger] child.children[j] is None);
     };
 }
 
@@ -661,7 +664,8 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     /// Per-edge constraint between a node-parent and its child at index `i`.
     pub open spec fn pt_edge_at(parent: OwnerSubtree<C>, i: int) -> bool {
         &&& parent.children[i] is Some
-        &&& parent.children[i]->0.value.path.len() == parent.value.node().tree_level + 1
+        &&& parent.children[i]->0.value.path.len() == parent.value.node().tree_level
+            + 1
         // The child either matches its PTE as an owned node/frame/absent
         // entry, OR — only at the top level (`level == NR_LEVELS`, e.g. a user
         // PT's shared kernel-half slots) — is a `borrowed` (translation-only)
@@ -1191,12 +1195,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     /// the config's `LEADING_BITS` high-half base. With `path[0] < t`, the range
     /// end is `<= t * 2^39 + LEADING_BITS * 2^48` — the per-config VA bound that
     /// discharges the user/kernel isolation theorems.
-    pub proof fn view_rec_top_index_va_bound(
-        self,
-        path: TreePath<NR_ENTRIES>,
-        m: Mapping,
-        t: int,
-    )
+    pub proof fn view_rec_top_index_va_bound(self, path: TreePath<NR_ENTRIES>, m: Mapping, t: int)
         requires
             self.pt_inv(),
             path.inv(),
@@ -1223,7 +1222,9 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         // high half.
         assert((path.index(0) as int + 1) * 0x80_0000_0000int <= t * 0x80_0000_0000int)
             by (nonlinear_arith)
-            requires (path.index(0) as int) < t;
+            requires
+                (path.index(0) as int) < t,
+        ;
     }
 
     /// `pt_inv` (plus the root's recorded path) lifts to a full
@@ -1768,10 +1769,9 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             assert forall|m: Mapping| self.view_rec(path).contains(m) implies false by {
                 let i = choose|i: int|
                     #![trigger self.0.children[i]]
-                    0 <= i < self.0.children.len() && self.0.children[i] is Some
-                        && PageTableOwner(self.0.children[i]->0).view_rec(
-                        path.push_tail(i as usize),
-                    ).contains(m);
+                    0 <= i < self.0.children.len() && self.0.children[i] is Some && PageTableOwner(
+                        self.0.children[i]->0,
+                    ).view_rec(path.push_tail(i as usize)).contains(m);
                 self.pt_inv_unroll(i);
                 // PTE `i` is absent — else `count_present(cp) >= 1`.
                 if cp[i].is_present() {
@@ -1787,9 +1787,8 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 // with an absent PTE forces the child `is_absent`.
                 assert(self.0.children[i]->0.value.is_absent());
                 // An absent entry is neither frame nor node ⟹ empty `view_rec`.
-                assert(PageTableOwner(self.0.children[i]->0).view_rec(
-                    path.push_tail(i as usize),
-                ) =~= set![]);
+                assert(PageTableOwner(self.0.children[i]->0).view_rec(path.push_tail(i as usize))
+                    =~= set![]);
             };
             assert(self.view_rec(path) =~= set![]);
         }

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -206,6 +206,117 @@ pub proof fn lemma_vaddr_strict_bound(path: TreePath<NR_ENTRIES>)
     }
 }
 
+/// The VA of any path is within the `2^39`-sized cell of its top-level index:
+/// `path[0] * 2^39 <= vaddr(path)` and `vaddr(path) + page_size <= (path[0]+1) * 2^39`.
+/// Pure VA arithmetic (x86 4-level paging). Used by `view_rec_top_index_va_bound`.
+pub proof fn lemma_vaddr_top_index_cell(path: TreePath<NR_ENTRIES>)
+    requires
+        path.inv(),
+        1 <= path.len() <= INC_LEVELS - 1,
+    ensures
+        (path.index(0) as int) * 0x80_0000_0000int <= vaddr(path) as int,
+        (vaddr(path) as int) + page_size((INC_LEVELS - path.len()) as PagingLevel) as int <= (
+        path.index(0) as int + 1) * 0x80_0000_0000int,
+{
+    broadcast use TreePath::index_satisfies_elem_inv;
+
+    lemma_page_size_spec_values();
+    vstd::arithmetic::power2::lemma2_to64();
+    vstd::arithmetic::power2::lemma2_to64_rest();
+    let i0 = path.index(0);
+    assert(0 <= i0 < NR_ENTRIES);
+    if path.len() == 1 {
+        assert(rec_vaddr(path, 1) == 0);
+        assert(rec_vaddr(path, 0) == vaddr_make::<NR_LEVELS>(0, i0) as usize);
+        assert(vaddr_make::<NR_LEVELS>(0, i0) == 0x80_0000_0000usize * i0) by (compute);
+        assert(page_size(4) == 0x80_0000_0000usize);
+        assert((0x80_0000_0000int * i0) + 0x80_0000_0000int == (i0 + 1) * 0x80_0000_0000int)
+            by (nonlinear_arith);
+    } else if path.len() == 2 {
+        let i1 = path.index(1);
+        assert(0 <= i1 < NR_ENTRIES);
+        assert(rec_vaddr(path, 2) == 0);
+        assert(rec_vaddr(path, 1) == vaddr_make::<NR_LEVELS>(1, i1) as usize);
+        assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, i0) + vaddr_make::<NR_LEVELS>(
+            1,
+            i1,
+        )) as usize);
+        assert(vaddr_make::<NR_LEVELS>(0, i0) == 0x80_0000_0000usize * i0) by (compute);
+        assert(vaddr_make::<NR_LEVELS>(1, i1) == 0x4000_0000usize * i1) by (compute);
+        assert(page_size(3) == 0x4000_0000usize);
+        assert(0x80_0000_0000int * i0 <= 0x80_0000_0000int * i0 + 0x4000_0000int * i1)
+            by (nonlinear_arith);
+        assert(0x80_0000_0000int * i0 + 0x4000_0000int * i1 + 0x4000_0000int <= (i0 + 1)
+            * 0x80_0000_0000int) by (nonlinear_arith)
+            requires
+                i1 < 512,
+        ;
+    } else if path.len() == 3 {
+        let i1 = path.index(1);
+        let i2 = path.index(2);
+        assert(0 <= i1 < NR_ENTRIES);
+        assert(0 <= i2 < NR_ENTRIES);
+        assert(rec_vaddr(path, 3) == 0);
+        assert(rec_vaddr(path, 2) == vaddr_make::<NR_LEVELS>(2, i2) as usize);
+        assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1) + vaddr_make::<NR_LEVELS>(
+            2,
+            i2,
+        )) as usize);
+        assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, i0) + vaddr_make::<NR_LEVELS>(
+            1,
+            i1,
+        ) + vaddr_make::<NR_LEVELS>(2, i2)) as usize);
+        assert(vaddr_make::<NR_LEVELS>(0, i0) == 0x80_0000_0000usize * i0) by (compute);
+        assert(vaddr_make::<NR_LEVELS>(1, i1) == 0x4000_0000usize * i1) by (compute);
+        assert(vaddr_make::<NR_LEVELS>(2, i2) == 0x20_0000usize * i2) by (compute);
+        assert(page_size(2) == 0x20_0000usize);
+        assert(0x80_0000_0000int * i0 <= 0x80_0000_0000int * i0 + 0x4000_0000int * i1 + 0x20_0000int
+            * i2) by (nonlinear_arith);
+        assert(0x80_0000_0000int * i0 + 0x4000_0000int * i1 + 0x20_0000int * i2 + 0x20_0000int <= (
+        i0 + 1) * 0x80_0000_0000int) by (nonlinear_arith)
+            requires
+                i1 < 512,
+                i2 < 512,
+        ;
+    } else {
+        assert(path.len() == 4);
+        let i1 = path.index(1);
+        let i2 = path.index(2);
+        let i3 = path.index(3);
+        assert(0 <= i1 < NR_ENTRIES);
+        assert(0 <= i2 < NR_ENTRIES);
+        assert(0 <= i3 < NR_ENTRIES);
+        assert(rec_vaddr(path, 4) == 0);
+        assert(rec_vaddr(path, 3) == vaddr_make::<NR_LEVELS>(3, i3) as usize);
+        assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, i2) + vaddr_make::<NR_LEVELS>(
+            3,
+            i3,
+        )) as usize);
+        assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1) + vaddr_make::<NR_LEVELS>(
+            2,
+            i2,
+        ) + vaddr_make::<NR_LEVELS>(3, i3)) as usize);
+        assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, i0) + vaddr_make::<NR_LEVELS>(
+            1,
+            i1,
+        ) + vaddr_make::<NR_LEVELS>(2, i2) + vaddr_make::<NR_LEVELS>(3, i3)) as usize);
+        assert(vaddr_make::<NR_LEVELS>(0, i0) == 0x80_0000_0000usize * i0) by (compute);
+        assert(vaddr_make::<NR_LEVELS>(1, i1) == 0x4000_0000usize * i1) by (compute);
+        assert(vaddr_make::<NR_LEVELS>(2, i2) == 0x20_0000usize * i2) by (compute);
+        assert(vaddr_make::<NR_LEVELS>(3, i3) == 0x1000usize * i3) by (compute);
+        assert(page_size(1) == 0x1000usize);
+        assert(0x80_0000_0000int * i0 <= 0x80_0000_0000int * i0 + 0x4000_0000int * i1 + 0x20_0000int
+            * i2 + 0x1000int * i3) by (nonlinear_arith);
+        assert(0x80_0000_0000int * i0 + 0x4000_0000int * i1 + 0x20_0000int * i2 + 0x1000int * i3
+            + 0x1000int <= (i0 + 1) * 0x80_0000_0000int) by (nonlinear_arith)
+            requires
+                i1 < 512,
+                i2 < 512,
+                i3 < 512,
+        ;
+    }
+}
+
 /// `vaddr_of::<C>(path)` in `int` equals the unconditional sum — no usize
 /// wrap. Holds because `vaddr(path) < 2^48` (any valid path) and
 /// `LEADING_BITS < 2^16`, so the sum is `< 2^64 = usize::MAX + 1`.

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -1870,7 +1870,9 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                                 sub_idx != changed_idx || (r1.slots.contains_key(sub_idx)
                                     && r1.slot_owners[sub_idx].inner_perms.ref_count.value()
                                     != crate::specs::mm::frame::meta_owners::REF_COUNT_UNUSED
-                                    && r1.slot_owners[sub_idx].inner_perms.ref_count.value() > 0)
+                                    && r1.slot_owners[sub_idx].inner_perms.ref_count.value() > 0
+                                    && r1.slot_owners[sub_idx].inner_perms.ref_count.value()
+                                    <= crate::specs::mm::frame::meta_owners::REF_COUNT_MAX)
                             }
                     },
             ),
@@ -1922,7 +1924,9 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                                 sub_idx != changed_idx || (r1.slots.contains_key(sub_idx)
                                     && r1.slot_owners[sub_idx].inner_perms.ref_count.value()
                                     != crate::specs::mm::frame::meta_owners::REF_COUNT_UNUSED
-                                    && r1.slot_owners[sub_idx].inner_perms.ref_count.value() > 0)
+                                    && r1.slot_owners[sub_idx].inner_perms.ref_count.value() > 0
+                                    && r1.slot_owners[sub_idx].inner_perms.ref_count.value()
+                                    <= crate::specs::mm::frame::meta_owners::REF_COUNT_MAX)
                             }
                     },
             ),

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -1175,6 +1175,46 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         }
     }
 
+    /// Any mapping in a subtree's `view_rec` has its VA range within the
+    /// `2^39`-sized cell of the subtree's top-level index `path[0]`, shifted by
+    /// the config's `LEADING_BITS` high-half base. With `path[0] < t`, the range
+    /// end is `<= t * 2^39 + LEADING_BITS * 2^48` — the per-config VA bound that
+    /// discharges the user/kernel isolation theorems.
+    pub proof fn view_rec_top_index_va_bound(
+        self,
+        path: TreePath<NR_ENTRIES>,
+        m: Mapping,
+        t: int,
+    )
+        requires
+            self.pt_inv(),
+            path.inv(),
+            1 <= path.len() <= INC_LEVELS - 1,
+            path.len() == self.0.level,
+            self.0.value.parent_level == (INC_LEVELS - self.0.level) as PagingLevel,
+            (path.index(0) as int) < t,
+            self.view_rec(path).contains(m),
+        ensures
+            (path.index(0) as int) * 0x80_0000_0000int + (C::LEADING_BITS_spec() as int)
+                * 0x1_0000_0000_0000int <= m.va_range.start,
+            m.va_range.start < m.va_range.end,
+            m.va_range.end <= t * 0x80_0000_0000int + (C::LEADING_BITS_spec() as int)
+                * 0x1_0000_0000_0000int,
+    {
+        self.view_rec_vaddr_range(path, m);
+        lemma_vaddr_of_eq_int::<C>(path);
+        lemma_vaddr_top_index_cell(path);
+        // `vaddr_of(path) == vaddr(path) + LEADING_BITS*2^48` (lemma_vaddr_of_eq_int);
+        // the positional `vaddr(path)` lies in the top-index cell
+        // `[index(0)*2^39, (index(0)+1)*2^39)` (lemma_vaddr_top_index_cell), and
+        // `(index(0)+1) <= t`. Adding the `LEADING_BITS*2^48` base shifts both
+        // ends — giving the user (LB=0) low half and the kernel (LB=0xffff)
+        // high half.
+        assert((path.index(0) as int + 1) * 0x80_0000_0000int <= t * 0x80_0000_0000int)
+            by (nonlinear_arith)
+            requires (path.index(0) as int) < t;
+    }
+
     /// `pt_inv` (plus the root's recorded path) lifts to a full
     /// `path_correct_pred` tree predicate: every entry's `.path` field
     /// equals its structural position.  `PageTableOwner::inv()` already

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -1739,21 +1739,61 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     {
     }
 
-    /// A node with nr_children == 0 has no present PTEs, so all children are absent
-    /// and the subtree contributes no mappings.
+    /// A node with `nr_children == 0` has no present PTEs, so all children are
+    /// absent and the subtree contributes no mappings.
     ///
-    /// Axiom: the link between `nr_children` and the count of present PTEs is maintained
-    /// by `Entry::replace` / `Entry::new` but not yet formalised as a `NodeOwner` invariant.
-    pub axiom fn view_rec_nr_children_zero_empty(self, path: TreePath<NR_ENTRIES>)
+    /// Proven (formerly an axiom): `count_consistent` ties `nr_children` to
+    /// `count_present(children_perm)`, so `nr_children == 0` forces every PTE
+    /// absent. `pt_edge_at` (from `pt_inv`) then forces each ghost child
+    /// `is_absent` — its `view_rec` is `∅` — and `lemma_view_rec_contains`
+    /// lifts that to the whole node's `view_rec`. (At the top level the
+    /// `borrowed` edge disjunct is ruled out: `borrowed_match_pte` needs a
+    /// *present* PTE, which `count_present == 0` denies.)
+    pub proof fn view_rec_nr_children_zero_empty(self, path: TreePath<NR_ENTRIES>)
         requires
-            self.0.inv(),
+            self.pt_inv(),
             self.0.value.is_node(),
             self.0.value.node().meta_own.nr_children.value() == 0,
+            self.0.value.node().count_consistent(),
             path.len() <= INC_LEVELS - 1,
             path.len() == self.0.level,
         ensures
             self.view_rec(path) == set![],
-    ;
+    {
+        if path.len() < INC_LEVELS - 1 {
+            let cp = self.0.value.node().children_perm.value();
+            // `count_consistent` + `nr_children == 0` ⟹ no present PTEs.
+            assert(crate::specs::mm::page_table::node::owners::count_present(cp) == 0);
+            self.lemma_view_rec_contains(path);
+            assert forall|m: Mapping| self.view_rec(path).contains(m) implies false by {
+                let i = choose|i: int|
+                    #![trigger self.0.children[i]]
+                    0 <= i < self.0.children.len() && self.0.children[i] is Some
+                        && PageTableOwner(self.0.children[i]->0).view_rec(
+                        path.push_tail(i as usize),
+                    ).contains(m);
+                self.pt_inv_unroll(i);
+                // PTE `i` is absent — else `count_present(cp) >= 1`.
+                if cp[i].is_present() {
+                    crate::specs::mm::page_table::node::owners::lemma_count_present_upto_present(
+                        cp,
+                        cp.len() as int,
+                        i,
+                    );
+                }
+                assert(!cp[i].is_present());
+                // `pt_edge_at`'s borrowed disjunct needs a present PTE, so it is
+                // false here; the `match_pte` disjunct holds, and `match_pte`
+                // with an absent PTE forces the child `is_absent`.
+                assert(self.0.children[i]->0.value.is_absent());
+                // An absent entry is neither frame nor node ⟹ empty `view_rec`.
+                assert(PageTableOwner(self.0.children[i]->0).view_rec(
+                    path.push_tail(i as usize),
+                ) =~= set![]);
+            };
+            assert(self.view_rec(path) =~= set![]);
+        }
+    }
 
     pub open spec fn metaregion_sound_pred(regions: MetaRegionOwners) -> (spec_fn(
         EntryOwner<C>,

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -662,10 +662,21 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     pub open spec fn pt_edge_at(parent: OwnerSubtree<C>, i: int) -> bool {
         &&& parent.children[i] is Some
         &&& parent.children[i]->0.value.path.len() == parent.value.node().tree_level + 1
-        &&& parent.children[i]->0.value.match_pte(
+        // The child either matches its PTE as an owned node/frame/absent
+        // entry, OR — only at the top level (`level == NR_LEVELS`, e.g. a user
+        // PT's shared kernel-half slots) — is a `borrowed` (translation-only)
+        // entry whose PTE is a present non-leaf node-PTE pointing at a sub-tree
+        // owned by another config. Borrowed children contribute nothing to
+        // `view_rec`. The top-level guard keeps deeper consumers on pure
+        // `match_pte`, so borrowing never appears below the root.
+        &&& (parent.children[i]->0.value.match_pte(
             parent.value.node().children_perm.value()[i],
             parent.value.node().level,
-        )
+        ) || (parent.value.node().level == NR_LEVELS && C::LEADING_BITS_spec() == 0
+            && parent.children[i]->0.value.borrowed_match_pte(
+            parent.value.node().children_perm.value()[i],
+            parent.value.node().level,
+        )))
         &&& parent.children[i]->0.value.path == parent.value.path.push_tail(i as usize)
         &&& parent.children[i]->0.value.parent_level == parent.value.node().level
     }

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -1742,13 +1742,13 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     /// A node with `nr_children == 0` has no present PTEs, so all children are
     /// absent and the subtree contributes no mappings.
     ///
-    /// Proven (formerly an axiom): `count_consistent` ties `nr_children` to
-    /// `count_present(children_perm)`, so `nr_children == 0` forces every PTE
-    /// absent. `pt_edge_at` (from `pt_inv`) then forces each ghost child
-    /// `is_absent` — its `view_rec` is `∅` — and `lemma_view_rec_contains`
-    /// lifts that to the whole node's `view_rec`. (At the top level the
-    /// `borrowed` edge disjunct is ruled out: `borrowed_match_pte` needs a
-    /// *present* PTE, which `count_present == 0` denies.)
+    /// `count_consistent` ties `nr_children` to `count_present(children_perm)`,
+    /// so `nr_children == 0` forces every PTE absent. `pt_edge_at` (from
+    /// `pt_inv`) then forces each ghost child `is_absent` — its `view_rec` is
+    /// `∅` — and `lemma_view_rec_contains` lifts that to the whole node's
+    /// `view_rec`. (At the top level the `borrowed` edge disjunct is ruled out:
+    /// `borrowed_match_pte` needs a *present* PTE, which `count_present == 0`
+    /// denies.)
     pub proof fn view_rec_nr_children_zero_empty(self, path: TreePath<NR_ENTRIES>)
         requires
             self.pt_inv(),

--- a/ostd/src/mm/frame/mod.rs
+++ b/ostd/src/mm/frame/mod.rs
@@ -388,12 +388,16 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotStorage>> Frame<M> {
     ///
     /// Currently, the level is always 1, which means the frame is a regular
     /// page frame.
-    pub const fn map_level(&self) -> PagingLevel {
+    pub const fn map_level(&self) -> PagingLevel
+        returns 1u8
+    {
         1
     }
 
     /// Gets the size of this page in bytes.
-    pub const fn size(&self) -> usize {
+    pub const fn size(&self) -> usize
+        returns 4096usize
+    {
         PAGE_SIZE
     }
 }

--- a/ostd/src/mm/frame/mod.rs
+++ b/ostd/src/mm/frame/mod.rs
@@ -389,14 +389,16 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotStorage>> Frame<M> {
     /// Currently, the level is always 1, which means the frame is a regular
     /// page frame.
     pub const fn map_level(&self) -> PagingLevel
-        returns 1u8
+        returns
+            1u8,
     {
         1
     }
 
     /// Gets the size of this page in bytes.
     pub const fn size(&self) -> usize
-        returns 4096usize
+        returns
+            4096usize,
     {
         PAGE_SIZE
     }

--- a/ostd/src/mm/frame/unique.rs
+++ b/ostd/src/mm/frame/unique.rs
@@ -540,11 +540,11 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> 
         let ghost idx = owner.slot_index;
 
         proof {
-            // Unfold `inv_with_regions`: re-derive the slot facts that used to be
-            // explicit preconditions. `owner.inv()` gives `idx < max_meta_slots`,
-            // so `regions.inv()` delivers `contains_key(idx)`, the `self_addr`
-            // shape, and `slot_owners[idx].inv()`; the latter's UNIQUE branch
-            // (under `rc == REF_COUNT_UNIQUE`) gives the storage/vtable init.
+            // Unfold `inv_with_regions` to recover the per-slot facts.
+            // `owner.inv()` gives `idx < max_meta_slots`, so `regions.inv()`
+            // delivers `contains_key(idx)`, the `self_addr` shape, and
+            // `slot_owners[idx].inv()`; the latter's UNIQUE branch (under
+            // `rc == REF_COUNT_UNIQUE`) gives the storage/vtable init.
             assert(regions.slot_owners.contains_key(idx));
             assert(regions.slot_owners[idx].self_addr == meta_addr(idx));
             assert(regions.slot_owners[idx].inner_perms.storage.is_init());

--- a/ostd/src/mm/frame/unique.rs
+++ b/ostd/src/mm/frame/unique.rs
@@ -280,7 +280,9 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrame<M> {
 
 impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> {
     /// Gets the size of this page in bytes.
-    pub const fn size(&self) -> usize {
+    pub const fn size(&self) -> usize
+        returns 4096usize
+    {
         PAGE_SIZE
     }
 
@@ -291,7 +293,9 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> 
     ///
     /// Currently, the level is always 1, which means the frame is a regular
     /// page frame.
-    pub const fn level(&self) -> PagingLevel {
+    pub const fn level(&self) -> PagingLevel
+        returns 1u8
+    {
         1
     }
 }
@@ -383,21 +387,20 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> 
             Tracked(owner): Tracked<UniqueFrameOwner<M>>,
             Tracked(regions): Tracked<&mut MetaRegionOwners>,
         requires
-            self.wf(owner),
-            owner.inv(),
-            old(regions).inv(),
-            old(regions).slot_owners.contains_key(owner.slot_index),
-            old(regions).slot_owners[owner.slot_index].self_addr == meta_addr(owner.slot_index),
-            old(regions).slot_owners[owner.slot_index].inner_perms.ref_count.value() == REF_COUNT_UNIQUE,
-            old(regions).slot_owners[owner.slot_index].inner_perms.in_list.value() == 0,
-            old(regions).slot_owners[owner.slot_index].inner_perms.storage.is_init(),
-            old(regions).slot_owners[owner.slot_index].inner_perms.vtable_ptr.is_init(),
-            old(regions).slot_owners[owner.slot_index].paths_in_pt.is_empty(),
+            self.inv_with_regions(owner, *old(regions)),
         ensures
             final(regions).inv(),
     )]
     pub fn reset_as_unused(self) {
         let ghost idx = owner.slot_index;
+
+        proof {
+            assert(regions.slot_owners.contains_key(idx));
+            assert(regions.slot_owners[idx].self_addr == meta_addr(idx));
+            assert(regions.slot_owners[idx].inner_perms.storage.is_init());
+            assert(regions.slot_owners[idx].inner_perms.vtable_ptr.is_init());
+        }
+
         let tracked mut slot_own = regions.slot_owners.tracked_remove(idx);
         let tracked perm_ref = regions.slots.tracked_borrow(idx);
 
@@ -487,7 +490,6 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> 
         (Self { ptr, _marker: PhantomData }, Tracked(owner))
     }
 
-    #[verifier::external_body]
     #[verus_spec(
         with
             Tracked(slot_perm): Tracked<&'a vstd::simple_pptr::PointsTo<MetaSlot>>,
@@ -498,11 +500,9 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> 
             slot_perm.value(),
     )]
     pub fn slot<'a>(&self) -> &'a MetaSlot {
-        unimplemented!()
         // SAFETY: `ptr` points to a valid `MetaSlot` that will never be
         // mutably borrowed, so taking an immutable reference to it is safe.
-        //        unsafe { &*self.ptr }
-
+        self.ptr.borrow(Tracked(slot_perm))
     }
 }
 
@@ -524,16 +524,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> 
             Tracked(owner): Tracked<UniqueFrameOwner<M>>,
             Tracked(regions): Tracked<&mut MetaRegionOwners>,
         requires
-            old(self).wf(owner),
-            owner.inv(),
-            old(regions).slot_owners.contains_key(owner.slot_index),
-            old(regions).slot_owners[owner.slot_index].self_addr == meta_addr(owner.slot_index),
-            old(regions).slot_owners[owner.slot_index].inner_perms.ref_count.value() == REF_COUNT_UNIQUE,
-            old(regions).slot_owners[owner.slot_index].inner_perms.in_list.value() == 0,
-            old(regions).slot_owners[owner.slot_index].inner_perms.storage.is_init(),
-            old(regions).slot_owners[owner.slot_index].inner_perms.vtable_ptr.is_init(),
-            old(regions).inv(),
-            old(regions).slot_owners[owner.slot_index].paths_in_pt.is_empty(),
+            old(self).inv_with_regions(owner, *old(regions)),
             old(regions).frame_obligations.count(owner.slot_index) > 0,
         ensures
             final(regions).inv(),
@@ -549,6 +540,16 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> 
         let ghost idx = owner.slot_index;
 
         proof {
+            // Unfold `inv_with_regions`: re-derive the slot facts that used to be
+            // explicit preconditions. `owner.inv()` gives `idx < max_meta_slots`,
+            // so `regions.inv()` delivers `contains_key(idx)`, the `self_addr`
+            // shape, and `slot_owners[idx].inv()`; the latter's UNIQUE branch
+            // (under `rc == REF_COUNT_UNIQUE`) gives the storage/vtable init.
+            assert(regions.slot_owners.contains_key(idx));
+            assert(regions.slot_owners[idx].self_addr == meta_addr(idx));
+            assert(regions.slot_owners[idx].inner_perms.storage.is_init());
+            assert(regions.slot_owners[idx].inner_perms.vtable_ptr.is_init());
+
             // Running `Drop` discharges the value's pending-Drop obligation.
             let tracked redeem_tok = vstd_extra::drop_tracking::DropObligation::tracked_mint(idx);
             regions.tracked_redeem_frame_obligation(redeem_tok);

--- a/ostd/src/mm/frame/unique.rs
+++ b/ostd/src/mm/frame/unique.rs
@@ -281,7 +281,8 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrame<M> {
 impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> {
     /// Gets the size of this page in bytes.
     pub const fn size(&self) -> usize
-        returns 4096usize
+        returns
+            4096usize,
     {
         PAGE_SIZE
     }
@@ -294,7 +295,8 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> 
     /// Currently, the level is always 1, which means the frame is a regular
     /// page frame.
     pub const fn level(&self) -> PagingLevel
-        returns 1u8
+        returns
+            1u8,
     {
         1
     }

--- a/ostd/src/mm/kspace/kvirt_area.rs
+++ b/ostd/src/mm/kspace/kvirt_area.rs
@@ -1007,16 +1007,13 @@ impl KVirtArea {
                 // same frame reuse it. `new_frame` fabricates an `EntryOwner` with
                 // the correct `new_frame` shape for the paddr/level/prop;
                 // `frame_entry_wf` holds for any future frame at the same paddr.
-                // Note: `new_frame` returns with `in_scope = true`; clear it for
-                // `inv()` to hold (which requires `!in_scope`).
-                let tracked mut fresh = EntryOwner::<KernelPtConfig>::tracked_new_frame(
+                let tracked fresh = EntryOwner::<KernelPtConfig>::tracked_new_frame(
                     cur_mapped_pa,
                     cur_path,
                     cur_parent_level,
                     prop,  /* is_tracked */
                     true,
                 );
-                fresh.in_scope = false;
                 entry_owners.tracked_insert(cur_mapped_pa, fresh);
             }
         }
@@ -1275,9 +1272,8 @@ impl KVirtArea {
                     assert(pa < MAX_PADDR);
                 }
                 proof_decl! {
-                    let tracked mut entry_owner =
+                    let tracked entry_owner =
                         EntryOwner::<KernelPtConfig>::new_untracked_frame(pa, level, prop);
-                    entry_owner.in_scope = false;
                 }
 
                 let ghost old_cursor_model: CursorView<KernelPtConfig> = cursor.0.model(

--- a/ostd/src/mm/kspace/kvirt_area.rs
+++ b/ostd/src/mm/kspace/kvirt_area.rs
@@ -958,6 +958,11 @@ impl KVirtArea {
                     if idx_i != cur_pa_idx {
                         assert(regions.slot_owners[idx_i].inner_perms.ref_count.value()
                             == regions_before_map.slot_owners[idx_i].inner_perms.ref_count.value());
+                        // `rc <= MAX` transfers from `regions_before_map` (where
+                        // `item_slot_in_regions` carries the SHARED bound) via the
+                        // ref_count equality at this non-mapped index.
+                        assert(regions.slot_owners[idx_i].inner_perms.ref_count.value()
+                            <= crate::specs::mm::frame::meta_owners::REF_COUNT_MAX);
                     }
                 };
             }
@@ -1320,6 +1325,35 @@ impl KVirtArea {
                     assert(regions.slots.contains_key(idx));
                     assert(regions.slot_owners[idx].inner_perms.ref_count.value()
                         != crate::specs::mm::frame::meta_owners::REF_COUNT_UNUSED);
+                    // Sub-pages of a huge untracked frame: each `pa + j*PAGE_SIZE`
+                    // lies in `[pa, pa + page_size(level)) ⊆ pa_range`, so the
+                    // per-PA loop invariant supplies their slot existence. (Rc /
+                    // usage clauses are tracked-gated, hence vacuous for untracked.)
+                    assert(pa as nat + page_size(level) as nat <= pa_range.end as nat);
+                    assert forall|j: usize|
+                        #![trigger crate::mm::frame::meta::mapping::frame_to_index((pa + j * PAGE_SIZE) as usize)]
+                        0 < j < page_size(level) / PAGE_SIZE implies {
+                        let sub_idx = crate::mm::frame::meta::mapping::frame_to_index(
+                            (pa + j * PAGE_SIZE) as usize,
+                        );
+                        regions.slots.contains_key(sub_idx)
+                    } by {
+                        let sub_pa = (pa + j * PAGE_SIZE) as usize;
+                        assert(j * PAGE_SIZE < page_size(level)) by (nonlinear_arith)
+                            requires
+                                0 < j < page_size(level) / PAGE_SIZE,
+                                PAGE_SIZE > 0,
+                        ;
+                        assert(pa_range.start <= sub_pa < pa_range.end);
+                        // (PAGE_SIZE*j + pa) % PAGE_SIZE == pa % PAGE_SIZE == 0.
+                        vstd::arithmetic::mul::lemma_mul_is_commutative(j as int, PAGE_SIZE as int);
+                        vstd::arithmetic::div_mod::lemma_mod_multiples_vanish(
+                            j as int,
+                            pa as int,
+                            PAGE_SIZE as int,
+                        );
+                        assert(sub_pa % PAGE_SIZE == 0);
+                    };
                     assert(CursorMut::<'a, KernelPtConfig, A>::item_slot_in_regions(
                         item,
                         *regions,

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -1102,6 +1102,14 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                     #[verus_spec(with Tracked(&mut child_node_owner), Tracked(&*regions))]
                     let nr_children = pt_guard.nr_children();
 
+                    // `nr_children()` required `child_node_owner.metaregion_sound_node`,
+                    // so `count_consistent` holds for the node just read; snapshot it
+                    // (the node is about to be moved back into the cursor tree).
+                    let ghost cur_node_owner = child_node_owner;
+                    proof {
+                        assert(cur_node_owner.count_consistent());
+                    }
+
                     proof {
                         child_owner.value.tracked_put_node(child_node_owner);
                         continuation.tracked_put_child(child_owner);
@@ -1142,6 +1150,15 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                             owner.move_forward_increases_va();
                             owner.move_forward_not_popped_too_high();
                             let ghost subtree = owner.cur_subtree();
+                            // `pt_inv` for the current subtree, from the current
+                            // continuation's `pt_inv_children`.
+                            owner.inv_continuation((owner.level - 1) as int);
+                            owner.continuations[owner.level - 1].pt_inv_children_unroll(
+                                owner.index() as int,
+                            );
+                            // The subtree's node is the one just read by `nr_children`,
+                            // carrying `count_consistent`.
+                            assert(subtree.value.node() == cur_node_owner);
                             PageTableOwner(subtree).view_rec_nr_children_zero_empty(
                                 subtree.value.path,
                             );

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -1102,9 +1102,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                     #[verus_spec(with Tracked(&mut child_node_owner), Tracked(&*regions))]
                     let nr_children = pt_guard.nr_children();
 
-                    // `nr_children()` required `child_node_owner.metaregion_sound_node`,
-                    // so `count_consistent` holds for the node just read; snapshot it
-                    // (the node is about to be moved back into the cursor tree).
+                    // `nr_children()` requires `child_node_owner.metaregion_sound_node`,
+                    // so `count_consistent` holds for this node. Capture it as a ghost
+                    // before the node is moved back into the cursor tree.
                     let ghost cur_node_owner = child_node_owner;
                     proof {
                         assert(cur_node_owner.count_consistent());

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -2868,6 +2868,18 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 ==>
                 final(regions).slot_owners[
                     frame_to_index(C::item_into_raw(item).0)].inner_perms.ref_count.value() > 0,
+            // At the mapped index, the SHARED upper bound is preserved: on the
+            // non-panic path the clone's saturation guard keeps `rc <= MAX`.
+            // Lets callers re-derive `item_slot_in_regions`'s `rc <= MAX` for the
+            // mapped frame (covers duplicate frames in a map sequence).
+            (C::tracked(item)
+                && old(regions).slot_owners[
+                    frame_to_index(C::item_into_raw(item).0)].inner_perms.ref_count.value()
+                    <= crate::specs::mm::frame::meta_owners::REF_COUNT_MAX)
+                ==>
+                final(regions).slot_owners[
+                    frame_to_index(C::item_into_raw(item).0)].inner_perms.ref_count.value()
+                    <= crate::specs::mm::frame::meta_owners::REF_COUNT_MAX,
             // `regions.slots` is monotonic — slot existence is preserved through map.
             forall|idx: usize| #![trigger final(regions).slots.contains_key(idx)]
                 old(regions).slots.contains_key(idx) ==> final(regions).slots.contains_key(idx),

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -149,8 +149,8 @@ fn path_slot_as_mut<'a, 'rcu, C: PageTableConfig>(
 ///
 /// ## Justification
 /// `Child::from_pte` (called inside `Entry::replace`) invokes `PageTableNode::from_raw`,
-/// which sets `regions.slot_owners[idx].raw_count = 0` and marks the entry owner
-/// `in_scope = true`.  Consequently `metaregion_sound` reports `raw_count == 0`, but
+/// which sets `regions.slot_owners[idx].raw_count = 0`.  Consequently `metaregion_sound`
+/// reports `raw_count == 0`, but
 /// `Frame::borrow` / `FrameRef::borrow_paddr` require `raw_count == 1`.
 ///
 /// This function bridges that gap: we have unique ownership of the live frame `pt`
@@ -1377,7 +1377,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                     }
 
                     proof {
-                        let ghost child_not_in_scope = !child_owner.value.in_scope;
                         assert(cur_entry.idx == cont0.idx);
                         let ghost reconstructed_entry_own = EntryOwner {
                             kind: EntryOwnerKind::Node(continuation.entry_own.node()),
@@ -2529,7 +2528,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                             0 <= i < NR_ENTRIES ==> (#[trigger] child_owner_children[i]) is Some
                                 && child_owner_children[i].unwrap().value.is_absent());
 
-                        let ghost child_not_in_scope = !child_owner.value.in_scope;
                         let ghost reconstructed_entry_own = EntryOwner {
                             kind: EntryOwnerKind::Node(parent_owner),
                             ..cont_pre_alloc.entry_own
@@ -2940,7 +2938,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 cont.level(),
                 prop,
                 is_tracked,
-            ).set_in_scope(false));
+            ));
             assert(new_owner.value.is_frame());
             assert(new_owner.value.frame().mapped_pa == pa);
 
@@ -3294,9 +3292,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             owner.cur_entry_owner().path,
             owner.level,
         );
-        proof {
-            absent_entry_owner.in_scope = false;
-        }
         let tracked subtree = OwnerSubtree::new_val_tracked(
             absent_entry_owner,
             (owner.continuations[owner.level - 1].tree_level + 1) as nat,
@@ -3680,8 +3675,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         let ghost child_owner_parent_level = child_owner.value.parent_level;
 
         proof {
-            let ghost child_not_in_scope = !child_owner.value.in_scope;
-
             continuation.tracked_put_child(child_owner);
             continuation.entry_own.tracked_put_node(parent_owner);
             cont0.take_put_child();
@@ -3696,7 +3689,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             };
             assert(owner.continuations[owner.level - 1].inv()) by {
                 let cont_new = owner.continuations[owner.level - 1];
-                assert(child_not_in_scope);
                 cont_new.continuation_inv_holds_after_child_restore(cont0, cont0.entry_own.node());
             };
             assert(owner.continuations[owner.level - 1].entry_own.metaregion_sound(*regions));
@@ -3875,14 +3867,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         assert(owner.continuations == owner0.continuations.remove(owner.level - 1));
 
         let ghost pre_new_owner_value = new_owner.value;
-        // Capture the old child value before Entry::replace mutates it (from_pte_owner_spec
-        // only changes in_scope, so meta_slot_paddr() is unchanged, but we need the pre-replace
+        // Capture the old child value before Entry::replace mutates it (we need the pre-replace
         // value to match Entry::metaregion_sound_neq_preserved's old(owner) parameter).
         let ghost old_child_pre_replace = old_child_owner.value;
-
-        proof {
-            new_owner.value.in_scope = true;
-        }
 
         #[verus_spec(with Tracked(regions),
             Tracked(&mut old_child_owner.value),
@@ -4118,7 +4105,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                     }
                     owner0.inv_continuation(i);
                     let eo = owner0.continuations[i].entry_own;
-                    assert(eo.inv() && eo.is_node() && !eo.in_scope);
+                    assert(eo.inv() && eo.is_node());
                     assert(eo.metaregion_sound(regions0));
 
                     if old_child_pre_replace.is_node() {

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -1562,7 +1562,6 @@ impl PageTable<KernelPtConfig> {
                 assert(entry_owner.parent_level == kern_node.level);
                 assert(child_subtree.inv());
                 assert(entry_owner.inv());
-                assert(!entry_owner.in_scope);
                 assert(root_owner.relate_guard(root_node));
 
                 kernel_owner.0.map_unroll_once(

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -1503,7 +1503,9 @@ impl PageTable<KernelPtConfig> {
                                     && regions.slot_owners[sub_idx].inner_perms.ref_count.value()
                                     != crate::specs::mm::frame::meta_owners::REF_COUNT_UNUSED
                                     && regions.slot_owners[sub_idx].inner_perms.ref_count.value()
-                                    > 0)
+                                    > 0
+                                    && regions.slot_owners[sub_idx].inner_perms.ref_count.value()
+                                    <= crate::specs::mm::frame::meta_owners::REF_COUNT_MAX)
                             }
                     },
             );

--- a/ostd/src/mm/page_table/node/child.rs
+++ b/ostd/src/mm/page_table/node/child.rs
@@ -106,9 +106,7 @@ impl<C: PageTableConfig> Child<C> {
                 assume(C::E::new_page_req(paddr, level, prop));
                 C::E::new_page(paddr, level, prop)
             },
-            Child::None => {
-                C::E::new_absent()
-            },
+            Child::None => { C::E::new_absent() },
         }
     }
 

--- a/ostd/src/mm/page_table/node/child.rs
+++ b/ostd/src/mm/page_table/node/child.rs
@@ -63,7 +63,6 @@ impl<C: PageTableConfig> Child<C> {
              Tracked(regions): Tracked<&mut MetaRegionOwners>,
         requires
             self.invariants(*old(owner), *old(regions)),
-            old(owner).in_scope,
             self matches Child::PageTable(node) ==> old(regions).frame_obligations.count(
                 frame_to_index(meta_to_frame(node.ptr.addr())),
             ) > 0,
@@ -99,22 +98,15 @@ impl<C: PageTableConfig> Child<C> {
                     assert(regions.frame_obligations == fo0.remove(node_index));
                     let spec_regions = owner.into_pte_regions_spec(*old(regions));
                     assert(regions.slot_owners == spec_regions.slot_owners);
-                    owner.in_scope = false;
                 }
 
                 C::E::new_pt(paddr)
             },
             Child::Frame(paddr, level, prop) => {
-                proof {
-                    owner.in_scope = false;
-                }
                 assume(C::E::new_page_req(paddr, level, prop));
                 C::E::new_page(paddr, level, prop)
             },
             Child::None => {
-                proof {
-                    owner.in_scope = false;
-                }
                 C::E::new_absent()
             },
         }
@@ -148,9 +140,6 @@ impl<C: PageTableConfig> Child<C> {
     )]
     pub unsafe fn from_pte(pte: C::E, level: PagingLevel) -> Self {
         if !pte.is_present() {
-            proof {
-                entry_own.in_scope = true;
-            }
             return Child::None;
         }
         let paddr = pte.paddr();
@@ -182,8 +171,6 @@ impl<C: PageTableConfig> Child<C> {
                 // `frame.drop`). Net effect over `from_pte` is +1 on
                 // the ledger, balancing the prior `-1` from
                 // `into_pte`'s `MD::new` consume.
-                entry_own.in_scope = true;
-
                 assert(regions.slot_owners == entry_own.from_pte_regions_spec(
                     *old(regions),
                 ).slot_owners);
@@ -191,9 +178,6 @@ impl<C: PageTableConfig> Child<C> {
             }
 
             return Child::PageTable(node);
-        }
-        proof {
-            entry_own.in_scope = true;
         }
         Child::Frame(paddr, level, pte.prop())
     }
@@ -269,7 +253,7 @@ impl<C: PageTableConfig> ChildRef<'_, C> {
 
             proof {
                 // borrow_paddr postcondition gives raw_count == 1 and field-by-field preservation.
-                // Since raw_count was already 1 (entry is in PTE, in_scope == false),
+                // Since raw_count was already 1 (entry is in PTE),
                 // slot_owners[idx] == old(slot_owners[idx]) follows field by field.
                 assert(regions.slot_owners == old(regions).slot_owners);
                 // slots: borrow_paddr inserts at borrow_idx. Prove existing keys preserved.

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -13,7 +13,7 @@ use crate::mm::frame::{Frame, FrameRef};
 use crate::mm::page_table::*;
 use crate::mm::{Paddr, PagingConstsTrait, PagingLevel, Vaddr};
 use crate::specs::arch::{NR_ENTRIES, NR_LEVELS, PAGE_SIZE};
-use crate::specs::mm::frame::meta_owners::{MetaSlotOwner, REF_COUNT_UNUSED};
+use crate::specs::mm::frame::meta_owners::{MetaSlotOwner, REF_COUNT_MAX, REF_COUNT_UNUSED};
 use crate::specs::mm::frame::meta_region_owners::MetaRegionOwners;
 use crate::specs::mm::page_table::{INC_LEVELS, PageTableOwner};
 use crate::specs::task::InAtomicMode;
@@ -1200,6 +1200,8 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                             &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value()
                                 != REF_COUNT_UNUSED
                             &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value() > 0
+                            &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value()
+                                <= REF_COUNT_MAX
                         }
                     },
                 // j = 0: the huge frame's own slot.
@@ -1211,6 +1213,8 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                     &&& regions.slot_owners[frame_to_index(pa)].inner_perms.ref_count.value()
                         != crate::specs::mm::frame::meta_owners::REF_COUNT_UNUSED
                     &&& regions.slot_owners[frame_to_index(pa)].inner_perms.ref_count.value() > 0
+                    &&& regions.slot_owners[frame_to_index(pa)].inner_perms.ref_count.value()
+                        <= crate::specs::mm::frame::meta_owners::REF_COUNT_MAX
                 },
                 new_page.ptr.addr() == new_owner_meta_addr,
                 new_owner.value.node().metaregion_sound_node(*regions),
@@ -1302,6 +1306,8 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                             &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value()
                                 != REF_COUNT_UNUSED
                             &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value() > 0
+                            &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value()
+                                <= REF_COUNT_MAX
                         }
                     } by {
                         let sub_pages_per_subframe = page_size((level - 1) as PagingLevel)
@@ -1344,6 +1350,15 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                         );
                         assert((small_pa + j_prime * PAGE_SIZE) as usize == (pa + big_j
                             * PAGE_SIZE) as usize);
+                        // Fire the established big-frame sub-page forall
+                        // (entry.rs:1100) at `j = big_j` by mentioning its trigger
+                        // term, so its `usage != MMIO ==> rc <= REF_COUNT_MAX`
+                        // carries onto this child sub-page (`sub_idx` equals the
+                        // big-frame sub-page index via the correspondence above).
+                        assert(0 < big_j_int);
+                        assert(regions.slots.contains_key(
+                            frame_to_index((pa + big_j * PAGE_SIZE) as usize),
+                        ));
                     }
                     assert(child_owner.frame_sub_pages_valid(*regions));
                 }

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -614,9 +614,9 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 &&& forall|i: int| 0 <= i < NR_ENTRIES ==>
                     (#[trigger] final(owner).children[i])->0.value.path
                         == final(owner).value.path.push_tail(i as usize)
-                // Grandchildren are all None (carried through from
-                // `PageTableNode::alloc`'s `allocated_empty_node_grandchildren_none`
-                // ensures; the rebase only touches paths).
+                // Grandchildren are all None (from `PageTableNode::alloc`'s
+                // `allocated_empty_node_grandchildren_none` ensures; the path
+                // rebasing leaves grandchildren untouched).
                 &&& crate::specs::mm::page_table::allocated_empty_node_grandchildren_none(*final(owner))
                 // Other child fields preserved from `allocated_empty_node_owner`.
                 &&& forall|i: int| 0 <= i < NR_ENTRIES ==>
@@ -1422,11 +1422,10 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             proof {
                 assert(new_owner.value.node().metaregion_sound_node(*regions));
             }
-            // Take the node OUT (vs borrowing in place) — mirrors main's
-            // take/put pattern, which keeps Verus's loop-invariant maintenance
-            // tracking intact across the per-child `replace` (the in-place
-            // `tracked_borrow_mut_node` form loses the new node's own-slot
-            // facts at the loop back-edge).
+            // Take the node OUT (vs borrowing in place) to keep Verus's
+            // loop-invariant maintenance tracking intact across the per-child
+            // `replace`; the in-place `tracked_borrow_mut_node` form loses the
+            // new node's own-slot facts at the loop back-edge.
             let tracked mut new_owner_node = new_owner.value.tracked_take_node();
             proof {
                 assert(new_owner_node.metaregion_sound_node(*regions));

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -684,6 +684,18 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 parent_owner.nr_children_absent_slot_bound(self.idx);
             }
 
+            // Snapshot the parent's slot perm + nr_children-id clause while
+            // `metaregion_sound_node` still fully holds (count consistent,
+            // nothing mutated). The `+ 1`'s `read` below needs the id clause,
+            // but by then `count_consistent` is momentarily broken; we frame
+            // the clause forward instead of re-deriving it from a false
+            // predicate.
+            let ghost regions_pre = *regions;
+            let ghost pre_meta_perm = parent_owner.meta_perm_of(*regions);
+            proof {
+                assert(parent_owner.metaregion_sound_node(*regions));
+            }
+
             proof_decl! {
                 let tracked mut new_node_owner: Tracked<OwnerSubtree<C>>;
             }
@@ -736,10 +748,18 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 // set the parent's PTE present via `set_children_perm`) and the
                 // `+ 1` below, so the full `metaregion_sound_node` doesn't hold
                 // here. But its id clause — all `nr_children_mut`/`read` need — is
-                // frame-stable: `meta_own` is preserved by
-                // `set_children_perm`/`write_pte`, and the parent slot's perms are
-                // untouched by allocating the child slot. State it directly so the
-                // prover doesn't have to discharge the (now-false) whole predicate.
+                // frame-stable, so we transfer it from the pre-`alloc` snapshot:
+                //  - `meta_own` is preserved by `set_children_perm`/`write_pte`.
+                //  - the parent slot (`!= child slot`, since the parent is a live
+                //    node with `rc != UNUSED` while the child slot was `UNUSED`)
+                //    is preserved by `alloc` (`get_from_unused`/`reparked` only
+                //    touch the child slot) and by `write_pte` (regions immutable),
+                //    so `meta_perm_of` — a deterministic `new_spec(slots[idx],
+                //    inner_perms)` — is structurally unchanged.
+                assert(regions.slots[parent_owner.slot_index] == regions_pre.slots[parent_owner.slot_index]);
+                assert(regions.slot_owners[parent_owner.slot_index].inner_perms
+                    == regions_pre.slot_owners[parent_owner.slot_index].inner_perms);
+                assert(parent_owner.meta_perm_of(*regions) == pre_meta_perm);
                 assert(parent_owner.meta_own.nr_children.id()
                     == parent_owner.meta_perm_of(*regions).value().metadata.nr_children.id());
             }
@@ -759,6 +779,10 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 // `owner.level` (from `allocated_empty_node_owner` + the
                 // `owner.level + parent_owner.level == INC_LEVELS` precond), so
                 // the grafted children's levels line up with `owner.level + 1`.
+                assert(level == parent_owner.level);
+                assert(owner.level + parent_owner.level == INC_LEVELS);
+                assert(new_node_owner.value.node().level == (level - 1) as PagingLevel);
+                assert(new_node_owner.level == INC_LEVELS - level);
                 assert(new_node_owner.level == owner.level);
                 owner.value = new_node_owner.value;
                 owner.value.parent_level = level as PagingLevel;
@@ -1296,7 +1320,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             }
 
             proof {
-                //assert(new_owner_node.metaregion_sound_node(*regions));
+                assert(new_owner.value.node().metaregion_sound_node(*regions));
             }
             #[verus_spec(with Tracked(regions),
                 Tracked(&mut new_owner_child.value),

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -756,12 +756,14 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 //    touch the child slot) and by `write_pte` (regions immutable),
                 //    so `meta_perm_of` — a deterministic `new_spec(slots[idx],
                 //    inner_perms)` — is structurally unchanged.
-                assert(regions.slots[parent_owner.slot_index] == regions_pre.slots[parent_owner.slot_index]);
+                assert(regions.slots[parent_owner.slot_index]
+                    == regions_pre.slots[parent_owner.slot_index]);
                 assert(regions.slot_owners[parent_owner.slot_index].inner_perms
                     == regions_pre.slot_owners[parent_owner.slot_index].inner_perms);
                 assert(parent_owner.meta_perm_of(*regions) == pre_meta_perm);
-                assert(parent_owner.meta_own.nr_children.id()
-                    == parent_owner.meta_perm_of(*regions).value().metadata.nr_children.id());
+                assert(parent_owner.meta_own.nr_children.id() == parent_owner.meta_perm_of(
+                    *regions,
+                ).value().metadata.nr_children.id());
             }
 
             let tracked parent_meta_perm2 = regions.borrow_typed_perm::<PageTablePageMeta<C>>(
@@ -827,9 +829,9 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 // `tree_predicate_map` conjuncts of the big `is_absent` ensures
                 // block.
                 broadcast use crate::specs::mm::frame::meta_owners::axiom_mmio_usage_iff_mmio_paddr;
-
                 // (a) Region predicates preserved off the new node's slot: the
                 // install only touches `new_idx`. (Mirrors `replace`.)
+
                 assert(Self::metaregion_sound_neq_preserved(
                     old_owner_val,
                     owner.value,
@@ -861,8 +863,14 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                         owner.children[i].unwrap().value,
                         owner.value.path.push_tail(i as usize),
                     )
-                    &&& f_ms(owner.children[i].unwrap().value, owner.value.path.push_tail(i as usize))
-                    &&& f_pt(owner.children[i].unwrap().value, owner.value.path.push_tail(i as usize))
+                    &&& f_ms(
+                        owner.children[i].unwrap().value,
+                        owner.value.path.push_tail(i as usize),
+                    )
+                    &&& f_pt(
+                        owner.children[i].unwrap().value,
+                        owner.value.path.push_tail(i as usize),
+                    )
                 } by {
                     assert(owner.children[i].unwrap().value.is_absent());
                 };
@@ -1187,7 +1195,9 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                     (pa + j * PAGE_SIZE) as usize)]
                     0 < j < page_size(level) / PAGE_SIZE ==> {
                         let sub_idx = frame_to_index((pa + j * PAGE_SIZE) as usize);
-                        &&& regions.slots.contains_key(sub_idx)
+                        &&& regions.slots.contains_key(
+                            sub_idx,
+                        )
                         // Sub-frames are data frames, never page-table nodes —
                         // discriminates them from the new node's slot
                         // (`usage == PageTable`) so the per-child path install
@@ -1222,14 +1232,16 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 // `metaregion_sound` conjuncts not derivable from
                 // `metaregion_sound_node` (self_addr/wf derive). Carried so
                 // `into_pte`'s `Child::invariants` holds after the loop.
-                regions.slot_owners[frame_to_index(meta_to_frame(new_owner_meta_addr))]
-                    .inner_perms.ref_count.value()
+                regions.slot_owners[frame_to_index(
+                    meta_to_frame(new_owner_meta_addr),
+                )].inner_perms.ref_count.value()
                     != crate::specs::mm::frame::meta_owners::REF_COUNT_UNUSED,
-                0 < regions.slot_owners[frame_to_index(meta_to_frame(new_owner_meta_addr))]
-                    .inner_perms.ref_count.value()
+                0 < regions.slot_owners[frame_to_index(
+                    meta_to_frame(new_owner_meta_addr),
+                )].inner_perms.ref_count.value()
                     <= crate::specs::mm::frame::meta_owners::REF_COUNT_MAX,
-                regions.slot_owners[frame_to_index(meta_to_frame(new_owner_meta_addr))]
-                    .paths_in_pt == set![new_owner_path],
+                regions.slot_owners[frame_to_index(meta_to_frame(new_owner_meta_addr))].paths_in_pt
+                    == set![new_owner_path],
         {
             proof {
                 C::lemma_page_table_config_constant_requirements();

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -1322,13 +1322,23 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             proof {
                 assert(new_owner.value.node().metaregion_sound_node(*regions));
             }
+            // Take the node OUT (vs borrowing in place) — mirrors main's
+            // take/put pattern, which keeps Verus's loop-invariant maintenance
+            // tracking intact across the per-child `replace` (the in-place
+            // `tracked_borrow_mut_node` form loses the new node's own-slot
+            // facts at the loop back-edge).
+            let tracked mut new_owner_node = new_owner.value.tracked_take_node();
+            proof {
+                assert(new_owner_node.metaregion_sound_node(*regions));
+            }
             #[verus_spec(with Tracked(regions),
                 Tracked(&mut new_owner_child.value),
                 Tracked(&mut child_owner),
-                Tracked(new_owner.value.tracked_borrow_mut_node()))]
+                Tracked(&mut new_owner_node))]
             let old = entry.replace(Child::Frame(small_pa, level - 1, prop));
 
             proof {
+                new_owner.value.tracked_put_node(new_owner_node);
                 OwnerSubtree::set_value_property(new_owner_child, child_owner);
                 new_owner_child.value = child_owner;
                 new_owner.children.tracked_insert(i as int, Some(new_owner_child));

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -146,7 +146,6 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         requires
             self.invariants(*owner, *old(regions)),
             self.node_matching(*owner, *parent_owner, *self.node),
-            !owner.in_scope,
             parent_owner.metaregion_sound_node(*old(regions)),
         ensures
             res.invariants(*owner, *final(regions)),
@@ -239,15 +238,27 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             final(owner).frame().is_tracked == old(owner).frame().is_tracked,
             final(owner).path == old(owner).path,
             final(owner).parent_level == old(owner).parent_level,
-            final(owner).in_scope == old(owner).in_scope,
             final(self).idx == old(self).idx,
             old(self).pte.is_present() ==> op.ensures(
                 (old(owner).frame().prop,),
                 final(owner).frame().prop,
             ),
+            // `protect` only changes a present PTE's `prop` (never its
+            // present-status) and never touches `nr_children`, so the present
+            // count and the counter are both unchanged — keeping the parent's
+            // `count_consistent` invariant intact for the caller.
+            crate::specs::mm::page_table::node::owners::count_present(
+                final(parent_owner).children_perm.value(),
+            ) == crate::specs::mm::page_table::node::owners::count_present(
+                old(parent_owner).children_perm.value(),
+            ),
+            final(parent_owner).meta_own.nr_children.value() == old(
+                parent_owner,
+            ).meta_own.nr_children.value(),
     )]
     pub(in crate::mm) fn protect(&mut self, op: impl FnOnce(PageProperty) -> PageProperty) {
         let ghost pte0 = self.pte;
+        let ghost cp_old = parent_owner.children_perm.value();
 
         if !self.pte.is_present() {
             return;
@@ -274,6 +285,14 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
 
         proof {
             owner.tracked_borrow_mut_frame().prop = new_prop;
+            // The PTE at `self.idx` stayed present (only `prop` changed), so the
+            // present-count is unchanged by the `write_pte` update.
+            crate::specs::mm::page_table::node::owners::lemma_count_present_upto_update(
+                cp_old,
+                NR_ENTRIES as int,
+                self.idx as int,
+                self.pte,
+            );
         }
     }
 
@@ -307,7 +326,6 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             new_child.invariants(*old(new_owner), *old(regions)),
             old(self).node_matching(*old(owner), *old(parent_owner), *old(self).node),
             old(self).new_owner_compatible(new_child, *old(owner), *old(new_owner), *old(regions)),
-            !old(owner).in_scope,
             old(parent_owner).metaregion_sound_node(*old(regions)),
             new_child matches Child::PageTable(node) ==> old(regions).frame_obligations.count(
                 frame_to_index(meta_to_frame(node.ptr.addr())),
@@ -390,6 +408,11 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
     pub(in crate::mm) fn replace(&mut self, new_child: Child<C>) -> Child<C> {
         let ghost new_idx = frame_to_index(new_owner.meta_slot_paddr().unwrap());
         let ghost old_idx = frame_to_index(owner.meta_slot_paddr().unwrap());
+        // For restoring `count_consistent` (the `nr_children == count_present`
+        // invariant) at the end: snapshot the parent's PTE array and counter
+        // before the PTE write + counter inc/dec.
+        let ghost cp0 = parent_owner.children_perm.value();
+        let ghost nr0 = parent_owner.meta_own.nr_children.value();
 
         #[cfg(feature = "allow_panic")]
         {
@@ -475,7 +498,6 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 new_meta_slot.paths_in_pt = set![new_owner.path];
                 regions.slot_owners.tracked_insert(new_idx, new_meta_slot);
             }
-            owner.in_scope = true;
         }
 
         proof {
@@ -491,6 +513,24 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 let paddr = new_owner.meta_slot_paddr().unwrap();
                 regions.inv_implies_correct_addr(paddr);
             }
+        }
+
+        proof {
+            // Restore `count_consistent` (`nr_children == count_present(children_perm)`):
+            // `write_pte` changed only slot `self.idx`, and `nr_children` was
+            // inc/dec'd by exactly that slot's present-status change.
+            assert(parent_owner.children_perm.value() == cp0.update(self.idx as int, new_pte));
+            crate::specs::mm::page_table::node::owners::lemma_count_present_upto_update(
+                cp0,
+                NR_ENTRIES as int,
+                self.idx as int,
+                new_pte,
+            );
+            // Present-status of the old/new PTEs is pinned to the owner kind by
+            // `match_pte`, and the counter branches keyed off `is_none()`.
+            assert(cp0[self.idx as int].is_present() == !old_child.is_none());
+            assert(new_pte.is_present() == !new_child.is_none());
+            assert(parent_owner.count_consistent());
         }
 
         old_child
@@ -522,18 +562,25 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             old(owner).inv(),
             old(self).node_matching(old(owner).value, *old(parent_owner), *old(self).node),
             old(owner).level < INC_LEVELS - 1,
+            // The cursor entry's ghost-tree level is its DEPTH
+            // (`INC_LEVELS - parent_PT_level`), tying it to the freshly-
+            // allocated node's depth (`new_node_owner.level`) so we can prove
+            // `final(owner).inv()`'s `child.level == self.level + 1`.
+            old(owner).level + old(parent_owner).level == INC_LEVELS,
             old(parent_owner).metaregion_sound_node(*old(regions)),
         ensures
             final(self).invariants(final(owner).value, *final(regions)),
             final(self).parent_perms_preserved(*old(parent_owner), *final(parent_owner)),
             final(self).idx == old(self).idx,
+            // Adding a child keeps the parent's `count_consistent` invariant:
+            // the new PT PTE is present (old slot was absent) and `nr_children`
+            // was incremented by 1. (Trivially preserved on the no-op path.)
+            final(parent_owner).count_consistent(),
             old(owner).value.is_absent() && old(parent_owner).level > 1 ==> {
                 // node_matching preserved: parent_owner still matches the child after allocation.
                 &&& final(self).node_matching(final(owner).value, *final(parent_owner), *final(self).node)
                 // OwnerSubtree inv (recursive tree invariant, not just value.inv()).
                 &&& final(owner).inv()
-                // After into_pte, the entry has in_scope == false.
-                &&& !final(owner).value.in_scope
             },
             old(owner).value.is_absent() && old(parent_owner).level > 1 ==> {
                 &&& res is Some
@@ -610,6 +657,8 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         PageTableGuard<'rcu, C>,
     > {
         let entry_is_present = self.pte.is_present();
+        // For restoring `count_consistent` after adding the child below.
+        let ghost cp0 = parent_owner.children_perm.value();
 
         let tracked parent_meta_perm = regions.borrow_typed_perm::<PageTablePageMeta<C>>(
             parent_owner.slot_index,
@@ -621,6 +670,19 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             None
         } else {
             let ghost old_path = owner.value.path;
+            let ghost old_owner_val = owner.value;
+
+            proof {
+                // `nr_children < NR_ENTRIES` (needed below so the `+ 1`
+                // increment yields a valid count). Established PRE-`alloc` while
+                // the parent slot at `self.idx` is still absent and
+                // `count_consistent` holds (from `metaregion_sound_node`).
+                // `alloc`/`write_pte` preserve `parent_owner.meta_own.nr_children`,
+                // so the bound persists to the increment.
+                assert(parent_owner.count_consistent());
+                assert(!parent_owner.children_perm.value()[self.idx as int].is_present());
+                parent_owner.nr_children_absent_slot_bound(self.idx);
+            }
 
             proof_decl! {
                 let tracked mut new_node_owner: Tracked<OwnerSubtree<C>>;
@@ -660,10 +722,6 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             #[verus_spec(with Tracked(&new_node_owner.value.tracked_borrow_node()), Tracked(guards))]
             let mut pt_lock_guard = pt_ref.lock(guard);
 
-            proof {
-                parent_owner.nr_children_absent_slot_bound(self.idx);
-            }
-
             // SAFETY:
             //  1. The index is within the bounds.
             //  2. The new PTE is a child in `C` and at the correct paging level.
@@ -672,6 +730,19 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 #[verus_spec(with Tracked(parent_owner), Tracked(&*regions))]
                 self.node.write_pte(self.idx, self.pte)
             };
+
+            proof {
+                // `count_consistent` is momentarily broken between `alloc` (which
+                // set the parent's PTE present via `set_children_perm`) and the
+                // `+ 1` below, so the full `metaregion_sound_node` doesn't hold
+                // here. But its id clause — all `nr_children_mut`/`read` need — is
+                // frame-stable: `meta_own` is preserved by
+                // `set_children_perm`/`write_pte`, and the parent slot's perms are
+                // untouched by allocating the child slot. State it directly so the
+                // prover doesn't have to discharge the (now-false) whole predicate.
+                assert(parent_owner.meta_own.nr_children.id()
+                    == parent_owner.meta_perm_of(*regions).value().metadata.nr_children.id());
+            }
 
             let tracked parent_meta_perm2 = regions.borrow_typed_perm::<PageTablePageMeta<C>>(
                 parent_owner.slot_index,
@@ -682,6 +753,13 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             nr_children.write(Tracked(&mut parent_owner.meta_own.nr_children), _tmp + 1);
 
             proof {
+                // For `final(owner).inv()`'s `child.level == self.level + 1`:
+                // the grafted children carry `new_node_owner.level + 1`, and
+                // `owner.level` is unchanged. The fresh node's depth equals
+                // `owner.level` (from `allocated_empty_node_owner` + the
+                // `owner.level + parent_owner.level == INC_LEVELS` precond), so
+                // the grafted children's levels line up with `owner.level + 1`.
+                assert(new_node_owner.level == owner.level);
                 owner.value = new_node_owner.value;
                 owner.value.parent_level = level as PagingLevel;
                 owner.value.path = old_path;
@@ -702,6 +780,84 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 let tracked mut new_meta_slot = regions.slot_owners.tracked_remove(new_idx);
                 new_meta_slot.paths_in_pt = set![owner.value.path];
                 regions.slot_owners.tracked_insert(new_idx, new_meta_slot);
+            }
+
+            proof {
+                // Restore the parent's `count_consistent`: the slot at `self.idx`
+                // went absent → present (the new PT node) and `nr_children` was
+                // incremented by 1.
+                assert(parent_owner.children_perm.value() == cp0.update(self.idx as int, self.pte));
+                crate::specs::mm::page_table::node::owners::lemma_count_present_upto_update(
+                    cp0,
+                    NR_ENTRIES as int,
+                    self.idx as int,
+                    self.pte,
+                );
+                assert(!cp0[self.idx as int].is_present());
+                assert(self.pte.is_present());
+                assert(parent_owner.count_consistent());
+            }
+
+            proof {
+                // Discharge the region-preservation + fresh-node
+                // `tree_predicate_map` conjuncts of the big `is_absent` ensures
+                // block.
+                broadcast use crate::specs::mm::frame::meta_owners::axiom_mmio_usage_iff_mmio_paddr;
+
+                // (a) Region predicates preserved off the new node's slot: the
+                // install only touches `new_idx`. (Mirrors `replace`.)
+                assert(Self::metaregion_sound_neq_preserved(
+                    old_owner_val,
+                    owner.value,
+                    *old(regions),
+                    *regions,
+                ));
+                assert(Self::path_tracked_pred_preserved(*old(regions), *regions));
+
+                // (b) `tree_predicate_map` over the fresh node: each predicate
+                // holds at the node root and trivially at the absent children
+                // (which have `None` grandchildren), via
+                // `fresh_node_tree_predicate_map`.
+                let ghost new_node_addr = owner.value.node().meta_addr_self();
+                let f_nu = CursorOwner::<'rcu, C>::node_unlocked_except(*guards, new_node_addr);
+                let f_ms = PageTableOwner::<C>::metaregion_sound_pred(*regions);
+                let f_pt = PageTableOwner::<C>::path_tracked_pred(*regions);
+
+                assert(owner.level + (level as nat) == INC_LEVELS);
+                assert(owner.level < INC_LEVELS - 1);
+
+                // Root predicates.
+                assert(f_nu(owner.value, owner.value.path));
+                assert(f_ms(owner.value, owner.value.path));
+                assert(f_pt(owner.value, owner.value.path));
+
+                // Child predicates (absent children ⟹ trivial).
+                assert forall|i: int| 0 <= i < NR_ENTRIES implies {
+                    &&& #[trigger] f_nu(
+                        owner.children[i].unwrap().value,
+                        owner.value.path.push_tail(i as usize),
+                    )
+                    &&& f_ms(owner.children[i].unwrap().value, owner.value.path.push_tail(i as usize))
+                    &&& f_pt(owner.children[i].unwrap().value, owner.value.path.push_tail(i as usize))
+                } by {
+                    assert(owner.children[i].unwrap().value.is_absent());
+                };
+
+                crate::specs::mm::page_table::fresh_node_tree_predicate_map(
+                    *owner,
+                    owner.value.path,
+                    f_nu,
+                );
+                crate::specs::mm::page_table::fresh_node_tree_predicate_map(
+                    *owner,
+                    owner.value.path,
+                    f_ms,
+                );
+                crate::specs::mm::page_table::fresh_node_tree_predicate_map(
+                    *owner,
+                    owner.value.path,
+                    f_pt,
+                );
             }
 
             Some(pt_lock_guard)
@@ -798,7 +954,6 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             final(owner).inv(),
             final(owner).value.parent_level == old(owner).value.parent_level,
             final(self).idx == old(self).idx,
-            old(owner).value.is_frame() && old(parent_owner).level > 1 ==> !final(owner).value.in_scope,
             old(owner).value.is_frame() && old(parent_owner).level > 1 ==>
                 final(self).node_matching(final(owner).value, *final(parent_owner), *final(self).node),
             final(regions).inv(),
@@ -929,7 +1084,6 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                     #![auto]
                     i <= j < NR_ENTRIES ==> {
                         &&& new_owner.children[j].unwrap().value.is_absent()
-                        &&& !new_owner.children[j].unwrap().value.in_scope
                         &&& new_owner.value.node().children_perm.value()[j]
                             == C::E::new_absent_spec()
                     },
@@ -975,7 +1129,6 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 ));
                 assert(the_node.relate_guard(pt_lock_guard));
                 assert(new_owner.children[i as int].unwrap().value.parent_level == the_node.level);
-                assert(!new_owner.children[i as int].unwrap().value.in_scope);
 
                 OwnerSubtree::child_some_properties(new_owner, i as usize);
                 EntryOwner::huge_frame_split_child_at(owner.value, *regions, i as usize);
@@ -1152,8 +1305,6 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             let old = entry.replace(Child::Frame(small_pa, level - 1, prop));
 
             proof {
-                new_owner_child.value.in_scope = false;
-                child_owner.in_scope = false;
                 OwnerSubtree::set_value_property(new_owner_child, child_owner);
                 new_owner_child.value = child_owner;
                 new_owner.children.tracked_insert(i as int, Some(new_owner_child));
@@ -1214,7 +1365,6 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
              Tracked(regions): Tracked<&MetaRegionOwners>,
         requires
             owner.inv(),
-            !owner.in_scope,
             parent_owner.inv(),
             parent_owner.relate_guard(*guard),
             idx < NR_ENTRIES,

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -1062,6 +1062,70 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         let ghost new_owner_path = new_owner.value.path;
         let ghost new_owner_meta_addr = new_owner.value.node().meta_addr_self();
 
+        proof {
+            // Carry the huge frame's slot facts (the precondition's
+            // `metaregion_sound`/`frame_sub_pages_valid`, stated about
+            // `old(regions)`) across `alloc` to post-alloc `regions`,
+            // establishing the split loop's j=0 and sub-page invariants.
+            //
+            // `alloc` (get_node_from_unused_spec + slot_perm_reparked_spec) only
+            // mutates the freshly-allocated node's slot `new_idx`; the huge
+            // frame's own slot and every sub-page slot is distinct from
+            // `new_idx`: non-MMIO slots have `rc != UNUSED` while `new_idx` was
+            // UNUSED pre-alloc; MMIO slots are `is_mmio` while the new node is
+            // `!is_mmio`.
+            broadcast use crate::specs::mm::frame::mapping::lemma_frame_to_index_injective;
+            broadcast use crate::specs::mm::frame::meta_owners::axiom_mmio_usage_iff_mmio_paddr;
+            broadcast use crate::mm::frame::meta::mapping::group_page_meta;
+
+            let new_idx = frame_to_index(meta_to_frame(new_owner_meta_addr));
+            let new_paddr = meta_to_frame(new_owner_meta_addr);
+            let nr_pages = page_size(level) / PAGE_SIZE;
+
+            // The huge frame's own slot (j = 0): `usage != PageTable` from the
+            // precondition's `metaregion_sound` (frame arm), preserved across
+            // `alloc` because `frame_to_index(pa) != new_idx`.
+            let pa_idx = frame_to_index(pa);
+            assert(old(regions).slots.contains_key(pa_idx));
+            assert(pa_idx != new_idx) by {
+                if old(regions).slot_owners[pa_idx].usage
+                    == crate::specs::mm::frame::meta_owners::PageUsage::MMIO {
+                    old(regions).inv_implies_correct_addr(pa);
+                } else {
+                    // metaregion_sound frame arm: non-MMIO ⟹ rc != UNUSED.
+                }
+            };
+
+            // Sub-pages (j > 0): `frame_sub_pages_valid` facts, preserved.
+            assert forall|j: usize|
+                #![trigger frame_to_index((pa + j * PAGE_SIZE) as usize)]
+                0 < j < nr_pages implies {
+                let sub_idx = frame_to_index((pa + j * PAGE_SIZE) as usize);
+                &&& regions.slots.contains_key(sub_idx)
+                &&& regions.slot_owners[sub_idx].usage
+                    != crate::specs::mm::frame::meta_owners::PageUsage::PageTable
+                &&& regions.slot_owners[sub_idx].usage
+                    != crate::specs::mm::frame::meta_owners::PageUsage::MMIO ==> {
+                    &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value()
+                        != REF_COUNT_UNUSED
+                    &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value() > 0
+                    &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value()
+                        <= crate::specs::mm::frame::meta_owners::REF_COUNT_MAX
+                }
+            } by {
+                let sub_idx = frame_to_index((pa + j * PAGE_SIZE) as usize);
+                assert(old(regions).slots.contains_key(sub_idx));
+                assert(sub_idx != new_idx) by {
+                    if old(regions).slot_owners[sub_idx].usage
+                        == crate::specs::mm::frame::meta_owners::PageUsage::MMIO {
+                        old(regions).inv_implies_correct_addr((pa + j * PAGE_SIZE) as usize);
+                    } else {
+                        // non-MMIO sub-page ⟹ rc != UNUSED ⟹ != new_idx.
+                    }
+                };
+            };
+        }
+
         for i in 0..nr_subpage_per_huge::<C>()
             invariant
                 1 < level < NR_LEVELS,
@@ -1124,6 +1188,13 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                     0 < j < page_size(level) / PAGE_SIZE ==> {
                         let sub_idx = frame_to_index((pa + j * PAGE_SIZE) as usize);
                         &&& regions.slots.contains_key(sub_idx)
+                        // Sub-frames are data frames, never page-table nodes —
+                        // discriminates them from the new node's slot
+                        // (`usage == PageTable`) so the per-child path install
+                        // (`tracked_remove/insert` at `sub_idx`) can't touch the
+                        // node's own slot.
+                        &&& regions.slot_owners[sub_idx].usage
+                            != crate::specs::mm::frame::meta_owners::PageUsage::PageTable
                         &&& regions.slot_owners[sub_idx].usage
                             != crate::specs::mm::frame::meta_owners::PageUsage::MMIO ==> {
                             &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value()
@@ -1134,6 +1205,8 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 // j = 0: the huge frame's own slot.
                 regions.slots.contains_key(frame_to_index(pa)),
                 regions.slot_owners[frame_to_index(pa)].usage
+                    != crate::specs::mm::frame::meta_owners::PageUsage::PageTable,
+                regions.slot_owners[frame_to_index(pa)].usage
                     != crate::specs::mm::frame::meta_owners::PageUsage::MMIO ==> {
                     &&& regions.slot_owners[frame_to_index(pa)].inner_perms.ref_count.value()
                         != crate::specs::mm::frame::meta_owners::REF_COUNT_UNUSED
@@ -1141,6 +1214,18 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 },
                 new_page.ptr.addr() == new_owner_meta_addr,
                 new_owner.value.node().metaregion_sound_node(*regions),
+                // The new node's own-slot rc + paths_in_pt — the only
+                // `metaregion_sound` conjuncts not derivable from
+                // `metaregion_sound_node` (self_addr/wf derive). Carried so
+                // `into_pte`'s `Child::invariants` holds after the loop.
+                regions.slot_owners[frame_to_index(meta_to_frame(new_owner_meta_addr))]
+                    .inner_perms.ref_count.value()
+                    != crate::specs::mm::frame::meta_owners::REF_COUNT_UNUSED,
+                0 < regions.slot_owners[frame_to_index(meta_to_frame(new_owner_meta_addr))]
+                    .inner_perms.ref_count.value()
+                    <= crate::specs::mm::frame::meta_owners::REF_COUNT_MAX,
+                regions.slot_owners[frame_to_index(meta_to_frame(new_owner_meta_addr))]
+                    .paths_in_pt == set![new_owner_path],
         {
             proof {
                 C::lemma_page_table_config_constant_requirements();
@@ -1331,6 +1416,17 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             proof {
                 assert(new_owner_node.metaregion_sound_node(*regions));
             }
+            // Snapshot the node's own-slot facts while the loop invariant still
+            // holds (regions unchanged since loop entry), so we can frame them
+            // across the `replace` below.
+            let ghost nidx = frame_to_index(meta_to_frame(new_owner_meta_addr));
+            proof {
+                // The loop invariant still holds for the current `regions`
+                // (unchanged since entry), so pin the node-slot paths_in_pt fact
+                // here for the post-`replace` preservation step to carry forward.
+                assert(regions.slot_owners[nidx].paths_in_pt == set![new_owner_path]);
+            }
+            let ghost regions_pre_replace = *regions;
             #[verus_spec(with Tracked(regions),
                 Tracked(&mut new_owner_child.value),
                 Tracked(&mut child_owner),
@@ -1345,6 +1441,17 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
 
                 TreePath::push_tail_property_len(new_owner_path, i as usize);
                 OwnerSubtree::insert_preserves_inv(new_owner, i as usize, new_owner_child);
+
+                // `replace` of a frame child preserves every slot's `inner_perms`
+                // (unconditional) and `paths_in_pt` (non-node child), so the new
+                // node's own-slot rc + paths_in_pt are unchanged — re-establish
+                // the loop invariant's node-slot clauses for the next iteration.
+                assert(regions.slot_owners[nidx].inner_perms
+                    == regions_pre_replace.slot_owners[nidx].inner_perms);
+                assert(regions.slot_owners[nidx].paths_in_pt
+                    == regions_pre_replace.slot_owners[nidx].paths_in_pt);
+                assert(regions_pre_replace.slot_owners[nidx].paths_in_pt == set![new_owner_path]);
+                assert(regions.slot_owners[nidx].paths_in_pt == set![new_owner_path]);
             }
         }
 

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -515,7 +515,7 @@ impl<C: PageTableConfig> PageTableNode<C> {
             allocated_empty_node_grandchildren_none(owner@),
             res.ptr.addr() == owner@.value.node().meta_addr_self(),
             guards.unlocked(owner@.value.node().meta_addr_self()),
-            MetaSlot::get_from_unused_spec(meta_to_frame(owner@.value.node().meta_addr_self()), false, *old(regions), *final(regions)),
+            MetaSlot::get_node_from_unused_spec(meta_to_frame(owner@.value.node().meta_addr_self()), *old(regions), *final(regions)),
             MetaSlot::slot_perm_reparked_spec(meta_to_frame(owner@.value.node().meta_addr_self()), *old(regions), *final(regions)),
 
             final(regions).frame_obligations == old(regions).frame_obligations.insert(

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -701,7 +701,6 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
              Tracked(regions): Tracked<&MetaRegionOwners>,
         requires
             owner.inv(),
-            !child_owner.in_scope,
             child_owner.inv(),
             owner.relate_guard(*old(self)),
             child_owner.match_pte(

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -1025,10 +1025,14 @@ impl<'a, A: InAtomicMode> CursorMut<'a, A> {
                 cursor_owner.va.reflect_prop(self.pt_cursor.0.va);
                 cursor_owner.view_preserves_inv();
                 // Per-config VA bound on prev_mappings — needed for
-                // preserving the `removed`-end-bound loop invariant.
-                crate::specs::mm::page_table::cursor::owners::axiom_view_in_vaddr_range::<
-                    UserPtConfig,
-                >(cursor_owner);
+                // preserving the `removed`-end-bound loop invariant. The user
+                // cursor's view lies in [0, 0x8000_0000_0000) by the PROVEN
+                // `lemma_view_in_vaddr_range_user` (no longer the generic
+                // axiom), which follows from `cursor_owner.inv()`'s isolation
+                // (borrowed-kernel-half) clause.
+                crate::specs::mm::page_table::cursor::owners::lemma_view_in_vaddr_range_user(
+                    cursor_owner,
+                );
                 crate::mm::page_table::lemma_vaddr_range_bounds_spec_user();
             }
 


### PR DESCRIPTION
This PR contains a few different threads.
- Before adding the drop obligation system, `EntryOwner`'s `in_scope` field distinguished an owner that corresponded to a live `Entry` object from a parked `E` value for purposes of the reference count conditions. This was fragile, and is unnecessary with drop obligations handling the reference count arithmetic. Removing that is the most important part of this PR.
- I've added `kspace`, `segment`, `unique`, and `linked_list` to `mm/specs/embedding`. The embedding tracks the reference counting arithmetic across sequential calls, which is an important check on the individual function specs.
- Proved `lemma_view_in_vaddr_range`, previously an axiom, which was one of the per-config lemmas that got axiomatized because it depended on different configs behaviors. I also deleted a few axioms that weren't being used, no sense in cluttering the trust boundary any more than it already is.