### PR TITLE
chore: rename `self_addr` into `slot_vaddr` in `MetaSlotOwner` and `MetaSlotModel`

### DIFF
--- a/ostd/specs/mm/embedding/cursor.rs
+++ b/ostd/specs/mm/embedding/cursor.rs
@@ -243,10 +243,10 @@ pub axiom fn cursor_query_embedded<'rcu>(
                 ).slot_owners[i]
             // At the cloned slot, only `ref_count` changes — everything
             // else (`raw_count`, `in_list`, `usage`, `paths_in_pt`,
-            // `storage`, `self_addr`, `vtable_ptr`) is preserved.
-            &&& final(regions).slot_owners[frame_to_index(paddr)].self_addr == old(
+            // `storage`, `slot_vaddr`, `vtable_ptr`) is preserved.
+            &&& final(regions).slot_owners[frame_to_index(paddr)].slot_vaddr == old(
                 regions,
-            ).slot_owners[frame_to_index(paddr)].self_addr
+            ).slot_owners[frame_to_index(paddr)].slot_vaddr
             &&& final(regions).slot_owners[frame_to_index(paddr)].usage == old(
                 regions,
             ).slot_owners[frame_to_index(paddr)].usage
@@ -511,14 +511,14 @@ pub axiom fn cursor_mut_unmap_embedded<'rcu>(
         // `slots` (the boot-fixed metadata perm map) preserved.
         final(regions).slots == old(regions).slots,
         // **Universal per-slot preservation.** Unmap doesn't change a
