### PR TITLE
refactor: using cargo verus and improve the verus update in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 VERIFICATION_TARGETS := \
 	ostd \
 
-.PHONY: all verify $(VERIFICATION_TARGETS) fmt clean verus update
+.PHONY: all verify $(VERIFICATION_TARGETS) fmt clean verus verus-upgrade
 
 $(VERIFICATION_TARGETS):
 	cargo dv verify --targets $@
@@ -11,7 +11,7 @@ $(VERIFICATION_TARGETS):
 all: verify
 
 verify:
-	cargo dv verify --targets $(VERIFICATION_TARGETS)
+	cargo dv verify --targets $(VERIFICATION_TARGETS) -- -Awarnings
 
 fmt:
 	cargo dv fmt
@@ -19,8 +19,11 @@ fmt:
 doc: verify
 	cargo dv doc --target ostd
 
-verus update:
-	cargo dv bootstrap $(if $(filter update,$@),--upgrade,)
+verus:
+	cargo dv bootstrap
+
+verus-upgrade:
+	cargo dv bootstrap --upgrade
 
 clean:
 	cargo clean

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,10 @@ verify:
 fmt:
 	cargo dv fmt
 
-doc: verify
+build:
+	cargo dv build
+
+doc: build
 	cargo dv doc --target ostd
 
 verus:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ $(VERIFICATION_TARGETS):
 all: verify
 
 verify:
-	cargo dv verify --targets $(VERIFICATION_TARGETS) -- -Awarnings
+	cargo dv verify --targets $(VERIFICATION_TARGETS)
 
 fmt:
 	cargo dv fmt

--- a/README.md
+++ b/README.md
@@ -71,14 +71,14 @@ cargo dv verify
 To verify only `ostd`, run:
 
 ```bash
-cargo dv verify --targets ostd
+cargo dv verify -f --targets ostd
 ```
 
 The `ostd` crate relies on a verified library: `vstd_extra`. To build it
 independently through `cargo-verus build`, run:
 
 ```bash
-cargo dv compile --targets vstd_extra
+cargo dv build --targets vstd_extra
 ```
 
 ### Clean Build Artifacts
@@ -106,6 +106,7 @@ make doc
 or
 
 ```bash
+cargo dv build
 cargo dv doc --target ostd
 ```
 

--- a/README.md
+++ b/README.md
@@ -65,10 +65,17 @@ make
 or
 
 ```bash
+cargo dv verify
+```
+
+To verify only `ostd`, run:
+
+```bash
 cargo dv verify --targets ostd
 ```
 
-The `ostd` crate relies on a verified library: `vstd_extra`. To compile and verify the library independently, run:
+The `ostd` crate relies on a verified library: `vstd_extra`. To build it
+independently through `cargo-verus build`, run:
 
 ```bash
 cargo dv compile --targets vstd_extra
@@ -76,13 +83,7 @@ cargo dv compile --targets vstd_extra
 
 ### Clean Build Artifacts
 
-`dv` automatically skips recompilation and reverification for libraries that have not changed since the last build. To remove the build artifact of a particular library and force a fresh build, run:
-
-```bash
-cargo dv clean --targets vstd_extra
-```
-
-To clean all artifacts at once, run:
+`cargo verus` automatically skips recompilation and reverification for libraries that have not changed since the last build. To remove the build artifact force a fresh build, run:
 
 ```bash
 make clean
@@ -127,6 +128,6 @@ We welcome your contributions!
 
 ### Tips
 
-- During your development process, please frequently run `make verus update` or `cargo dv bootstrap --upgrade` to stay up-to-date with the [latest supported version](https://github.com/asterinas/verus) of Verus.
+- During your development process, please frequently run `make verus-upgrade` or `cargo dv bootstrap --upgrade` to stay up-to-date with the [latest supported version](https://github.com/asterinas/verus) of Verus.
 - Format checking is not enforced, but we still recommend formatting your code with `cargo dv fmt --paths path_to_your_file` before submission.
 - If you are contributing to Verus, we recommend submitting pull requests to [the upstream repo](https://github.com/verus-lang/verus) rather than our fork, since we aim to minimize differences between them.


### PR DESCRIPTION
Now VOSTD is transfered to using `cargo verus` now.