### PR TITLE
chore: remove redundant `as int` conversions

### DIFF
--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -2189,7 +2189,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         };
         assert(tvi + NR_ENTRIES * ps <= 0x1_0000_0000_0000int);
 
-        assert(pv + ps <= usize::MAX as int) by (nonlinear_arith)
+        assert(pv + ps <= usize::MAX) by (nonlinear_arith)
             requires
                 pv == tvi + lb * 0x1_0000_0000_0000int,
                 tvi + NR_ENTRIES * ps <= 0x1_0000_0000_0000int,
@@ -2270,7 +2270,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         };
         assert(tvi + NR_ENTRIES * ps <= 0x1_0000_0000_0000int);
 
-        assert(va_val + psl <= usize::MAX as int) by (nonlinear_arith)
+        assert(va_val + psl <= usize::MAX) by (nonlinear_arith)
             requires
                 va_val < pv + ps,
                 pv == tvi + lb * 0x1_0000_0000_0000int,
@@ -2883,15 +2883,15 @@ pub proof fn lemma_view_in_vaddr_range<'rcu, C: PageTableConfig>(owner: &CursorO
                 start >= 0,
                 start < end,
                 cell > 0,
-                end * cell <= usize::MAX as int,
-                (usize::MAX as int) < 0x1_0000_0000_0000_0000int,
+                end * cell <= usize::MAX,
+                usize::MAX < 0x1_0000_0000_0000_0000int,
         ;
         assert(0 <= end_pre <= usize::MAX) by (nonlinear_arith)
             requires
                 end_pre == end * cell - 1,
                 end > 0,
                 cell > 0,