-        // slot's identity (`usage`/`self_addr`/`raw_count`/`in_list`/
+        // slot's identity (`usage`/`slot_vaddr`/`raw_count`/`in_list`/
         // `vtable_ptr`) and never bumps `rc` to `UNIQUE` (UNIQUE is a
         // unique-handle sentinel produced only by
         // `Frame::into_unique`, not by unmap).
         forall|i: usize|
             #![trigger final(regions).slot_owners[i]]
             {
-                &&& final(regions).slot_owners[i].self_addr == old(regions).slot_owners[i].self_addr
+                &&& final(regions).slot_owners[i].slot_vaddr == old(regions).slot_owners[i].slot_vaddr
                 &&& final(regions).slot_owners[i].usage == old(regions).slot_owners[i].usage
                 &&& final(regions).slot_owners[i].inner_perms.in_list == old(
                     regions,
@@ -932,7 +932,7 @@ pub(super) proof fn cursor_mut_regions_step<'rcu>(
         final(tlb_model).inv(),
         // Mirror the faithful `cursor_mut_unmap_embedded` ensures: per-
         // slot universal preservation (raw_count, in_list, usage,
-        // self_addr, vtable_ptr); rc doesn't bump to UNIQUE; storage
+        // slot_vaddr, vtable_ptr); rc doesn't bump to UNIQUE; storage
         // preserved at non-UNUSED post; and at Frame slots, the
         // "non-mapping count" `rc - paths.len()` is invariant with
         // `rc` and `paths.len` monotonically non-increasing.
@@ -940,7 +940,7 @@ pub(super) proof fn cursor_mut_regions_step<'rcu>(
         forall|i: usize|
             #![trigger final(regions).slot_owners[i]]
             {
-                &&& final(regions).slot_owners[i].self_addr == old(regions).slot_owners[i].self_addr
+                &&& final(regions).slot_owners[i].slot_vaddr == old(regions).slot_owners[i].slot_vaddr
                 &&& final(regions).slot_owners[i].usage == old(regions).slot_owners[i].usage
                 &&& final(regions).slot_owners[i].inner_perms.in_list == old(
                     regions,

--- a/ostd/specs/mm/embedding/cursor.rs
+++ b/ostd/specs/mm/embedding/cursor.rs
@@ -518,7 +518,9 @@ pub axiom fn cursor_mut_unmap_embedded<'rcu>(
         forall|i: usize|
             #![trigger final(regions).slot_owners[i]]
             {
-                &&& final(regions).slot_owners[i].slot_vaddr == old(regions).slot_owners[i].slot_vaddr
+                &&& final(regions).slot_owners[i].slot_vaddr == old(
+                    regions,
+                ).slot_owners[i].slot_vaddr
                 &&& final(regions).slot_owners[i].usage == old(regions).slot_owners[i].usage
                 &&& final(regions).slot_owners[i].inner_perms.in_list == old(
                     regions,
@@ -940,7 +942,9 @@ pub(super) proof fn cursor_mut_regions_step<'rcu>(
         forall|i: usize|
             #![trigger final(regions).slot_owners[i]]
             {
-                &&& final(regions).slot_owners[i].slot_vaddr == old(regions).slot_owners[i].slot_vaddr
+                &&& final(regions).slot_owners[i].slot_vaddr == old(
+                    regions,
+                ).slot_owners[i].slot_vaddr
                 &&& final(regions).slot_owners[i].usage == old(regions).slot_owners[i].usage
                 &&& final(regions).slot_owners[i].inner_perms.in_list == old(
                     regions,

--- a/ostd/specs/mm/embedding/frame.rs
+++ b/ostd/specs/mm/embedding/frame.rs
@@ -209,9 +209,9 @@ pub axiom fn frame_drop_embedded(tracked regions: &mut MetaRegionOwners, paddr: 
             ).slot_owners[i],
         final(regions).slots == old(regions).slots,
         final(regions).slot_owners.dom() == old(regions).slot_owners.dom(),
-        final(regions).slot_owners[frame_to_index(paddr)].self_addr == old(
+        final(regions).slot_owners[frame_to_index(paddr)].slot_vaddr == old(
             regions,
-        ).slot_owners[frame_to_index(paddr)].self_addr,
+        ).slot_owners[frame_to_index(paddr)].slot_vaddr,
         final(regions).slot_owners[frame_to_index(paddr)].usage == old(
             regions,
         ).slot_owners[frame_to_index(paddr)].usage,

--- a/ostd/specs/mm/embedding/mod.rs
+++ b/ostd/specs/mm/embedding/mod.rs
@@ -110,7 +110,7 @@
 //!
 //! 4. **Strengthen `cursor_mut_unmap_embedded`** — DONE. The axiom
 //!    now mirrors exec: universal preservation of
-//!    `raw_count`/`in_list`/`usage`/`self_addr`/`vtable_ptr`;
+//!    `raw_count`/`in_list`/`usage`/`slot_vaddr`/`vtable_ptr`;
 //!    storage preserved at slots ending non-UNUSED; rc doesn't bump
 //!    to UNIQUE; at Frame slots the "non-mapping count"
 //!    `rc - paths.len` is invariant with both monotonically non-
@@ -2143,7 +2143,7 @@ proof fn step_unmap<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId, len: usize
         cursor::CursorMutRegionsMethod::Unmap(len),
     );
     // Discharge `accounting_inv` clause-by-clause. The unmap axiom
-    // gives: usage/raw_count/in_list/self_addr/vtable_ptr preserved
+    // gives: usage/raw_count/in_list/slot_vaddr/vtable_ptr preserved
     // universally; rc doesn't bump to UNIQUE; storage preserved at
     // post-non-UNUSED; at Frame slots, `rc - paths.len` is invariant
     // with both monotonically non-increasing. `s.frames` is unchanged.

--- a/ostd/specs/mm/embedding/segment.rs
+++ b/ostd/specs/mm/embedding/segment.rs
@@ -177,7 +177,7 @@ pub axiom fn segment_drop_embedded(
                     let so_new = final(regions).slot_owners[idx];
                     &&& so_new.usage == so_old.usage
                     &&& so_new.paths_in_pt == so_old.paths_in_pt
-                    &&& so_new.self_addr == so_old.self_addr
+                    &&& so_new.slot_vaddr == so_old.slot_vaddr
                     &&& so_new.inner_perms.in_list == so_old.inner_perms.in_list
                     &&& so_old.inner_perms.ref_count.value() == 1
                         ==> so_new.inner_perms.ref_count.value() == REF_COUNT_UNUSED
@@ -237,7 +237,7 @@ pub axiom fn segment_next_embedded(
             let so_new = final(regions).slot_owners[idx];
             &&& so_new.inner_perms.ref_count == so_old.inner_perms.ref_count
             &&& so_new.usage == so_old.usage
-            &&& so_new.self_addr == so_old.self_addr
+            &&& so_new.slot_vaddr == so_old.slot_vaddr
             &&& so_new.paths_in_pt == so_old.paths_in_pt
             &&& so_new.inner_perms.in_list == so_old.inner_perms.in_list
             &&& so_new.inner_perms.storage == so_old.inner_perms.storage
@@ -345,7 +345,7 @@ pub(super) proof fn drop_step(
                 let so_new = final(regions).slot_owners[idx];
                 &&& so_new.usage == so_old.usage
                 &&& so_new.paths_in_pt == so_old.paths_in_pt
-                &&& so_new.self_addr == so_old.self_addr
+                &&& so_new.slot_vaddr == so_old.slot_vaddr
                 &&& so_new.inner_perms.in_list == so_old.inner_perms.in_list
                 &&& so_old.inner_perms.ref_count.value() == 1
                     ==> so_new.inner_perms.ref_count.value() == REF_COUNT_UNUSED
@@ -401,7 +401,7 @@ pub axiom fn segment_clone_embedded(
                     &&& so_new.inner_perms.ref_count.value()
                             == (so_old.inner_perms.ref_count.value() + 1) as u64
                     &&& so_new.usage == so_old.usage
-                    &&& so_new.self_addr == so_old.self_addr
+                    &&& so_new.slot_vaddr == so_old.slot_vaddr
                     &&& so_new.paths_in_pt == so_old.paths_in_pt
                     &&& so_new.inner_perms.in_list == so_old.inner_perms.in_list
                     &&& so_new.inner_perms.storage == so_old.inner_perms.storage

--- a/ostd/specs/mm/embedding/unique.rs
+++ b/ostd/specs/mm/embedding/unique.rs
@@ -93,7 +93,7 @@ pub axiom fn unique_from_unused_embedded(tracked regions: &mut MetaRegionOwners,
             &&& so_new.inner_perms.in_list.value() == 0
             &&& so_new.inner_perms.storage.is_init()
             &&& so_new.paths_in_pt == so_old.paths_in_pt
-            &&& so_new.self_addr == so_old.self_addr
+            &&& so_new.slot_vaddr == so_old.slot_vaddr
         },
         // All other slots fully preserved.
         forall|i: usize|
@@ -109,7 +109,7 @@ pub axiom fn unique_from_unused_embedded(tracked regions: &mut MetaRegionOwners,
 /// exclusive handle is released: the slot transitions
 /// `rc == REF_COUNT_UNIQUE` → `rc == REF_COUNT_UNUSED` (last-ref
 /// teardown via `drop_last_in_place`, uninitialising storage), with
-/// `usage`, `paths_in_pt` (empty), `in_list` (0), and `self_addr`
+/// `usage`, `paths_in_pt` (empty), `in_list` (0), and `slot_vaddr`
 /// preserved.
 ///
 /// **Preconditions** mirror `UniqueFrame::inv_with_regions` (the parts
@@ -129,7 +129,7 @@ pub axiom fn unique_drop_embedded(tracked regions: &mut MetaRegionOwners, paddr:
         final(regions).inv(),
         final(regions).slots =~= old(regions).slots,
         // At `paddr`: UNIQUE → UNUSED teardown; usage / paths / in_list
-        // / self_addr preserved.
+        // / slot_vaddr preserved.
         {
             let idx = frame_to_index(paddr);
             let so_old = old(regions).slot_owners[idx];
@@ -138,7 +138,7 @@ pub axiom fn unique_drop_embedded(tracked regions: &mut MetaRegionOwners, paddr:
             &&& so_new.usage == so_old.usage
             &&& so_new.paths_in_pt == so_old.paths_in_pt
             &&& so_new.inner_perms.in_list == so_old.inner_perms.in_list
-            &&& so_new.self_addr == so_old.self_addr
+            &&& so_new.slot_vaddr == so_old.slot_vaddr
         },
         // All other slots fully preserved.
         forall|i: usize|
@@ -154,7 +154,7 @@ pub axiom fn unique_drop_embedded(tracked regions: &mut MetaRegionOwners, paddr:
 /// exclusive handle at `paddr` into a shared one: `rc` drops from the
 /// `REF_COUNT_UNIQUE` sentinel to 1, with `usage` (Frame),
 /// `paths_in_pt` (empty), `in_list` (0), `storage`, `vtable_ptr`, and
-/// `self_addr` preserved (only the count `store` runs). `metaregion_sound`
+/// `slot_vaddr` preserved (only the count `store` runs). `metaregion_sound`
 /// is preserved: a UNIQUE slot has no live PTE (a mapping is a
 /// reference), so no cursor's `OwnerSubtree` maps it, and dropping the
 /// count to 1 keeps it referenced.
@@ -176,7 +176,7 @@ pub axiom fn from_unique_embedded(tracked regions: &mut MetaRegionOwners, paddr:
             &&& so_new.paths_in_pt == so_old.paths_in_pt
             &&& so_new.inner_perms.in_list == so_old.inner_perms.in_list
             &&& so_new.inner_perms.storage == so_old.inner_perms.storage
-            &&& so_new.self_addr == so_old.self_addr
+            &&& so_new.slot_vaddr == so_old.slot_vaddr
         },
         forall|i: usize|
             #![trigger final(regions).slot_owners[i]]
@@ -192,7 +192,7 @@ pub axiom fn from_unique_embedded(tracked regions: &mut MetaRegionOwners, paddr:
 /// transitions from a sole-reference shared frame (`rc == 1`,
 /// `usage == Frame`, no PTE) to an exclusive UNIQUE one, with `usage`,
 /// `paths_in_pt` (empty), `in_list` (0), `storage`, `vtable_ptr`, and
-/// `self_addr` preserved. (The failure path — `rc != 1` — leaves
+/// `slot_vaddr` preserved. (The failure path — `rc != 1` — leaves
 /// `regions` untouched and is modeled in the step as a no-op.)
 pub axiom fn try_from_shared_embedded(tracked regions: &mut MetaRegionOwners, paddr: Paddr)
     requires
@@ -213,7 +213,7 @@ pub axiom fn try_from_shared_embedded(tracked regions: &mut MetaRegionOwners, pa
             &&& so_new.paths_in_pt == so_old.paths_in_pt
             &&& so_new.inner_perms.in_list == so_old.inner_perms.in_list
             &&& so_new.inner_perms.storage == so_old.inner_perms.storage
-            &&& so_new.self_addr == so_old.self_addr
+            &&& so_new.slot_vaddr == so_old.slot_vaddr
         },
         forall|i: usize|
             #![trigger final(regions).slot_owners[i]]

--- a/ostd/specs/mm/frame/frame_specs.rs
+++ b/ostd/specs/mm/frame/frame_specs.rs
@@ -33,7 +33,7 @@ impl<'a, M: ?Sized> Frame<M> {
     /// the PT-node ownership model only exposes `!= UNUSED`.)
     pub open spec fn from_raw_requires_safety(regions: MetaRegionOwners, paddr: Paddr) -> bool {
         &&& regions.slot_owners.contains_key(frame_to_index(paddr))
-        &&& regions.slot_owners[frame_to_index(paddr)].self_addr == frame_to_meta(paddr)
+        &&& regions.slot_owners[frame_to_index(paddr)].slot_vaddr == frame_to_meta(paddr)
         &&& has_safe_slot(paddr)
         &&& regions.inv()
         &&& regions.slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
@@ -50,7 +50,7 @@ impl<'a, M: ?Sized> Frame<M> {
         &&& new_regions.slots.contains_key(frame_to_index(paddr))
         &&& new_regions.slot_owners[frame_to_index(paddr)]
             =~= old_regions.slot_owners[frame_to_index(paddr)]
-        &&& new_regions.slot_owners[frame_to_index(paddr)].self_addr == r.ptr.addr()
+        &&& new_regions.slot_owners[frame_to_index(paddr)].slot_vaddr == r.ptr.addr()
         &&& forall|i: usize|
             #![trigger new_regions.slot_owners[i], old_regions.slot_owners[i]]
             i != frame_to_index(paddr) ==> new_regions.slot_owners[i] == old_regions.slot_owners[i]
@@ -273,7 +273,7 @@ impl<M: ?Sized> TrackDrop for Frame<M> {
             =~= s0.slot_owners.dom()
         // The slot's identity / page-table linkage is preserved by a
         // drop (it only adjusts refcount and, on teardown, storage).
-        &&& so1.self_addr == so0.self_addr
+        &&& so1.slot_vaddr == so0.slot_vaddr
         &&& so1.usage == so0.usage
         &&& so1.paths_in_pt
             == so0.paths_in_pt

--- a/ostd/specs/mm/frame/meta_owners.rs
+++ b/ostd/specs/mm/frame/meta_owners.rs
@@ -68,7 +68,7 @@ pub uninterp spec fn is_mmio_paddr(pa: Paddr) -> bool;
 pub broadcast axiom fn axiom_mmio_usage_iff_mmio_paddr(slot: MetaSlotOwner)
     ensures
         (#[trigger] slot.usage == PageUsage::MMIO) <==> is_mmio_paddr(
-            meta_to_frame(slot.self_addr),
+            meta_to_frame(slot.slot_vaddr),
         ),
 ;
 
@@ -191,7 +191,7 @@ pub tracked struct MetadataInnerPerms {
 
 pub tracked struct MetaSlotOwner {
     pub inner_perms: MetadataInnerPerms,
-    pub ghost self_addr: Vaddr,
+    pub ghost slot_vaddr: Vaddr,
     pub ghost usage: PageUsage,
     /// The set of tree paths at which this slot is referenced. For PT-node
     /// slots this is a singleton. For data-frame slots this tracks every
@@ -247,8 +247,8 @@ impl Inv for MetaSlotOwner {
         &&& self.inner_perms.ref_count.value() == 0 ==> {
             &&& self.inner_perms.in_list.value() == 0
         }
-        &&& FRAME_METADATA_RANGE.start <= self.self_addr < FRAME_METADATA_RANGE.end
-        &&& self.self_addr % META_SLOT_SIZE == 0
+        &&& FRAME_METADATA_RANGE.start <= self.slot_vaddr < FRAME_METADATA_RANGE.end
+        &&& self.slot_vaddr % META_SLOT_SIZE == 0
     }
 }
 
@@ -258,7 +258,7 @@ pub ghost struct MetaSlotModel {
     pub ref_count: u64,
     pub vtable_ptr: MemContents<usize>,
     pub in_list: u64,
-    pub self_addr: Vaddr,
+    pub slot_vaddr: Vaddr,
     pub usage: PageUsage,
 }
 
@@ -285,7 +285,7 @@ impl View for MetaSlotOwner {
         let ref_count = self.inner_perms.ref_count.value();
         let vtable_ptr = self.inner_perms.vtable_ptr.mem_contents();
         let in_list = self.inner_perms.in_list.value();
-        let self_addr = self.self_addr;
+        let slot_vaddr = self.slot_vaddr;
         let usage = self.usage;
         let status = match ref_count {
             REF_COUNT_UNUSED => MetaSlotStatus::UNUSED,
@@ -294,7 +294,7 @@ impl View for MetaSlotOwner {
             _ if ref_count <= REF_COUNT_MAX => MetaSlotStatus::SHARED,
             _ => MetaSlotStatus::OVERFLOW,
         };
-        MetaSlotModel { status, storage, ref_count, vtable_ptr, in_list, self_addr, usage }
+        MetaSlotModel { status, storage, ref_count, vtable_ptr, in_list, slot_vaddr, usage }
     }
 }
 

--- a/ostd/specs/mm/frame/meta_region_owners.rs
+++ b/ostd/specs/mm/frame/meta_region_owners.rs
@@ -84,7 +84,7 @@ impl Inv for MetaRegionOwners {
                     &&& self.slots[i].is_init()
                     &&& self.slots[i].addr() == meta_addr(i)
                     &&& self.slots[i].value().wf(self.slot_owners[i])
-                    &&& self.slot_owners[i].self_addr == self.slots[i].addr()
+                    &&& self.slot_owners[i].slot_vaddr == self.slots[i].addr()
                 }
         }
     }
@@ -151,7 +151,7 @@ impl MetaRegionOwners {
     /// is live, `self` is mutably borrowed; on borrow-end, `self.slots[i]` and
     /// `self.slot_owners[i].inner_perms` are restored from the final cast_ptr.
     /// Every other slot/slot_owner is fully preserved, and the other fields of
-    /// `slot_owners[i]` (raw_count/usage/self_addr/paths_in_pt) are unchanged.
+    /// `slot_owners[i]` (raw_count/usage/slot_vaddr/paths_in_pt) are unchanged.
     pub axiom fn borrow_mut_typed_perm<M: AnyFrameMeta + Repr<MetaSlotStorage>>(
         &mut self,
         i: usize,
@@ -175,7 +175,7 @@ impl MetaRegionOwners {
             forall|k: usize|
                 k != i ==> #[trigger] final(self).slot_owners[k] == old(self).slot_owners[k],
             final(self).slot_owners[i].usage == old(self).slot_owners[i].usage,
-            final(self).slot_owners[i].self_addr == old(self).slot_owners[i].self_addr,
+            final(self).slot_owners[i].slot_vaddr == old(self).slot_owners[i].slot_vaddr,
             final(self).slot_owners[i].paths_in_pt == old(self).slot_owners[i].paths_in_pt,
             final(self).frame_obligations == old(self).frame_obligations,
     ;

--- a/ostd/specs/mm/frame/meta_specs.rs
+++ b/ostd/specs/mm/frame/meta_specs.rs
@@ -96,7 +96,7 @@ impl MetaSlot {
                 post.slot_owners[idx].inner_perms,
             )
             &&& post.slot_owners[idx].usage == PageUsage::Frame
-            &&& post.slot_owners[idx].self_addr == pre.slot_owners[idx].self_addr
+            &&& post.slot_owners[idx].slot_vaddr == pre.slot_owners[idx].slot_vaddr
             &&& post.slot_owners[idx].paths_in_pt == pre.slot_owners[idx].paths_in_pt
             &&& forall|i: usize| i != idx ==> (#[trigger] post.slot_owners[i] == pre.slot_owners[i])
             &&& pre.slot_owners[idx].inner_perms.ref_count.value()
@@ -129,7 +129,7 @@ impl MetaSlot {
             &&& post.slot_owners.dom() =~= pre.slot_owners.dom()
             &&& MetaSlot::get_from_unused_inner_perms_spec(false, post.slot_owners[idx].inner_perms)
             &&& post.slot_owners[idx].usage == PageUsage::PageTable
-            &&& post.slot_owners[idx].self_addr == pre.slot_owners[idx].self_addr
+            &&& post.slot_owners[idx].slot_vaddr == pre.slot_owners[idx].slot_vaddr
             &&& post.slot_owners[idx].paths_in_pt == pre.slot_owners[idx].paths_in_pt
             &&& forall|i: usize| i != idx ==> (#[trigger] post.slot_owners[i] == pre.slot_owners[i])
             &&& pre.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNUSED
@@ -231,7 +231,7 @@ impl MetaSlot {
                 == pre.slot_owners[idx].inner_perms.vtable_ptr
             &&& post.slot_owners[idx].inner_perms.in_list
                 == pre.slot_owners[idx].inner_perms.in_list
-            &&& post.slot_owners[idx].self_addr == pre.slot_owners[idx].self_addr
+            &&& post.slot_owners[idx].slot_vaddr == pre.slot_owners[idx].slot_vaddr
             &&& post.slot_owners[idx].usage == pre.slot_owners[idx].usage
             &&& post.slot_owners[idx].paths_in_pt == pre.slot_owners[idx].paths_in_pt
             &&& forall|i: usize| i != idx ==> (#[trigger] post.slot_owners[i] == pre.slot_owners[i])

--- a/ostd/specs/mm/frame/meta_specs.rs
+++ b/ostd/specs/mm/frame/meta_specs.rs
@@ -209,12 +209,6 @@ impl MetaSlot {
         &&& perm.addr() % META_SLOT_SIZE == 0
     }
 
-    pub open spec fn get_from_in_use_panic_cond(paddr: Paddr, regions: MetaRegionOwners) -> bool {
-        let idx = frame_to_index(paddr);
-        let pre_perms = regions.slot_owners[idx].inner_perms.ref_count.value();
-        pre_perms + 1 >= REF_COUNT_MAX
-    }
-
     pub open spec fn get_from_in_use_success(
         paddr: Paddr,
         pre: MetaRegionOwners,

--- a/ostd/specs/mm/frame/segment.rs
+++ b/ostd/specs/mm/frame/segment.rs
@@ -146,7 +146,7 @@ impl<M: AnyFrameMeta + ?Sized> SegmentOwner<M> {
     ///
     /// For every frame `i` in the segment, this asserts:
     /// - the slot owner is present in `regions` and the perm matches it,
-    /// - the slot's `self_addr` is consistent with its index,
+    /// - the slot's `slot_vaddr` is consistent with its index,
     /// - the slot has a live, non-`UNUSED` reference count,
     /// - `raw_count == 1` (the segment holds one forgotten reference per frame),
     /// - the slot's perm is *not* in `regions.slots` (it lives in `self.perms`),
@@ -173,7 +173,7 @@ impl<M: AnyFrameMeta + ?Sized> SegmentOwner<M> {
                     idx,
                 )
                 // Borrow-protocol transition: `raw_count` is dormant.
-                &&& regions.slot_owners[idx].self_addr == meta_addr(idx)
+                &&& regions.slot_owners[idx].slot_vaddr == meta_addr(idx)
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value()
                     > 0
                 // Segment frames are shared (never `UNIQUE`); the upper
@@ -214,7 +214,7 @@ impl<M: AnyFrameMeta + ?Sized> SegmentOwner<M> {
                     idx,
                 )
                 // Borrow-protocol transition: `raw_count` is dormant.
-                &&& regions.slot_owners[idx].self_addr == meta_addr(idx)
+                &&& regions.slot_owners[idx].slot_vaddr == meta_addr(idx)
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value() > 0
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value()
                     <= crate::mm::frame::meta::REF_COUNT_MAX

--- a/ostd/specs/mm/frame/unique.rs
+++ b/ostd/specs/mm/frame/unique.rs
@@ -70,7 +70,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrame<M> {
     /// [`UniqueFrame::drop`]) can state a single invariant instead of re-listing
     /// each conjunct.
     ///
-    /// The slot's `slot_owners.contains_key(idx)`, `self_addr == meta_addr(idx)`,
+    /// The slot's `slot_owners.contains_key(idx)`, `slot_vaddr == meta_addr(idx)`,
     /// `storage.is_init()`, and `vtable_ptr.is_init()` are **derived**, not
     /// required: `regions.inv()` (with `owner.inv()`'s `idx < max_meta_slots`)
     /// delivers the first two and `slot_owners[idx].inv()`; the latter's UNIQUE
@@ -132,7 +132,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrameOwner<M> {
         &&& perm.addr() == meta_addr(self.slot_index)
         &&& perm.addr() == perm.points_to.addr()
         &&& perm.value().metadata.wf(self.meta_own)
-        &&& regions.slot_owners[self.slot_index].self_addr == meta_addr(self.slot_index)
+        &&& regions.slot_owners[self.slot_index].slot_vaddr == meta_addr(self.slot_index)
         &&& regions.slot_owners[self.slot_index].inner_perms.ref_count.value()
             == REF_COUNT_UNIQUE
         // Data-frame node-repark discriminator (our change): a unique frame's
@@ -219,8 +219,8 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> TrackDrop for UniqueFram
     ) -> bool {
         &&& s1.slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].inner_perms
             == s0.slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].inner_perms
-        &&& s1.slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].self_addr
-            == s0.slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].self_addr
+        &&& s1.slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].slot_vaddr
+            == s0.slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].slot_vaddr
         &&& s1.slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].usage
             == s0.slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].usage
         &&& s1.slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].paths_in_pt

--- a/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
@@ -170,8 +170,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 i != changed_idx ==> regions0.slot_owners[i] == regions1.slot_owners[i],
             regions1.slot_owners[changed_idx].inner_perms
                 == regions0.slot_owners[changed_idx].inner_perms,
-            regions1.slot_owners[changed_idx].self_addr
-                == regions0.slot_owners[changed_idx].self_addr,
+            regions1.slot_owners[changed_idx].slot_vaddr
+                == regions0.slot_owners[changed_idx].slot_vaddr,
             regions1.slot_owners[changed_idx].usage == regions0.slot_owners[changed_idx].usage,
             regions1.slot_owners[changed_idx].paths_in_pt
                 == regions0.slot_owners[changed_idx].paths_in_pt.insert(new_path),
@@ -468,8 +468,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 i != changed_idx ==> regions0.slot_owners[i] == regions1.slot_owners[i],
             regions1.slot_owners[changed_idx].inner_perms
                 == regions0.slot_owners[changed_idx].inner_perms,
-            regions1.slot_owners[changed_idx].self_addr
-                == regions0.slot_owners[changed_idx].self_addr,
+            regions1.slot_owners[changed_idx].slot_vaddr
+                == regions0.slot_owners[changed_idx].slot_vaddr,
             regions1.slot_owners[changed_idx].usage == regions0.slot_owners[changed_idx].usage,
             regions1.slot_owners[changed_idx].paths_in_pt
                 == regions0.slot_owners[changed_idx].paths_in_pt.remove(removed_path),
@@ -616,8 +616,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 i != removed_idx ==> regions0.slot_owners[i] == regions1.slot_owners[i],
             regions1.slot_owners[removed_idx].inner_perms
                 == regions0.slot_owners[removed_idx].inner_perms,
-            regions1.slot_owners[removed_idx].self_addr
-                == regions0.slot_owners[removed_idx].self_addr,
+            regions1.slot_owners[removed_idx].slot_vaddr
+                == regions0.slot_owners[removed_idx].slot_vaddr,
             regions1.slot_owners[removed_idx].usage == regions0.slot_owners[removed_idx].usage,
             regions1.slot_owners[removed_idx].paths_in_pt
                 == regions0.slot_owners[removed_idx].paths_in_pt.remove(removed_path),

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -1201,7 +1201,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         // is connected to its paddr's MMIO-ness by `axiom_frame_is_tracked_iff_not_mmio`,
         // and `usage == MMIO` to the paddr by `axiom_mmio_usage_iff_mmio_paddr`.
         EntryOwner::<C>::axiom_frame_is_tracked_iff_not_mmio(entry);
-        assert(regions.slot_owners[idx].self_addr == crate::specs::mm::frame::mapping::meta_addr(
+        assert(regions.slot_owners[idx].slot_vaddr == crate::specs::mm::frame::mapping::meta_addr(
             idx,
         ));
         if C::tracked(item) {
@@ -1245,7 +1245,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 == old_regions.slot_owners[idx].inner_perms.in_list,
             // Other MetaSlotOwner fields at idx unchanged
             new_regions.slot_owners[idx].paths_in_pt == old_regions.slot_owners[idx].paths_in_pt,
-            new_regions.slot_owners[idx].self_addr == old_regions.slot_owners[idx].self_addr,
+            new_regions.slot_owners[idx].slot_vaddr == old_regions.slot_owners[idx].slot_vaddr,
             new_regions.slot_owners[idx].usage == old_regions.slot_owners[idx].usage,
             // All other slot_owners unchanged
             new_regions.slot_owners.dom() == old_regions.slot_owners.dom(),
@@ -1274,7 +1274,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 &&& new_regions.slot_owners[i].inv()
                 &&& new_regions.slots[i].is_init()
                 &&& new_regions.slots[i].value().wf(new_regions.slot_owners[i])
-                &&& new_regions.slot_owners[i].self_addr == new_regions.slots[i].addr()
+                &&& new_regions.slot_owners[i].slot_vaddr == new_regions.slots[i].addr()
             } by {
                 assert(old_regions.slots.contains_key(i));
             };
@@ -2615,7 +2615,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             regions1.slot_owners[idx].inner_perms.in_list
                 == regions0.slot_owners[idx].inner_perms.in_list,
             regions1.slot_owners[idx].paths_in_pt == regions0.slot_owners[idx].paths_in_pt,
-            regions1.slot_owners[idx].self_addr == regions0.slot_owners[idx].self_addr,
+            regions1.slot_owners[idx].slot_vaddr == regions0.slot_owners[idx].slot_vaddr,
             regions1.slot_owners[idx].usage == regions0.slot_owners[idx].usage,
             regions1.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED,
             // Bumped rc stays in the SHARED range (needed for the node branch).
@@ -2670,8 +2670,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             // All other fields at changed_idx preserved
             regions1.slot_owners[changed_idx].inner_perms
                 == regions0.slot_owners[changed_idx].inner_perms,
-            regions1.slot_owners[changed_idx].self_addr
-                == regions0.slot_owners[changed_idx].self_addr,
+            regions1.slot_owners[changed_idx].slot_vaddr
+                == regions0.slot_owners[changed_idx].slot_vaddr,
             regions1.slot_owners[changed_idx].usage == regions0.slot_owners[changed_idx].usage,
             regions1.slot_owners[changed_idx].paths_in_pt
                 == regions0.slot_owners[changed_idx].paths_in_pt,

--- a/ostd/specs/mm/page_table/node/entry_owners.rs
+++ b/ostd/specs/mm/page_table/node/entry_owners.rs
@@ -606,7 +606,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
             let idx = frame_to_index(self.meta_slot_paddr()->0);
             &&& regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
             &&& 0 < regions.slot_owners[idx].inner_perms.ref_count.value() <= REF_COUNT_MAX
-            &&& regions.slot_owners[idx].self_addr == self.node().meta_addr_self()
+            &&& regions.slot_owners[idx].slot_vaddr == self.node().meta_addr_self()
             &&& regions.slots[idx].value().wf(regions.slot_owners[idx])
             &&& regions.slot_owners[idx].paths_in_pt == set![self.path]
             &&& self.node().metaregion_sound_node(regions)
@@ -765,7 +765,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
                 i != changed_idx ==> r0.slot_owners[i] == r1.slot_owners[i],
             // At changed_idx, only paths_in_pt differs.
             r1.slot_owners[changed_idx].inner_perms == r0.slot_owners[changed_idx].inner_perms,
-            r1.slot_owners[changed_idx].self_addr == r0.slot_owners[changed_idx].self_addr,
+            r1.slot_owners[changed_idx].slot_vaddr == r0.slot_owners[changed_idx].slot_vaddr,
             r1.slot_owners[changed_idx].usage == r0.slot_owners[changed_idx].usage,
             // For nodes at changed_idx: the new paths_in_pt must match this entry's path.
             self.is_node() && self.meta_slot_paddr() is Some && frame_to_index(
@@ -876,7 +876,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
                     == r0.slot_owners[idx].inner_perms.vtable_ptr
                 &&& r1.slot_owners[idx].inner_perms.in_list
                     == r0.slot_owners[idx].inner_perms.in_list
-                &&& r1.slot_owners[idx].self_addr == r0.slot_owners[idx].self_addr
+                &&& r1.slot_owners[idx].slot_vaddr == r0.slot_owners[idx].slot_vaddr
                 &&& r1.slot_owners[idx].paths_in_pt
                     == r0.slot_owners[idx].paths_in_pt
                 // `usage` is part of `metaregion_sound_node` (node-repark
@@ -952,12 +952,12 @@ impl<C: PageTableConfig> EntryOwner<C> {
         ensures
             self.node().meta_addr_self() != other.node().meta_addr_self(),
     {
-        let self_addr = self.node().meta_addr_self();
+        let slot_vaddr = self.node().meta_addr_self();
         let other_addr = other.node().meta_addr_self();
-        let self_idx = frame_to_index(meta_to_frame(self_addr));
+        let self_idx = frame_to_index(meta_to_frame(slot_vaddr));
         let other_idx = frame_to_index(meta_to_frame(other_addr));
 
-        if self_addr == other_addr {
+        if slot_vaddr == other_addr {
             assert(regions.slot_owners[self_idx].paths_in_pt == set![self.path]);
             assert(regions.slot_owners[other_idx].paths_in_pt == set![other.path]);
             assert(set![self.path].contains(other.path));

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -854,7 +854,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                 &&& final(regions).slot_owners[idx].inner_perms.in_list.value() == 0
                 &&& final(regions).slot_owners[idx].inner_perms.storage.is_init()
                 &&& final(regions).slot_owners[idx].inner_perms.vtable_ptr.is_init()
-                &&& final(regions).slot_owners[idx].self_addr == meta_addr(idx)
+                &&& final(regions).slot_owners[idx].slot_vaddr == meta_addr(idx)
                 &&& final(regions).slot_owners[idx].paths_in_pt == old(
                     regions,
                 ).slot_owners[idx].paths_in_pt
@@ -863,9 +863,9 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                 #![trigger final(regions).slot_owners[j]]
                 j != frame_to_index(meta_to_frame(old(self).current->0.addr())) ==> {
                     &&& final(regions).slot_owners[j].usage == old(regions).slot_owners[j].usage
-                    &&& final(regions).slot_owners[j].self_addr == old(
+                    &&& final(regions).slot_owners[j].slot_vaddr == old(
                         regions,
-                    ).slot_owners[j].self_addr
+                    ).slot_owners[j].slot_vaddr
                     &&& final(regions).slot_owners[j].paths_in_pt == old(
                         regions,
                     ).slot_owners[j].paths_in_pt
@@ -919,7 +919,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
             assert(regions.slots.dom() == regions0.slots.dom());
             assert forall|j: usize| #![trigger regions0.slot_owners[j]] j != idx implies {
                 &&& regions.slot_owners[j].usage == regions0.slot_owners[j].usage
-                &&& regions.slot_owners[j].self_addr == regions0.slot_owners[j].self_addr
+                &&& regions.slot_owners[j].slot_vaddr == regions0.slot_owners[j].slot_vaddr
                 &&& regions.slot_owners[j].paths_in_pt == regions0.slot_owners[j].paths_in_pt
             } by {}
         }
@@ -954,7 +954,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                 assert(regions.slots.dom() == regions0.slots.dom());
                 assert forall|j: usize| #![trigger regions0.slot_owners[j]] j != idx implies {
                     &&& regions.slot_owners[j].usage == regions0.slot_owners[j].usage
-                    &&& regions.slot_owners[j].self_addr == regions0.slot_owners[j].self_addr
+                    &&& regions.slot_owners[j].slot_vaddr == regions0.slot_owners[j].slot_vaddr
                     &&& regions.slot_owners[j].paths_in_pt == regions0.slot_owners[j].paths_in_pt
                 } by {
                     if j == frame_to_index(meta_to_frame(prev.addr())) {
@@ -969,7 +969,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                 assert(regions.slots.dom() == regions0.slots.dom());
                 assert forall|j: usize| #![trigger regions0.slot_owners[j]] j != idx implies {
                     &&& regions.slot_owners[j].usage == regions0.slot_owners[j].usage
-                    &&& regions.slot_owners[j].self_addr == regions0.slot_owners[j].self_addr
+                    &&& regions.slot_owners[j].slot_vaddr == regions0.slot_owners[j].slot_vaddr
                     &&& regions.slot_owners[j].paths_in_pt == regions0.slot_owners[j].paths_in_pt
                 } by {}
             }
@@ -998,7 +998,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                 assert(regions.slots.dom() == regions0.slots.dom());
                 assert forall|j: usize| #![trigger regions0.slot_owners[j]] j != idx implies {
                     &&& regions.slot_owners[j].usage == regions0.slot_owners[j].usage
-                    &&& regions.slot_owners[j].self_addr == regions0.slot_owners[j].self_addr
+                    &&& regions.slot_owners[j].slot_vaddr == regions0.slot_owners[j].slot_vaddr
                     &&& regions.slot_owners[j].paths_in_pt == regions0.slot_owners[j].paths_in_pt
                 } by {
                     if j == frame_to_index(meta_to_frame(next.addr())) {
@@ -1015,7 +1015,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                 assert(regions.slots.dom() == regions0.slots.dom());
                 assert forall|j: usize| #![trigger regions0.slot_owners[j]] j != idx implies {
                     &&& regions.slot_owners[j].usage == regions0.slot_owners[j].usage
-                    &&& regions.slot_owners[j].self_addr == regions0.slot_owners[j].self_addr
+                    &&& regions.slot_owners[j].slot_vaddr == regions0.slot_owners[j].slot_vaddr
                     &&& regions.slot_owners[j].paths_in_pt == regions0.slot_owners[j].paths_in_pt
                 } by {}
             }
@@ -1041,7 +1041,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
             assert(regions.slot_owners[idx].paths_in_pt == regions0.slot_owners[idx].paths_in_pt);
             assert forall|j: usize| #![trigger regions0.slot_owners[j]] j != idx implies {
                 &&& regions.slot_owners[j].usage == regions0.slot_owners[j].usage
-                &&& regions.slot_owners[j].self_addr == regions0.slot_owners[j].self_addr
+                &&& regions.slot_owners[j].slot_vaddr == regions0.slot_owners[j].slot_vaddr
                 &&& regions.slot_owners[j].paths_in_pt == regions0.slot_owners[j].paths_in_pt
             } by {}
         }
@@ -1529,7 +1529,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> TrackDrop for LinkedList<M> {
                 )) ==> {
                 &&& s1.1.frame_obligations.count(idx) == s0.1.frame_obligations.count(idx)
                 &&& s1.1.slot_owners[idx].usage == s0.1.slot_owners[idx].usage
-                &&& s1.1.slot_owners[idx].self_addr == s0.1.slot_owners[idx].self_addr
+                &&& s1.1.slot_owners[idx].slot_vaddr == s0.1.slot_owners[idx].slot_vaddr
                 &&& s1.1.slot_owners[idx].paths_in_pt == s0.1.slot_owners[idx].paths_in_pt
             }
         &&& s1.1.slots.dom() =~= s0.1.slots.dom()
@@ -1643,8 +1643,8 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> Drop for LinkedList<M> {
                             == original_regions.frame_obligations.count(idx)
                         &&& regions.slot_owners[idx].usage
                             == original_regions.slot_owners[idx].usage
-                        &&& regions.slot_owners[idx].self_addr
-                            == original_regions.slot_owners[idx].self_addr
+                        &&& regions.slot_owners[idx].slot_vaddr
+                            == original_regions.slot_owners[idx].slot_vaddr
                         &&& regions.slot_owners[idx].paths_in_pt
                             == original_regions.slot_owners[idx].paths_in_pt
                     },

--- a/ostd/src/mm/frame/meta.rs
+++ b/ostd/src/mm/frame/meta.rs
@@ -778,7 +778,7 @@ impl MetaSlot {
             final(owner).inner_perms.vtable_ptr.is_uninit(),
             final(owner).inner_perms.vtable_ptr.pptr() == old(owner).inner_perms.vtable_ptr.pptr(),
             final(owner).inner_perms.in_list == old(owner).inner_perms.in_list,
-            final(owner).self_addr == old(owner).self_addr,
+            final(owner).slot_vaddr == old(owner).slot_vaddr,
             final(owner).usage == old(owner).usage,
             final(owner).paths_in_pt == old(owner).paths_in_pt,
     )]
@@ -828,7 +828,7 @@ impl MetaSlot {
             final(slot_own).inner_perms.in_list == old(slot_own).inner_perms.in_list,
             final(slot_own).inner_perms.vtable_ptr.is_uninit(),
             final(slot_own).inner_perms.vtable_ptr.pptr() == old(slot_own).inner_perms.vtable_ptr.pptr(),
-            final(slot_own).self_addr == old(slot_own).self_addr,
+            final(slot_own).slot_vaddr == old(slot_own).slot_vaddr,
             final(slot_own).usage == old(slot_own).usage,
             final(slot_own).paths_in_pt == old(slot_own).paths_in_pt,
     )]

--- a/ostd/src/mm/frame/meta.rs
+++ b/ostd/src/mm/frame/meta.rs
@@ -656,6 +656,14 @@ impl MetaSlot {
     }*/
     /// Gets the stored metadata as type `M`.
     ///
+    /// Calling the method should be safe, but using the returned pointer would
+    /// be unsafe. Specifically, the derefernecer should ensure that:
+    ///  - the stored metadata is initialized (by [`Self::write_meta`]) and
+    ///    valid;
+    ///  - the initialized metadata is of type `M`;
+    ///  - the returned pointer should not be dereferenced as mutable unless
+    ///    having exclusive access to the metadata slot.
+    ///
     /// # Verified Properties
     /// ## Preconditions
     /// - **Safety**: The caller must provide an existing permission that matches the contents of the metadata slot.
@@ -688,6 +696,10 @@ impl MetaSlot {
     }
 
     /// Writes the metadata to the slot without reading or dropping the previous value.
+    ///
+    /// # Safety
+    ///
+    /// The caller should have exclusive access to the metadata slot's fields.
     ///
     /// # Verification Design
     /// This function is axiomatized for now because of trait constraints.
@@ -730,6 +742,12 @@ impl MetaSlot {
     }
 
     /// Drops the metadata and deallocates the frame.
+    ///
+    /// # Safety
+    ///
+    /// The caller should ensure that:
+    ///  - the reference count is `0` (so we are the sole owner of the frame);
+    ///  - the metadata is initialized;
     ///
     /// # Verified Properties
     /// ## Preconditions

--- a/ostd/src/mm/frame/meta.rs
+++ b/ostd/src/mm/frame/meta.rs
@@ -533,15 +533,9 @@ impl MetaSlot {
             match slot.borrow(Tracked(&slot_perm)).ref_count.load(
                 Tracked(&mut slot_own.inner_perms.ref_count),
             ) {
-                REF_COUNT_UNUSED => {
-                    return Err(GetFrameError::Unused);
-                },
-                REF_COUNT_UNIQUE => {
-                    return Err(GetFrameError::Unique);
-                },
-                0 => {
-                    return Err(GetFrameError::Busy);
-                },
+                REF_COUNT_UNUSED => return Err(GetFrameError::Unused),
+                REF_COUNT_UNIQUE => return Err(GetFrameError::Unique),
+                0 => return Err(GetFrameError::Busy),
                 last_ref_cnt => {
                     if last_ref_cnt >= REF_COUNT_MAX {
                         // See `Self::inc_ref_count` for the explanation.

--- a/ostd/src/mm/frame/mod.rs
+++ b/ostd/src/mm/frame/mod.rs
@@ -696,7 +696,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage>> RCClone for Frame<M> {
         &&& new_perm.slot_owners[idx].inner_perms.in_list
             == old_perm.slot_owners[idx].inner_perms.in_list
         &&& new_perm.slot_owners[idx].paths_in_pt == old_perm.slot_owners[idx].paths_in_pt
-        &&& new_perm.slot_owners[idx].self_addr == old_perm.slot_owners[idx].self_addr
+        &&& new_perm.slot_owners[idx].slot_vaddr == old_perm.slot_owners[idx].slot_vaddr
         &&& new_perm.slot_owners[idx].usage
             == old_perm.slot_owners[idx].usage
         // Other slot_owners unchanged
@@ -766,7 +766,7 @@ impl<M: ?Sized> Drop for Frame<M> {
         // are untouched here.
         proof {
             assert(last_ref_cnt == so0.inner_perms.ref_count.value());
-            assert(slot_own.self_addr == so0.self_addr);
+            assert(slot_own.slot_vaddr == so0.slot_vaddr);
             assert(slot_own.usage == so0.usage);
             assert(slot_own.paths_in_pt == so0.paths_in_pt);
         }
@@ -794,10 +794,10 @@ impl<M: ?Sized> Drop for Frame<M> {
 
             proof {
                 // last-ref teardown: slot is UNUSED, identity preserved
-                // (drop_last_in_place ensures self_addr/usage/paths_in_pt).
+                // (drop_last_in_place ensures slot_vaddr/usage/paths_in_pt).
                 assert(so0.inner_perms.ref_count.value() == 1);
                 assert(slot_own.inner_perms.ref_count.value() == REF_COUNT_UNUSED);
-                assert(slot_own.self_addr == so0.self_addr);
+                assert(slot_own.slot_vaddr == so0.slot_vaddr);
                 assert(slot_own.usage == so0.usage);
                 assert(slot_own.paths_in_pt == so0.paths_in_pt);
             }
@@ -814,7 +814,7 @@ impl<M: ?Sized> Drop for Frame<M> {
                 assert(so0.inner_perms.ref_count.value() > 1);
                 assert(slot_own.inner_perms.ref_count.value() == (so0.inner_perms.ref_count.value()
                     - 1) as u64);
-                assert(slot_own.self_addr == so0.self_addr);
+                assert(slot_own.slot_vaddr == so0.slot_vaddr);
                 assert(slot_own.usage == so0.usage);
                 assert(slot_own.paths_in_pt == so0.paths_in_pt);
             }
@@ -833,7 +833,7 @@ impl<M: ?Sized> Drop for Frame<M> {
             // is now `slot_own` (the post-drop owner).
             assert(so0 == old_regions.slot_owners[idx]);
             assert(regions.slot_owners[idx] == slot_own);
-            assert(regions.slot_owners[idx].self_addr == old_regions.slot_owners[idx].self_addr);
+            assert(regions.slot_owners[idx].slot_vaddr == old_regions.slot_owners[idx].slot_vaddr);
             assert(regions.slot_owners[idx].usage == old_regions.slot_owners[idx].usage);
             assert(regions.slot_owners[idx].paths_in_pt
                 == old_regions.slot_owners[idx].paths_in_pt);
@@ -864,13 +864,13 @@ impl<M: ?Sized> Drop for Frame<M> {
                 &&& regions.slots[i].is_init()
                 &&& regions.slots[i].addr() == meta_addr(i)
                 &&& regions.slots[i].value().wf(regions.slot_owners[i])
-                &&& regions.slot_owners[i].self_addr == regions.slots[i].addr()
+                &&& regions.slot_owners[i].slot_vaddr == regions.slots[i].addr()
             }) by {
                 if i == idx {
                     assert(regions.slots[i].is_init());
                     assert(regions.slots[i].addr() == meta_addr(i));
                     assert(regions.slots[i].value().wf(regions.slot_owners[i]));
-                    assert(regions.slot_owners[i].self_addr == regions.slots[i].addr());
+                    assert(regions.slot_owners[i].slot_vaddr == regions.slots[i].addr());
                 }
             }
 
@@ -995,9 +995,9 @@ impl TryFrom<Frame<dyn AnyFrameMeta>> for UFrame {
         final(regions).slot_owners[frame_to_index(paddr)].paths_in_pt == old(
             regions,
         ).slot_owners[frame_to_index(paddr)].paths_in_pt,
-        final(regions).slot_owners[frame_to_index(paddr)].self_addr == old(
+        final(regions).slot_owners[frame_to_index(paddr)].slot_vaddr == old(
             regions,
-        ).slot_owners[frame_to_index(paddr)].self_addr,
+        ).slot_owners[frame_to_index(paddr)].slot_vaddr,
         final(regions).slot_owners[frame_to_index(paddr)].usage == old(
             regions,
         ).slot_owners[frame_to_index(paddr)].usage,
@@ -1034,7 +1034,7 @@ pub(in crate::mm) unsafe fn inc_frame_ref_count(paddr: Paddr) {
             regions,
         ).slot_owners[idx].inner_perms.ref_count.id());
 
-        // slot_own.inv() holds: rc in (0, REF_COUNT_MAX), vtable_ptr init, self_addr ok
+        // slot_own.inv() holds: rc in (0, REF_COUNT_MAX), vtable_ptr init, slot_vaddr ok
         assert(slot_own.inv());
 
         // wf: the slot's cell ids still match the (updated) inner_perms ids

--- a/ostd/src/mm/frame/segment.rs
+++ b/ostd/src/mm/frame/segment.rs
@@ -301,7 +301,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                         let idx = frame_to_index(addrs[j]);
                         &&& regions.slots.contains_key(idx)
                         &&& regions.slot_owners.contains_key(idx)
-                        &&& regions.slot_owners[idx].self_addr == meta_addr(idx)
+                        &&& regions.slot_owners[idx].slot_vaddr == meta_addr(idx)
                         &&& regions.slot_owners[idx].inner_perms.ref_count.value() > 0
                         &&& regions.slot_owners[idx].inner_perms.ref_count.value()
                             <= crate::mm::frame::meta::REF_COUNT_MAX
@@ -349,7 +349,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                                     let idx = frame_to_index(addrs[j]);
                                     &&& regions.slots.contains_key(idx)
                                     &&& regions.slot_owners.contains_key(idx)
-                                    &&& regions.slot_owners[idx].self_addr == meta_addr(idx)
+                                    &&& regions.slot_owners[idx].slot_vaddr == meta_addr(idx)
                                     &&& regions.slot_owners[idx].inner_perms.ref_count.value() > 0
                                     &&& regions.slot_owners[idx].inner_perms.ref_count.value()
                                         <= crate::mm::frame::meta::REF_COUNT_MAX
@@ -616,7 +616,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                 &&& regions.frame_obligations.count(idx) >= 1
                 &&& regions.slot_owners.contains_key(idx)
                 &&& regions.slots.contains_key(idx)
-                &&& regions.slot_owners[idx].self_addr == meta_addr(idx)
+                &&& regions.slot_owners[idx].slot_vaddr == meta_addr(idx)
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value() > 0
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value()
                     <= crate::mm::frame::meta::REF_COUNT_MAX
@@ -632,7 +632,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                 &&& regions.frame_obligations.count(idx) >= 1
                 &&& regions.slot_owners.contains_key(idx)
                 &&& regions.slots.contains_key(idx)
-                &&& regions.slot_owners[idx].self_addr == meta_addr(idx)
+                &&& regions.slot_owners[idx].slot_vaddr == meta_addr(idx)
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value() > 0
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value()
                     <= crate::mm::frame::meta::REF_COUNT_MAX
@@ -1113,7 +1113,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> SegmentIterator<'a, 
                     &&& (**regions_ref).frame_obligations.count(idx) >= 1
                     &&& (**regions_ref).slot_owners.contains_key(idx)
                     &&& (**regions_ref).slots.contains_key(idx)
-                    &&& (**regions_ref).slot_owners[idx].self_addr == meta_addr(idx)
+                    &&& (**regions_ref).slot_owners[idx].slot_vaddr == meta_addr(idx)
                     &&& (**regions_ref).slot_owners[idx].inner_perms.ref_count.value() > 0
                     &&& (**regions_ref).slot_owners[idx].inner_perms.ref_count.value()
                         <= crate::mm::frame::meta::REF_COUNT_MAX

--- a/ostd/src/mm/frame/unique.rs
+++ b/ostd/src/mm/frame/unique.rs
@@ -400,7 +400,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> 
 
         proof {
             assert(regions.slot_owners.contains_key(idx));
-            assert(regions.slot_owners[idx].self_addr == meta_addr(idx));
+            assert(regions.slot_owners[idx].slot_vaddr == meta_addr(idx));
             assert(regions.slot_owners[idx].inner_perms.storage.is_init());
             assert(regions.slot_owners[idx].inner_perms.vtable_ptr.is_init());
         }
@@ -546,11 +546,11 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> 
         proof {
             // Unfold `inv_with_regions` to recover the per-slot facts.
             // `owner.inv()` gives `idx < max_meta_slots`, so `regions.inv()`
-            // delivers `contains_key(idx)`, the `self_addr` shape, and
+            // delivers `contains_key(idx)`, the `slot_vaddr` shape, and
             // `slot_owners[idx].inv()`; the latter's UNIQUE branch (under
             // `rc == REF_COUNT_UNIQUE`) gives the storage/vtable init.
             assert(regions.slot_owners.contains_key(idx));
-            assert(regions.slot_owners[idx].self_addr == meta_addr(idx));
+            assert(regions.slot_owners[idx].slot_vaddr == meta_addr(idx));
             assert(regions.slot_owners[idx].inner_perms.storage.is_init());
             assert(regions.slot_owners[idx].inner_perms.vtable_ptr.is_init());
 

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -229,9 +229,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                 &&& final(regions).slot_owners[frame_to_index(pa)].paths_in_pt == old(
                     regions,
                 ).slot_owners[frame_to_index(pa)].paths_in_pt
-                &&& final(regions).slot_owners[frame_to_index(pa)].self_addr == old(
+                &&& final(regions).slot_owners[frame_to_index(pa)].slot_vaddr == old(
                     regions,
-                ).slot_owners[frame_to_index(pa)].self_addr
+                ).slot_owners[frame_to_index(pa)].slot_vaddr
                 &&& final(regions).slot_owners[frame_to_index(pa)].usage == old(
                     regions,
                 ).slot_owners[frame_to_index(pa)].usage
@@ -499,9 +499,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                         &&& regions.slot_owners[idx].paths_in_pt == old(
                             regions,
                         ).slot_owners[idx].paths_in_pt
-                        &&& regions.slot_owners[idx].self_addr == old(
+                        &&& regions.slot_owners[idx].slot_vaddr == old(
                             regions,
-                        ).slot_owners[idx].self_addr
+                        ).slot_owners[idx].slot_vaddr
                         &&& regions.slot_owners[idx].usage == old(regions).slot_owners[idx].usage
                         &&& regions.slot_owners[idx].inner_perms.ref_count.id() == old(
                             regions,
@@ -675,7 +675,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                             EntryOwner::<C>::axiom_frame_is_tracked_iff_not_mmio(
                                 owner.cur_entry_owner(),
                             );
-                            assert(old_regions.slot_owners[idx].self_addr == meta_addr(idx));
+                            assert(old_regions.slot_owners[idx].slot_vaddr == meta_addr(idx));
                             assert(old_regions.slot_owners[idx].inner_perms.ref_count.value()
                                 != REF_COUNT_UNUSED);
                             assert(0 < old_regions.slot_owners[idx].inner_perms.ref_count.value());
@@ -3182,7 +3182,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                     &&& regions.slots[i].is_init()
                     &&& regions.slots[i].addr() == meta_addr(i)
                     &&& regions.slots[i].value().wf(regions.slot_owners[i])
-                    &&& regions.slot_owners[i].self_addr == regions.slots[i].addr()
+                    &&& regions.slot_owners[i].slot_vaddr == regions.slots[i].addr()
                 } by {
                     assert(regions_before_new_child.slots.contains_key(i));
                     if i == pa_idx_install {

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -392,8 +392,8 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
                     == old_regions.slot_owners[frame_to_index(pa)].inner_perms.in_list
                 &&& new_regions.slot_owners[frame_to_index(pa)].paths_in_pt
                     == old_regions.slot_owners[frame_to_index(pa)].paths_in_pt
-                &&& new_regions.slot_owners[frame_to_index(pa)].self_addr
-                    == old_regions.slot_owners[frame_to_index(pa)].self_addr
+                &&& new_regions.slot_owners[frame_to_index(pa)].slot_vaddr
+                    == old_regions.slot_owners[frame_to_index(pa)].slot_vaddr
                 &&& new_regions.slot_owners[frame_to_index(pa)].usage
                     == old_regions.slot_owners[frame_to_index(pa)].usage
             },

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -1186,7 +1186,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 new_owner.value.node().metaregion_sound_node(*regions),
                 // The new node's own-slot rc + paths_in_pt — the only
                 // `metaregion_sound` conjuncts not derivable from
-                // `metaregion_sound_node` (self_addr/wf derive). Carried so
+                // `metaregion_sound_node` (slot_vaddr/wf derive). Carried so
                 // `into_pte`'s `Child::invariants` holds after the loop.
                 regions.slot_owners[frame_to_index(
                     meta_to_frame(new_owner_meta_addr),


### PR DESCRIPTION
I believe the new name is more explanatory.