### PR TITLE
fix: remove `vaddr_range_bounds`

### DIFF
--- a/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
@@ -183,14 +183,14 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             assert(self.continuations[NR_LEVELS - 1].idx == self.va.index[NR_LEVELS - 1]);
             assert(self.continuations[NR_LEVELS - 1].idx == owner0.continuations[owner0.level
                 - 1].idx);
-            assert(C::TOP_LEVEL_INDEX_RANGE_spec().start <= owner0.continuations[owner0.level
-                - 1].idx < C::TOP_LEVEL_INDEX_RANGE_spec().end);
+            assert(C::TOP_LEVEL_INDEX_RANGE().start <= owner0.continuations[owner0.level - 1].idx
+                < C::TOP_LEVEL_INDEX_RANGE().end);
             assert(forall|j: int|
-                0 <= j < NR_ENTRIES && !(C::TOP_LEVEL_INDEX_RANGE_spec().start <= j
-                    < C::TOP_LEVEL_INDEX_RANGE_spec().end) ==> (
-                #[trigger] self.continuations[NR_LEVELS - 1].children[j]) is Some ==> (
-                self.continuations[NR_LEVELS - 1].children[j].unwrap().value.is_borrowed()
-                    || self.continuations[NR_LEVELS - 1].children[j].unwrap().value.is_absent()));
+                0 <= j < NR_ENTRIES && !(C::TOP_LEVEL_INDEX_RANGE().start <= j
+                    < C::TOP_LEVEL_INDEX_RANGE().end) ==> (#[trigger] self.continuations[NR_LEVELS
+                    - 1].children[j]) is Some ==> (self.continuations[NR_LEVELS
+                    - 1].children[j].unwrap().value.is_borrowed() || self.continuations[NR_LEVELS
+                    - 1].children[j].unwrap().value.is_absent()));
         }
     }
 

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -715,7 +715,7 @@ impl<'rcu, C: PageTableConfig> Inv for CursorOwner<'rcu, C> {
         // Locked range stays within the config's managed VA space. Established at
         // cursor construction (barrier_va == *va with is_valid_range_spec(va)) and
         // preserved by all cursor operations since they don't modify prefix/guard_level.
-        &&& self.locked_range().end <= crate::mm::page_table::vaddr_range_bounds_spec::<C>().1
+        &&& self.locked_range().end <= crate::mm::page_table::vaddr_range_spec::<C>().1
             + 1
         // Per-config tightening: e.g. `KernelPtConfig` overrides this to
         // `FRAME_METADATA_BASE_VADDR`, which the kvirt allocator enforces and
@@ -2801,14 +2801,14 @@ impl<C: PageTableConfig> Inv for CursorView<C> {
                 ==> m.inv()
         // Config-aware VA range: user page tables live in `[0, 2^47)`,
         // kernel page tables in `[0xffff_8000_…, usize::MAX]`, etc.
-        // `vaddr_range_bounds_spec<C>` gives inclusive `(start, end_inclusive)`
+        // `vaddr_range_spec<C>` gives inclusive `(start, end_inclusive)`
         // bounds derived from `LEADING_BITS_spec` + `TOP_LEVEL_INDEX_RANGE_spec`,
         // so `Mapping::inv` can stay config-agnostic.
         &&& forall|m: Mapping|
             #![auto]
             self.mappings.contains(m) ==> {
-                &&& vaddr_range_bounds_spec::<C>().0 <= m.va_range.start
-                &&& m.va_range.end <= vaddr_range_bounds_spec::<C>().1 + 1
+                &&& vaddr_range_spec::<C>().0 <= m.va_range.start
+                &&& m.va_range.end <= vaddr_range_spec::<C>().1 + 1
             }
         &&& self.non_overlapping()
     }
@@ -2834,14 +2834,13 @@ pub proof fn lemma_view_in_vaddr_range<'rcu, C: PageTableConfig>(owner: &CursorO
         forall|m: Mapping|
             #![auto]
             owner.view_mappings().contains(m) ==> {
-                &&& vaddr_range_bounds_spec::<C>().0 <= m.va_range.start
-                &&& m.va_range.end <= vaddr_range_bounds_spec::<C>().1 + 1
+                &&& vaddr_range_spec::<C>().0 <= m.va_range.start
+                &&& m.va_range.end <= vaddr_range_spec::<C>().1 + 1
             },
 {
     C::lemma_paging_consts_properties();
     C::lemma_page_table_config_constant_properties();
     lemma_arch_specific_consts_properties::<C>();
-    lemma_vaddr_range_bounds_spec_unfold::<C>();
     vstd::arithmetic::power2::lemma2_to64();
     vstd::arithmetic::power2::lemma2_to64_rest();
     vstd::arithmetic::power2::lemma_pow2_adds(
@@ -2856,7 +2855,7 @@ pub proof fn lemma_view_in_vaddr_range<'rcu, C: PageTableConfig>(owner: &CursorO
     let lb = C::LEADING_BITS_spec() as int;
     let base = lb * 0x1_0000_0000_0000int;
     let cell = 0x80_0000_0000int;
-    let bounds = vaddr_range_bounds_spec::<C>();
+    let bounds = vaddr_range_spec::<C>();
 
     let aw = C::ADDRESS_WIDTH() as nat;
     let top_w = (C::ADDRESS_WIDTH() - pte_index_bit_offset_spec::<C>(C::NR_LEVELS())) as nat;
@@ -2915,8 +2914,8 @@ pub proof fn lemma_view_in_vaddr_range<'rcu, C: PageTableConfig>(owner: &CursorO
     assert(bounds.1 == base + end * cell - 1);
 
     assert forall|m: Mapping| #[trigger] owner.view_mappings().contains(m) implies {
-        &&& vaddr_range_bounds_spec::<C>().0 <= m.va_range.start
-        &&& m.va_range.end <= vaddr_range_bounds_spec::<C>().1 + 1
+        &&& vaddr_range_spec::<C>().0 <= m.va_range.start
+        &&& m.va_range.end <= vaddr_range_spec::<C>().1 + 1
     } by {
         owner.lemma_view_mappings_contains();
         let i = choose|i: int|
@@ -3065,14 +3064,11 @@ pub proof fn lemma_view_in_vaddr_range_kernel<'rcu>(
         forall|m: Mapping|
             #![auto]
             owner.view_mappings().contains(m) ==> {
-                &&& vaddr_range_bounds_spec::<crate::mm::kspace::KernelPtConfig>().0
-                    <= m.va_range.start
-                &&& m.va_range.end <= vaddr_range_bounds_spec::<
-                    crate::mm::kspace::KernelPtConfig,
-                >().1 + 1
+                &&& vaddr_range_spec::<crate::mm::kspace::KernelPtConfig>().0 <= m.va_range.start
+                &&& m.va_range.end <= vaddr_range_spec::<crate::mm::kspace::KernelPtConfig>().1 + 1
             },
 {
-    crate::mm::page_table::lemma_vaddr_range_bounds_spec_kernel();
+    crate::mm::page_table::lemma_vaddr_range_spec_kernel();
     let start = crate::mm::kspace::KernelPtConfig::TOP_LEVEL_INDEX_RANGE_spec().start as int;
     let end = crate::mm::kspace::KernelPtConfig::TOP_LEVEL_INDEX_RANGE_spec().end as int;
     let lb = crate::mm::kspace::KernelPtConfig::LEADING_BITS_spec() as int;
@@ -3094,8 +3090,8 @@ pub proof fn lemma_view_in_vaddr_range_kernel<'rcu>(
             lb == 0xffff,
     ;
     assert forall|m: Mapping| #[trigger] owner.view_mappings().contains(m) implies {
-        &&& vaddr_range_bounds_spec::<crate::mm::kspace::KernelPtConfig>().0 <= m.va_range.start
-        &&& m.va_range.end <= vaddr_range_bounds_spec::<crate::mm::kspace::KernelPtConfig>().1 + 1
+        &&& vaddr_range_spec::<crate::mm::kspace::KernelPtConfig>().0 <= m.va_range.start
+        &&& m.va_range.end <= vaddr_range_spec::<crate::mm::kspace::KernelPtConfig>().1 + 1
     } by {
         owner.lemma_view_mappings_contains();
         let i = choose|i: int|
@@ -3167,7 +3163,7 @@ impl<'rcu, C: PageTableConfig> InvView for CursorOwner<'rcu, C> {
         //     alignment, PA/VA size equal page_size, and PA bound.
         self.view_mapping_inv();
         // (4) Config-aware VA bound: every mapping's VA range is contained
-        //     in `vaddr_range_bounds_spec::<C>()`.
+        //     in `vaddr_range_spec::<C>()`.
         lemma_view_in_vaddr_range::<C>(&self);
     }
 }

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -660,13 +660,13 @@ impl<'rcu, C: PageTableConfig> Inv for CursorOwner<'rcu, C> {
         // The top-level index of the cursor's VA must be within the page table config's
         // managed range. This ensures cursors for UserPtConfig and KernelPtConfig operate
         // on disjoint portions of the virtual address space.
-        &&& C::TOP_LEVEL_INDEX_RANGE_spec().start <= self.va.index[NR_LEVELS
+        &&& C::TOP_LEVEL_INDEX_RANGE().start <= self.va.index[NR_LEVELS
             - 1]
         // The top index may equal TOP_LEVEL_INDEX_RANGE.end as a "one-past-end"
         // sentinel meaning the cursor has been advanced past the very last in-range
         // top-level slot. In this state the cursor is `above_locked_range`.
         &&& self.va.index[NR_LEVELS - 1]
-            <= C::TOP_LEVEL_INDEX_RANGE_spec().end
+            <= C::TOP_LEVEL_INDEX_RANGE().end
         // The cursor's VA is always at or above the start of the locked range.
         &&& self.in_locked_range()
             || self.above_locked_range()
@@ -688,13 +688,13 @@ impl<'rcu, C: PageTableConfig> Inv for CursorOwner<'rcu, C> {
             //      (`lemma_view_in_vaddr_range_user`) and kernel
             //      (`lemma_view_in_vaddr_range_kernel`) view bounds provable.
         &&& self.level <= NR_LEVELS - 1 ==> {
-            &&& C::TOP_LEVEL_INDEX_RANGE_spec().start <= self.continuations[NR_LEVELS - 1].idx
-            &&& self.continuations[NR_LEVELS - 1].idx < C::TOP_LEVEL_INDEX_RANGE_spec().end
+            &&& C::TOP_LEVEL_INDEX_RANGE().start <= self.continuations[NR_LEVELS - 1].idx
+            &&& self.continuations[NR_LEVELS - 1].idx < C::TOP_LEVEL_INDEX_RANGE().end
         }
         &&& forall|j: int|
             #![trigger self.continuations[NR_LEVELS - 1].children[j]]
-            0 <= j < NR_ENTRIES && !(C::TOP_LEVEL_INDEX_RANGE_spec().start <= j
-                < C::TOP_LEVEL_INDEX_RANGE_spec().end) ==> self.continuations[NR_LEVELS
+            0 <= j < NR_ENTRIES && !(C::TOP_LEVEL_INDEX_RANGE().start <= j
+                < C::TOP_LEVEL_INDEX_RANGE().end) ==> self.continuations[NR_LEVELS
                 - 1].children[j] is Some ==> (self.continuations[NR_LEVELS
                 - 1].children[j].unwrap().value.is_borrowed() || self.continuations[NR_LEVELS
                 - 1].children[j].unwrap().value.is_absent())
@@ -707,7 +707,7 @@ impl<'rcu, C: PageTableConfig> Inv for CursorOwner<'rcu, C> {
             // This is established at construction (when prefix == va, which itself starts
             // strictly in-range) and preserved by all cursor operations (none touch prefix).
         &&& self.prefix.index[NR_LEVELS - 1]
-            < C::TOP_LEVEL_INDEX_RANGE_spec().end
+            < C::TOP_LEVEL_INDEX_RANGE().end
         // Top-of-address-space sentinel reservation: none of our `PtConfig`s actually use
         // the very last index. The first half of the address space
         &&& self.prefix.index[NR_LEVELS - 1] + 1
@@ -992,7 +992,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             old(self).in_locked_range(),
             old(self).continuations[old(self).level - 1].idx + 1 < NR_ENTRIES,
             old(self).level == NR_LEVELS ==> (old(self).continuations[old(self).level - 1].idx + 1)
-                <= C::TOP_LEVEL_INDEX_RANGE_spec().end,
+                <= C::TOP_LEVEL_INDEX_RANGE().end,
         ensures
             final(self).inv(),
             *final(self) == old(self).inc_index(),
@@ -1709,7 +1709,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.in_locked_range(),
             !self.popped_too_high,
         ensures
-            self.va.index[NR_LEVELS - 1] < C::TOP_LEVEL_INDEX_RANGE_spec().end,
+            self.va.index[NR_LEVELS - 1] < C::TOP_LEVEL_INDEX_RANGE().end,
     {
         self.in_locked_range_level_le_guard_level();
         if self.guard_level == NR_LEVELS {
@@ -1773,7 +1773,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
     {
         self.in_locked_range_top_index_lt_top_end();
         self.in_locked_range_guard_index_eq_prefix();
-        let top_end = C::TOP_LEVEL_INDEX_RANGE_spec().end as int;
+        let top_end = C::TOP_LEVEL_INDEX_RANGE().end as int;
         if top_end >= NR_ENTRIES {
             assert(self.continuations[self.level - 1].idx + 1 < NR_ENTRIES);
         }
@@ -2802,7 +2802,7 @@ impl<C: PageTableConfig> Inv for CursorView<C> {
         // Config-aware VA range: user page tables live in `[0, 2^47)`,
         // kernel page tables in `[0xffff_8000_…, usize::MAX]`, etc.
         // `vaddr_range_spec<C>` gives inclusive `(start, end_inclusive)`
-        // bounds derived from `LEADING_BITS_spec` + `TOP_LEVEL_INDEX_RANGE_spec`,
+        // bounds derived from `LEADING_BITS_spec` + `TOP_LEVEL_INDEX_RANGE`,
         // so `Mapping::inv` can stay config-agnostic.
         &&& forall|m: Mapping|
             #![auto]
@@ -2849,7 +2849,7 @@ pub proof fn lemma_view_in_vaddr_range<'rcu, C: PageTableConfig>(owner: &CursorO
     );
     vstd::layout::unsigned_int_max_values();
 
-    let idx = C::TOP_LEVEL_INDEX_RANGE_spec();
+    let idx = C::TOP_LEVEL_INDEX_RANGE();
     let start = idx.start as int;
     let end = idx.end as int;
     let lb = C::LEADING_BITS_spec() as int;
@@ -2981,7 +2981,7 @@ pub proof fn lemma_view_in_vaddr_range_user<'rcu>(
                 &&& m.va_range.end <= 0x8000_0000_0000int
             },
 {
-    let end = crate::mm::vm_space::UserPtConfig::TOP_LEVEL_INDEX_RANGE_spec().end as int;
+    let end = crate::mm::vm_space::UserPtConfig::TOP_LEVEL_INDEX_RANGE().end as int;
     assert(end == 256);
     assert(end * 0x80_0000_0000int == 0x8000_0000_0000int) by (nonlinear_arith)
         requires
@@ -3062,8 +3062,10 @@ pub proof fn lemma_view_in_vaddr_range_kernel<'rcu>(
         forall|m: Mapping|
             #![auto]
             owner.view_mappings().contains(m) ==> {
-                &&& vaddr_range_spec::<crate::mm::kspace::KernelPtConfig>()@.start <= m.va_range.start
-                &&& m.va_range.end <= vaddr_range_spec::<crate::mm::kspace::KernelPtConfig>()@.end + 1
+                &&& vaddr_range_spec::<crate::mm::kspace::KernelPtConfig>()@.start
+                    <= m.va_range.start
+                &&& m.va_range.end <= vaddr_range_spec::<crate::mm::kspace::KernelPtConfig>()@.end
+                    + 1
             },
 {
     crate::mm::page_table::lemma_vaddr_range_spec_kernel();

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -715,7 +715,7 @@ impl<'rcu, C: PageTableConfig> Inv for CursorOwner<'rcu, C> {
         // Locked range stays within the config's managed VA space. Established at
         // cursor construction (barrier_va == *va with is_valid_range_spec(va)) and
         // preserved by all cursor operations since they don't modify prefix/guard_level.
-        &&& self.locked_range().end <= crate::mm::page_table::vaddr_range_spec::<C>().1
+        &&& self.locked_range().end <= crate::mm::page_table::vaddr_range_spec::<C>()@.end
             + 1
         // Per-config tightening: e.g. `KernelPtConfig` overrides this to
         // `FRAME_METADATA_BASE_VADDR`, which the kvirt allocator enforces and
@@ -2807,8 +2807,8 @@ impl<C: PageTableConfig> Inv for CursorView<C> {
         &&& forall|m: Mapping|
             #![auto]
             self.mappings.contains(m) ==> {
-                &&& vaddr_range_spec::<C>().0 <= m.va_range.start
-                &&& m.va_range.end <= vaddr_range_spec::<C>().1 + 1
+                &&& vaddr_range_spec::<C>()@.start <= m.va_range.start
+                &&& m.va_range.end <= vaddr_range_spec::<C>()@.end + 1
             }
         &&& self.non_overlapping()
     }
@@ -2834,8 +2834,8 @@ pub proof fn lemma_view_in_vaddr_range<'rcu, C: PageTableConfig>(owner: &CursorO
         forall|m: Mapping|
             #![auto]
             owner.view_mappings().contains(m) ==> {
-                &&& vaddr_range_spec::<C>().0 <= m.va_range.start
-                &&& m.va_range.end <= vaddr_range_spec::<C>().1 + 1
+                &&& vaddr_range_spec::<C>()@.start <= m.va_range.start
+                &&& m.va_range.end <= vaddr_range_spec::<C>()@.end + 1
             },
 {
     C::lemma_paging_consts_properties();
@@ -2910,12 +2910,10 @@ pub proof fn lemma_view_in_vaddr_range<'rcu, C: PageTableConfig>(owner: &CursorO
                 usize::MAX == 0x1_0000_0000_0000_0000int - 1,
         ;
     }
-    assert(bounds.0 == base + start * cell);
-    assert(bounds.1 == base + end * cell - 1);
 
     assert forall|m: Mapping| #[trigger] owner.view_mappings().contains(m) implies {
-        &&& vaddr_range_spec::<C>().0 <= m.va_range.start
-        &&& m.va_range.end <= vaddr_range_spec::<C>().1 + 1
+        &&& vaddr_range_spec::<C>()@.start <= m.va_range.start
+        &&& m.va_range.end <= vaddr_range_spec::<C>()@.end + 1
     } by {
         owner.lemma_view_mappings_contains();
         let i = choose|i: int|
@@ -3064,19 +3062,17 @@ pub proof fn lemma_view_in_vaddr_range_kernel<'rcu>(
         forall|m: Mapping|
             #![auto]
             owner.view_mappings().contains(m) ==> {
-                &&& vaddr_range_spec::<crate::mm::kspace::KernelPtConfig>().0 <= m.va_range.start
-                &&& m.va_range.end <= vaddr_range_spec::<crate::mm::kspace::KernelPtConfig>().1 + 1
+                &&& vaddr_range_spec::<crate::mm::kspace::KernelPtConfig>()@.start <= m.va_range.start
+                &&& m.va_range.end <= vaddr_range_spec::<crate::mm::kspace::KernelPtConfig>()@.end + 1
             },
 {
     crate::mm::page_table::lemma_vaddr_range_spec_kernel();
-    let start = crate::mm::kspace::KernelPtConfig::TOP_LEVEL_INDEX_RANGE_spec().start as int;
-    let end = crate::mm::kspace::KernelPtConfig::TOP_LEVEL_INDEX_RANGE_spec().end as int;
+    let start = crate::mm::kspace::KernelPtConfig::TOP_LEVEL_INDEX_RANGE().start as int;
+    let end = crate::mm::kspace::KernelPtConfig::TOP_LEVEL_INDEX_RANGE().end as int;
     let lb = crate::mm::kspace::KernelPtConfig::LEADING_BITS_spec() as int;
     assert(start == 256);
     assert(end == 512);
     assert(lb == 0xffff);
-    // bound == (256·2^39 + 0xffff·2^48, 512·2^39 + 0xffff·2^48 - 1)
-    //       == (0xFFFF_8000_0000_0000, 0xFFFF_FFFF_FFFF_FFFF).
     assert(start * 0x80_0000_0000int + lb * 0x1_0000_0000_0000int == 0xFFFF_8000_0000_0000int)
         by (nonlinear_arith)
         requires
@@ -3090,8 +3086,8 @@ pub proof fn lemma_view_in_vaddr_range_kernel<'rcu>(
             lb == 0xffff,
     ;
     assert forall|m: Mapping| #[trigger] owner.view_mappings().contains(m) implies {
-        &&& vaddr_range_spec::<crate::mm::kspace::KernelPtConfig>().0 <= m.va_range.start
-        &&& m.va_range.end <= vaddr_range_spec::<crate::mm::kspace::KernelPtConfig>().1 + 1
+        &&& vaddr_range_spec::<crate::mm::kspace::KernelPtConfig>()@.start <= m.va_range.start
+        &&& m.va_range.end <= vaddr_range_spec::<crate::mm::kspace::KernelPtConfig>()@.end + 1
     } by {
         owner.lemma_view_mappings_contains();
         let i = choose|i: int|

--- a/ostd/specs/mm/page_table/mapping_set_lemmas.rs
+++ b/ostd/specs/mm/page_table/mapping_set_lemmas.rs
@@ -117,7 +117,7 @@ pub proof fn lemma_mapping_set_cardinality_bound(s: Set<Mapping>, bound: usize)
 /// Corollary: the cardinality fits in usize.
 ///
 /// The bound `0x0000_8000_0000_0000` (= 2^47) is the new upper end derived
-/// from `vaddr_range_bounds_spec::<UserPtConfig>` — one page looser than
+/// from `vaddr_range_spec::<UserPtConfig>` — one page looser than
 /// the old `MAX_USERSPACE_VADDR`, but still gives a comfortable
 /// `2^35 < usize::MAX`.
 pub proof fn lemma_mapping_set_cardinality_fits_usize(s: Set<Mapping>)

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -809,11 +809,11 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     }
 
     /// For a top-level (root) page table, entries at indices outside of
-    /// `C::TOP_LEVEL_INDEX_RANGE_spec()` are absent. This ensures that
+    /// `C::TOP_LEVEL_INDEX_RANGE()` are absent. This ensures that
     /// UserPtConfig and KernelPtConfig page tables manage disjoint portions
     /// of the virtual address space.
     pub open spec fn top_level_indices_absent(self) -> bool {
-        let range = C::TOP_LEVEL_INDEX_RANGE_spec();
+        let range = C::TOP_LEVEL_INDEX_RANGE();
         self.0.value.is_node() ==> forall|i: int|
             #![trigger self.0.children[i]]
             0 <= i < NR_ENTRIES && !(range.start <= i < range.end) ==> self.0.children[i] is Some

--- a/ostd/specs/mm/page_table/vaddr_range_proofs.rs
+++ b/ostd/specs/mm/page_table/vaddr_range_proofs.rs
@@ -21,7 +21,7 @@ pub proof fn lemma_pt_va_range_start_shift_facts<C: PageTableConfig>(
     offset: usize,
 )
     requires
-        idx_start == C::TOP_LEVEL_INDEX_RANGE_spec().start,
+        idx_start == C::TOP_LEVEL_INDEX_RANGE().start,
         offset == pte_index_bit_offset_spec::<C>(C::NR_LEVELS()),
     ensures
         offset < usize::BITS,
@@ -40,7 +40,7 @@ pub proof fn lemma_pt_va_range_start_shift_facts<C: PageTableConfig>(
     lemma_pow2_pos(top_w);
     lemma_pow2_pos(aw);
 
-    let i_start = C::TOP_LEVEL_INDEX_RANGE_spec().start as int;
+    let i_start = C::TOP_LEVEL_INDEX_RANGE().start as int;
     let p_off = pow2(off) as int;
     let p_top = pow2(top_w) as int;
 
@@ -59,7 +59,7 @@ pub proof fn lemma_pt_va_range_start_shift_facts<C: PageTableConfig>(
 /// `idx.end * 2^offset` for `pt_va_range_end`.
 pub proof fn lemma_pt_va_range_end_shift_facts<C: PageTableConfig>(idx_end: usize, offset: usize)
     requires
-        idx_end == C::TOP_LEVEL_INDEX_RANGE_spec().end,
+        idx_end == C::TOP_LEVEL_INDEX_RANGE().end,
         offset == pte_index_bit_offset_spec::<C>(C::NR_LEVELS()),
     ensures
         offset < usize::BITS,
@@ -71,7 +71,7 @@ pub proof fn lemma_pt_va_range_end_shift_facts<C: PageTableConfig>(idx_end: usiz
     C::lemma_page_table_config_constant_properties();
     lemma_pow2_pos(offset as nat);
 
-    let i_end = C::TOP_LEVEL_INDEX_RANGE_spec().end as int;
+    let i_end = C::TOP_LEVEL_INDEX_RANGE().end as int;
     let p_off = pow2(offset as nat) as int;
     assert(i_end * p_off > 0) by (nonlinear_arith)
         requires
@@ -111,17 +111,17 @@ pub proof fn lemma_pt_va_range_end_wrapping_sub<C: PageTableConfig>(
 /// is a no-op when the value is positive.
 pub proof fn lemma_idx_times_pow2_bound<C: PageTableConfig>(start: Vaddr, end: Vaddr)
     requires
-        start == C::TOP_LEVEL_INDEX_RANGE_spec().start * (pow2(
+        start == C::TOP_LEVEL_INDEX_RANGE().start * (pow2(
             pte_index_bit_offset_spec::<C>(C::NR_LEVELS()) as nat,
         ) as int),
-        end == (C::TOP_LEVEL_INDEX_RANGE_spec().end * (pow2(
+        end == (C::TOP_LEVEL_INDEX_RANGE().end * (pow2(
             pte_index_bit_offset_spec::<C>(C::NR_LEVELS()) as nat,
         ) as int) - 1) % 0x1_0000_0000_0000_0000int,
     ensures
         start < pow2(C::ADDRESS_WIDTH() as nat),
         end < pow2(C::ADDRESS_WIDTH() as nat),
         // For the end-of-range arithmetic ensures of `vaddr_range`:
-        end == C::TOP_LEVEL_INDEX_RANGE_spec().end * pow2(
+        end == C::TOP_LEVEL_INDEX_RANGE().end * pow2(
             pte_index_bit_offset_spec::<C>(C::NR_LEVELS()) as nat,
         ) - 1,
 {
@@ -135,8 +135,8 @@ pub proof fn lemma_idx_times_pow2_bound<C: PageTableConfig>(start: Vaddr, end: V
     lemma_pow2_pos(top_w);
     lemma_pow2_pos(aw);
     // Constants for clarity.
-    let i_start = C::TOP_LEVEL_INDEX_RANGE_spec().start as int;
-    let i_end = C::TOP_LEVEL_INDEX_RANGE_spec().end as int;
+    let i_start = C::TOP_LEVEL_INDEX_RANGE().start as int;
+    let i_end = C::TOP_LEVEL_INDEX_RANGE().end as int;
     let p_off = pow2(off) as int;
     let p_top = pow2(top_w) as int;
     let p_aw = pow2(aw) as int;

--- a/ostd/specs/mm/page_table/view.rs
+++ b/ostd/specs/mm/page_table/view.rs
@@ -68,7 +68,7 @@ impl Mapping {
             64,
         )
         // Per-config VA range bounds are enforced by `CursorView<C>::inv`
-        // via `vaddr_range_bounds_spec<C>`, not here — a single
+        // via `vaddr_range_spec<C>`, not here — a single
         // config-agnostic `Mapping::inv` cannot express them.
 
     }

--- a/ostd/src/mm/kspace/kvirt_area.rs
+++ b/ostd/src/mm/kspace/kvirt_area.rs
@@ -257,7 +257,7 @@ pub proof fn lemma_kernel_range_valid(r: core::ops::Range<Vaddr>)
     ensures
         is_valid_range_spec::<KernelPtConfig>(&r),
 {
-    crate::mm::page_table::lemma_vaddr_range_bounds_spec_kernel();
+    crate::mm::page_table::lemma_vaddr_range_spec_kernel();
     assert(KERNEL_BASE_VADDR == 0xFFFF_8000_0000_0000usize) by (compute_only);
 }
 

--- a/ostd/src/mm/kspace/mod.rs
+++ b/ostd/src/mm/kspace/mod.rs
@@ -193,13 +193,13 @@ unsafe impl PageTableConfig for KernelPtConfig {
         assert(256 * pow2(39) == pow2(47));
         assert((256 * pow2(39) as int) / (pow2(47) as int) == 1);
         assert(pte_index_bit_offset_spec::<Self::C>(Self::C::NR_LEVELS()) == 39);
-        assert(Self::TOP_LEVEL_INDEX_RANGE_spec().start * (pow2(
+        assert(Self::TOP_LEVEL_INDEX_RANGE().start * (pow2(
             pte_index_bit_offset_spec::<Self::C>(Self::C::NR_LEVELS()) as nat,
         )) == pow2(47));
-        assert(((Self::TOP_LEVEL_INDEX_RANGE_spec().start * pow2(
+        assert(((Self::TOP_LEVEL_INDEX_RANGE().start * pow2(
             pte_index_bit_offset_spec::<Self::C>(Self::C::NR_LEVELS()) as nat,
         )) / (pow2((Self::C::ADDRESS_WIDTH() - 1) as nat) as int)) == 1);
-        assert(((Self::TOP_LEVEL_INDEX_RANGE_spec().start * pow2(
+        assert(((Self::TOP_LEVEL_INDEX_RANGE().start * pow2(
             pte_index_bit_offset_spec::<Self::C>(Self::C::NR_LEVELS()) as nat,
         )) / (pow2((Self::C::ADDRESS_WIDTH() - 1) as nat) as int)) % 2 == 1);
         lemma_pow2_adds(16, 48);

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -1749,9 +1749,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
             // locked_range.end and hence idx[NR_LEVELS-1] < top_end (strict).
             if owner.level == NR_LEVELS {
                 owner0.in_locked_range_top_index_lt_top_end();
-                assert(owner0.va.index[NR_LEVELS - 1] < C::TOP_LEVEL_INDEX_RANGE_spec().end);
+                assert(owner0.va.index[NR_LEVELS - 1] < C::TOP_LEVEL_INDEX_RANGE().end);
                 assert(owner.continuations[owner.level - 1].idx + 1
-                    <= C::TOP_LEVEL_INDEX_RANGE_spec().end);
+                    <= C::TOP_LEVEL_INDEX_RANGE().end);
             }
             owner.do_inc_index();
             owner.zero_preserves_all_but_va();

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -686,7 +686,7 @@ fn vaddr_range<C: PageTableConfig>() -> (ret: RangeInclusive<Vaddr>)
         start = apply_sign_ext::<C>(start);
         end = apply_sign_ext::<C>(end);
     }
-    start.. = end
+    start..=end
 }
 
 /// Spec for whether a range is within the page table's managed address space.

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -595,7 +595,7 @@ fn pt_va_range_start<C: PageTableConfig>() -> (ret: Vaddr)
 /// left shift followed by `wrapping_sub(1)`.
 fn pt_va_range_end<C: PageTableConfig>() -> (ret: Vaddr)
     ensures
-        ret == (C::TOP_LEVEL_INDEX_RANGE_spec().end * pow2(
+        ret == (C::TOP_LEVEL_INDEX_RANGE().end * pow2(
             pte_index_bit_offset_spec::<C>(C::NR_LEVELS()) as nat,
         ) - 1) % 0x1_0000_0000_0000_0000int,
 {
@@ -667,7 +667,7 @@ pub open spec fn vaddr_range_spec<C: PageTableConfig>() -> RangeInclusive<Vaddr>
 /// exclusive end of a [`Range<Vaddr>`].
 #[verusfmt::skip]
 fn vaddr_range<C: PageTableConfig>() -> (ret: RangeInclusive<Vaddr>)
-    returns 
+    returns
         vaddr_range_spec::<C>(),
 {
     let mut start = pt_va_range_start::<C>();
@@ -693,7 +693,8 @@ fn vaddr_range<C: PageTableConfig>() -> (ret: RangeInclusive<Vaddr>)
 #[verifier::inline]
 pub open spec fn is_valid_range_spec<C: PageTableConfig>(r: &Range<Vaddr>) -> bool {
     let va_range = vaddr_range_spec::<C>();
-    (r.start == 0 && r.end == 0) || (va_range@.start <= r.start && r.end > 0 && r.end - 1 <= va_range@.end)
+    (r.start == 0 && r.end == 0) || (va_range@.start <= r.start && r.end > 0 && r.end - 1
+        <= va_range@.end)
 }
 
 /// A handle to a page table.
@@ -899,8 +900,8 @@ impl PageTable<KernelPtConfig> {
     pub open spec fn create_user_pt_panic_condition(root_owner: NodeOwner<KernelPtConfig>) -> bool {
         exists|i: usize|
             #![trigger root_owner.children_perm.value()[i as int]]
-            KernelPtConfig::TOP_LEVEL_INDEX_RANGE_spec().start <= i
-                < KernelPtConfig::TOP_LEVEL_INDEX_RANGE_spec().end && {
+            KernelPtConfig::TOP_LEVEL_INDEX_RANGE().start <= i
+                < KernelPtConfig::TOP_LEVEL_INDEX_RANGE().end && {
                 let pte = root_owner.children_perm.value()[i as int];
                 ||| !pte.is_present()
                 ||| pte.is_last(root_owner.level)
@@ -1119,8 +1120,8 @@ impl PageTable<KernelPtConfig> {
                 kernel_owner.0.value.is_node(),
                 regions.inv(),
                 !Self::create_user_pt_panic_condition(kernel_owner.0.value.node()),
-                i <= KernelPtConfig::TOP_LEVEL_INDEX_RANGE_spec().end,
-                KernelPtConfig::TOP_LEVEL_INDEX_RANGE_spec().start <= i,
+                i <= KernelPtConfig::TOP_LEVEL_INDEX_RANGE().end,
+                KernelPtConfig::TOP_LEVEL_INDEX_RANGE().start <= i,
                 // Lock postcondition for the kernel root.
                 *root_owner == kernel_owner.0.value.node(),
                 root_owner.relate_guard(root_node),
@@ -1130,14 +1131,14 @@ impl PageTable<KernelPtConfig> {
                 new_node_owner.inv(),
                 new_node_owner.relate_guard(new_node),
                 regions.slots.contains_key(new_node_owner.slot_index),
-            decreases KernelPtConfig::TOP_LEVEL_INDEX_RANGE_spec().end - i,
+            decreases KernelPtConfig::TOP_LEVEL_INDEX_RANGE().end - i,
         {
             proof {
                 let kern_node = kernel_owner.0.value.node();
                 assert forall|j: usize|
                     #![trigger kern_node.children_perm.value()[j as int]]
-                    KernelPtConfig::TOP_LEVEL_INDEX_RANGE_spec().start <= j
-                        < KernelPtConfig::TOP_LEVEL_INDEX_RANGE_spec().end implies {
+                    KernelPtConfig::TOP_LEVEL_INDEX_RANGE().start <= j
+                        < KernelPtConfig::TOP_LEVEL_INDEX_RANGE().end implies {
                     let pte = kern_node.children_perm.value()[j as int];
                     pte.is_present() && !pte.is_last(kern_node.level)
                 } by {
@@ -1187,11 +1188,11 @@ impl PageTable<KernelPtConfig> {
 
                 assert(pte.is_present() && !pte.is_last(kern_node.level)) by {
                     if !pte.is_present() || pte.is_last(kern_node.level) {
-                        assert(KernelPtConfig::TOP_LEVEL_INDEX_RANGE_spec().start <= i
-                            < KernelPtConfig::TOP_LEVEL_INDEX_RANGE_spec().end);
+                        assert(KernelPtConfig::TOP_LEVEL_INDEX_RANGE().start <= i
+                            < KernelPtConfig::TOP_LEVEL_INDEX_RANGE().end);
                         assert(exists|j: usize|
-                            KernelPtConfig::TOP_LEVEL_INDEX_RANGE_spec().start <= j
-                                < KernelPtConfig::TOP_LEVEL_INDEX_RANGE_spec().end && {
+                            KernelPtConfig::TOP_LEVEL_INDEX_RANGE().start <= j
+                                < KernelPtConfig::TOP_LEVEL_INDEX_RANGE().end && {
                                 let p = #[trigger] kern_node.children_perm.value()[j as int];
                                 ||| !p.is_present()
                                 ||| p.is_last(kern_node.level)

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -649,13 +649,14 @@ fn sign_bit_of_va<C: PageTableConfig>(va: Vaddr) -> (ret: bool)
 /// `UserPtConfig` `(LEADING_BITS=0, idx=0..256)` this is `(0, 2^47 - 1)`;
 /// for `KernelPtConfig` `(LEADING_BITS=0xffff, idx=256..512)` this is
 /// `(0xffff_8000_0000_0000, 0xffff_ffff_ffff_ffff)`.
-pub open spec fn vaddr_range_spec<C: PageTableConfig>() -> (Vaddr, Vaddr) {
+#[verusfmt::skip]
+pub open spec fn vaddr_range_spec<C: PageTableConfig>() -> RangeInclusive<Vaddr> {
     let off = pte_index_bit_offset_spec::<C>(C::NR_LEVELS()) as nat;
     let lb = C::LEADING_BITS_spec() as int;
     let base = lb * 0x1_0000_0000_0000int;
     let start = (base + (C::TOP_LEVEL_INDEX_RANGE().start) * pow2(off)) as usize;
-    let end_inclusive = (base + (C::TOP_LEVEL_INDEX_RANGE().end) * pow2(off) - 1) as usize;
-    (start, end_inclusive)
+    let end = (base + (C::TOP_LEVEL_INDEX_RANGE().end) * pow2(off) - 1) as usize;
+    start..=end
 }
 
 /// Gets the managed virtual addresses range for the page table.
@@ -666,10 +667,8 @@ pub open spec fn vaddr_range_spec<C: PageTableConfig>() -> (Vaddr, Vaddr) {
 /// exclusive end of a [`Range<Vaddr>`].
 #[verusfmt::skip]
 fn vaddr_range<C: PageTableConfig>() -> (ret: RangeInclusive<Vaddr>)
-    ensures
-        ret@.start == vaddr_range_spec::<C>().0,
-        ret@.end == vaddr_range_spec::<C>().1,
-        ret@.exhausted == false,
+    returns 
+        vaddr_range_spec::<C>(),
 {
     let mut start = pt_va_range_start::<C>();
     let mut end = pt_va_range_end::<C>();
@@ -694,7 +693,7 @@ fn vaddr_range<C: PageTableConfig>() -> (ret: RangeInclusive<Vaddr>)
 #[verifier::inline]
 pub open spec fn is_valid_range_spec<C: PageTableConfig>(r: &Range<Vaddr>) -> bool {
     let va_range = vaddr_range_spec::<C>();
-    (r.start == 0 && r.end == 0) || (va_range.0 <= r.start && r.end > 0 && r.end - 1 <= va_range.1)
+    (r.start == 0 && r.end == 0) || (va_range@.start <= r.start && r.end > 0 && r.end - 1 <= va_range@.end)
 }
 
 /// A handle to a page table.
@@ -785,10 +784,8 @@ fn is_valid_range<C: PageTableConfig>(r: &Range<Vaddr>) -> (ret: bool)
 /// `(0, 0x0000_7FFF_FFFF_FFFF)`, i.e. the low-half 47-bit user VA space.
 pub(crate) proof fn lemma_vaddr_range_spec_user()
     ensures
-        vaddr_range_spec::<crate::mm::vm_space::UserPtConfig>() == (
-            0_usize,
-            0x0000_7FFF_FFFF_FFFF_usize,
-        ),
+        vaddr_range_spec::<crate::mm::vm_space::UserPtConfig>()@.start == 0,
+        vaddr_range_spec::<crate::mm::vm_space::UserPtConfig>()@.end == 0x0000_7FFF_FFFF_FFFF,
 {
     use vstd::arithmetic::power2::{lemma2_to64, lemma2_to64_rest, lemma_pow2_adds};
     lemma2_to64();
@@ -809,10 +806,8 @@ pub(crate) proof fn lemma_vaddr_range_spec_user()
 /// upper half `(0xFFFF_8000_0000_0000, 0xFFFF_FFFF_FFFF_FFFF)`.
 pub(crate) proof fn lemma_vaddr_range_spec_kernel()
     ensures
-        vaddr_range_spec::<KernelPtConfig>() == (
-            0xFFFF_8000_0000_0000_usize,
-            0xFFFF_FFFF_FFFF_FFFF_usize,
-        ),
+        vaddr_range_spec::<KernelPtConfig>()@.start == 0xFFFF_8000_0000_0000,
+        vaddr_range_spec::<KernelPtConfig>()@.end == 0xFFFF_FFFF_FFFF_FFFF,
 {
     use vstd::arithmetic::power2::{lemma2_to64, lemma2_to64_rest, lemma_pow2_adds};
     lemma2_to64();

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -133,8 +133,8 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
     ///
     /// Combined with `TOP_LEVEL_INDEX_RANGE`, this fully determines
     /// the managed VA range, computed as
-    /// [`vaddr_range_bounds_spec::<Self>`]. Callers that previously used
-    /// `VADDR_RANGE_spec()` should use `vaddr_range_bounds_spec::<C>()`
+    /// [`vaddr_range_spec::<Self>`]. Callers that previously used
+    /// `VADDR_RANGE_spec()` should use `vaddr_range_spec::<C>()`
     /// directly — the inclusive `(start, end_inclusive)` form avoids the
     /// `end == usize::MAX + 1` overflow that plagues `Range<Vaddr>` for
     /// sign-extended kernel configurations.
@@ -159,7 +159,7 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
 
     /// VERIFICATION only: Upper bound on `locked_range().end` for cursors of this config.
     ///
-    /// May be tighter than the structural `vaddr_range_bounds_spec().1 + 1`
+    /// May be tighter than the structural `vaddr_range_spec().1 + 1`
     /// when the actual sources of cursor ranges (e.g. the kvirt allocator
     /// for `KernelPtConfig`) draw from a sub-window of the configured VA
     /// range. `KernelPtConfig` overrides this to `FRAME_METADATA_BASE_VADDR`,
@@ -643,26 +643,13 @@ fn sign_bit_of_va<C: PageTableConfig>(va: Vaddr) -> (ret: bool)
     (va >> (C::ADDRESS_WIDTH() - 1)) & 1 != 0
 }
 
-/// Spec for the managed virtual address range (exclusive end).
-/// For configs without VA_SIGN_EXT (e.g. UserPtConfig) or when the base range has sign bit 0.
-/// Configs with sign extension (e.g. KernelPtConfig) use
-/// `vaddr_range_bounds_spec` for their canonical high-half bounds.
-#[verifier::inline]
-pub open spec fn vaddr_range_spec<C: PageTableConfig>() -> Range<Vaddr> {
-    let idx_range = C::TOP_LEVEL_INDEX_RANGE();
-    let offset = pte_index_bit_offset_spec::<C>(C::NR_LEVELS()) as nat;
-    let start = idx_range.start * pow2(offset);
-    let end_inclusive = idx_range.end * pow2(offset) - 1;
-    (start as Vaddr)..((end_inclusive + 1) as Vaddr)
-}
-
 /// Canonical bounds of the VA range managed by a page-table config,
 ///
 /// Derived from `LEADING_BITS_spec` and `TOP_LEVEL_INDEX_RANGE`. For
 /// `UserPtConfig` `(LEADING_BITS=0, idx=0..256)` this is `(0, 2^47 - 1)`;
 /// for `KernelPtConfig` `(LEADING_BITS=0xffff, idx=256..512)` this is
 /// `(0xffff_8000_0000_0000, 0xffff_ffff_ffff_ffff)`.
-pub closed spec fn vaddr_range_bounds_spec<C: PageTableConfig>() -> (Vaddr, Vaddr) {
+pub open spec fn vaddr_range_spec<C: PageTableConfig>() -> (Vaddr, Vaddr) {
     let off = pte_index_bit_offset_spec::<C>(C::NR_LEVELS()) as nat;
     let lb = C::LEADING_BITS_spec() as int;
     let base = lb * 0x1_0000_0000_0000int;
@@ -671,17 +658,22 @@ pub closed spec fn vaddr_range_bounds_spec<C: PageTableConfig>() -> (Vaddr, Vadd
     (start, end_inclusive)
 }
 
-/// Gets the inclusive bounds of the managed virtual-address range.
-fn vaddr_range_bounds<C: PageTableConfig>() -> (ret: (Vaddr, Vaddr))
+/// Gets the managed virtual addresses range for the page table.
+///
+/// Returns a [`RangeInclusive`] because the end address, when the range
+/// reaches the top of the 64-bit address space (e.g. the canonical
+/// high-half kernel range ending at `usize::MAX`), would overflow the
+/// exclusive end of a [`Range<Vaddr>`].
+fn vaddr_range<C: PageTableConfig>() -> (ret: RangeInclusive<Vaddr>)
     ensures
-        ret.0 == vaddr_range_bounds_spec::<C>().0,
-        ret.1 == vaddr_range_bounds_spec::<C>().1,
+        ret@.start == vaddr_range_spec::<C>().0,
+        ret@.end == vaddr_range_spec::<C>().1,
+        ret@.exhausted == false,
 {
     let mut start = pt_va_range_start::<C>();
     let mut end = pt_va_range_end::<C>();
 
     proof {
-        lemma_vaddr_range_bounds_spec_unfold::<C>();
         C::lemma_paging_consts_properties();
         C::lemma_page_table_config_constant_properties();
         crate::specs::mm::page_table::vaddr_range_proofs::lemma_idx_times_pow2_bound::<C>(
@@ -694,29 +686,13 @@ fn vaddr_range_bounds<C: PageTableConfig>() -> (ret: (Vaddr, Vaddr))
         start = apply_sign_ext::<C>(start);
         end = apply_sign_ext::<C>(end);
     }
-    (start, end)
-}
-
-/// Gets the managed virtual addresses range for the page table.
-///
-/// Returns a [`RangeInclusive`] because the end address, when the range
-/// reaches the top of the 64-bit address space (e.g. the canonical
-/// high-half kernel range ending at `usize::MAX`), would overflow the
-/// exclusive end of a [`Range<Vaddr>`].
-fn vaddr_range<C: PageTableConfig>() -> (ret: RangeInclusive<Vaddr>)
-    ensures
-        ret@.start == vaddr_range_bounds_spec::<C>().0,
-        ret@.end == vaddr_range_bounds_spec::<C>().1,
-        ret@.exhausted == false,
-{
-    let (start, end) = vaddr_range_bounds::<C>();
-    RangeInclusive::new(start, end)
+    start.. = end
 }
 
 /// Spec for whether a range is within the page table's managed address space.
 #[verifier::inline]
 pub open spec fn is_valid_range_spec<C: PageTableConfig>(r: &Range<Vaddr>) -> bool {
-    let va_range = vaddr_range_bounds_spec::<C>();
+    let va_range = vaddr_range_spec::<C>();
     (r.start == 0 && r.end == 0) || (va_range.0 <= r.start && r.end > 0 && r.end - 1 <= va_range.1)
 }
 
@@ -799,55 +775,16 @@ fn is_valid_range<C: PageTableConfig>(r: &Range<Vaddr>) -> (ret: bool)
     ensures
         ret == is_valid_range_spec::<C>(r),
 {
-    let (va_start, va_end) = vaddr_range_bounds::<C>();
-    (r.start == 0 && r.end == 0) || (va_start <= r.start && r.end > 0 && r.end - 1 <= va_end)
-}
-
-/// Sanity-check: for x86_64 kernel PT, `vaddr_range_spec` evaluates to the
-/// low-half `[2^47, 2^48)` window. The exec path (`vaddr_range`) applies
-/// sign extension on top of this and wraps at `usize::MAX + 1`, which is
-/// the "KNOWN BUG" referenced in `vm_space::unmap`. See
-/// `vaddr_range_bounds_spec` below for the overflow-free formulation.
-pub(crate) proof fn lemma_vaddr_range_spec_kernel()
-    ensures
-        vaddr_range_spec::<KernelPtConfig>() == (
-        0x0000_8000_0000_0000_usize..0x0001_0000_0000_0000_usize),
-{
-    use vstd::arithmetic::power2::{lemma2_to64, lemma2_to64_rest, lemma_pow2_adds};
-    lemma2_to64();
-    lemma2_to64_rest();
-    lemma_usize_pow2_ilog2(12);
-    lemma_arch_specific_consts_properties::<PagingConsts>();
-    lemma_usize_pow2_ilog2(9);
-    assert(pte_index_bit_offset_spec::<PagingConsts>(4) == 39);
-    lemma_pow2_adds(8, 39);
-    lemma_pow2_adds(9, 39);
-    assert(256 * pow2(39) == pow2(47));
-    assert(512 * pow2(39) == pow2(48));
-}
-
-/// Reveal the body of `vaddr_range_bounds_spec` at a call site without
-/// making the function itself open (which causes z3-context pollution in
-/// cursor invariants).
-pub proof fn lemma_vaddr_range_bounds_spec_unfold<C: PageTableConfig>()
-    ensures
-        vaddr_range_bounds_spec::<C>() == {
-            let idx = C::TOP_LEVEL_INDEX_RANGE_spec();
-            let off = pte_index_bit_offset_spec::<C>(C::NR_LEVELS()) as nat;
-            let lb = C::LEADING_BITS_spec() as int;
-            let base = lb * 0x1_0000_0000_0000int;
-            let start = (base + (idx.start) * pow2(off)) as usize;
-            let end_inclusive = (base + (idx.end) * pow2(off) - 1) as usize;
-            (start, end_inclusive)
-        },
-{
+    let va_range = vaddr_range::<C>();
+    (r.start == 0 && r.end == 0) || (*va_range.start() <= r.start && r.end > 0 && r.end - 1
+        <= *va_range.end())
 }
 
 /// Sanity-check: for x86_64 user PT, the bounds are
 /// `(0, 0x0000_7FFF_FFFF_FFFF)`, i.e. the low-half 47-bit user VA space.
-pub(crate) proof fn lemma_vaddr_range_bounds_spec_user()
+pub(crate) proof fn lemma_vaddr_range_spec_user()
     ensures
-        vaddr_range_bounds_spec::<crate::mm::vm_space::UserPtConfig>() == (
+        vaddr_range_spec::<crate::mm::vm_space::UserPtConfig>() == (
             0_usize,
             0x0000_7FFF_FFFF_FFFF_usize,
         ),
@@ -869,9 +806,9 @@ pub(crate) proof fn lemma_vaddr_range_bounds_spec_user()
 
 /// Sanity-check: for x86_64 kernel PT, the bounds are the canonical
 /// upper half `(0xFFFF_8000_0000_0000, 0xFFFF_FFFF_FFFF_FFFF)`.
-pub(crate) proof fn lemma_vaddr_range_bounds_spec_kernel()
+pub(crate) proof fn lemma_vaddr_range_spec_kernel()
     ensures
-        vaddr_range_bounds_spec::<KernelPtConfig>() == (
+        vaddr_range_spec::<KernelPtConfig>() == (
             0xFFFF_8000_0000_0000_usize,
             0xFFFF_FFFF_FFFF_FFFF_usize,
         ),

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -656,6 +656,21 @@ pub open spec fn vaddr_range_spec<C: PageTableConfig>() -> Range<Vaddr> {
     (start as Vaddr)..((end_inclusive + 1) as Vaddr)
 }
 
+/// Canonical bounds of the VA range managed by a page-table config,
+///
+/// Derived from `LEADING_BITS_spec` and `TOP_LEVEL_INDEX_RANGE`. For
+/// `UserPtConfig` `(LEADING_BITS=0, idx=0..256)` this is `(0, 2^47 - 1)`;
+/// for `KernelPtConfig` `(LEADING_BITS=0xffff, idx=256..512)` this is
+/// `(0xffff_8000_0000_0000, 0xffff_ffff_ffff_ffff)`.
+pub closed spec fn vaddr_range_bounds_spec<C: PageTableConfig>() -> (Vaddr, Vaddr) {
+    let off = pte_index_bit_offset_spec::<C>(C::NR_LEVELS()) as nat;
+    let lb = C::LEADING_BITS_spec() as int;
+    let base = lb * 0x1_0000_0000_0000int;
+    let start = (base + (C::TOP_LEVEL_INDEX_RANGE().start) * pow2(off)) as usize;
+    let end_inclusive = (base + (C::TOP_LEVEL_INDEX_RANGE().end) * pow2(off) - 1) as usize;
+    (start, end_inclusive)
+}
+
 /// Gets the inclusive bounds of the managed virtual-address range.
 fn vaddr_range_bounds<C: PageTableConfig>() -> (ret: (Vaddr, Vaddr))
     ensures
@@ -674,45 +689,10 @@ fn vaddr_range_bounds<C: PageTableConfig>() -> (ret: (Vaddr, Vaddr))
             end,
         );
     }
-    let pt_start = pt_va_range_start::<C>();
-    let va_sign_ext = C::VA_SIGN_EXT();
-    let sign_bit_set = sign_bit_of_va::<C>(pt_start);
-    if va_sign_ext && sign_bit_set {
-        proof {
-            let off = pte_index_bit_offset_spec::<C>(C::NR_LEVELS()) as nat;
-            let aw_m1 = (C::ADDRESS_WIDTH() - 1) as nat;
-            let i_start = C::TOP_LEVEL_INDEX_RANGE_spec().start as int;
-            let p_off = pow2(off) as int;
-            let p_aw_m1 = pow2(aw_m1) as int;
-        }
+
+    if C::VA_SIGN_EXT() && sign_bit_of_va::<C>(pt_va_range_start::<C>()) {
         start = apply_sign_ext::<C>(start);
         end = apply_sign_ext::<C>(end);
-    } else {
-        proof {
-            // The if-condition was false, so either va_sign_ext is false
-            // or sign_bit_set is false. The contrapositive of the
-            // leading-bits requirement gives LEADING_BITS == 0.
-            assert(!va_sign_ext || !sign_bit_set);
-            assert(va_sign_ext == C::VA_SIGN_EXT());
-            let off = pte_index_bit_offset_spec::<C>(C::NR_LEVELS()) as nat;
-            let aw_m1 = (C::ADDRESS_WIDTH() - 1) as nat;
-            let i_start = C::TOP_LEVEL_INDEX_RANGE().start as int;
-            let p_off = pow2(off) as int;
-            let p_aw_m1 = pow2(aw_m1) as int;
-            assert(pt_start == i_start * p_off);
-            assert(sign_bit_set == ((pt_start as int / p_aw_m1) % 2 == 1));
-            assert(sign_bit_set == ((i_start * p_off / p_aw_m1) % 2 == 1));
-        }
-    }
-    proof {
-        assert(start == (C::LEADING_BITS_spec()) * 0x1_0000_0000_0000int + (
-        C::TOP_LEVEL_INDEX_RANGE().start) * (pow2(
-            pte_index_bit_offset_spec::<C>(C::NR_LEVELS()) as nat,
-        )));
-        assert(end == (C::LEADING_BITS_spec()) * 0x1_0000_0000_0000int + (
-        C::TOP_LEVEL_INDEX_RANGE().end) * (pow2(
-            pte_index_bit_offset_spec::<C>(C::NR_LEVELS()) as nat,
-        )) - 1);
     }
     (start, end)
 }
@@ -844,25 +824,6 @@ pub(crate) proof fn lemma_vaddr_range_spec_kernel()
     lemma_pow2_adds(9, 39);
     assert(256 * pow2(39) == pow2(47));
     assert(512 * pow2(39) == pow2(48));
-}
-
-/// Canonical bounds of the VA range managed by a page-table config,
-/// returned as inclusive `(start, end_inclusive)`. `end_inclusive` may
-/// equal `usize::MAX` for sign-extended kernel configs, which is why the
-/// inclusive form is used — `Range<Vaddr>` cannot represent that.
-///
-/// Derived from `LEADING_BITS_spec` and `TOP_LEVEL_INDEX_RANGE_spec`. For
-/// `UserPtConfig` `(LEADING_BITS=0, idx=0..256)` this is `(0, 2^47 - 1)`;
-/// for `KernelPtConfig` `(LEADING_BITS=0xffff, idx=256..512)` this is
-/// `(0xffff_8000_0000_0000, 0xffff_ffff_ffff_ffff)`.
-pub closed spec fn vaddr_range_bounds_spec<C: PageTableConfig>() -> (Vaddr, Vaddr) {
-    let idx = C::TOP_LEVEL_INDEX_RANGE_spec();
-    let off = pte_index_bit_offset_spec::<C>(C::NR_LEVELS()) as nat;
-    let lb = C::LEADING_BITS_spec() as int;
-    let base = lb * 0x1_0000_0000_0000int;
-    let start = (base + (idx.start) * pow2(off)) as usize;
-    let end_inclusive = (base + (idx.end) * pow2(off) - 1) as usize;
-    (start, end_inclusive)
 }
 
 /// Reveal the body of `vaddr_range_bounds_spec` at a call site without

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -664,6 +664,7 @@ pub open spec fn vaddr_range_spec<C: PageTableConfig>() -> (Vaddr, Vaddr) {
 /// reaches the top of the 64-bit address space (e.g. the canonical
 /// high-half kernel range ending at `usize::MAX`), would overflow the
 /// exclusive end of a [`Range<Vaddr>`].
+#[verusfmt::skip]
 fn vaddr_range<C: PageTableConfig>() -> (ret: RangeInclusive<Vaddr>)
     ensures
         ret@.start == vaddr_range_spec::<C>().0,

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -949,9 +949,9 @@ impl<'a, A: InAtomicMode> CursorMut<'a, A> {
 
         proof {
             // end_va <= barrier_va.end == locked_range().end. The cursor invariant
-            // bounds locked_range().end by `vaddr_range_bounds_spec::<C>().1 + 1`,
+            // bounds locked_range().end by `vaddr_range_spec::<C>().1 + 1`,
             // and for UserPtConfig that evaluates to 2^47.
-            crate::mm::page_table::lemma_vaddr_range_bounds_spec_user();
+            crate::mm::page_table::lemma_vaddr_range_spec_user();
             assert((self.pt_cursor.0.va + len) % PAGE_SIZE as int == 0) by (compute);
         }
 
@@ -1028,7 +1028,7 @@ impl<'a, A: InAtomicMode> CursorMut<'a, A> {
                 crate::specs::mm::page_table::cursor::owners::lemma_view_in_vaddr_range_user(
                     cursor_owner,
                 );
-                crate::mm::page_table::lemma_vaddr_range_bounds_spec_user();
+                crate::mm::page_table::lemma_vaddr_range_spec_user();
             }
 
             // SAFETY: It is safe to un-map memory in the userspace.
@@ -1076,7 +1076,7 @@ impl<'a, A: InAtomicMode> CursorMut<'a, A> {
                 PageTableFrag::Mapped { va, item, .. } => {
                     let frame = item.frame;
                     proof {
-                        crate::mm::page_table::lemma_vaddr_range_bounds_spec_user();
+                        crate::mm::page_table::lemma_vaddr_range_spec_user();
                         // `wf_mapping_set(removed)` from the wf adjusted_base
                         // via subset; `va_range.end <= 2^47` for every removed
                         // mapping is a loop invariant. Together they give
@@ -1114,7 +1114,7 @@ impl<'a, A: InAtomicMode> CursorMut<'a, A> {
                             old_adjusted,
                             new_removed,
                         );
-                        crate::mm::page_table::lemma_vaddr_range_bounds_spec_user();
+                        crate::mm::page_table::lemma_vaddr_range_spec_user();
                         crate::specs::mm::page_table::mapping_set_lemmas::lemma_mapping_set_cardinality_fits_usize(
                         new_removed);
                         // |new_removed| = |old_removed| + |subtree| (disjoint).

--- a/verified_libs/vstd_extra/src/external/range.rs
+++ b/verified_libs/vstd_extra/src/external/range.rs
@@ -1,4 +1,4 @@
-use core::ops::Range;
+use core::ops::{Range, RangeInclusive};
 use vstd::prelude::*;
 
 verus! {
@@ -44,5 +44,15 @@ pub fn range_usize_is_empty(r: &Range<usize>) -> (ret: bool)
 {
     !(r.start < r.end)
 }
+
+pub assume_specification<Idx>[ RangeInclusive::start ](r: &RangeInclusive<Idx>) -> (ret: &Idx)
+    ensures
+        *ret == r@.start,
+;
+
+pub assume_specification<Idx>[ RangeInclusive::end ](r: &RangeInclusive<Idx>) -> (ret: &Idx)
+    ensures
+        *ret == r@.end,
+;
 
 } // verus!


### PR DESCRIPTION
`vaddr_range_bounds` does not exist in the source code.