-                end * cell <= usize::MAX as int,
+                end * cell <= usize::MAX,
         ;
     } else {
         assert(base == 0x1_0000_0000_0000_0000int - p_aw);
@@ -2905,7 +2905,7 @@ pub proof fn lemma_view_in_vaddr_range<'rcu, C: PageTableConfig>(owner: &CursorO
                 cell > 0,
                 end * cell <= p_aw,
         ;
-        assert(0 <= end_pre <= usize::MAX as int) by (nonlinear_arith)
+        assert(0 <= end_pre <= usize::MAX) by (nonlinear_arith)
             requires
                 end_pre == 0x1_0000_0000_0000_0000int - p_aw + end * cell - 1,
                 base == 0x1_0000_0000_0000_0000int - p_aw,

--- a/ostd/specs/mm/page_table/mod.rs
+++ b/ostd/specs/mm/page_table/mod.rs
@@ -949,15 +949,13 @@ impl AbstractVaddr {
                 assert(prev_aligned.leading_bits == self.leading_bits);
                 assert(self.offset == 0);
 
-                assert(prev_aligned.to_vaddr() + (NR_ENTRIES - 1) * ps
-                    == self.to_vaddr() as int);
+                assert(prev_aligned.to_vaddr() + (NR_ENTRIES - 1) * ps == self.to_vaddr() as int);
 
                 // Now: prev_aligned.to_vaddr() + page_size(level + 1) == self.to_vaddr() + ps.
                 assert(prev_aligned.to_vaddr() + ps1 as int == self.to_vaddr() + ps)
                     by (nonlinear_arith)
                     requires
-                        prev_aligned.to_vaddr() + (NR_ENTRIES - 1) * ps
-                            == self.to_vaddr() as int,
+                        prev_aligned.to_vaddr() + (NR_ENTRIES - 1) * ps == self.to_vaddr() as int,
                         ps1 as int == NR_ENTRIES * ps,
                 ;
                 assert(prev_aligned.to_vaddr() + page_size((level + 1) as PagingLevel)
@@ -1091,8 +1089,7 @@ impl AbstractVaddr {
                 assert(self.to_vaddr() == (NR_ENTRIES - 1) * ps + self.leading_bits
                     * 0x1_0000_0000_0000int);
                 assert(NR_ENTRIES * ps == 0x1_0000_0000_0000int) by (compute);
-                assert(advanced_top.to_vaddr() as int == self.to_vaddr() + ps)
-                    by (nonlinear_arith)
+                assert(advanced_top.to_vaddr() as int == self.to_vaddr() + ps) by (nonlinear_arith)
                     requires
                         advanced_top.to_vaddr() as int == (self.leading_bits + 1)
                             * 0x1_0000_0000_0000int,

--- a/ostd/specs/mm/page_table/mod.rs
+++ b/ostd/specs/mm/page_table/mod.rs
@@ -470,8 +470,8 @@ impl AbstractVaddr {
             1 <= level <= NR_LEVELS,
         ensures
             self.align_down(level).to_vaddr() as int % page_size(level as PagingLevel) as int == 0,
-            0 <= self.to_vaddr() as int - self.align_down(level).to_vaddr() as int,
-            (self.to_vaddr() as int - self.align_down(level).to_vaddr() as int) < page_size(
+            0 <= self.to_vaddr() - self.align_down(level).to_vaddr() as int,
+            (self.to_vaddr() - self.align_down(level).to_vaddr() as int) < page_size(
                 level as PagingLevel,
             ) as int,
     {
@@ -949,14 +949,14 @@ impl AbstractVaddr {
                 assert(prev_aligned.leading_bits == self.leading_bits);
                 assert(self.offset == 0);
 
-                assert(prev_aligned.to_vaddr() as int + (NR_ENTRIES - 1) * ps
+                assert(prev_aligned.to_vaddr() + (NR_ENTRIES - 1) * ps
                     == self.to_vaddr() as int);
 
                 // Now: prev_aligned.to_vaddr() + page_size(level + 1) == self.to_vaddr() + ps.
-                assert(prev_aligned.to_vaddr() as int + ps1 as int == self.to_vaddr() as int + ps)
+                assert(prev_aligned.to_vaddr() + ps1 as int == self.to_vaddr() + ps)
                     by (nonlinear_arith)
                     requires
-                        prev_aligned.to_vaddr() as int + (NR_ENTRIES - 1) * ps
+                        prev_aligned.to_vaddr() + (NR_ENTRIES - 1) * ps
                             == self.to_vaddr() as int,
                         ps1 as int == NR_ENTRIES * ps,
                 ;
@@ -1001,13 +1001,13 @@ impl AbstractVaddr {
                 assert(self.to_vaddr_indices(NR_LEVELS - 1) == self.index[NR_LEVELS - 1] * ps_top);
                 assert(self.to_vaddr_indices(0) == (NR_ENTRIES - 1) * ps_top);
                 assert(self.offset == 0);
-                assert(self.to_vaddr() as int == (NR_ENTRIES - 1) * ps_top + self.leading_bits
+                assert(self.to_vaddr() == (NR_ENTRIES - 1) * ps_top + self.leading_bits
                     * 0x1_0000_0000_0000int);
                 assert(NR_ENTRIES * ps_top == 0x1_0000_0000_0000int) by (compute);
                 // Now apply the overflow bound.
                 assert(self.leading_bits + 1 < 0x1_0000) by (nonlinear_arith)
                     requires
-                        self.to_vaddr() as int == (NR_ENTRIES - 1) * ps_top + self.leading_bits
+                        self.to_vaddr() == (NR_ENTRIES - 1) * ps_top + self.leading_bits
                             * 0x1_0000_0000_0000int,
                         self.to_vaddr() + ps_top <= usize::MAX,
                         ps_top == 0x80_0000_0000,
@@ -1088,15 +1088,15 @@ impl AbstractVaddr {
                 assert(advanced_top.leading_bits == self.leading_bits + 1);
                 assert(advanced_top.to_vaddr() as int == (self.leading_bits + 1)
                     * 0x1_0000_0000_0000int);
-                assert(self.to_vaddr() as int == (NR_ENTRIES - 1) * ps + self.leading_bits
+                assert(self.to_vaddr() == (NR_ENTRIES - 1) * ps + self.leading_bits
                     * 0x1_0000_0000_0000int);
                 assert(NR_ENTRIES * ps == 0x1_0000_0000_0000int) by (compute);
-                assert(advanced_top.to_vaddr() as int == self.to_vaddr() as int + ps)
+                assert(advanced_top.to_vaddr() as int == self.to_vaddr() + ps)
                     by (nonlinear_arith)
                     requires
                         advanced_top.to_vaddr() as int == (self.leading_bits + 1)
                             * 0x1_0000_0000_0000int,
-                        self.to_vaddr() as int == (NR_ENTRIES - 1) * ps + self.leading_bits
+                        self.to_vaddr() == (NR_ENTRIES - 1) * ps + self.leading_bits
                             * 0x1_0000_0000_0000int,
                         NR_ENTRIES * ps == 0x1_0000_0000_0000int,
                 ;
@@ -1608,7 +1608,7 @@ impl AbstractVaddr {
         }
     }
 
-    /// `rec_compute_vaddr(start) as int == to_vaddr_indices(start) + offset`.
+    /// `rec_compute_vaddr(start) == to_vaddr_indices(start) + offset`.
     /// The two formulations of the positional sum agree (no overflow in the
     /// `as Vaddr` casts since the sum is bounded by `pow2(12 + 9*NR_LEVELS) + PAGE_SIZE`).
     pub proof fn rec_compute_vaddr_is_to_vaddr_indices(self, start: int)
@@ -1616,7 +1616,7 @@ impl AbstractVaddr {
             self.inv(),
             0 <= start <= NR_LEVELS,
         ensures
-            self.rec_compute_vaddr(start) as int == self.to_vaddr_indices(start) + self.offset,
+            self.rec_compute_vaddr(start) == self.to_vaddr_indices(start) + self.offset,
         decreases NR_LEVELS - start,
     {
         vstd::arithmetic::power2::lemma2_to64();
@@ -1653,7 +1653,7 @@ impl AbstractVaddr {
         requires
             self.inv(),
         ensures
-            self.to_vaddr() as int == self.compute_vaddr() as int + self.leading_bits
+            self.to_vaddr() == self.compute_vaddr() as int + self.leading_bits
                 * 0x1_0000_0000_0000int,
     {
         self.to_vaddr_bounded();
@@ -1696,7 +1696,7 @@ impl AbstractVaddr {
             self.inv(),
         ensures
             0 <= self.offset + self.to_vaddr_indices(0) < 0x1_0000_0000_0000int,
-            self.to_vaddr() as int == self.offset + self.to_vaddr_indices(0) + self.leading_bits
+            self.to_vaddr() == self.offset + self.to_vaddr_indices(0) + self.leading_bits
                 * 0x1_0000_0000_0000int,
             self.offset + self.to_vaddr_indices(0) + self.leading_bits * 0x1_0000_0000_0000int
                 < 0x1_0000_0000_0000_0000int,
@@ -1738,7 +1738,7 @@ impl AbstractVaddr {
         };
         self.to_vaddr_bounded();
         new_va.to_vaddr_bounded();
-        assert(new_va.to_vaddr() as int - self.to_vaddr() as int == new_va.to_vaddr_indices(0)
+        assert(new_va.to_vaddr() as int - self.to_vaddr() == new_va.to_vaddr_indices(0)
             - self.to_vaddr_indices(0));
         vstd::arithmetic::power2::lemma2_to64();
         vstd::arithmetic::power2::lemma2_to64_rest();

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -317,8 +317,7 @@ pub proof fn lemma_vaddr_of_eq_int<C: PageTableConfig>(path: TreePath<NR_ENTRIES
         path.inv(),
         path.len() <= INC_LEVELS - 1,
     ensures
-        vaddr_of::<C>(path) == vaddr(path) + C::LEADING_BITS_spec() as int
-            * 0x1_0000_0000_0000int,
+        vaddr_of::<C>(path) == vaddr(path) + C::LEADING_BITS_spec() as int * 0x1_0000_0000_0000int,
 {
     C::lemma_page_table_config_constant_properties();
     lemma_vaddr_strict_bound(path);
@@ -998,8 +997,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             assert(rec_vaddr(pt, 2) == 0);
             assert(rec_vaddr(pt, 1) == vaddr_make::<NR_LEVELS>(1, i) as usize);
             assert(vaddr_make::<NR_LEVELS>(1, i) == 0x4000_0000usize * i) by (compute);
-            assert(rec_vaddr(pt, 0) == (0x80_0000_0000usize * i0) + (0x4000_0000usize
-                * i) as int);
+            assert(rec_vaddr(pt, 0) == (0x80_0000_0000usize * i0) + (0x4000_0000usize * i) as int);
             assert(page_size(3) == 0x4000_0000usize);
             assert(0x80_0000_0000usize * i0 + 0x4000_0000usize * (i + 1) <= usize::MAX)
                 by (nonlinear_arith)
@@ -1178,8 +1176,8 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             // counterparts, and the `vaddr` identity above lifts directly.
             lemma_vaddr_of_eq_int::<C>(path);
             lemma_vaddr_of_eq_int::<C>(path.push_tail(i as usize));
-            assert(vaddr_of::<C>(path.push_tail(i as usize)) == vaddr_of::<C>(path) as int
-                + i * child_ps);
+            assert(vaddr_of::<C>(path.push_tail(i as usize)) == vaddr_of::<C>(path) as int + i
+                * child_ps);
             assert(i * child_ps + child_ps == (i + 1) * child_ps) by (nonlinear_arith);
             assert(m.va_range.end <= vaddr_of::<C>(path) + (i + 1) * child_ps);
             assert(m.va_range.end <= vaddr_of::<C>(path) + parent_ps);

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -959,12 +959,11 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             path.len() < INC_LEVELS - 1,
             i < NR_ENTRIES,
         ensures
-            vaddr(path.push_tail(i)) as int == vaddr(path) as int + (i as int) * (page_size(
+            vaddr(path.push_tail(i)) == vaddr(path) + i * page_size(
                 (INC_LEVELS - path.len() - 1) as PagingLevel,
-            ) as int),
-            vaddr(path) as int + (i as int + 1) * (page_size(
-                (INC_LEVELS - path.len() - 1) as PagingLevel,
-            ) as int) <= usize::MAX as int,
+            ),
+            vaddr(path) + (i + 1) * page_size((INC_LEVELS - path.len() - 1) as PagingLevel)
+                <= usize::MAX,
     {
         broadcast use TreePath::push_tail_property;
         broadcast use TreePath::index_satisfies_elem_inv;

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -89,7 +89,7 @@ pub open spec fn vaddr(path: TreePath<NR_ENTRIES>) -> usize {
 /// `vaddr(path)`; for `leading_bits == 0xffff` and a kernel path this yields
 /// the canonical sign-extended high-half address.
 pub open spec fn vaddr_at(path: TreePath<NR_ENTRIES>, leading_bits: int) -> usize {
-    (vaddr(path) as int + leading_bits * 0x1_0000_0000_0000int) as usize
+    (vaddr(path) + leading_bits * 0x1_0000_0000_0000int) as usize
 }
 
 /// Config-aware `vaddr`: reads `leading_bits` from `C::LEADING_BITS_spec()`.
@@ -213,9 +213,9 @@ pub proof fn lemma_vaddr_top_index_cell(path: TreePath<NR_ENTRIES>)
         path.inv(),
         1 <= path.len() <= INC_LEVELS - 1,
     ensures
-        (path.index(0) as int) * 0x80_0000_0000int <= vaddr(path) as int,
+        (path.index(0)) * 0x80_0000_0000int <= vaddr(path) as int,
         (vaddr(path) as int) + page_size((INC_LEVELS - path.len()) as PagingLevel) as int <= (
-        path.index(0) as int + 1) * 0x80_0000_0000int,
+        path.index(0) + 1) * 0x80_0000_0000int,
 {
     broadcast use TreePath::index_satisfies_elem_inv;
 
@@ -317,7 +317,7 @@ pub proof fn lemma_vaddr_of_eq_int<C: PageTableConfig>(path: TreePath<NR_ENTRIES
         path.inv(),
         path.len() <= INC_LEVELS - 1,
     ensures
-        vaddr_of::<C>(path) as int == vaddr(path) as int + C::LEADING_BITS_spec() as int
+        vaddr_of::<C>(path) == vaddr(path) + C::LEADING_BITS_spec() as int
             * 0x1_0000_0000_0000int,
 {
     C::lemma_page_table_config_constant_properties();
@@ -845,7 +845,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             let page_size = page_size(pt_level as PagingLevel);
 
             set![Mapping {
-                va_range: Range { start: va as int, end: va as int + page_size as int },
+                va_range: Range { start: va as int, end: va + page_size },
                 pa_range: Range {
                     start: self.0.value.frame().mapped_pa,
                     end: (self.0.value.frame().mapped_pa + page_size) as Paddr,
@@ -998,7 +998,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             assert(rec_vaddr(pt, 2) == 0);
             assert(rec_vaddr(pt, 1) == vaddr_make::<NR_LEVELS>(1, i) as usize);
             assert(vaddr_make::<NR_LEVELS>(1, i) == 0x4000_0000usize * i) by (compute);
-            assert(rec_vaddr(pt, 0) as int == (0x80_0000_0000usize * i0) as int + (0x4000_0000usize
+            assert(rec_vaddr(pt, 0) == (0x80_0000_0000usize * i0) + (0x4000_0000usize
                 * i) as int);
             assert(page_size(3) == 0x4000_0000usize);
             assert(0x80_0000_0000usize * i0 + 0x4000_0000usize * (i + 1) <= usize::MAX)
@@ -1102,7 +1102,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         ensures
             vaddr_of::<C>(path) as int <= m.va_range.start,
             m.va_range.start < m.va_range.end,
-            m.va_range.end <= vaddr_of::<C>(path) as int + page_size(
+            m.va_range.end <= vaddr_of::<C>(path) + page_size(
                 (INC_LEVELS - path.len()) as PagingLevel,
             ) as int,
         decreases INC_LEVELS - path.len(),
@@ -1117,7 +1117,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             let expected = Mapping {
                 va_range: Range {
                     start: vaddr_of::<C>(path) as int,
-                    end: vaddr_of::<C>(path) as int + page_size(pt_level) as int,
+                    end: vaddr_of::<C>(path) + page_size(pt_level),
                 },
                 pa_range: Range {
                     start: frame.mapped_pa,
@@ -1171,18 +1171,18 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                     0 <= i < 512,
                     child_ps >= 0,
             ;
-            assert(m.va_range.end <= vaddr_of::<C>(path.push_tail(i as usize)) as int + child_ps);
+            assert(m.va_range.end <= vaddr_of::<C>(path.push_tail(i as usize)) + child_ps);
             assert(vaddr(path.push_tail(i as usize)) == vaddr(path) + i * child_ps);
             // Bridge `vaddr_of(push_tail(i)) == vaddr_of(path) + i * child_ps`
             // via the no-wrap helper: both `vaddr_of` terms equal their `int`
             // counterparts, and the `vaddr` identity above lifts directly.
             lemma_vaddr_of_eq_int::<C>(path);
             lemma_vaddr_of_eq_int::<C>(path.push_tail(i as usize));
-            assert(vaddr_of::<C>(path.push_tail(i as usize)) as int == vaddr_of::<C>(path) as int
+            assert(vaddr_of::<C>(path.push_tail(i as usize)) == vaddr_of::<C>(path) as int
                 + i * child_ps);
             assert(i * child_ps + child_ps == (i + 1) * child_ps) by (nonlinear_arith);
-            assert(m.va_range.end <= vaddr_of::<C>(path) as int + (i + 1) * child_ps);
-            assert(m.va_range.end <= vaddr_of::<C>(path) as int + parent_ps);
+            assert(m.va_range.end <= vaddr_of::<C>(path) + (i + 1) * child_ps);
+            assert(m.va_range.end <= vaddr_of::<C>(path) + parent_ps);
         }
     }
 
@@ -1201,7 +1201,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             (path.index(0) as int) < t,
             self.view_rec(path).contains(m),
         ensures
-            (path.index(0) as int) * 0x80_0000_0000int + (C::LEADING_BITS_spec() as int)
+            (path.index(0)) * 0x80_0000_0000int + (C::LEADING_BITS_spec() as int)
                 * 0x1_0000_0000_0000int <= m.va_range.start,
             m.va_range.start < m.va_range.end,
             m.va_range.end <= t * 0x80_0000_0000int + (C::LEADING_BITS_spec() as int)
@@ -1216,7 +1216,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         // `(index(0)+1) <= t`. Adding the `LEADING_BITS*2^48` base shifts both
         // ends — giving the user (LB=0) low half and the kernel (LB=0xffff)
         // high half.
-        assert((path.index(0) as int + 1) * 0x80_0000_0000int <= t * 0x80_0000_0000int)
+        assert((path.index(0) + 1) * 0x80_0000_0000int <= t * 0x80_0000_0000int)
             by (nonlinear_arith)
             requires
                 (path.index(0) as int) < t,
@@ -1315,7 +1315,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             let expected = Mapping {
                 va_range: Range {
                     start: vaddr_of::<C>(path) as int,
-                    end: vaddr_of::<C>(path) as int + page_size(pt_level) as int,
+                    end: vaddr_of::<C>(path) + page_size(pt_level),
                 },
                 pa_range: Range {
                     start: frame.mapped_pa,
@@ -1327,7 +1327,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             assert(self.view_rec(path) == set![expected]);
             assert(self.view_rec(path).contains(expected));
             assert(ambient.contains(expected));
-            assert(vaddr_of::<C>(path) as int != vaddr_of::<C>(removed_path) as int);
+            assert(vaddr_of::<C>(path) != vaddr_of::<C>(removed_path) as int);
             assert(self.0.value.path != removed_path);
         }
         assert(g(self.0.value, path));
@@ -1643,7 +1643,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             let m = Mapping {
                 va_range: Range {
                     start: vaddr_of::<C>(path) as int,
-                    end: vaddr_of::<C>(path) as int + page_size(pt_level) as int,
+                    end: vaddr_of::<C>(path) + page_size(pt_level),
                 },
                 pa_range: Range {
                     start: frame.mapped_pa,
@@ -1655,7 +1655,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             assert(self.view_rec(path) == set![m]);
             assert(set![4096usize, 2097152usize, 1073741824usize].contains(m.page_size));
             let ps = page_size(pt_level) as int;
-            assert((frame.mapped_pa as int + ps) % ps == 0) by (nonlinear_arith)
+            assert((frame.mapped_pa + ps) % ps == 0) by (nonlinear_arith)
                 requires
                     (frame.mapped_pa as int) % ps == 0,
                     ps > 0,
@@ -1682,7 +1682,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 ps,
             );
             assert((vaddr_of::<C>(path) as int) % ps == 0);
-            assert((vaddr_of::<C>(path) as int + ps) % ps == 0) by (nonlinear_arith)
+            assert((vaddr_of::<C>(path) + ps) % ps == 0) by (nonlinear_arith)
                 requires
                     (vaddr_of::<C>(path) as int) % ps == 0,
                     ps > 0,
@@ -1698,9 +1698,9 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                     (ps == 0x1000int || ps == 0x20_0000int || ps == 0x4000_0000int),
                     (0x1_0000_0000_0000int % ps == 0),
             ;
-            assert(vaddr_of::<C>(path) as int + ps <= pow2(64)) by (nonlinear_arith)
+            assert(vaddr_of::<C>(path) + ps <= pow2(64)) by (nonlinear_arith)
                 requires
-                    vaddr_of::<C>(path) as int == v + lb * 0x1_0000_0000_0000int,
+                    vaddr_of::<C>(path) == v + lb * 0x1_0000_0000_0000int,
                     v + ps <= 0x1_0000_0000_0000int,
                     lb < 0x1_0000int,
                     lb >= 0,

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -301,7 +301,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
             final(owner).relate_region(*final(regions)),
             final(regions).inv(),
             old(owner).list.len() > 0 ==> final(owner).list == old(owner).list.insert(
-                old(owner).list.len() as int - 1, final(frame_own).meta_own),
+                old(owner).list.len() - 1, final(frame_own).meta_own),
             old(owner).list.len() == 0 ==> final(owner).list == old(owner).list.insert(
                 0, final(frame_own).meta_own),
             // Id preserved when already minted; a fresh (empty) list adopts a
@@ -1512,7 +1512,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> Drop for LinkedList<M> {
         proof {
             if n > 0 {
                 cursor_own.list_own.relate_region_at_facts(*regions, 0);
-                cursor_own.list_own.relate_region_at_facts(*regions, n as int - 1);
+                cursor_own.list_own.relate_region_at_facts(*regions, n - 1);
             }
         }
 

--- a/ostd/src/mm/frame/segment.rs
+++ b/ostd/src/mm/frame/segment.rs
@@ -277,7 +277,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
         while i < addr_len
             invariant
                 i <= addr_len,
-                i as int == addrs.len(),
+                i == addrs.len(),
                 range.start % PAGE_SIZE == 0,
                 range.end % PAGE_SIZE == 0,
                 range.end <= MAX_PADDR,
@@ -335,7 +335,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                             regions.frame_obligations == old(regions).frame_obligations,
                             regions.slot_owners.dom() == old(regions).slot_owners.dom(),
                             range.start % PAGE_SIZE == 0,
-                            i as int == addrs.len(),
+                            i == addrs.len(),
                             segment.range.end == range.start + i * PAGE_SIZE,
                             segment.range.end <= MAX_PADDR,
                             range.start <= p <= segment.range.end,
@@ -629,7 +629,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                 &&& regions.slot_owners[idx].paths_in_pt.is_empty()
                 &&& regions.slot_owners[idx].usage is Frame
             } by {
-                owner.relate_regions_at(old_regions, i + (offset / PAGE_SIZE) as int);
+                owner.relate_regions_at(old_regions, i + (offset / PAGE_SIZE));
             }
 
             assert forall|i: int, j: int|
@@ -651,7 +651,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                 owner.relate_regions_distinct(
                     old_regions,
                     i + (offset / PAGE_SIZE) as int,
-                    j + (offset / PAGE_SIZE) as int,
+                    j + (offset / PAGE_SIZE),
                 );
             }
         }
@@ -708,13 +708,13 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
             range.start % PAGE_SIZE != 0 ==> may_panic(),
             range.end % PAGE_SIZE != 0 ==> may_panic(),
             range.start > range.end ==> may_panic(),
-            self.range.start as int + range.end as int > self.range.end as int ==> may_panic(),
+            self.range.start + range.end > self.range.end as int ==> may_panic(),
             self.page_in_range_saturated(range, *old(regions)) ==> may_panic(),
         ensures
             range.start % PAGE_SIZE == 0,
             range.end % PAGE_SIZE == 0,
             range.start <= range.end,
-            self.range.start as int + range.end as int <= self.range.end as int,
+            self.range.start + range.end <= self.range.end as int,
             !self.page_in_range_saturated(range, *old(regions)),
             r.inv(),
             r.start_paddr() == self.start_paddr() + range.start,

--- a/ostd/src/mm/io.rs
+++ b/ostd/src/mm/io.rs
@@ -1465,8 +1465,8 @@ pub trait VmIo<P: Sized>: Send + Sync + Sized {
     >)
         requires
             !Self::obeys_vmio_write_requires(),
-            offset + align <= usize::MAX as int,
-            core::mem::size_of::<T>() + align <= usize::MAX as int,
+            offset + align <= usize::MAX,
+            core::mem::size_of::<T>() + align <= usize::MAX,
             iter.obeys_prophetic_iter_laws(),
             iter.decrease() is Some,
             // `align_up` (called for `align > 1`) diverges unless `align`

--- a/ostd/src/mm/io.rs
+++ b/ostd/src/mm/io.rs
@@ -396,7 +396,7 @@ impl<'a> VmWriter<'a, Infallible> {
             reader_owner@.has_read_view(),
             reader_owner@.is_kernel == old(writer_owner).is_kernel,
             // Return value: exactly `avail / size_of::<T>()` elements written.
-            r as int * core::mem::size_of::<T>() == old(self).avail_spec(),
+            r * core::mem::size_of::<T>() == old(self).avail_spec(),
     )]
     pub fn fill<T: Pod>(&mut self, value: T) -> usize {
         let cursor = self.cursor.cast::<T>();
@@ -1465,8 +1465,8 @@ pub trait VmIo<P: Sized>: Send + Sync + Sized {
     >)
         requires
             !Self::obeys_vmio_write_requires(),
-            offset as int + align as int <= usize::MAX as int,
-            core::mem::size_of::<T>() as int + align as int <= usize::MAX as int,
+            offset + align <= usize::MAX as int,
+            core::mem::size_of::<T>() + align <= usize::MAX as int,
             iter.obeys_prophetic_iter_laws(),
             iter.decrease() is Some,
             // `align_up` (called for `align > 1`) diverges unless `align`

--- a/ostd/src/mm/kspace/kvirt_area.rs
+++ b/ostd/src/mm/kspace/kvirt_area.rs
@@ -441,8 +441,7 @@ impl KVirtArea {
                 vstd::arithmetic::power2::lemma_pow2,
             ;
 
-            let witness: nat = choose|i: nat|
-                vstd::arithmetic::power::pow(2, i) == PAGE_SIZE as int;
+            let witness: nat = choose|i: nat| vstd::arithmetic::power::pow(2, i) == PAGE_SIZE;
         }
         let start = addr.align_down(PAGE_SIZE);
         proof {
@@ -521,7 +520,7 @@ impl KVirtArea {
         ||| area_size % PAGE_SIZE != 0
         ||| map_offset % PAGE_SIZE != 0
         ||| map_offset >= area_size
-        ||| map_offset as int + n_frames as int * PAGE_SIZE as int > area_size as int
+        ||| map_offset + n_frames * PAGE_SIZE > area_size as int
     }
 
     /// Full panic condition for [`Self::map_frames`] = bounds OR OOM.
@@ -741,7 +740,7 @@ impl KVirtArea {
                 KernelPtConfig::item_into_raw_spec_tracked_level(item);
                 lemma_va_align_page_size_level_1(cursor.0.va);
                 cursor_owner.locked_range_page_aligned();
-                let ghost diff: int = cursor.0.barrier_va.end as int - cursor.0.va as int;
+                let ghost diff: int = cursor.0.barrier_va.end - cursor.0.va;
                 vstd::arithmetic::mul::lemma_mul_by_zero_is_zero(
                     nr_subpage_per_huge::<PagingConsts>().ilog2() as int,
                 );
@@ -782,8 +781,7 @@ impl KVirtArea {
             proof {
                 let cur_pa = KernelPtConfig::item_into_raw_spec(item).0;
                 let cur_pa_idx = frame_to_index(cur_pa);
-                assert forall|i: int|
-                    (it.index() as int + 1) <= i < it.seq().len() implies CursorMut::<
+                assert forall|i: int| (it.index() + 1) <= i < it.seq().len() implies CursorMut::<
                     'a,
                     KernelPtConfig,
                     A,
@@ -860,8 +858,7 @@ impl KVirtArea {
         ||| pa_range.end % PAGE_SIZE != 0
         ||| area_size % PAGE_SIZE != 0
         ||| map_offset % PAGE_SIZE != 0
-        ||| map_offset as int + vstd_extra::external::range::range_usize_len(pa_range) as int
-            > area_size as int
+        ||| map_offset + vstd_extra::external::range::range_usize_len(pa_range) > area_size as int
     }
 
     /// Full panic condition for [`Self::map_untracked_frames`] = bounds OR OOM.

--- a/ostd/src/mm/kspace/mod.rs
+++ b/ostd/src/mm/kspace/mod.rs
@@ -188,12 +188,12 @@ unsafe impl PageTableConfig for KernelPtConfig {
         assert(nr_pte_index_bits::<PagingConsts>() == 9_usize);
         assert(PagingConsts::BASE_PAGE_SIZE().ilog2() == 12u32);
         assert(pte_index_bit_offset_spec::<PagingConsts>(4) == 39);
-        assert((256 as int) * pow2(39) == pow2(47));
-        assert(((256 as int) * (pow2(39) as int)) / (pow2(47) as int) == 1);
+        assert(256 * pow2(39) == pow2(47));
+        assert((256 * pow2(39) as int) / (pow2(47) as int) == 1);
         assert(pte_index_bit_offset_spec::<Self::C>(Self::C::NR_LEVELS()) == 39);
-        assert((Self::TOP_LEVEL_INDEX_RANGE_spec().start as int) * (pow2(
+        assert((Self::TOP_LEVEL_INDEX_RANGE_spec().start) * (pow2(
             pte_index_bit_offset_spec::<Self::C>(Self::C::NR_LEVELS()) as nat,
-        ) as int) == pow2(47) as int);
+        )) == pow2(47));
         assert((((Self::TOP_LEVEL_INDEX_RANGE_spec().start as int) * (pow2(
             pte_index_bit_offset_spec::<Self::C>(Self::C::NR_LEVELS()) as nat,
         ) as int)) / (pow2((Self::C::ADDRESS_WIDTH() - 1) as nat) as int)) == 1);
@@ -201,8 +201,8 @@ unsafe impl PageTableConfig for KernelPtConfig {
             pte_index_bit_offset_spec::<Self::C>(Self::C::NR_LEVELS()) as nat,
         ) as int)) / (pow2((Self::C::ADDRESS_WIDTH() - 1) as nat) as int)) % 2 == 1);
         lemma_pow2_adds(16, 48);
-        assert(Self::LEADING_BITS_spec() as int * 0x1_0000_0000_0000int
-            == 0x1_0000_0000_0000_0000int - pow2(Self::C::ADDRESS_WIDTH() as nat) as int);
+        assert(Self::LEADING_BITS_spec() * 0x1_0000_0000_0000int == 0x1_0000_0000_0000_0000int
+            - pow2(Self::C::ADDRESS_WIDTH() as nat));
     }
 
     fn TOP_LEVEL_INDEX_RANGE() -> (r: Range<usize>) {

--- a/ostd/src/mm/page_table/cursor/locking.rs
+++ b/ostd/src/mm/page_table/cursor/locking.rs
@@ -115,7 +115,7 @@ pub fn lock_range<'rcu, C: PageTableConfig, A: InAtomicMode>(
     guard: &'rcu A,
     va: &Range<Vaddr>,
 ) -> (Cursor<'rcu, C, A>, Tracked<CursorOwner<'rcu, C>>) {
-    let ghost start_idx = AbstractVaddr::from_vaddr(va.start).index[NR_LEVELS as int - 1];
+    let ghost start_idx = AbstractVaddr::from_vaddr(va.start).index[NR_LEVELS - 1];
 
     let tracked mut cursor_own: CursorOwner<'rcu, C> = CursorOwner::tracked_new(
         pt_own.0,
@@ -236,7 +236,7 @@ pub fn unlock_range<C: PageTableConfig, A: InAtomicMode>(cursor: &mut Cursor<'_,
         Tracked(guards): Tracked<&mut Guards<'rcu>>
     requires
         old(cursor_own).level == NR_LEVELS,
-        old(cursor_own).continuations[(NR_LEVELS - 1) as int].all_some(),
+        old(cursor_own).continuations[NR_LEVELS - 1].all_some(),
     ensures
         // Phase 6: the retry loop in the commented-out body would handle the
         // stray-node race; the external_body shipped here is the post-retry
@@ -250,12 +250,12 @@ pub fn unlock_range<C: PageTableConfig, A: InAtomicMode>(cursor: &mut Cursor<'_,
             &&& final(cursor_own).popped_too_high == false
             &&& 1 <= final(cursor_own).level <= NR_LEVELS
             &&& final(cursor_own).continuations.dom().contains(final(cursor_own).level - 1)
-            &&& final(cursor_own).continuations[(final(cursor_own).level - 1) as int].inv()
-            &&& final(cursor_own).continuations[(final(cursor_own).level - 1) as int].guard == r->0
+            &&& final(cursor_own).continuations[final(cursor_own).level - 1].inv()
+            &&& final(cursor_own).continuations[final(cursor_own).level - 1].guard == r->0
         },
         // The subtree root's entry_own is a valid node with matching guard.
         {
-            let cont = final(cursor_own).continuations[(final(cursor_own).level - 1) as int];
+            let cont = final(cursor_own).continuations[final(cursor_own).level - 1];
             &&& cont.entry_own.is_node()
             &&& cont.entry_own.inv()
             &&& cont.entry_own.node().relate_guard(cont.guard)
@@ -263,7 +263,7 @@ pub fn unlock_range<C: PageTableConfig, A: InAtomicMode>(cursor: &mut Cursor<'_,
         },
         // The subtree root is lock_held in guards.
         final(guards).lock_held(
-            final(cursor_own).continuations[(final(cursor_own).level - 1) as int]
+            final(cursor_own).continuations[final(cursor_own).level - 1]
                 .entry_own.node().meta_addr_self()),
         // regions invariant preserved
         final(regions).inv(),
@@ -768,9 +768,9 @@ fn dfs_get_idx_range<C: PagingConstsTrait>(
                 let m = psu / ai;
                 // lemma gives: cur_node_va == psu * k + (cur_node_va % psu)
                 //              psu == ai * m + (psu % ai)
-                assert(cur_node_va as int == (m * k) * ai) by (nonlinear_arith)
+                assert(cur_node_va == (m * k) * ai) by (nonlinear_arith)
                     requires
-                        cur_node_va as int == psu * k + 0,
+                        cur_node_va == psu * k + 0,
                         psu == ai * m + 0,
                         cur_node_va as int % psu == 0,
                         psu % ai == 0,
@@ -804,10 +804,10 @@ fn dfs_get_idx_range<C: PagingConstsTrait>(
                     ai > 0,
             ;
 
-            assert(start_idx as int * ai < end_idx as int * ai) by (nonlinear_arith)
+            assert(start_idx * ai < end_idx * ai) by (nonlinear_arith)
                 requires
-                    start_idx as int * ai == si,
-                    end_idx as int * ai >= xi,
+                    start_idx * ai == si,
+                    end_idx * ai >= xi,
                     si < xi,
             ;
             vstd::arithmetic::mul::lemma_mul_strict_inequality_converse(
@@ -822,9 +822,9 @@ fn dfs_get_idx_range<C: PagingConstsTrait>(
         // So ceil_div(diff, ps) <= NR_ENTRIES.
         let psu = page_size((cur_node_level + 1) as PagingLevel) as int;
         // (psu + ai - 1) / ai == NR_ENTRIES (since psu = NR_ENTRIES * ai)
-        assert(psu + ai - 1 == NR_ENTRIES as int * ai + (ai - 1)) by (nonlinear_arith)
+        assert(psu + ai - 1 == NR_ENTRIES * ai + (ai - 1)) by (nonlinear_arith)
             requires
-                psu == NR_ENTRIES as int * ai,
+                psu == NR_ENTRIES * ai,
         ;
         lemma_fundamental_div_mod_converse(psu + ai - 1, ai, NR_ENTRIES as int, ai - 1);
         // So (psu + ai - 1) / ai == NR_ENTRIES

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -1825,7 +1825,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
         let taken = self.path[self.level as usize - 1].take().unwrap_or_panic();
         proof {
             let ghost child_cont = owner.continuations[owner.level - 1];
-            assert(old(self).path[old(self).level as int - 1] is Some);
+            assert(old(self).path[old(self).level - 1] is Some);
             assert(child_cont.all_some());
             assert(child_cont.inv());
             assert(taken == owner.continuations[owner.level - 1].guard);
@@ -1944,7 +1944,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
             old(owner).in_locked_range(),
             old(self).wf(*old(owner)),
             1 <= old(self).level <= 4,
-            old(self).path[old(self).level as int - 1] is Some,
+            old(self).path[old(self).level - 1] is Some,
             old(owner).metaregion_sound(*regions),
             regions.inv(),
         ensures
@@ -1955,19 +1955,19 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
             final(self).guard_level == old(self).guard_level,
             final(self).va == old(self).va,
             final(self).barrier_va == old(self).barrier_va,
-            *res.node == old(self).path[old(self).level as int - 1]->0,
-            final(self).path[old(self).level as int - 1] is Some,
-            final(self).path[old(self).level as int - 1]->0 == *final(res.node),
-            *final(res.node) == old(self).path[old(self).level as int - 1]->0
-                ==> final(self).path[old(self).level as int - 1]->0
-                    == old(self).path[old(self).level as int - 1]->0,
-            *final(res.node) == *res.node ==> final(self).path[old(self).level as int - 1]->0
+            *res.node == old(self).path[old(self).level - 1]->0,
+            final(self).path[old(self).level - 1] is Some,
+            final(self).path[old(self).level - 1]->0 == *final(res.node),
+            *final(res.node) == old(self).path[old(self).level - 1]->0
+                ==> final(self).path[old(self).level - 1]->0
+                    == old(self).path[old(self).level - 1]->0,
+            *final(res.node) == *res.node ==> final(self).path[old(self).level - 1]->0
                 == *res.node,
-            *final(res.node) == old(self).path[old(self).level as int - 1]->0
+            *final(res.node) == old(self).path[old(self).level - 1]->0
                 ==> final(self).wf(*final(owner)),
             *final(res.node) == *res.node ==> final(self).wf(*final(owner)),
             forall|i: int|
-                0 <= i < NR_LEVELS && i != old(self).level as int - 1 ==> #[trigger] final(self).path[i]
+                0 <= i < NR_LEVELS && i != old(self).level - 1 ==> #[trigger] final(self).path[i]
                     == old(self).path[i],
             *final(owner) == *old(owner),
             final(owner).metaregion_sound(*regions),
@@ -2117,10 +2117,10 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
     fn protect_cur_entry(&mut self, op: impl FnOnce(PageProperty) -> PageProperty) {
         proof {
             assert(self.0.wf(*owner));
-            assert(self.0.path[self.0.level as int - 1] is Some);
+            assert(self.0.path[self.0.level - 1] is Some);
         }
         let entry_idx = pte_index::<C>(self.0.va, self.0.level);
-        let ghost cur_path_guard = self.0.path[self.0.level as int - 1]->0;
+        let ghost cur_path_guard = self.0.path[self.0.level - 1]->0;
 
         let ghost owner0 = *owner;
 
@@ -2155,7 +2155,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             assert(owner.continuations[owner.level - 1].all_some()) by {
                 let cont_new = owner.continuations[owner.level - 1];
                 assert forall|i: int| 0 <= i < NR_ENTRIES implies cont_new.children[i] is Some by {
-                    if i != cont_new.idx as int {
+                    if i != cont_new.idx {
                         assert(cont0.children[i] is Some);
                     }
                 };
@@ -2422,7 +2422,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
     fn map_branch_pt(&mut self, pt: PageTableNodeRef<'rcu, C>, rcu_guard: &'rcu A) {
         let ghost guards0 = *guards;
 
-        let ghost level_key = owner.level as int - 1;
+        let ghost level_key = owner.level - 1;
         let ghost cont_orig = owner.continuations[level_key];
 
         let tracked mut continuation = owner.continuations.tracked_remove(owner.level - 1);
@@ -2627,10 +2627,10 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                     let ghost guards_pre_none = *guards;
                     proof {
                         assert(self.0.wf(owner1));
-                        assert(self.0.path[cur_level as int - 1] is Some);
+                        assert(self.0.path[cur_level - 1] is Some);
                     }
                     let entry_idx = pte_index::<C>(self.0.va, self.0.level);
-                    let ghost cur_path_guard = self.0.path[cur_level as int - 1]->0;
+                    let ghost cur_path_guard = self.0.path[cur_level - 1]->0;
 
                     let tracked mut continuation = owner.continuations.tracked_remove(
                         owner.level - 1,
@@ -2642,10 +2642,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
 
                     proof {
                         assert(owner_pre_none == owner1);
-                        assert(cont_pre_alloc == owner1.continuations[cur_level as int - 1]);
-                        assert(entry_idx == AbstractVaddr::from_vaddr(
-                            self.0.va,
-                        ).index[cur_level as int - 1]);
+                        assert(cont_pre_alloc == owner1.continuations[cur_level - 1]);
+                        assert(entry_idx == AbstractVaddr::from_vaddr(self.0.va).index[cur_level
+                            - 1]);
                         assert(entry_idx == cont_pre_alloc.idx);
                         assert(cur_path_guard == cont_pre_alloc.guard);
                         assert(parent_owner.relate_guard(cur_path_guard));
@@ -2781,7 +2780,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                             assert(cont_new.children[cont_new.idx as int] is Some);
                             assert forall|i: int|
                                 0 <= i < NR_ENTRIES implies cont_new.children[i] is Some by {
-                                if i != cont_new.idx as int {
+                                if i != cont_new.idx {
                                     assert(cont_pre_alloc.children[i] is Some);
                                 }
                             };
@@ -3113,7 +3112,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
 
         proof {
             // Hoist common facts about new_owner from new_child postcondition.
-            let cont = owner1.continuations[owner1.level as int - 1];
+            let cont = owner1.continuations[owner1.level - 1];
             assert(new_owner.value == EntryOwner::<C>::new_frame(
                 pa,
                 cont.path().push_tail(cont.idx as usize),
@@ -3944,10 +3943,10 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
 
         proof {
             assert(self.0.wf(owner0));
-            assert(self.0.path[level as int - 1] is Some);
+            assert(self.0.path[level - 1] is Some);
         }
         let entry_idx = pte_index::<C>(self.0.va, self.0.level);
-        let ghost cur_path_guard = self.0.path[level as int - 1]->0;
+        let ghost cur_path_guard = self.0.path[level - 1]->0;
 
         let tracked mut continuation = owner.continuations.tracked_remove((owner.level - 1) as int);
         let ghost cont0 = continuation;
@@ -3969,8 +3968,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         let ghost old_child_pre_replace = old_child_owner.value;
 
         proof {
-            assert(cont0 == owner0.continuations[(owner0.level - 1) as int]);
-            assert(entry_idx == AbstractVaddr::from_vaddr(self.0.va).index[level as int - 1]);
+            assert(cont0 == owner0.continuations[owner0.level - 1]);
+            assert(entry_idx == AbstractVaddr::from_vaddr(self.0.va).index[level - 1]);
             assert(entry_idx == cont0.idx);
             assert(cur_path_guard == cont0.guard);
             cont0.inv_children_rel_unroll(cont0.idx as int);
@@ -4167,7 +4166,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         0 <= j < NR_ENTRIES
                             && final_cont.children[j] is Some implies final_cont.children[j].unwrap().tree_predicate_map(
                     final_cont.path().push_tail(j as usize), g_sound) by {
-                        if j != idx as int {
+                        if j != idx {
                             cont0.inv_children_unroll(j);
                             let subtree = cont0.children[j].unwrap();
                             let path_j = final_cont.path().push_tail(j as usize);

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -156,7 +156,7 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
             Self::TOP_LEVEL_CAN_UNMAP(),
     ;
 
-    /// VERIFICATION only: Upper bound on `locked_range().end as int` for cursors of this config.
+    /// VERIFICATION only: Upper bound on `locked_range().end` for cursors of this config.
     ///
     /// May be tighter than the structural `vaddr_range_bounds_spec().1 + 1`
     /// when the actual sources of cursor ranges (e.g. the kvirt allocator
@@ -178,88 +178,6 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
 
     /// The paging constants.
     type C: PagingConstsTrait;
-
-    /// Core constant properties that each config must prove.
-    /// Combines bounds on the top-level index range, leading-bits
-    /// constraints, and the NR_ENTRIES identity.
-    proof fn lemma_page_table_config_constant_requirements()
-        ensures
-            (Self::TOP_LEVEL_INDEX_RANGE_spec().start as int) < (pow2(
-                (Self::C::ADDRESS_WIDTH() - pte_index_bit_offset_spec::<Self::C>(
-                    Self::C::NR_LEVELS(),
-                )) as nat,
-            ) as int),
-            Self::TOP_LEVEL_INDEX_RANGE_spec().end as int <= pow2(
-                (Self::C::ADDRESS_WIDTH() - pte_index_bit_offset_spec::<Self::C>(
-                    Self::C::NR_LEVELS(),
-                )) as nat,
-            ) as int,
-            pte_index_bit_offset_spec::<Self::C>(Self::C::NR_LEVELS())
-                <= Self::C::ADDRESS_WIDTH() as int,
-            pte_index_bit_offset_spec::<Self::C>(Self::C::NR_LEVELS()) < usize::BITS as int,
-            pte_index_bit_offset_spec::<Self::C>(Self::C::NR_LEVELS()) >= 0,
-            0 < Self::C::ADDRESS_WIDTH() as int,
-            (Self::TOP_LEVEL_INDEX_RANGE_spec().start as int) < (
-            Self::TOP_LEVEL_INDEX_RANGE_spec().end as int),
-            Self::C::ADDRESS_WIDTH() as int <= 64,
-            (Self::TOP_LEVEL_INDEX_RANGE_spec().end) * (pow2(
-                pte_index_bit_offset_spec::<Self::C>(Self::C::NR_LEVELS()) as nat,
-            )) <= usize::MAX as int,
-            Self::LEADING_BITS_spec() != 0usize ==> (Self::C::VA_SIGN_EXT() && (((
-            Self::TOP_LEVEL_INDEX_RANGE_spec().start) * (pow2(
-                pte_index_bit_offset_spec::<Self::C>(Self::C::NR_LEVELS()) as nat,
-            ))) / (pow2((Self::C::ADDRESS_WIDTH() - 1) as nat) as int)) % 2 == 1),
-            (Self::C::VA_SIGN_EXT() && ((((Self::TOP_LEVEL_INDEX_RANGE_spec().start) * (pow2(
-                pte_index_bit_offset_spec::<Self::C>(Self::C::NR_LEVELS()) as nat,
-            ))) / (pow2((Self::C::ADDRESS_WIDTH() - 1) as nat) as int)) % 2 == 1)) ==> {
-                &&& 48 <= Self::C::ADDRESS_WIDTH() as int
-                &&& Self::C::ADDRESS_WIDTH() < usize::BITS
-                &&& Self::LEADING_BITS_spec() * 0x1_0000_0000_0000int == 0x1_0000_0000_0000_0000int
-                    - pow2(Self::C::ADDRESS_WIDTH() as nat)
-            },
-            Self::LEADING_BITS_spec() < 0x1_0000_usize,
-            pow2(
-                (Self::C::ADDRESS_WIDTH() - pte_index_bit_offset_spec::<Self::C>(
-                    Self::C::NR_LEVELS(),
-                )) as nat,
-            ) == NR_ENTRIES,
-    ;
-
-    /// Properties derived from the constant requirements.
-    /// Implementors get this for free.
-    proof fn lemma_page_table_config_derived_properties()
-        ensures
-            Self::TOP_LEVEL_INDEX_RANGE_spec().end <= NR_ENTRIES,
-    {
-        Self::lemma_page_table_config_constant_requirements();
-    }
-
-    /// Layout identity: the PTE type's Rust `size_of` matches the config's
-    /// `PTE_SIZE_spec`. Concrete impls satisfy this via their `global
-    /// layout` declaration. Exposed for generic code that calls
-    /// `core::mem::size_of::<Self::E>()`.
-    proof fn axiom_pte_size_eq_size_of()
-        ensures
-            core::mem::size_of::<Self::E>() == Self::C::PTE_SIZE_spec(),
-    ;
-
-    /// A full PT-node's worth of PTEs fills exactly one base page.
-    proof fn lemma_pte_walk_fills_page()
-        ensures
-            NR_ENTRIES * core::mem::size_of::<Self::E>() == crate::specs::arch::PAGE_SIZE,
-    ;
-
-    // dubious: why is this an axiom
-    /// `align_of::<E>()` divides `size_of::<E>()`. True for any sized Rust
-    /// type (the alignment divides the size by the layout rules), but
-    /// Verus's `size_of`/`align_of` are uninterpreted so we expose it as
-    /// an axiom. Used by PT-node `on_drop` to prove cursor alignment is
-    /// preserved across `read_once` iterations.
-    proof fn axiom_pte_align_divides_size()
-        ensures
-            core::mem::size_of::<Self::E>() % core::mem::align_of::<Self::E>() == 0,
-            core::mem::align_of::<Self::E>() > 0,
-    ;
 
     /// The item that can be mapped into the virtual memory space using the
     /// page table.
@@ -806,11 +724,6 @@ fn sign_bit_of_va<C: PageTableConfig>(va: Vaddr) -> (ret: bool)
     bit != 0
 }
 
-#[verifier::inline]
-pub open spec fn pte_index_bit_offset_spec<C: PagingConstsTrait>(level: PagingLevel) -> int {
-    (C::BASE_PAGE_SIZE().ilog2()) + (nr_pte_index_bits::<C>()) * (level - 1)
-}
-
 /// Spec for the managed virtual address range (exclusive end).
 /// For configs without VA_SIGN_EXT (e.g. UserPtConfig) or when the base range has sign bit 0.
 /// Configs with sign extension (e.g. KernelPtConfig) use
@@ -923,7 +836,7 @@ fn vaddr_range<C: PageTableConfig>() -> (ret: RangeInclusive<Vaddr>)
 /// disjoint.
 fn apply_sign_ext<C: PageTableConfig>(va: Vaddr) -> (ret: Vaddr)
     requires
-        (va as int) < pow2(C::ADDRESS_WIDTH() as nat) as int,
+        va < pow2(C::ADDRESS_WIDTH() as nat),
         C::ADDRESS_WIDTH() < usize::BITS,
         C::LEADING_BITS_spec() * 0x1_0000_0000_0000int == 0x1_0000_0000_0000_0000int - pow2(
             C::ADDRESS_WIDTH() as nat,
@@ -1121,7 +1034,7 @@ fn pte_index<C: PagingConstsTrait>(va: Vaddr, level: PagingLevel) -> (res: usize
     proof {
         lemma_pte_index_consts::<C>();
         assert(offset == 12 + 9 * (level - 1));
-        assert(0 <= (offset as int) && (offset as int) < (usize::BITS as int)) by (nonlinear_arith)
+        assert(0 <= offset < usize::BITS) by (nonlinear_arith)
             requires
                 1 <= level <= NR_LEVELS,
                 NR_LEVELS == 4,
@@ -1150,7 +1063,7 @@ fn pte_index<C: PagingConstsTrait>(va: Vaddr, level: PagingLevel) -> (res: usize
 
 #[verifier::inline]
 pub open spec fn pte_index_bit_offset_spec<C: PagingConstsTrait>(level: PagingLevel) -> usize {
-    (C::BASE_PAGE_SIZE().ilog2() + nr_pte_index_bits::<C>() * (level as int - 1)) as usize
+    (C::BASE_PAGE_SIZE().ilog2() + nr_pte_index_bits::<C>() * (level - 1)) as usize
 }
 
 /// The bit offset of the entry offset part in a virtual address.
@@ -1710,7 +1623,7 @@ impl<C: PageTableConfig> PageTable<C> {
         requires
             owner.inv(),
             // Per-config tightening; see `Cursor::new`.
-            va.end as int <= C::LOCKED_END_BOUND_spec(),
+            va.end <= C::LOCKED_END_BOUND_spec(),
         ensures
             Cursor::<C, G>::cursor_new_success_conditions(va) ==> {
                 &&& r is Ok
@@ -1765,7 +1678,7 @@ impl<C: PageTableConfig> PageTable<C> {
         requires
             owner.inv(),
             // Per-config tightening; see `Cursor::new`.
-            va.end as int <= C::LOCKED_END_BOUND_spec(),
+            va.end <= C::LOCKED_END_BOUND_spec(),
         ensures
             Cursor::<C, G>::cursor_new_success_conditions(va) ==> {
                 &&& r is Ok

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -190,12 +190,12 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
     proof fn lemma_page_table_config_constant_requirements()
         ensures
             (Self::TOP_LEVEL_INDEX_RANGE_spec().start as int) < (pow2(
-                (Self::C::ADDRESS_WIDTH() as int - pte_index_bit_offset_spec::<Self::C>(
+                (Self::C::ADDRESS_WIDTH() - pte_index_bit_offset_spec::<Self::C>(
                     Self::C::NR_LEVELS(),
                 )) as nat,
             ) as int),
             Self::TOP_LEVEL_INDEX_RANGE_spec().end as int <= pow2(
-                (Self::C::ADDRESS_WIDTH() as int - pte_index_bit_offset_spec::<Self::C>(
+                (Self::C::ADDRESS_WIDTH() - pte_index_bit_offset_spec::<Self::C>(
                     Self::C::NR_LEVELS(),
                 )) as nat,
             ) as int,
@@ -207,27 +207,27 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
             (Self::TOP_LEVEL_INDEX_RANGE_spec().start as int) < (
             Self::TOP_LEVEL_INDEX_RANGE_spec().end as int),
             Self::C::ADDRESS_WIDTH() as int <= 64,
-            (Self::TOP_LEVEL_INDEX_RANGE_spec().end as int) * (pow2(
+            (Self::TOP_LEVEL_INDEX_RANGE_spec().end) * (pow2(
                 pte_index_bit_offset_spec::<Self::C>(Self::C::NR_LEVELS()) as nat,
-            ) as int) <= usize::MAX as int,
+            )) <= usize::MAX as int,
             Self::LEADING_BITS_spec() != 0usize ==> (Self::C::VA_SIGN_EXT() && (((
-            Self::TOP_LEVEL_INDEX_RANGE_spec().start as int) * (pow2(
+            Self::TOP_LEVEL_INDEX_RANGE_spec().start) * (pow2(
                 pte_index_bit_offset_spec::<Self::C>(Self::C::NR_LEVELS()) as nat,
-            ) as int)) / (pow2((Self::C::ADDRESS_WIDTH() - 1) as nat) as int)) % 2 == 1),
-            (Self::C::VA_SIGN_EXT() && ((((Self::TOP_LEVEL_INDEX_RANGE_spec().start as int) * (pow2(
+            ))) / (pow2((Self::C::ADDRESS_WIDTH() - 1) as nat) as int)) % 2 == 1),
+            (Self::C::VA_SIGN_EXT() && ((((Self::TOP_LEVEL_INDEX_RANGE_spec().start) * (pow2(
                 pte_index_bit_offset_spec::<Self::C>(Self::C::NR_LEVELS()) as nat,
-            ) as int)) / (pow2((Self::C::ADDRESS_WIDTH() - 1) as nat) as int)) % 2 == 1)) ==> {
+            ))) / (pow2((Self::C::ADDRESS_WIDTH() - 1) as nat) as int)) % 2 == 1)) ==> {
                 &&& 48 <= Self::C::ADDRESS_WIDTH() as int
                 &&& Self::C::ADDRESS_WIDTH() < usize::BITS
-                &&& Self::LEADING_BITS_spec() as int * 0x1_0000_0000_0000int
-                    == 0x1_0000_0000_0000_0000int - pow2(Self::C::ADDRESS_WIDTH() as nat) as int
+                &&& Self::LEADING_BITS_spec() * 0x1_0000_0000_0000int == 0x1_0000_0000_0000_0000int
+                    - pow2(Self::C::ADDRESS_WIDTH() as nat)
             },
             Self::LEADING_BITS_spec() < 0x1_0000_usize,
             pow2(
-                (Self::C::ADDRESS_WIDTH() as int - pte_index_bit_offset_spec::<Self::C>(
+                (Self::C::ADDRESS_WIDTH() - pte_index_bit_offset_spec::<Self::C>(
                     Self::C::NR_LEVELS(),
                 )) as nat,
-            ) as int == NR_ENTRIES as int,
+            ) == NR_ENTRIES,
     ;
 
     /// Properties derived from the constant requirements.
@@ -813,9 +813,9 @@ fn top_level_index_width<C: PageTableConfig>() -> (ret: usize)
 /// Concrete positional start of the VA range: `idx_range.start * 2^offset`.
 fn pt_va_range_start<C: PageTableConfig>() -> (ret: Vaddr)
     ensures
-        ret as int == C::TOP_LEVEL_INDEX_RANGE_spec().start as int * pow2(
+        ret == C::TOP_LEVEL_INDEX_RANGE_spec().start * pow2(
             pte_index_bit_offset_spec::<C>(C::NR_LEVELS()) as nat,
-        ) as int,
+        ),
 {
     let idx_start = C::TOP_LEVEL_INDEX_RANGE().start;
     proof {
@@ -843,9 +843,9 @@ fn pt_va_range_start<C: PageTableConfig>() -> (ret: Vaddr)
 /// left shift followed by `wrapping_sub(1)`.
 fn pt_va_range_end<C: PageTableConfig>() -> (ret: Vaddr)
     ensures
-        ret as int == (C::TOP_LEVEL_INDEX_RANGE_spec().end as int * pow2(
+        ret == (C::TOP_LEVEL_INDEX_RANGE_spec().end * pow2(
             pte_index_bit_offset_spec::<C>(C::NR_LEVELS()) as nat,
-        ) as int - 1) % 0x1_0000_0000_0000_0000int,
+        ) - 1) % 0x1_0000_0000_0000_0000int,
 {
     let idx_end = C::TOP_LEVEL_INDEX_RANGE().end;
     proof {
@@ -904,7 +904,7 @@ fn sign_bit_of_va<C: PageTableConfig>(va: Vaddr) -> (ret: bool)
 
 #[verifier::inline]
 pub open spec fn pte_index_bit_offset_spec<C: PagingConstsTrait>(level: PagingLevel) -> int {
-    (C::BASE_PAGE_SIZE().ilog2() as int) + (nr_pte_index_bits::<C>() as int) * (level as int - 1)
+    (C::BASE_PAGE_SIZE().ilog2()) + (nr_pte_index_bits::<C>()) * (level - 1)
 }
 
 /// Spec for the managed virtual address range (exclusive end).
@@ -915,8 +915,8 @@ pub open spec fn pte_index_bit_offset_spec<C: PagingConstsTrait>(level: PagingLe
 pub open spec fn vaddr_range_spec<C: PageTableConfig>() -> Range<Vaddr> {
     let idx_range = C::TOP_LEVEL_INDEX_RANGE_spec();
     let offset = pte_index_bit_offset_spec::<C::C>(C::NR_LEVELS()) as nat;
-    let start = (idx_range.start as int) * pow2(offset);
-    let end_inclusive = (idx_range.end as int) * pow2(offset) - 1;
+    let start = (idx_range.start) * pow2(offset);
+    let end_inclusive = (idx_range.end) * pow2(offset) - 1;
     (start as Vaddr)..((end_inclusive + 1) as Vaddr)
 }
 
@@ -974,7 +974,7 @@ fn vaddr_range_bounds<C: PageTableConfig>() -> (ret: (Vaddr, Vaddr))
             let i_start = C::TOP_LEVEL_INDEX_RANGE_spec().start as int;
             let p_off = pow2(off) as int;
             let p_aw_m1 = pow2(aw_m1) as int;
-            assert(pt_start as int == i_start * p_off);
+            assert(pt_start == i_start * p_off);
             assert(sign_bit_set == ((pt_start as int / p_aw_m1) % 2 == 1));
             assert(sign_bit_set == ((i_start * p_off / p_aw_m1) % 2 == 1));
         }
@@ -984,14 +984,14 @@ fn vaddr_range_bounds<C: PageTableConfig>() -> (ret: (Vaddr, Vaddr))
         //   start as int == lb * 2^48 + idx.start * 2^off
         //   end as int   == lb * 2^48 + idx.end * 2^off - 1
         // matching the unfolded `vaddr_range_bounds_spec`.
-        assert(start as int == (C::LEADING_BITS_spec() as int) * 0x1_0000_0000_0000int + (
-        C::TOP_LEVEL_INDEX_RANGE_spec().start as int) * (pow2(
+        assert(start == (C::LEADING_BITS_spec()) * 0x1_0000_0000_0000int + (
+        C::TOP_LEVEL_INDEX_RANGE_spec().start) * (pow2(
             pte_index_bit_offset_spec::<C>(C::NR_LEVELS()) as nat,
-        ) as int));
-        assert(end as int == (C::LEADING_BITS_spec() as int) * 0x1_0000_0000_0000int + (
-        C::TOP_LEVEL_INDEX_RANGE_spec().end as int) * (pow2(
+        )));
+        assert(end == (C::LEADING_BITS_spec()) * 0x1_0000_0000_0000int + (
+        C::TOP_LEVEL_INDEX_RANGE_spec().end) * (pow2(
             pte_index_bit_offset_spec::<C>(C::NR_LEVELS()) as nat,
-        ) as int) - 1);
+        )) - 1);
     }
     (start, end)
 }
@@ -1022,11 +1022,11 @@ fn apply_sign_ext<C: PageTableConfig>(va: Vaddr) -> (ret: Vaddr)
     requires
         (va as int) < pow2(C::ADDRESS_WIDTH() as nat) as int,
         C::ADDRESS_WIDTH() < usize::BITS,
-        C::LEADING_BITS_spec() as int * 0x1_0000_0000_0000int == 0x1_0000_0000_0000_0000int - pow2(
+        C::LEADING_BITS_spec() * 0x1_0000_0000_0000int == 0x1_0000_0000_0000_0000int - pow2(
             C::ADDRESS_WIDTH() as nat,
-        ) as int,
+        ),
     ensures
-        ret as int == va as int + C::LEADING_BITS_spec() as int * 0x1_0000_0000_0000int,
+        ret == va + C::LEADING_BITS_spec() * 0x1_0000_0000_0000int,
 {
     let address_width = C::ADDRESS_WIDTH();
     let low_bit = 1usize << address_width;
@@ -1049,10 +1049,8 @@ fn apply_sign_ext<C: PageTableConfig>(va: Vaddr) -> (ret: Vaddr)
         assert(pow2(64) == 0x1_0000_0000_0000_0000nat) by {
             vstd::arithmetic::power2::lemma2_to64();
         };
-        assert(sign_ext_mask as int == 0x1_0000_0000_0000_0000int - pow2(
-            address_width as nat,
-        ) as int);
-        assert(sign_ext_mask as int == C::LEADING_BITS_spec() as int * 0x1_0000_0000_0000int);
+        assert(sign_ext_mask == 0x1_0000_0000_0000_0000int - pow2(address_width as nat));
+        assert(sign_ext_mask == C::LEADING_BITS_spec() * 0x1_0000_0000_0000int);
 
         assert((va & sign_ext_mask) == 0usize) by (bit_vector)
             requires
@@ -1101,8 +1099,8 @@ pub(crate) proof fn lemma_vaddr_range_spec_kernel()
     assert(pte_index_bit_offset_spec::<PagingConsts>(4) == 39);
     lemma_pow2_adds(8, 39);
     lemma_pow2_adds(9, 39);
-    assert((256 as int) * pow2(39) == pow2(47));
-    assert((512 as int) * pow2(39) == pow2(48));
+    assert(256 * pow2(39) == pow2(47));
+    assert(512 * pow2(39) == pow2(48));
 }
 
 /// Canonical bounds of the VA range managed by a page-table config,
@@ -1119,8 +1117,8 @@ pub closed spec fn vaddr_range_bounds_spec<C: PageTableConfig>() -> (Vaddr, Vadd
     let off = pte_index_bit_offset_spec::<C::C>(C::NR_LEVELS()) as nat;
     let lb = C::LEADING_BITS_spec() as int;
     let base = lb * 0x1_0000_0000_0000int;
-    let start = (base + (idx.start as int) * pow2(off)) as usize;
-    let end_inclusive = (base + (idx.end as int) * pow2(off) - 1) as usize;
+    let start = (base + (idx.start) * pow2(off)) as usize;
+    let end_inclusive = (base + (idx.end) * pow2(off) - 1) as usize;
     (start, end_inclusive)
 }
 
@@ -1134,8 +1132,8 @@ pub proof fn lemma_vaddr_range_bounds_spec_unfold<C: PageTableConfig>()
             let off = pte_index_bit_offset_spec::<C>(C::NR_LEVELS()) as nat;
             let lb = C::LEADING_BITS_spec() as int;
             let base = lb * 0x1_0000_0000_0000int;
-            let start = (base + (idx.start as int) * pow2(off)) as usize;
-            let end_inclusive = (base + (idx.end as int) * pow2(off) - 1) as usize;
+            let start = (base + (idx.start) * pow2(off)) as usize;
+            let end_inclusive = (base + (idx.end) * pow2(off) - 1) as usize;
             (start, end_inclusive)
         },
 {
@@ -1159,9 +1157,9 @@ pub(crate) proof fn lemma_vaddr_range_bounds_spec_user()
     assert(nr_subpage_per_huge::<PagingConsts>() == 512_usize);
     assert(nr_pte_index_bits::<PagingConsts>() == 9_usize);
     assert(pte_index_bit_offset_spec::<PagingConsts>(4) == 39);
-    assert((0 as int) * pow2(39) == 0);
-    assert((256 as int) * pow2(39) == pow2(47));
-    assert(pow2(47) as int - 1 == 0x0000_7FFF_FFFF_FFFF_int);
+    assert(0 * pow2(39) == 0);
+    assert(256 * pow2(39) == pow2(47));
+    assert(pow2(47) - 1 == 0x0000_7FFF_FFFF_FFFF_int);
     // UserPtConfig: LEADING_BITS = 0 via trait default.
     assert(<crate::mm::vm_space::UserPtConfig as PageTableConfig>::LEADING_BITS_spec() == 0_usize);
 }
@@ -1186,10 +1184,10 @@ pub(crate) proof fn lemma_vaddr_range_bounds_spec_kernel()
     assert(nr_pte_index_bits::<PagingConsts>() == 9_usize);
     assert(PagingConsts::BASE_PAGE_SIZE().ilog2() == 12u32);
     assert(pte_index_bit_offset_spec::<PagingConsts>(4) == 39);
-    assert((256 as int) * pow2(39) == pow2(47));
-    assert((512 as int) * pow2(39) == pow2(48));
-    assert(0xffff_int * 0x1_0000_0000_0000int + pow2(47) as int == 0xffff_8000_0000_0000int);
-    assert(0xffff_int * 0x1_0000_0000_0000int + pow2(48) as int - 1 == 0xffff_ffff_ffff_ffffint);
+    assert(256 * pow2(39) == pow2(47));
+    assert(512 * pow2(39) == pow2(48));
+    assert(0xffff_int * 0x1_0000_0000_0000int + pow2(47) == 0xffff_8000_0000_0000int);
+    assert(0xffff_int * 0x1_0000_0000_0000int + pow2(48) - 1 == 0xffff_ffff_ffff_ffffint);
 }
 
 // Here are some const values that are determined by the paging constants.
@@ -1219,13 +1217,13 @@ fn pte_index<C: PagingConstsTrait>(va: Vaddr, level: PagingLevel) -> (res: usize
     let offset = pte_index_bit_offset::<C>(level);
     proof {
         lemma_pte_index_consts::<C>();
-        assert(offset as int == 12 + 9 * (level as int - 1));
+        assert(offset == 12 + 9 * (level - 1));
         assert(0 <= (offset as int) && (offset as int) < (usize::BITS as int)) by (nonlinear_arith)
             requires
                 1 <= level <= NR_LEVELS,
                 NR_LEVELS == 4,
                 usize::BITS == 64,
-                offset as int == 12 + 9 * (level as int - 1),
+                offset == 12 + 9 * (level - 1),
         ;
     }
 
@@ -1256,11 +1254,11 @@ fn pte_index_bit_offset<C: PagingConstsTrait>(level: PagingLevel) -> (ret: usize
     requires
         1 <= level <= NR_LEVELS,
     ensures
-        ret as int == pte_index_bit_offset_spec::<C>(level),
+        ret == pte_index_bit_offset_spec::<C>(level),
 {
     proof {
         lemma_pte_index_consts::<C>();
-        assert(12 + 9 * (level as int - 1) <= 39) by (nonlinear_arith)
+        assert(12 + 9 * (level - 1) <= 39) by (nonlinear_arith)
             requires
                 1 <= level <= NR_LEVELS,
                 NR_LEVELS == 4,

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -926,7 +926,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             // `inv_children_rel` for the unchanged children when restoring the
             // parent NodeOwner into the cursor's continuation.
             old(owner).value.is_frame() && old(parent_owner).level > 1 ==>
-                forall|j: int| 0 <= j < NR_ENTRIES && j != old(self).idx as int ==>
+                forall|j: int| 0 <= j < NR_ENTRIES && j != old(self).idx ==>
                     #[trigger] final(parent_owner).children_perm.value()[j]
                         == old(parent_owner).children_perm.value()[j],
     )]
@@ -1193,8 +1193,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                     } by {
                         let sub_pages_per_subframe = page_size((level - 1) as PagingLevel)
                             / PAGE_SIZE;
-                        let big_j_int: int = i as int * sub_pages_per_subframe as int
-                            + j_prime as int;
+                        let big_j_int: int = i * sub_pages_per_subframe + j_prime;
                         vstd::arithmetic::mul::lemma_mul_nonnegative(
                             i as int,
                             sub_pages_per_subframe as int,
@@ -1438,7 +1437,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
             final(owner).frame().is_tracked == old(owner).frame().is_tracked,
             final(owner).path == old(owner).path,
             final(owner).parent_level == old(owner).parent_level,
-            forall|j: int| 0 <= j < NR_ENTRIES && j != idx as int ==>
+            forall|j: int| 0 <= j < NR_ENTRIES && j != idx ==>
                 #[trigger] final(parent_owner).children_perm.value()[j]
                     == old(parent_owner).children_perm.value()[j],
             // Only a present PTE's `prop` changed, so the present-count — and
@@ -1553,7 +1552,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
             final(parent_owner).level == old(parent_owner).level,
             final(parent_owner).relate_guard(*final(self)),
             final(parent_owner).metaregion_sound_node(*final(regions)),
-            forall|j: int| 0 <= j < NR_ENTRIES && j != idx as int ==>
+            forall|j: int| 0 <= j < NR_ENTRIES && j != idx ==>
                 #[trigger] final(parent_owner).children_perm.value()[j]
                     == old(parent_owner).children_perm.value()[j],
             forall|slot: usize|
@@ -1779,7 +1778,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
             final(parent_owner).level == old(parent_owner).level,
             final(parent_owner).relate_guard(*final(self)),
             final(parent_owner).metaregion_sound_node(*final(regions)),
-            forall|j: int| 0 <= j < NR_ENTRIES && j != idx as int ==>
+            forall|j: int| 0 <= j < NR_ENTRIES && j != idx ==>
                 #[trigger] final(parent_owner).children_perm.value()[j]
                     == old(parent_owner).children_perm.value()[j],
             *final(self) == *old(self),
@@ -1982,7 +1981,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
                 *final(regions),
             ),
             forall|i: int|
-                0 <= i < NR_ENTRIES && i != idx as int ==> #[trigger] old(parent_owner).children_perm.value()[i]
+                0 <= i < NR_ENTRIES && i != idx ==> #[trigger] old(parent_owner).children_perm.value()[i]
                     == final(parent_owner).children_perm.value()[i],
             final(parent_owner).slot_index == old(parent_owner).slot_index,
             final(parent_owner).level == old(parent_owner).level,

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -192,13 +192,10 @@ unsafe impl<C: PageTableConfig> AnyFrameMeta for PageTablePageMeta<C> {
             vstd::arithmetic::div_mod::lemma_fundamental_div_mod(size_of_e, align_of_e);
             vstd::arithmetic::mul::lemma_mul_is_commutative(align_of_e, k);
             vstd::arithmetic::mul::lemma_mul_is_associative(range.start as int, k, align_of_e);
-            vstd::arithmetic::div_mod::lemma_mod_multiples_basic(
-                range.start as int * k,
-                align_of_e,
-            );
+            vstd::arithmetic::div_mod::lemma_mod_multiples_basic(range.start * k, align_of_e);
             vstd::arithmetic::div_mod::lemma_mod_adds(
                 pre_skip_cursor,
-                range.start as int * size_of_e,
+                range.start * size_of_e,
                 align_of_e,
             );
         }
@@ -222,7 +219,7 @@ unsafe impl<C: PageTableConfig> AnyFrameMeta for PageTablePageMeta<C> {
             );
             vstd::arithmetic::mul::lemma_mul_inequality(
                 range_end - range_start,
-                NR_ENTRIES as int - range_start,
+                NR_ENTRIES - range_start,
                 size_of_e,
             );
         }
@@ -235,20 +232,20 @@ unsafe impl<C: PageTableConfig> AnyFrameMeta for PageTablePageMeta<C> {
                 vm_io_owner.read_view_initialized(),
                 regions.inv(),
                 reader.cursor.vaddr as int % align_of_e == 0,
-                size_of_e == core::mem::size_of::<C::E>() as int,
-                align_of_e == core::mem::align_of::<C::E>() as int,
+                size_of_e == core::mem::size_of::<C::E>(),
+                align_of_e == core::mem::align_of::<C::E>(),
                 size_of_e % align_of_e == 0,
                 align_of_e > 0,
                 size_of_e > 0,
                 iter_count <= n_iters,
-                n_iters as int == range_end - range_start,
+                n_iters == range_end - range_start,
                 // Verus loses non-negativity of `range_start` / `range_end`
                 // across the loop boundary; pin it via these invariants so
                 // `lemma_mul_nonnegative` preconditions discharge in the body.
                 0 <= range_start,
                 range_start <= range_end,
                 range_end <= NR_ENTRIES as int,
-                reader.remain_spec() as int == post_skip_remain - iter_count as int * size_of_e,
+                reader.remain_spec() == post_skip_remain - iter_count * size_of_e,
                 post_skip_remain >= (range_end - range_start) * size_of_e,
                 regions.slots.dom() == initial_dom,
                 Self::child_perms_embedding(*regions, removed_indices),
@@ -260,7 +257,7 @@ unsafe impl<C: PageTableConfig> AnyFrameMeta for PageTablePageMeta<C> {
                 self.level == level,
                 reader.end == initial_reader.end,
                 reader.cursor.vaddr == initial_reader.cursor.vaddr + range_start * size_of_e
-                    + iter_count as int * size_of_e,
+                    + iter_count * size_of_e,
                 forall|i: usize|
                     #![trigger initial_view.addr_transl(i)]
                     initial_reader.cursor.vaddr <= i < initial_reader.end.vaddr ==> {
@@ -305,7 +302,7 @@ unsafe impl<C: PageTableConfig> AnyFrameMeta for PageTablePageMeta<C> {
                 );
                 vstd::arithmetic::mul::lemma_mul_inequality(
                     1,
-                    range_end - range_start - iter_count as int,
+                    range_end - range_start - iter_count,
                     size_of_e,
                 );
             }
@@ -337,7 +334,7 @@ unsafe impl<C: PageTableConfig> AnyFrameMeta for PageTablePageMeta<C> {
                             iter_count as int,
                         );
                         vstd::arithmetic::div_mod::lemma_mod_multiples_basic(
-                            range_start + iter_count as int,
+                            range_start + iter_count,
                             size_of_e,
                         );
                         Self::lemma_coverage_at(
@@ -415,7 +412,7 @@ unsafe impl<C: PageTableConfig> AnyFrameMeta for PageTablePageMeta<C> {
                         removed_indices = removed_indices.insert(frame_to_index(paddr));
                         assert({
                             let cj = (initial_reader.cursor.vaddr + range_start * size_of_e
-                                + iter_count as int * size_of_e) as usize;
+                                + iter_count * size_of_e) as usize;
                             let pte_j = Self::walk_pte_at_view(initial_view, cj);
                             &&& cj == cursor_pre_read
                             &&& pte_j == pte
@@ -442,7 +439,7 @@ unsafe impl<C: PageTableConfig> AnyFrameMeta for PageTablePageMeta<C> {
             }
             proof {
                 vstd::arithmetic::div_mod::lemma_mod_adds(
-                    reader.cursor.vaddr as int - size_of_e,
+                    reader.cursor.vaddr - size_of_e,
                     size_of_e,
                     align_of_e,
                 );

--- a/ostd/src/sync/rcu/non_null/either.rs
+++ b/ostd/src/sync/rcu/non_null/either.rs
@@ -63,12 +63,12 @@ unsafe impl<L: NonNullPtr, R: NonNullPtr> NonNullPtr for Either<L, R> {
                         let big = 1usize << l_align_bits;
                         let q = left_addr / big;
                         vstd::arithmetic::div_mod::lemma_fundamental_div_mod(left_addr as int, big as int);
-                        assert(left_addr as int == (q as int * scale as int) * tag as int) by (nonlinear_arith)
+                        assert(left_addr == q * scale * tag) by (nonlinear_arith)
                         requires
-                            left_addr as int == q as int * big as int,
+                            left_addr == q * big,
                             big == tag * scale,
                         ;
-                        vstd::arithmetic::div_mod::lemma_mod_multiples_basic(q as int * scale as int, tag as int);
+                        vstd::arithmetic::div_mod::lemma_mod_multiples_basic(q * scale, tag as int);
                     };
                     lemma_aligned_addr_clears_tag_bit(left_addr, tag, align_bits, l_align_bits);
                 }
@@ -116,12 +116,12 @@ unsafe impl<L: NonNullPtr, R: NonNullPtr> NonNullPtr for Either<L, R> {
                         let big = 1usize << r_align_bits;
                         let q = addr / big;
                         vstd::arithmetic::div_mod::lemma_fundamental_div_mod(addr as int, big as int);
-                        assert(addr as int == (q as int * scale as int) * tag as int) by (nonlinear_arith)
+                        assert(addr == q * scale * tag) by (nonlinear_arith)
                         requires
-                            addr as int == q as int * big as int,
+                            addr == q * big,
                             big == tag * scale,
                         ;
-                        vstd::arithmetic::div_mod::lemma_mod_multiples_basic(q as int * scale as int, tag as int);
+                        vstd::arithmetic::div_mod::lemma_mod_multiples_basic(q * scale, tag as int);
                     }
                     lemma_aligned_addr_clears_tag_bit(addr, tag, align_bits, r_align_bits);
                     assert(tagged_addr & !tag == addr) by (bit_vector)


### PR DESCRIPTION
The [typing constraint](https://verus-lang.github.io/verus/guide/spec-arithmetic.html#typing) about integer arithmetic is much more flexible in spec mode.