### PR TITLE
fix: Some preparation for general arch support

### DIFF
--- a/ostd/specs/arch/x86/mod.rs
+++ b/ostd/specs/arch/x86/mod.rs
@@ -1,8 +1,10 @@
 use crate::mm::frame::meta::{META_SLOT_SIZE, mapping::meta_to_frame};
 use crate::mm::kspace::FRAME_METADATA_RANGE;
 use crate::mm::kspace::{LINEAR_MAPPING_BASE_VADDR, VMALLOC_BASE_VADDR, paddr_to_vaddr};
-use crate::mm::{Paddr, Vaddr, page_size};
+use crate::mm::page_table::nr_pte_index_bits;
+use crate::mm::{Paddr, PagingConstsTrait, Vaddr, page_size};
 use crate::specs::mm::frame::mapping::lemma_meta_to_frame_soundness;
+use vstd::arithmetic::power2::{lemma2_to64, pow2};
 use vstd::prelude::*;
 use vstd_extra::prelude::*;
 
@@ -100,6 +102,20 @@ pub broadcast proof fn lemma_meta_frame_vaddr_properties(meta: Vaddr)
     assert(va % PAGE_SIZE == 0) by {
         lemma_mod_0_add(pa as int, LINEAR_MAPPING_BASE_VADDR as int, PAGE_SIZE as int);
     };
+}
+
+// Here are some architecture-specific const value properties.
+// Any use of this lemma in architecture-independent code should be removed.
+pub(crate) proof fn lemma_arch_specific_consts_properties<C: PagingConstsTrait>()
+    ensures
+        C::BASE_PAGE_SIZE().ilog2() == 12u32,
+        nr_pte_index_bits::<C>() == 9usize,
+        pow2(9) == NR_ENTRIES,
+{
+    C::lemma_paging_consts_properties();
+    lemma2_to64();
+    lemma_usize_pow2_ilog2(12);
+    lemma_usize_pow2_ilog2(9);
 }
 
 } // verus!

--- a/ostd/specs/arch/x86/mod.rs
+++ b/ostd/specs/arch/x86/mod.rs
@@ -1,9 +1,10 @@
 use crate::mm::frame::meta::{META_SLOT_SIZE, mapping::meta_to_frame};
 use crate::mm::kspace::FRAME_METADATA_RANGE;
 use crate::mm::kspace::{LINEAR_MAPPING_BASE_VADDR, VMALLOC_BASE_VADDR, paddr_to_vaddr};
-use crate::mm::page_table::nr_pte_index_bits;
 use crate::mm::{Paddr, PagingConstsTrait, Vaddr, page_size};
-use crate::specs::mm::frame::mapping::lemma_meta_to_frame_soundness;
+use crate::specs::mm::{
+    frame::mapping::lemma_meta_to_frame_soundness, page_table::nr_pte_index_bits_spec,
+};
 use vstd::arithmetic::power2::{lemma2_to64, pow2};
 use vstd::prelude::*;
 use vstd_extra::prelude::*;
@@ -109,7 +110,7 @@ pub broadcast proof fn lemma_meta_frame_vaddr_properties(meta: Vaddr)
 pub(crate) proof fn lemma_arch_specific_consts_properties<C: PagingConstsTrait>()
     ensures
         C::BASE_PAGE_SIZE().ilog2() == 12u32,
-        nr_pte_index_bits::<C>() == 9usize,
+        nr_pte_index_bits_spec::<C>() == 9usize,
         pow2(9) == NR_ENTRIES,
 {
     C::lemma_paging_consts_properties();

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -24,7 +24,7 @@ use crate::mm::{
     MAX_USERSPACE_VADDR, Paddr, PagingConstsTrait, PagingLevel, Vaddr, nr_subpage_per_huge,
     page_size,
 };
-use crate::specs::arch::{MAX_PADDR, NR_ENTRIES, NR_LEVELS, PAGE_SIZE, has_safe_slot};
+use crate::specs::arch::*;
 use crate::specs::mm::frame::mapping::frame_to_index;
 use crate::specs::mm::page_table::cursor::page_size_lemmas::{
     lemma_page_size_divides, lemma_page_size_ge_page_size, lemma_page_size_spec_level1,
@@ -2840,7 +2840,7 @@ pub proof fn lemma_view_in_vaddr_range<'rcu, C: PageTableConfig>(owner: &CursorO
 {
     C::lemma_paging_consts_properties();
     C::lemma_page_table_config_constant_properties();
-    crate::mm::page_table::lemma_pte_index_consts::<C>();
+    lemma_arch_specific_consts_properties::<C>();
     lemma_vaddr_range_bounds_spec_unfold::<C>();
     vstd::arithmetic::power2::lemma2_to64();
     vstd::arithmetic::power2::lemma2_to64_rest();

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -3,14 +3,11 @@ use vstd::prelude::*;
 use vstd::seq_lib::*;
 use vstd::set::lemma_set_contains_len;
 
-use vstd_extra::arithmetic::{
-    lemma_nat_align_down_monotone, lemma_nat_align_down_sound, lemma_nat_align_down_within_block,
-    lemma_nat_align_up_sound,
-};
 use vstd_extra::drop_tracking::*;
 use vstd_extra::ghost_tree::*;
 use vstd_extra::ownership::*;
 use vstd_extra::panic::may_panic;
+use vstd_extra::prelude::*;
 use vstd_extra::seq_extra::{forall_seq, lemma_forall_seq_index};
 
 use core::marker::PhantomData;
@@ -26,12 +23,15 @@ use crate::mm::{
 };
 use crate::specs::arch::*;
 use crate::specs::mm::frame::mapping::frame_to_index;
-use crate::specs::mm::page_table::cursor::page_size_lemmas::{
-    lemma_page_size_divides, lemma_page_size_ge_page_size, lemma_page_size_spec_level1,
-};
 use crate::specs::mm::page_table::owners::*;
+use crate::specs::mm::page_table::{
+    cursor::page_size_lemmas::{
+        lemma_page_size_divides, lemma_page_size_ge_page_size, lemma_page_size_spec_level1,
+    },
+    owners::*,
+    pte_index_bit_offset_spec,
+};
 
-use crate::specs::mm::page_table::{nat_align_down, nat_align_up};
 use crate::specs::mm::{
     frame::{mapping::meta_addr, meta_region_owners::MetaRegionOwners},
     page_table::{AbstractVaddr, Guards, Mapping},

--- a/ostd/specs/mm/page_table/mod.rs
+++ b/ostd/specs/mm/page_table/mod.rs
@@ -18,13 +18,30 @@ use vstd_extra::arithmetic::*;
 use vstd_extra::ghost_tree::TreePath;
 use vstd_extra::ownership::*;
 
-use crate::mm::page_table::PageTableConfig;
-use crate::mm::{PagingLevel, Vaddr, page_size};
+use crate::mm::{
+    PagingConstsTrait, PagingLevel, Vaddr, nr_subpage_per_huge, page_size,
+    page_table::PageTableConfig,
+};
 use crate::specs::arch::*;
 
 use align_ext::AlignExt;
 
 verus! {
+
+#[verifier::inline]
+pub open spec fn nr_pte_index_bits_spec<C: PagingConstsTrait>() -> usize {
+    nr_subpage_per_huge::<C>().ilog2() as usize
+}
+
+#[verifier::inline]
+pub open spec fn pte_index_bit_offset_spec<C: PagingConstsTrait>(level: PagingLevel) -> usize {
+    (C::BASE_PAGE_SIZE().ilog2() + nr_pte_index_bits_spec::<C>() * (level - 1)) as usize
+}
+
+#[verifier::inline]
+pub open spec fn top_level_index_width_spec<C: PageTableConfig>() -> usize {
+    (C::ADDRESS_WIDTH_spec() - pte_index_bit_offset_spec::<C>(C::NR_LEVELS())) as usize
+}
 
 /// An abstract representation of a virtual address as a sequence of indices, representing the
 /// values of the bit-fields that index into each level of the page table.

--- a/ostd/specs/mm/page_table/mod.rs
+++ b/ostd/specs/mm/page_table/mod.rs
@@ -1857,6 +1857,7 @@ impl AbstractVaddr {
             vaddr(path) == self.align_down(NR_LEVELS - path.len() + 1).compute_vaddr()
                 - self.align_down(NR_LEVELS - path.len() + 1).offset,
     {
+        lemma_arch_specific_consts_properties::<crate::mm::PagingConsts>();
         if path.len() == 0 {
             let aligned = self.align_down(5);
             self.align_down_shape(4);

--- a/ostd/specs/mm/page_table/vaddr_range_proofs.rs
+++ b/ostd/specs/mm/page_table/vaddr_range_proofs.rs
@@ -8,8 +8,9 @@
 use vstd::arithmetic::power2::{lemma_pow2_adds, lemma_pow2_pos, pow2};
 use vstd::prelude::*;
 
-use crate::mm::page_table::{PageTableConfig, pte_index_bit_offset_spec};
+use crate::mm::page_table::PageTableConfig;
 use crate::mm::{PagingConstsTrait, Vaddr};
+use crate::specs::mm::page_table::pte_index_bit_offset_spec;
 
 verus! {
 
@@ -88,43 +89,17 @@ pub proof fn lemma_pt_va_range_end_wrapping_sub<C: PageTableConfig>(
     ret: usize,
 )
     requires
-        idx_end == C::TOP_LEVEL_INDEX_RANGE_spec().end,
+        idx_end == C::TOP_LEVEL_INDEX_RANGE().end,
         offset == pte_index_bit_offset_spec::<C>(C::NR_LEVELS()),
         shifted == idx_end * pow2(offset as nat),
         ret == vstd::wrapping::usize_specs::wrapping_sub(shifted, 1usize),
     ensures
-        ret == (C::TOP_LEVEL_INDEX_RANGE_spec().end * pow2(
+        ret == (C::TOP_LEVEL_INDEX_RANGE().end * pow2(
             pte_index_bit_offset_spec::<C>(C::NR_LEVELS()) as nat,
         ) - 1) % 0x1_0000_0000_0000_0000int,
 {
     lemma_pt_va_range_end_shift_facts::<C>(idx_end, offset);
     vstd::layout::unsigned_int_max_values();
-}
-
-/// Facts needed to connect `(va >> (ADDRESS_WIDTH - 1)) & 1` with the
-/// arithmetic bit-test specification.
-pub proof fn lemma_sign_bit_facts<C: PageTableConfig>(
-    va: Vaddr,
-    address_width: usize,
-    shift: usize,
-    shifted: usize,
-    bit: usize,
-)
-    requires
-        address_width == C::ADDRESS_WIDTH(),
-        shift == address_width - 1,
-        shifted == va >> shift,
-        bit == shifted & 1usize,
-    ensures
-        (bit != 0) == ((va as int / pow2((C::ADDRESS_WIDTH() - 1) as nat) as int) % 2 == 1),
-{
-    C::lemma_paging_consts_properties();
-    C::lemma_page_table_config_constant_properties();
-
-    vstd::bits::lemma_usize_shr_is_div(va, shift);
-    vstd::bits::lemma_usize_low_bits_mask_is_mod(shifted, 1);
-    vstd::bits::lemma_low_bits_mask_values();
-    vstd::arithmetic::power2::lemma2_to64();
 }
 
 /// Two-in-one: `start = idx.start * 2^off < 2^ADDRESS_WIDTH` and

--- a/ostd/src/mm/kspace/mod.rs
+++ b/ostd/src/mm/kspace/mod.rs
@@ -55,10 +55,13 @@ use super::{
 use crate::mm::frame::DynFrame;
 use crate::mm::page_table::RCClone;
 use crate::specs::arch::*;
-use crate::specs::mm::frame::meta_region_owners::MetaRegionOwners;
-use crate::specs::mm::frame::{
-    mapping::group_page_meta,
-    meta_owners::{MetaPerm, MetaSlotStorage},
+use crate::specs::mm::{
+    frame::{
+        mapping::group_page_meta,
+        meta_owners::{MetaPerm, MetaSlotStorage},
+        meta_region_owners::MetaRegionOwners,
+    },
+    page_table::{nr_pte_index_bits_spec, pte_index_bit_offset_spec},
 };
 use crate::{
     arch::mm::{PageTableEntry, PagingConsts},
@@ -68,6 +71,7 @@ use crate::{
 };
 
 use vstd_extra::ownership::*;
+use vstd_extra::prelude::*;
 
 verus! {
 
@@ -172,21 +176,18 @@ unsafe impl PageTableConfig for KernelPtConfig {
 
     proof fn lemma_page_table_config_constant_requirements() {
         use crate::mm::nr_subpage_per_huge;
-        use crate::mm::page_table::{nr_pte_index_bits, pte_index_bit_offset_spec};
         use vstd::arithmetic::power2::{lemma2_to64, lemma2_to64_rest, lemma_pow2_adds, pow2};
-        use vstd_extra::prelude::lemma_usize_pow2_ilog2;
         Self::C::lemma_paging_consts_properties();
         PageTableEntry::lemma_layout();
         lemma2_to64();
         lemma2_to64_rest();
-        assert(usize::BITS == 64) by (compute);
         vstd::layout::unsigned_int_max_values();
         lemma_usize_pow2_ilog2(12);
         lemma_usize_pow2_ilog2(9);
         lemma_pow2_adds(9, 39);
         lemma_pow2_adds(8, 39);
         assert(nr_subpage_per_huge::<PagingConsts>() == 512_usize);
-        assert(nr_pte_index_bits::<PagingConsts>() == 9_usize);
+        assert(nr_pte_index_bits_spec::<PagingConsts>() == 9_usize);
         assert(PagingConsts::BASE_PAGE_SIZE().ilog2() == 12u32);
         assert(pte_index_bit_offset_spec::<PagingConsts>(4) == 39);
         assert(256 * pow2(39) == pow2(47));

--- a/ostd/src/mm/mod.rs
+++ b/ostd/src/mm/mod.rs
@@ -138,23 +138,21 @@ pub trait PagingConstsTrait: Clone + Debug + Send + Sync + 'static {
     /// `CursorMut::take_next`'s `replace_cur_entry` discharge).
     proof fn lemma_paging_consts_requirements()
         ensures
-            0 < Self::BASE_PAGE_SIZE() / Self::PTE_SIZE() <= Self::BASE_PAGE_SIZE(),
-            // Copied from the postcondition of `lemma_paging_consts_requirements`
-            // so that we only need to call this lemma in proofs.
             0 < Self::BASE_PAGE_SIZE(),
             is_pow2(Self::BASE_PAGE_SIZE() as int),
             Self::NR_LEVELS() > 0,
             is_pow2(Self::PTE_SIZE() as int),
             0 < Self::PTE_SIZE() <= Self::BASE_PAGE_SIZE(),
             0 < Self::ADDRESS_WIDTH() < usize::BITS,
-            Self::BASE_PAGE_SIZE().ilog2() + (Self::BASE_PAGE_SIZE() / Self::PTE_SIZE()).ilog2() * (
-            Self::NR_LEVELS() - 1) <= Self::ADDRESS_WIDTH(),
+            Self::BASE_PAGE_SIZE().ilog2() + (Self::BASE_PAGE_SIZE() / Self::PTE_SIZE()).ilog2()
+                * Self::NR_LEVELS() <= Self::ADDRESS_WIDTH(),
+            Self::PTE_SIZE() == core::mem::size_of::<usize>(),
             // The following statement holds for all architectures,
             // but the actual value of the constants may vary.
+            // Maybe we can remove this requirement.
             Self::BASE_PAGE_SIZE() == PAGE_SIZE,
             Self::NR_LEVELS() == NR_LEVELS,
             Self::BASE_PAGE_SIZE() / Self::PTE_SIZE() == NR_ENTRIES,
-            Self::PTE_SIZE() == core::mem::size_of::<usize>(),
     ;
 
     /// The derived properties of the paging constants.
@@ -164,6 +162,8 @@ pub trait PagingConstsTrait: Clone + Debug + Send + Sync + 'static {
         ensures
     // Derived properties.
 
+            Self::BASE_PAGE_SIZE().ilog2() + (Self::BASE_PAGE_SIZE() / Self::PTE_SIZE()).ilog2() * (
+            Self::NR_LEVELS() - 1) <= Self::ADDRESS_WIDTH(),
             0 < Self::BASE_PAGE_SIZE() / Self::PTE_SIZE() <= Self::BASE_PAGE_SIZE(),
             NR_ENTRIES * Self::PTE_SIZE() == PAGE_SIZE,
             // Copied from the postcondition of `lemma_paging_consts_requirements`
@@ -174,14 +174,15 @@ pub trait PagingConstsTrait: Clone + Debug + Send + Sync + 'static {
             is_pow2(Self::PTE_SIZE() as int),
             0 < Self::PTE_SIZE() <= Self::BASE_PAGE_SIZE(),
             0 < Self::ADDRESS_WIDTH() < usize::BITS,
-            Self::BASE_PAGE_SIZE().ilog2() + (Self::BASE_PAGE_SIZE() / Self::PTE_SIZE()).ilog2() * (
-            Self::NR_LEVELS() - 1) <= Self::ADDRESS_WIDTH(),
+            Self::BASE_PAGE_SIZE().ilog2() + (Self::BASE_PAGE_SIZE() / Self::PTE_SIZE()).ilog2()
+                * Self::NR_LEVELS() <= Self::ADDRESS_WIDTH(),
+            Self::PTE_SIZE() == core::mem::size_of::<usize>(),
             // The following statement holds for all architectures,
             // but the actual value of the constants may vary.
+            // Maybe we can remove this requirement.
             Self::BASE_PAGE_SIZE() == PAGE_SIZE,
             Self::NR_LEVELS() == NR_LEVELS,
             Self::BASE_PAGE_SIZE() / Self::PTE_SIZE() == NR_ENTRIES,
-            Self::PTE_SIZE() == core::mem::size_of::<usize>(),
     {
         Self::lemma_paging_consts_requirements();
         broadcast use group_div_basics;

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -499,46 +499,6 @@ impl<C: PageTableConfig> PagingConstsTrait for C {
     }
 }
 
-/// A handle to a page table.
-/// A page table can track the lifetime of the mapped physical pages.
-pub struct PageTable<C: PageTableConfig> {
-    pub root: PageTableNode<C>,
-}
-
-#[verifier::inline]
-pub open spec fn nr_pte_index_bits_spec<C: PagingConstsTrait>() -> usize {
-    nr_subpage_per_huge::<C>().ilog2() as usize
-}
-
-/// The number of virtual address bits used to index a PTE in a page.
-#[inline(always)]
-#[verifier::when_used_as_spec(nr_pte_index_bits_spec)]
-pub fn nr_pte_index_bits<C: PagingConstsTrait>() -> usize
-    returns
-        nr_pte_index_bits_spec::<C>(),
-{
-    proof {
-        C::lemma_paging_consts_properties();
-    }
-    nr_subpage_per_huge::<C>().ilog2() as usize
-}
-
-pub proof fn lemma_nr_pte_index_bits_bounded<C: PagingConstsTrait>()
-    ensures
-        0 <= nr_pte_index_bits::<C>() <= C::BASE_PAGE_SIZE().ilog2(),
-{
-    C::lemma_paging_consts_properties();
-    let nr = nr_subpage_per_huge::<C>();
-    assert(1 <= nr <= C::BASE_PAGE_SIZE());
-    let bits = nr.ilog2();
-    assert(0 <= bits) by {
-        lemma_usize_ilog2_ordered(1, nr);
-    }
-    assert(bits <= C::BASE_PAGE_SIZE().ilog2()) by {
-        lemma_usize_ilog2_ordered(nr, C::BASE_PAGE_SIZE());
-    }
-}
-
 /// Splits the address range into largest page table items.
 ///
 /// Each of the returned items is a tuple of the physical address and the
@@ -594,6 +554,121 @@ pub fn largest_pages<C: PageTableConfig>(
                 Some((item_start, level))
             },
     )
+}
+
+/// Spec for the managed virtual address range (exclusive end).
+/// For configs without VA_SIGN_EXT (e.g. UserPtConfig) or when the base range has sign bit 0.
+/// Configs with sign extension (e.g. KernelPtConfig) use
+/// `vaddr_range_bounds_spec` for their canonical high-half bounds.
+#[verifier::inline]
+pub open spec fn vaddr_range_spec<C: PageTableConfig>() -> Range<Vaddr> {
+    let idx_range = C::TOP_LEVEL_INDEX_RANGE();
+    let offset = pte_index_bit_offset::<C>(C::NR_LEVELS()) as nat;
+    let start = idx_range.start * pow2(offset);
+    let end_inclusive = idx_range.end * pow2(offset) - 1;
+    (start as Vaddr)..((end_inclusive + 1) as Vaddr)
+}
+
+/// Spec for whether a range is within the page table's managed address space.
+#[verifier::inline]
+pub open spec fn is_valid_range_spec<C: PageTableConfig>(r: &Range<Vaddr>) -> bool {
+    let va_range = vaddr_range_bounds_spec::<C>();
+    (r.start == 0 && r.end == 0) || (va_range.0 <= r.start && r.end > 0 && r.end - 1 <= va_range.1)
+}
+
+/// Gets the inclusive bounds of the managed virtual-address range.
+fn vaddr_range_bounds<C: PageTableConfig>() -> (ret: (Vaddr, Vaddr))
+    ensures
+        ret.0 == vaddr_range_bounds_spec::<C>().0,
+        ret.1 == vaddr_range_bounds_spec::<C>().1,
+{
+    let mut start = pt_va_range_start::<C>();
+    let mut end = pt_va_range_end::<C>();
+
+    proof {
+        lemma_vaddr_range_bounds_spec_unfold::<C>();
+        C::lemma_paging_consts_properties();
+        C::lemma_page_table_config_constant_properties();
+        crate::specs::mm::page_table::vaddr_range_proofs::lemma_idx_times_pow2_bound::<C>(
+            start,
+            end,
+        );
+    }
+    let pt_start = pt_va_range_start::<C>();
+    let va_sign_ext = C::VA_SIGN_EXT();
+    let sign_bit_set = sign_bit_of_va::<C>(pt_start);
+    if va_sign_ext && sign_bit_set {
+        proof {
+            let off = pte_index_bit_offset::<C>(C::NR_LEVELS()) as nat;
+            let aw_m1 = (C::ADDRESS_WIDTH() - 1) as nat;
+            let i_start = C::TOP_LEVEL_INDEX_RANGE_spec().start as int;
+            let p_off = pow2(off) as int;
+            let p_aw_m1 = pow2(aw_m1) as int;
+        }
+        start = apply_sign_ext::<C>(start);
+        end = apply_sign_ext::<C>(end);
+    } else {
+        proof {
+            // The if-condition was false, so either va_sign_ext is false
+            // or sign_bit_set is false. The contrapositive of the
+            // leading-bits requirement gives LEADING_BITS == 0.
+            assert(!va_sign_ext || !sign_bit_set);
+            // Bridge exec bool to spec form. `va_sign_ext == C::VA_SIGN_EXT()`
+            // by `when_used_as_spec`; `sign_bit_set == ((pt_start as int /
+            // 2^(aw-1)) % 2 == 1)` by `sign_bit_of_va`'s ensures.
+            assert(va_sign_ext == C::VA_SIGN_EXT());
+            let off = pte_index_bit_offset::<C>(C::NR_LEVELS()) as nat;
+            let aw_m1 = (C::ADDRESS_WIDTH() - 1) as nat;
+            let i_start = C::TOP_LEVEL_INDEX_RANGE_spec().start as int;
+            let p_off = pow2(off) as int;
+            let p_aw_m1 = pow2(aw_m1) as int;
+            assert(pt_start == i_start * p_off);
+            assert(sign_bit_set == ((pt_start as int / p_aw_m1) % 2 == 1));
+            assert(sign_bit_set == ((i_start * p_off / p_aw_m1) % 2 == 1));
+        }
+    }
+    proof {
+        // Both branches now establish the equation
+        //   start == lb * 2^48 + idx.start * 2^off
+        //   end == lb * 2^48 + idx.end * 2^off - 1
+        // matching the unfolded `vaddr_range_bounds_spec`.
+        assert(start == (C::LEADING_BITS_spec()) * 0x1_0000_0000_0000int + (
+        C::TOP_LEVEL_INDEX_RANGE_spec().start) * (pow2(
+            pte_index_bit_offset::<C>(C::NR_LEVELS()) as nat,
+        )));
+        assert(end == (C::LEADING_BITS_spec()) * 0x1_0000_0000_0000int + (
+        C::TOP_LEVEL_INDEX_RANGE_spec().end) * (pow2(
+            pte_index_bit_offset::<C>(C::NR_LEVELS()) as nat,
+        )) - 1);
+    }
+    (start, end)
+}
+
+/// Gets the managed virtual addresses range for the page table.
+///
+/// Returns a [`RangeInclusive`] because the end address, when the range
+/// reaches the top of the 64-bit address space (e.g. the canonical
+/// high-half kernel range ending at `usize::MAX`), would overflow the
+/// exclusive end of a [`Range<Vaddr>`].
+fn vaddr_range<C: PageTableConfig>() -> (ret: RangeInclusive<Vaddr>)
+    ensures
+        ret@.start == vaddr_range_bounds_spec::<C>().0,
+        ret@.end == vaddr_range_bounds_spec::<C>().1,
+        ret@.exhausted == false,
+{
+    let (start, end) = vaddr_range_bounds::<C>();
+    RangeInclusive::new(start, end)
+}
+
+/// A handle to a page table.
+/// A page table can track the lifetime of the mapped physical pages.
+pub struct PageTable<C: PageTableConfig> {
+    pub root: PageTableNode<C>,
+}
+
+#[verifier::inline]
+pub open spec fn nr_pte_index_bits_spec<C: PagingConstsTrait>() -> usize {
+    nr_subpage_per_huge::<C>().ilog2() as usize
 }
 
 /// Gets the top-level index width, in bits, for the page table.
@@ -702,108 +777,33 @@ fn sign_bit_of_va<C: PageTableConfig>(va: Vaddr) -> (ret: bool)
     bit != 0
 }
 
-/// Spec for the managed virtual address range (exclusive end).
-/// For configs without VA_SIGN_EXT (e.g. UserPtConfig) or when the base range has sign bit 0.
-/// Configs with sign extension (e.g. KernelPtConfig) use
-/// `vaddr_range_bounds_spec` for their canonical high-half bounds.
-#[verifier::inline]
-pub open spec fn vaddr_range_spec<C: PageTableConfig>() -> Range<Vaddr> {
-    let idx_range = C::TOP_LEVEL_INDEX_RANGE_spec();
-    let offset = pte_index_bit_offset::<C::C>(C::NR_LEVELS()) as nat;
-    let start = idx_range.start * pow2(offset);
-    let end_inclusive = idx_range.end * pow2(offset) - 1;
-    (start as Vaddr)..((end_inclusive + 1) as Vaddr)
-}
-
-/// Spec for whether a range is within the page table's managed address space.
-#[verifier::inline]
-pub open spec fn is_valid_range_spec<C: PageTableConfig>(r: &Range<Vaddr>) -> bool {
-    let va_range = vaddr_range_bounds_spec::<C>();
-    (r.start == 0 && r.end == 0) || (va_range.0 <= r.start && r.end > 0 && r.end - 1 <= va_range.1)
-}
-
-/// Gets the inclusive bounds of the managed virtual-address range.
-fn vaddr_range_bounds<C: PageTableConfig>() -> (ret: (Vaddr, Vaddr))
-    ensures
-        ret.0 == vaddr_range_bounds_spec::<C>().0,
-        ret.1 == vaddr_range_bounds_spec::<C>().1,
+/// The number of virtual address bits used to index a PTE in a page.
+#[inline(always)]
+#[verifier::when_used_as_spec(nr_pte_index_bits_spec)]
+pub fn nr_pte_index_bits<C: PagingConstsTrait>() -> usize
+    returns
+        nr_pte_index_bits_spec::<C>(),
 {
-    let mut start = pt_va_range_start::<C>();
-    let mut end = pt_va_range_end::<C>();
-
     proof {
-        lemma_vaddr_range_bounds_spec_unfold::<C>();
         C::lemma_paging_consts_properties();
-        C::lemma_page_table_config_constant_properties();
-        crate::specs::mm::page_table::vaddr_range_proofs::lemma_idx_times_pow2_bound::<C>(
-            start,
-            end,
-        );
     }
-    let pt_start = pt_va_range_start::<C>();
-    let va_sign_ext = C::VA_SIGN_EXT();
-    let sign_bit_set = sign_bit_of_va::<C>(pt_start);
-    if va_sign_ext && sign_bit_set {
-        proof {
-            let off = pte_index_bit_offset::<C>(C::NR_LEVELS()) as nat;
-            let aw_m1 = (C::ADDRESS_WIDTH() - 1) as nat;
-            let i_start = C::TOP_LEVEL_INDEX_RANGE_spec().start as int;
-            let p_off = pow2(off) as int;
-            let p_aw_m1 = pow2(aw_m1) as int;
-        }
-        start = apply_sign_ext::<C>(start);
-        end = apply_sign_ext::<C>(end);
-    } else {
-        proof {
-            // The if-condition was false, so either va_sign_ext is false
-            // or sign_bit_set is false. The contrapositive of the
-            // leading-bits requirement gives LEADING_BITS == 0.
-            assert(!va_sign_ext || !sign_bit_set);
-            // Bridge exec bool to spec form. `va_sign_ext == C::VA_SIGN_EXT()`
-            // by `when_used_as_spec`; `sign_bit_set == ((pt_start as int /
-            // 2^(aw-1)) % 2 == 1)` by `sign_bit_of_va`'s ensures.
-            assert(va_sign_ext == C::VA_SIGN_EXT());
-            let off = pte_index_bit_offset::<C>(C::NR_LEVELS()) as nat;
-            let aw_m1 = (C::ADDRESS_WIDTH() - 1) as nat;
-            let i_start = C::TOP_LEVEL_INDEX_RANGE_spec().start as int;
-            let p_off = pow2(off) as int;
-            let p_aw_m1 = pow2(aw_m1) as int;
-            assert(pt_start == i_start * p_off);
-            assert(sign_bit_set == ((pt_start as int / p_aw_m1) % 2 == 1));
-            assert(sign_bit_set == ((i_start * p_off / p_aw_m1) % 2 == 1));
-        }
-    }
-    proof {
-        // Both branches now establish the equation
-        //   start == lb * 2^48 + idx.start * 2^off
-        //   end == lb * 2^48 + idx.end * 2^off - 1
-        // matching the unfolded `vaddr_range_bounds_spec`.
-        assert(start == (C::LEADING_BITS_spec()) * 0x1_0000_0000_0000int + (
-        C::TOP_LEVEL_INDEX_RANGE_spec().start) * (pow2(
-            pte_index_bit_offset::<C>(C::NR_LEVELS()) as nat,
-        )));
-        assert(end == (C::LEADING_BITS_spec()) * 0x1_0000_0000_0000int + (
-        C::TOP_LEVEL_INDEX_RANGE_spec().end) * (pow2(
-            pte_index_bit_offset::<C>(C::NR_LEVELS()) as nat,
-        )) - 1);
-    }
-    (start, end)
+    nr_subpage_per_huge::<C>().ilog2() as usize
 }
 
-/// Gets the managed virtual addresses range for the page table.
-///
-/// Returns a [`RangeInclusive`] because the end address, when the range
-/// reaches the top of the 64-bit address space (e.g. the canonical
-/// high-half kernel range ending at `usize::MAX`), would overflow the
-/// exclusive end of a [`Range<Vaddr>`].
-fn vaddr_range<C: PageTableConfig>() -> (ret: RangeInclusive<Vaddr>)
+pub proof fn lemma_nr_pte_index_bits_bounded<C: PagingConstsTrait>()
     ensures
-        ret@.start == vaddr_range_bounds_spec::<C>().0,
-        ret@.end == vaddr_range_bounds_spec::<C>().1,
-        ret@.exhausted == false,
+        0 <= nr_pte_index_bits::<C>() <= C::BASE_PAGE_SIZE().ilog2(),
 {
-    let (start, end) = vaddr_range_bounds::<C>();
-    RangeInclusive::new(start, end)
+    C::lemma_paging_consts_properties();
+    let nr = nr_subpage_per_huge::<C>();
+    assert(1 <= nr <= C::BASE_PAGE_SIZE());
+    let bits = nr.ilog2();
+    assert(0 <= bits) by {
+        lemma_usize_ilog2_ordered(1, nr);
+    }
+    assert(bits <= C::BASE_PAGE_SIZE().ilog2()) by {
+        lemma_usize_ilog2_ordered(nr, C::BASE_PAGE_SIZE());
+    }
 }
 
 /// Apply the sign-extension OR to a positional value.
@@ -908,7 +908,7 @@ pub(crate) proof fn lemma_vaddr_range_spec_kernel()
 /// `(0xffff_8000_0000_0000, 0xffff_ffff_ffff_ffff)`.
 pub closed spec fn vaddr_range_bounds_spec<C: PageTableConfig>() -> (Vaddr, Vaddr) {
     let idx = C::TOP_LEVEL_INDEX_RANGE_spec();
-    let off = pte_index_bit_offset::<C::C>(C::NR_LEVELS()) as nat;
+    let off = pte_index_bit_offset::<C>(C::NR_LEVELS()) as nat;
     let lb = C::LEADING_BITS_spec() as int;
     let base = lb * 0x1_0000_0000_0000int;
     let start = (base + (idx.start) * pow2(off)) as usize;
@@ -984,23 +984,6 @@ pub(crate) proof fn lemma_vaddr_range_bounds_spec_kernel()
     assert(0xffff_int * 0x1_0000_0000_0000int + pow2(48) - 1 == 0xffff_ffff_ffff_ffffint);
 }
 
-// Here are some const values that are determined by the paging constants.
-pub(crate) proof fn lemma_pte_index_consts<C: PagingConstsTrait>()
-    ensures
-        usize::BITS == 64,
-        0 < C::BASE_PAGE_SIZE(),
-        C::BASE_PAGE_SIZE().ilog2() == 12u32,
-        C::NR_LEVELS() == NR_LEVELS,
-        nr_subpage_per_huge::<C>() == NR_ENTRIES,
-        nr_pte_index_bits::<C>() == 9usize,
-        pow2(9) as usize == NR_ENTRIES,
-{
-    C::lemma_paging_consts_properties();
-    lemma2_to64();
-    lemma_usize_pow2_ilog2(12);
-    lemma_usize_pow2_ilog2(9);
-}
-
 /// The index of a VA's PTE in a page table node at the given level.
 fn pte_index<C: PagingConstsTrait>(va: Vaddr, level: PagingLevel) -> (res: usize)
     requires
@@ -1010,7 +993,8 @@ fn pte_index<C: PagingConstsTrait>(va: Vaddr, level: PagingLevel) -> (res: usize
 {
     let offset = pte_index_bit_offset::<C>(level);
     proof {
-        lemma_pte_index_consts::<C>();
+        C::lemma_paging_consts_properties();
+        lemma_arch_specific_consts_properties::<C>();
         assert(offset == 12 + 9 * (level - 1));
         assert(0 <= offset < usize::BITS) by (nonlinear_arith)
             requires
@@ -1023,10 +1007,6 @@ fn pte_index<C: PagingConstsTrait>(va: Vaddr, level: PagingLevel) -> (res: usize
 
     let shifted = va >> offset;
     let nr_subpages = nr_subpage_per_huge::<C>();
-    proof {
-        assert(nr_subpages == NR_ENTRIES);
-        assert(nr_subpages > 0);
-    }
     let mask = nr_subpages - 1;
     proof {
         lemma2_to64();
@@ -1057,7 +1037,8 @@ pub fn pte_index_bit_offset<C: PagingConstsTrait>(level: PagingLevel) -> usize
         pte_index_bit_offset_spec::<C>(level),
 {
     proof {
-        lemma_pte_index_consts::<C>();
+        C::lemma_paging_consts_properties();
+        lemma_arch_specific_consts_properties::<C>();
         assert(12 + 9 * (level - 1) <= 39) by (nonlinear_arith)
             requires
                 1 <= level <= NR_LEVELS,

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -130,7 +130,7 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
     /// configurations that place their managed range at a non-canonical
     /// fixed offset.
     ///
-    /// Combined with `TOP_LEVEL_INDEX_RANGE_spec`, this fully determines
+    /// Combined with `TOP_LEVEL_INDEX_RANGE`, this fully determines
     /// the managed VA range, computed as
     /// [`vaddr_range_bounds_spec::<Self>`]. Callers that previously used
     /// `VADDR_RANGE_spec()` should use `vaddr_range_bounds_spec::<C>()`
@@ -386,7 +386,6 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
             (Self::C::VA_SIGN_EXT() && (((Self::TOP_LEVEL_INDEX_RANGE().start * pow2(
                 pte_index_bit_offset::<Self::C>(Self::C::NR_LEVELS()) as nat,
             )) / (pow2((Self::C::ADDRESS_WIDTH() - 1) as nat) as int)) % 2 == 1)) ==> {
-                &&& 48 <= Self::C::ADDRESS_WIDTH()
                 &&& Self::LEADING_BITS_spec() * 0x1_0000_0000_0000int == 0x1_0000_0000_0000_0000int
                     - pow2(Self::C::ADDRESS_WIDTH() as nat)
             },
@@ -426,7 +425,6 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
             (Self::C::VA_SIGN_EXT() && (((Self::TOP_LEVEL_INDEX_RANGE().start * pow2(
                 pte_index_bit_offset::<Self::C>(Self::C::NR_LEVELS()) as nat,
             )) / (pow2((Self::C::ADDRESS_WIDTH() - 1) as nat) as int)) % 2 == 1)) ==> {
-                &&& 48 <= Self::C::ADDRESS_WIDTH()
                 &&& Self::LEADING_BITS_spec() * 0x1_0000_0000_0000int == 0x1_0000_0000_0000_0000int
                     - pow2(Self::C::ADDRESS_WIDTH() as nat)
             },
@@ -556,6 +554,25 @@ pub fn largest_pages<C: PageTableConfig>(
     )
 }
 
+#[verifier::inline]
+pub open spec fn top_level_index_width_spec<C: PageTableConfig>() -> usize {
+    (C::ADDRESS_WIDTH_spec() - pte_index_bit_offset::<C>(C::NR_LEVELS())) as usize
+}
+
+/// Gets the top-level index width, in bits, for the page table.
+#[verifier::when_used_as_spec(top_level_index_width_spec)]
+fn top_level_index_width<C: PageTableConfig>() -> (ret: usize)
+    returns
+        top_level_index_width_spec::<C>(),
+{
+    proof {
+        C::lemma_paging_consts_properties();
+        C::lemma_page_table_config_constant_properties();
+    }
+
+    C::ADDRESS_WIDTH() - pte_index_bit_offset::<C>(C::NR_LEVELS())
+}
+
 /// Spec for the managed virtual address range (exclusive end).
 /// For configs without VA_SIGN_EXT (e.g. UserPtConfig) or when the base range has sign bit 0.
 /// Configs with sign extension (e.g. KernelPtConfig) use
@@ -669,19 +686,6 @@ pub struct PageTable<C: PageTableConfig> {
 #[verifier::inline]
 pub open spec fn nr_pte_index_bits_spec<C: PagingConstsTrait>() -> usize {
     nr_subpage_per_huge::<C>().ilog2() as usize
-}
-
-/// Gets the top-level index width, in bits, for the page table.
-fn top_level_index_width<C: PageTableConfig>() -> (ret: usize)
-    ensures
-        ret == C::ADDRESS_WIDTH() - pte_index_bit_offset::<C>(C::NR_LEVELS()),
-{
-    proof {
-        C::lemma_paging_consts_properties();
-        C::lemma_page_table_config_constant_properties();
-    }
-
-    C::ADDRESS_WIDTH() - pte_index_bit_offset::<C>(C::NR_LEVELS())
 }
 
 /// Concrete positional start of the VA range: `idx_range.start * 2^offset`.

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -13,8 +13,9 @@ use crate::specs::task::InAtomicMode;
 
 use crate::mm::frame::meta::{REF_COUNT_MAX, REF_COUNT_UNIQUE, REF_COUNT_UNUSED};
 use crate::mm::kspace::kvirt_area::disable_preempt;
-use crate::specs::mm::frame::{
-    mapping::frame_to_index, meta_owners::MetaPerm, meta_region_owners::MetaRegionOwners,
+use crate::specs::mm::{
+    frame::{mapping::frame_to_index, meta_owners::MetaPerm, meta_region_owners::MetaRegionOwners},
+    page_table::{nr_pte_index_bits_spec, pte_index_bit_offset_spec, top_level_index_width_spec},
 };
 
 use core::{
@@ -372,19 +373,19 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
             core::mem::size_of::<Self::E>() == Self::C::PTE_SIZE(),
             Self::TOP_LEVEL_INDEX_RANGE().start < Self::TOP_LEVEL_INDEX_RANGE().end,
             Self::TOP_LEVEL_INDEX_RANGE().end <= pow2(
-                (Self::C::ADDRESS_WIDTH() - pte_index_bit_offset::<Self::C>(
+                (Self::C::ADDRESS_WIDTH() - pte_index_bit_offset_spec::<Self::C>(
                     Self::C::NR_LEVELS(),
                 )) as nat,
             ),
             Self::TOP_LEVEL_INDEX_RANGE().end * pow2(
-                pte_index_bit_offset::<Self::C>(Self::C::NR_LEVELS()) as nat,
+                pte_index_bit_offset_spec::<Self::C>(Self::C::NR_LEVELS()) as nat,
             ) <= usize::MAX,
             Self::LEADING_BITS_spec() != 0usize ==> (Self::C::VA_SIGN_EXT() && ((
             Self::TOP_LEVEL_INDEX_RANGE().start * pow2(
-                pte_index_bit_offset::<Self::C>(Self::C::NR_LEVELS()) as nat,
+                pte_index_bit_offset_spec::<Self::C>(Self::C::NR_LEVELS()) as nat,
             )) / (pow2((Self::C::ADDRESS_WIDTH() - 1) as nat) as int)) % 2 == 1),
             (Self::C::VA_SIGN_EXT() && (((Self::TOP_LEVEL_INDEX_RANGE().start * pow2(
-                pte_index_bit_offset::<Self::C>(Self::C::NR_LEVELS()) as nat,
+                pte_index_bit_offset_spec::<Self::C>(Self::C::NR_LEVELS()) as nat,
             )) / (pow2((Self::C::ADDRESS_WIDTH() - 1) as nat) as int)) % 2 == 1)) ==> {
                 &&& Self::LEADING_BITS_spec() * 0x1_0000_0000_0000int == 0x1_0000_0000_0000_0000int
                     - pow2(Self::C::ADDRESS_WIDTH() as nat)
@@ -392,7 +393,7 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
             Self::LEADING_BITS_spec() < 0x1_0000_usize,
             // FIXME: This property does not hold in general, `ADDRESS_WIDTH` can be wider.
             pow2(
-                (Self::C::ADDRESS_WIDTH() - pte_index_bit_offset::<Self::C>(
+                (Self::C::ADDRESS_WIDTH() - pte_index_bit_offset_spec::<Self::C>(
                     Self::C::NR_LEVELS(),
                 )) as nat,
             ) == NR_ENTRIES,
@@ -411,19 +412,19 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
             core::mem::size_of::<Self::E>() == Self::C::PTE_SIZE(),
             Self::TOP_LEVEL_INDEX_RANGE().start < Self::TOP_LEVEL_INDEX_RANGE().end,
             Self::TOP_LEVEL_INDEX_RANGE().end <= pow2(
-                (Self::C::ADDRESS_WIDTH() - pte_index_bit_offset::<Self::C>(
+                (Self::C::ADDRESS_WIDTH() - pte_index_bit_offset_spec::<Self::C>(
                     Self::C::NR_LEVELS(),
                 )) as nat,
             ),
             Self::TOP_LEVEL_INDEX_RANGE().end * pow2(
-                pte_index_bit_offset::<Self::C>(Self::C::NR_LEVELS()) as nat,
+                pte_index_bit_offset_spec::<Self::C>(Self::C::NR_LEVELS()) as nat,
             ) <= usize::MAX,
             Self::LEADING_BITS_spec() != 0usize ==> (Self::C::VA_SIGN_EXT() && ((
             Self::TOP_LEVEL_INDEX_RANGE().start * pow2(
-                pte_index_bit_offset::<Self::C>(Self::C::NR_LEVELS()) as nat,
+                pte_index_bit_offset_spec::<Self::C>(Self::C::NR_LEVELS()) as nat,
             )) / (pow2((Self::C::ADDRESS_WIDTH() - 1) as nat) as int)) % 2 == 1),
             (Self::C::VA_SIGN_EXT() && (((Self::TOP_LEVEL_INDEX_RANGE().start * pow2(
-                pte_index_bit_offset::<Self::C>(Self::C::NR_LEVELS()) as nat,
+                pte_index_bit_offset_spec::<Self::C>(Self::C::NR_LEVELS()) as nat,
             )) / (pow2((Self::C::ADDRESS_WIDTH() - 1) as nat) as int)) % 2 == 1)) ==> {
                 &&& Self::LEADING_BITS_spec() * 0x1_0000_0000_0000int == 0x1_0000_0000_0000_0000int
                     - pow2(Self::C::ADDRESS_WIDTH() as nat)
@@ -431,7 +432,7 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
             Self::LEADING_BITS_spec() < 0x1_0000_usize,
             // FIXME: This property does not hold in general, `ADDRESS_WIDTH` can be wider.
             pow2(
-                (Self::C::ADDRESS_WIDTH() - pte_index_bit_offset::<Self::C>(
+                (Self::C::ADDRESS_WIDTH() - pte_index_bit_offset_spec::<Self::C>(
                     Self::C::NR_LEVELS(),
                 )) as nat,
             ) == NR_ENTRIES,
@@ -554,13 +555,7 @@ pub fn largest_pages<C: PageTableConfig>(
     )
 }
 
-#[verifier::inline]
-pub open spec fn top_level_index_width_spec<C: PageTableConfig>() -> usize {
-    (C::ADDRESS_WIDTH_spec() - pte_index_bit_offset::<C>(C::NR_LEVELS())) as usize
-}
-
 /// Gets the top-level index width, in bits, for the page table.
-#[verifier::when_used_as_spec(top_level_index_width_spec)]
 fn top_level_index_width<C: PageTableConfig>() -> (ret: usize)
     returns
         top_level_index_width_spec::<C>(),
@@ -573,135 +568,16 @@ fn top_level_index_width<C: PageTableConfig>() -> (ret: usize)
     C::ADDRESS_WIDTH() - pte_index_bit_offset::<C>(C::NR_LEVELS())
 }
 
-/// Spec for the managed virtual address range (exclusive end).
-/// For configs without VA_SIGN_EXT (e.g. UserPtConfig) or when the base range has sign bit 0.
-/// Configs with sign extension (e.g. KernelPtConfig) use
-/// `vaddr_range_bounds_spec` for their canonical high-half bounds.
-#[verifier::inline]
-pub open spec fn vaddr_range_spec<C: PageTableConfig>() -> Range<Vaddr> {
-    let idx_range = C::TOP_LEVEL_INDEX_RANGE();
-    let offset = pte_index_bit_offset::<C>(C::NR_LEVELS()) as nat;
-    let start = idx_range.start * pow2(offset);
-    let end_inclusive = idx_range.end * pow2(offset) - 1;
-    (start as Vaddr)..((end_inclusive + 1) as Vaddr)
-}
-
-/// Spec for whether a range is within the page table's managed address space.
-#[verifier::inline]
-pub open spec fn is_valid_range_spec<C: PageTableConfig>(r: &Range<Vaddr>) -> bool {
-    let va_range = vaddr_range_bounds_spec::<C>();
-    (r.start == 0 && r.end == 0) || (va_range.0 <= r.start && r.end > 0 && r.end - 1 <= va_range.1)
-}
-
-/// Gets the inclusive bounds of the managed virtual-address range.
-fn vaddr_range_bounds<C: PageTableConfig>() -> (ret: (Vaddr, Vaddr))
-    ensures
-        ret.0 == vaddr_range_bounds_spec::<C>().0,
-        ret.1 == vaddr_range_bounds_spec::<C>().1,
-{
-    let mut start = pt_va_range_start::<C>();
-    let mut end = pt_va_range_end::<C>();
-
-    proof {
-        lemma_vaddr_range_bounds_spec_unfold::<C>();
-        C::lemma_paging_consts_properties();
-        C::lemma_page_table_config_constant_properties();
-        crate::specs::mm::page_table::vaddr_range_proofs::lemma_idx_times_pow2_bound::<C>(
-            start,
-            end,
-        );
-    }
-    let pt_start = pt_va_range_start::<C>();
-    let va_sign_ext = C::VA_SIGN_EXT();
-    let sign_bit_set = sign_bit_of_va::<C>(pt_start);
-    if va_sign_ext && sign_bit_set {
-        proof {
-            let off = pte_index_bit_offset::<C>(C::NR_LEVELS()) as nat;
-            let aw_m1 = (C::ADDRESS_WIDTH() - 1) as nat;
-            let i_start = C::TOP_LEVEL_INDEX_RANGE_spec().start as int;
-            let p_off = pow2(off) as int;
-            let p_aw_m1 = pow2(aw_m1) as int;
-        }
-        start = apply_sign_ext::<C>(start);
-        end = apply_sign_ext::<C>(end);
-    } else {
-        proof {
-            // The if-condition was false, so either va_sign_ext is false
-            // or sign_bit_set is false. The contrapositive of the
-            // leading-bits requirement gives LEADING_BITS == 0.
-            assert(!va_sign_ext || !sign_bit_set);
-            // Bridge exec bool to spec form. `va_sign_ext == C::VA_SIGN_EXT()`
-            // by `when_used_as_spec`; `sign_bit_set == ((pt_start as int /
-            // 2^(aw-1)) % 2 == 1)` by `sign_bit_of_va`'s ensures.
-            assert(va_sign_ext == C::VA_SIGN_EXT());
-            let off = pte_index_bit_offset::<C>(C::NR_LEVELS()) as nat;
-            let aw_m1 = (C::ADDRESS_WIDTH() - 1) as nat;
-            let i_start = C::TOP_LEVEL_INDEX_RANGE_spec().start as int;
-            let p_off = pow2(off) as int;
-            let p_aw_m1 = pow2(aw_m1) as int;
-            assert(pt_start == i_start * p_off);
-            assert(sign_bit_set == ((pt_start as int / p_aw_m1) % 2 == 1));
-            assert(sign_bit_set == ((i_start * p_off / p_aw_m1) % 2 == 1));
-        }
-    }
-    proof {
-        // Both branches now establish the equation
-        //   start == lb * 2^48 + idx.start * 2^off
-        //   end == lb * 2^48 + idx.end * 2^off - 1
-        // matching the unfolded `vaddr_range_bounds_spec`.
-        assert(start == (C::LEADING_BITS_spec()) * 0x1_0000_0000_0000int + (
-        C::TOP_LEVEL_INDEX_RANGE_spec().start) * (pow2(
-            pte_index_bit_offset::<C>(C::NR_LEVELS()) as nat,
-        )));
-        assert(end == (C::LEADING_BITS_spec()) * 0x1_0000_0000_0000int + (
-        C::TOP_LEVEL_INDEX_RANGE_spec().end) * (pow2(
-            pte_index_bit_offset::<C>(C::NR_LEVELS()) as nat,
-        )) - 1);
-    }
-    (start, end)
-}
-
-/// Gets the managed virtual addresses range for the page table.
-///
-/// Returns a [`RangeInclusive`] because the end address, when the range
-/// reaches the top of the 64-bit address space (e.g. the canonical
-/// high-half kernel range ending at `usize::MAX`), would overflow the
-/// exclusive end of a [`Range<Vaddr>`].
-fn vaddr_range<C: PageTableConfig>() -> (ret: RangeInclusive<Vaddr>)
-    ensures
-        ret@.start == vaddr_range_bounds_spec::<C>().0,
-        ret@.end == vaddr_range_bounds_spec::<C>().1,
-        ret@.exhausted == false,
-{
-    let (start, end) = vaddr_range_bounds::<C>();
-    RangeInclusive::new(start, end)
-}
-
-/// A handle to a page table.
-/// A page table can track the lifetime of the mapped physical pages.
-pub struct PageTable<C: PageTableConfig> {
-    pub root: PageTableNode<C>,
-}
-
-#[verifier::inline]
-pub open spec fn nr_pte_index_bits_spec<C: PagingConstsTrait>() -> usize {
-    nr_subpage_per_huge::<C>().ilog2() as usize
-}
-
-/// Concrete positional start of the VA range: `idx_range.start * 2^offset`.
 fn pt_va_range_start<C: PageTableConfig>() -> (ret: Vaddr)
     ensures
-        ret == C::TOP_LEVEL_INDEX_RANGE_spec().start * pow2(
-            pte_index_bit_offset::<C>(C::NR_LEVELS()) as nat,
+        ret == C::TOP_LEVEL_INDEX_RANGE().start * pow2(
+            pte_index_bit_offset_spec::<C>(C::NR_LEVELS()) as nat,
         ),
 {
-    let idx_start = C::TOP_LEVEL_INDEX_RANGE().start;
     proof {
         C::lemma_paging_consts_properties();
-    }
-    let offset = pte_index_bit_offset::<C>(C::NR_LEVELS());
-
-    proof {
+        let ghost idx_start = C::TOP_LEVEL_INDEX_RANGE().start;
+        let ghost offset = pte_index_bit_offset_spec::<C>(C::NR_LEVELS());
         crate::specs::mm::page_table::vaddr_range_proofs::lemma_pt_va_range_start_shift_facts::<C>(
             idx_start,
             offset,
@@ -709,9 +585,7 @@ fn pt_va_range_start<C: PageTableConfig>() -> (ret: Vaddr)
         vstd::bits::lemma_usize_shl_is_mul(idx_start, offset);
     }
 
-    let ret = idx_start << offset;
-
-    ret
+    C::TOP_LEVEL_INDEX_RANGE().start << pte_index_bit_offset::<C>(C::NR_LEVELS())
 }
 
 /// Concrete positional end of the VA range (inclusive):
@@ -722,7 +596,7 @@ fn pt_va_range_start<C: PageTableConfig>() -> (ret: Vaddr)
 fn pt_va_range_end<C: PageTableConfig>() -> (ret: Vaddr)
     ensures
         ret == (C::TOP_LEVEL_INDEX_RANGE_spec().end * pow2(
-            pte_index_bit_offset::<C>(C::NR_LEVELS()) as nat,
+            pte_index_bit_offset_spec::<C>(C::NR_LEVELS()) as nat,
         ) - 1) % 0x1_0000_0000_0000_0000int,
 {
     let idx_end = C::TOP_LEVEL_INDEX_RANGE().end;
@@ -754,37 +628,126 @@ fn pt_va_range_end<C: PageTableConfig>() -> (ret: Vaddr)
     ret
 }
 
-/// Test whether bit `ADDRESS_WIDTH - 1` of `va` is set.
 fn sign_bit_of_va<C: PageTableConfig>(va: Vaddr) -> (ret: bool)
     ensures
         ret == ((va as int / pow2((C::ADDRESS_WIDTH() - 1) as nat) as int) % 2 == 1),
 {
-    let address_width = C::ADDRESS_WIDTH();
     proof {
         C::lemma_paging_consts_properties();
         C::lemma_page_table_config_constant_properties();
+        vstd::bits::lemma_usize_shr_is_div(va, (C::ADDRESS_WIDTH() - 1) as usize);
+        vstd::bits::lemma_usize_low_bits_mask_is_mod(va >> (C::ADDRESS_WIDTH() - 1), 1);
+        vstd::bits::lemma_low_bits_mask_values();
+        vstd::arithmetic::power2::lemma2_to64();
     }
+    (va >> (C::ADDRESS_WIDTH() - 1)) & 1 != 0
+}
 
-    let shift = address_width - 1;
-    let shifted = va >> shift;
-    let bit = shifted & 1;
+/// Spec for the managed virtual address range (exclusive end).
+/// For configs without VA_SIGN_EXT (e.g. UserPtConfig) or when the base range has sign bit 0.
+/// Configs with sign extension (e.g. KernelPtConfig) use
+/// `vaddr_range_bounds_spec` for their canonical high-half bounds.
+#[verifier::inline]
+pub open spec fn vaddr_range_spec<C: PageTableConfig>() -> Range<Vaddr> {
+    let idx_range = C::TOP_LEVEL_INDEX_RANGE();
+    let offset = pte_index_bit_offset_spec::<C>(C::NR_LEVELS()) as nat;
+    let start = idx_range.start * pow2(offset);
+    let end_inclusive = idx_range.end * pow2(offset) - 1;
+    (start as Vaddr)..((end_inclusive + 1) as Vaddr)
+}
+
+/// Gets the inclusive bounds of the managed virtual-address range.
+fn vaddr_range_bounds<C: PageTableConfig>() -> (ret: (Vaddr, Vaddr))
+    ensures
+        ret.0 == vaddr_range_bounds_spec::<C>().0,
+        ret.1 == vaddr_range_bounds_spec::<C>().1,
+{
+    let mut start = pt_va_range_start::<C>();
+    let mut end = pt_va_range_end::<C>();
 
     proof {
-        crate::specs::mm::page_table::vaddr_range_proofs::lemma_sign_bit_facts::<C>(
-            va,
-            address_width,
-            shift,
-            shifted,
-            bit,
+        lemma_vaddr_range_bounds_spec_unfold::<C>();
+        C::lemma_paging_consts_properties();
+        C::lemma_page_table_config_constant_properties();
+        crate::specs::mm::page_table::vaddr_range_proofs::lemma_idx_times_pow2_bound::<C>(
+            start,
+            end,
         );
     }
-    bit != 0
+    let pt_start = pt_va_range_start::<C>();
+    let va_sign_ext = C::VA_SIGN_EXT();
+    let sign_bit_set = sign_bit_of_va::<C>(pt_start);
+    if va_sign_ext && sign_bit_set {
+        proof {
+            let off = pte_index_bit_offset_spec::<C>(C::NR_LEVELS()) as nat;
+            let aw_m1 = (C::ADDRESS_WIDTH() - 1) as nat;
+            let i_start = C::TOP_LEVEL_INDEX_RANGE_spec().start as int;
+            let p_off = pow2(off) as int;
+            let p_aw_m1 = pow2(aw_m1) as int;
+        }
+        start = apply_sign_ext::<C>(start);
+        end = apply_sign_ext::<C>(end);
+    } else {
+        proof {
+            // The if-condition was false, so either va_sign_ext is false
+            // or sign_bit_set is false. The contrapositive of the
+            // leading-bits requirement gives LEADING_BITS == 0.
+            assert(!va_sign_ext || !sign_bit_set);
+            assert(va_sign_ext == C::VA_SIGN_EXT());
+            let off = pte_index_bit_offset_spec::<C>(C::NR_LEVELS()) as nat;
+            let aw_m1 = (C::ADDRESS_WIDTH() - 1) as nat;
+            let i_start = C::TOP_LEVEL_INDEX_RANGE().start as int;
+            let p_off = pow2(off) as int;
+            let p_aw_m1 = pow2(aw_m1) as int;
+            assert(pt_start == i_start * p_off);
+            assert(sign_bit_set == ((pt_start as int / p_aw_m1) % 2 == 1));
+            assert(sign_bit_set == ((i_start * p_off / p_aw_m1) % 2 == 1));
+        }
+    }
+    proof {
+        assert(start == (C::LEADING_BITS_spec()) * 0x1_0000_0000_0000int + (
+        C::TOP_LEVEL_INDEX_RANGE().start) * (pow2(
+            pte_index_bit_offset_spec::<C>(C::NR_LEVELS()) as nat,
+        )));
+        assert(end == (C::LEADING_BITS_spec()) * 0x1_0000_0000_0000int + (
+        C::TOP_LEVEL_INDEX_RANGE().end) * (pow2(
+            pte_index_bit_offset_spec::<C>(C::NR_LEVELS()) as nat,
+        )) - 1);
+    }
+    (start, end)
+}
+
+/// Gets the managed virtual addresses range for the page table.
+///
+/// Returns a [`RangeInclusive`] because the end address, when the range
+/// reaches the top of the 64-bit address space (e.g. the canonical
+/// high-half kernel range ending at `usize::MAX`), would overflow the
+/// exclusive end of a [`Range<Vaddr>`].
+fn vaddr_range<C: PageTableConfig>() -> (ret: RangeInclusive<Vaddr>)
+    ensures
+        ret@.start == vaddr_range_bounds_spec::<C>().0,
+        ret@.end == vaddr_range_bounds_spec::<C>().1,
+        ret@.exhausted == false,
+{
+    let (start, end) = vaddr_range_bounds::<C>();
+    RangeInclusive::new(start, end)
+}
+
+/// Spec for whether a range is within the page table's managed address space.
+#[verifier::inline]
+pub open spec fn is_valid_range_spec<C: PageTableConfig>(r: &Range<Vaddr>) -> bool {
+    let va_range = vaddr_range_bounds_spec::<C>();
+    (r.start == 0 && r.end == 0) || (va_range.0 <= r.start && r.end > 0 && r.end - 1 <= va_range.1)
+}
+
+/// A handle to a page table.
+/// A page table can track the lifetime of the mapped physical pages.
+pub struct PageTable<C: PageTableConfig> {
+    pub root: PageTableNode<C>,
 }
 
 /// The number of virtual address bits used to index a PTE in a page.
-#[inline(always)]
-#[verifier::when_used_as_spec(nr_pte_index_bits_spec)]
-pub fn nr_pte_index_bits<C: PagingConstsTrait>() -> usize
+fn nr_pte_index_bits<C: PagingConstsTrait>() -> usize
     returns
         nr_pte_index_bits_spec::<C>(),
 {
@@ -792,22 +755,6 @@ pub fn nr_pte_index_bits<C: PagingConstsTrait>() -> usize
         C::lemma_paging_consts_properties();
     }
     nr_subpage_per_huge::<C>().ilog2() as usize
-}
-
-pub proof fn lemma_nr_pte_index_bits_bounded<C: PagingConstsTrait>()
-    ensures
-        0 <= nr_pte_index_bits::<C>() <= C::BASE_PAGE_SIZE().ilog2(),
-{
-    C::lemma_paging_consts_properties();
-    let nr = nr_subpage_per_huge::<C>();
-    assert(1 <= nr <= C::BASE_PAGE_SIZE());
-    let bits = nr.ilog2();
-    assert(0 <= bits) by {
-        lemma_usize_ilog2_ordered(1, nr);
-    }
-    assert(bits <= C::BASE_PAGE_SIZE().ilog2()) by {
-        lemma_usize_ilog2_ordered(nr, C::BASE_PAGE_SIZE());
-    }
 }
 
 /// Apply the sign-extension OR to a positional value.
@@ -890,11 +837,9 @@ pub(crate) proof fn lemma_vaddr_range_spec_kernel()
     lemma2_to64();
     lemma2_to64_rest();
     lemma_usize_pow2_ilog2(12);
-    assert(PagingConsts::BASE_PAGE_SIZE().ilog2() == 12u32);
-    assert(nr_subpage_per_huge::<PagingConsts>() == 512_usize);
+    lemma_arch_specific_consts_properties::<PagingConsts>();
     lemma_usize_pow2_ilog2(9);
-    assert(nr_pte_index_bits::<PagingConsts>() == 9_usize);
-    assert(pte_index_bit_offset::<PagingConsts>(4) == 39);
+    assert(pte_index_bit_offset_spec::<PagingConsts>(4) == 39);
     lemma_pow2_adds(8, 39);
     lemma_pow2_adds(9, 39);
     assert(256 * pow2(39) == pow2(47));
@@ -912,7 +857,7 @@ pub(crate) proof fn lemma_vaddr_range_spec_kernel()
 /// `(0xffff_8000_0000_0000, 0xffff_ffff_ffff_ffff)`.
 pub closed spec fn vaddr_range_bounds_spec<C: PageTableConfig>() -> (Vaddr, Vaddr) {
     let idx = C::TOP_LEVEL_INDEX_RANGE_spec();
-    let off = pte_index_bit_offset::<C>(C::NR_LEVELS()) as nat;
+    let off = pte_index_bit_offset_spec::<C>(C::NR_LEVELS()) as nat;
     let lb = C::LEADING_BITS_spec() as int;
     let base = lb * 0x1_0000_0000_0000int;
     let start = (base + (idx.start) * pow2(off)) as usize;
@@ -927,7 +872,7 @@ pub proof fn lemma_vaddr_range_bounds_spec_unfold<C: PageTableConfig>()
     ensures
         vaddr_range_bounds_spec::<C>() == {
             let idx = C::TOP_LEVEL_INDEX_RANGE_spec();
-            let off = pte_index_bit_offset::<C>(C::NR_LEVELS()) as nat;
+            let off = pte_index_bit_offset_spec::<C>(C::NR_LEVELS()) as nat;
             let lb = C::LEADING_BITS_spec() as int;
             let base = lb * 0x1_0000_0000_0000int;
             let start = (base + (idx.start) * pow2(off)) as usize;
@@ -952,9 +897,8 @@ pub(crate) proof fn lemma_vaddr_range_bounds_spec_user()
     lemma_usize_pow2_ilog2(12);
     lemma_usize_pow2_ilog2(9);
     lemma_pow2_adds(8, 39);
-    assert(nr_subpage_per_huge::<PagingConsts>() == 512_usize);
-    assert(nr_pte_index_bits::<PagingConsts>() == 9_usize);
-    assert(pte_index_bit_offset::<PagingConsts>(4) == 39);
+    lemma_arch_specific_consts_properties::<PagingConsts>();
+    assert(pte_index_bit_offset_spec::<PagingConsts>(4) == 39);
     assert(0 * pow2(39) == 0);
     assert(256 * pow2(39) == pow2(47));
     assert(pow2(47) - 1 == 0x0000_7FFF_FFFF_FFFF_int);
@@ -978,10 +922,8 @@ pub(crate) proof fn lemma_vaddr_range_bounds_spec_kernel()
     lemma_usize_pow2_ilog2(9);
     lemma_pow2_adds(8, 39);
     lemma_pow2_adds(9, 39);
-    assert(nr_subpage_per_huge::<PagingConsts>() == 512_usize);
-    assert(nr_pte_index_bits::<PagingConsts>() == 9_usize);
-    assert(PagingConsts::BASE_PAGE_SIZE().ilog2() == 12u32);
-    assert(pte_index_bit_offset::<PagingConsts>(4) == 39);
+    lemma_arch_specific_consts_properties::<PagingConsts>();
+    assert(pte_index_bit_offset_spec::<PagingConsts>(4) == 39);
     assert(256 * pow2(39) == pow2(47));
     assert(512 * pow2(39) == pow2(48));
     assert(0xffff_int * 0x1_0000_0000_0000int + pow2(47) == 0xffff_8000_0000_0000int);
@@ -1016,16 +958,10 @@ fn pte_index<C: PagingConstsTrait>(va: Vaddr, level: PagingLevel) -> (res: usize
         lemma2_to64();
         lemma2_to64_rest();
         vstd::bits::lemma_usize_shr_is_div(va, offset);
-
         vstd::bits::lemma_low_bits_mask_values();
         vstd::bits::lemma_usize_low_bits_mask_is_mod(shifted, 9);
     }
     shifted & mask
-}
-
-#[verifier::inline]
-pub open spec fn pte_index_bit_offset_spec<C: PagingConstsTrait>(level: PagingLevel) -> usize {
-    (C::BASE_PAGE_SIZE().ilog2() + nr_pte_index_bits::<C>() * (level - 1)) as usize
 }
 
 /// The bit offset of the entry offset part in a virtual address.
@@ -1033,8 +969,7 @@ pub open spec fn pte_index_bit_offset_spec<C: PagingConstsTrait>(level: PagingLe
 /// This function returns the bit offset of the least significant bit. Take
 /// x86-64 as an example, the `pte_index_bit_offset(2)` should return 21, which
 /// is 12 (the 4KiB in-page offset) plus 9 (index width in the level-1 table).
-#[verifier::when_used_as_spec(pte_index_bit_offset_spec)]
-pub fn pte_index_bit_offset<C: PagingConstsTrait>(level: PagingLevel) -> usize
+fn pte_index_bit_offset<C: PagingConstsTrait>(level: PagingLevel) -> usize
     requires
         1 <= level <= NR_LEVELS,
     returns


### PR DESCRIPTION
- Adjust the code in `page_table/mod.rs` to match the source code.
- Add a `lemma_arch_specific_consts_properties` in `specs/arch/x86` to mark the usage of x86-specific constants in proofs. Any usage of this lemma outside `arch` should eventually be eliminated.
