### PR TITLE
fix: Stop emitting `PointsTo` from `MetaSlot::get_from_unused`

### DIFF
--- a/ostd/specs/mm/frame/frame_specs.rs
+++ b/ostd/specs/mm/frame/frame_specs.rs
@@ -5,7 +5,7 @@ use vstd_extra::drop_tracking::*;
 use vstd_extra::ownership::*;
 
 use crate::mm::frame::meta::{
-    META_SLOT_SIZE, REF_COUNT_MAX, REF_COUNT_UNIQUE, REF_COUNT_UNUSED,
+    META_SLOT_SIZE, MetaSlot, REF_COUNT_MAX, REF_COUNT_UNIQUE, REF_COUNT_UNUSED,
     mapping::{frame_to_meta, meta_to_frame},
 };
 use crate::mm::frame::*;
@@ -13,7 +13,9 @@ use crate::mm::kspace::FRAME_METADATA_RANGE;
 use crate::mm::{Paddr, PagingLevel, Vaddr};
 use crate::specs::arch::*;
 
-use crate::specs::mm::frame::{mapping::frame_to_index, meta_region_owners::MetaRegionOwners};
+use crate::specs::mm::frame::{
+    mapping::frame_to_index, meta_owners::PageUsage, meta_region_owners::MetaRegionOwners,
+};
 
 use core::marker::PhantomData;
 
@@ -115,6 +117,29 @@ impl<M: ?Sized> Frame<M> {
 
     pub open spec fn index(self) -> usize {
         frame_to_index(self.paddr())
+    }
+
+    pub open spec fn from_unused_spec(
+        paddr: Paddr,
+        pre: MetaRegionOwners,
+        post: MetaRegionOwners,
+    ) -> bool
+        recommends
+            paddr % PAGE_SIZE == 0,
+            paddr < MAX_PADDR,
+            pre.inv(),
+    {
+        let idx = frame_to_index(paddr);
+        let pre_owner = pre.slot_owners[idx];
+        let post_owner = post.slot_owners[idx];
+        {
+            &&& pre_owner.inner_perms.ref_count.value() == REF_COUNT_UNUSED
+            &&& MetaSlot::get_from_unused_inner_perms_spec(false, post_owner.inner_perms)
+            &&& post_owner.usage == PageUsage::Frame
+            &&& post_owner.slot_vaddr == pre_owner.slot_vaddr
+            &&& post_owner.paths_in_pt == pre_owner.paths_in_pt
+            &&& post =~= pre.insert_slot_owner(paddr, post_owner).mint_frame_obligation(idx)
+        }
     }
 }
 

--- a/ostd/specs/mm/frame/meta_region_owners.rs
+++ b/ostd/specs/mm/frame/meta_region_owners.rs
@@ -107,6 +107,11 @@ impl InvView for MetaRegionOwners {
 }
 
 impl MetaRegionOwners {
+    pub open spec fn insert_slot_owner(self, paddr: Paddr, owner: MetaSlotOwner) -> Self {
+        let index = frame_to_index(paddr);
+        Self { slot_owners: self.slot_owners.insert(index, owner), ..self }
+    }
+
     pub open spec fn ref_count(self, i: usize) -> (res: u64)
         recommends
             self.inv(),
@@ -231,21 +236,6 @@ impl MetaRegionOwners {
             self.slot_owners.contains_key(frame_to_index(paddr) as usize),
     {
     }
-
-    /// Move a slot pointer permission *into* `slots[index]` from caller-supplied storage.
-    /// Used by `Frame::from_raw` after the migration to typed slot perms — the perm being
-    /// returned to `regions.slots` has no `inner_perms` baggage; the inner-perms live in
-    /// `slot_owners[index].inner_perms`.
-    pub axiom fn sync_slot_perm(
-        tracked &mut self,
-        index: usize,
-        perm: &simple_pptr::PointsTo<MetaSlot>,
-    )
-        ensures
-            final(self).slots == old(self).slots.insert(index, *perm),
-            final(self).slot_owners == old(self).slot_owners,
-            final(self).frame_obligations == old(self).frame_obligations,
-    ;
 
     // ----------------------------------------------------------------------
     // Per-frame linear-drop ledger machinery.

--- a/ostd/specs/mm/frame/meta_specs.rs
+++ b/ostd/specs/mm/frame/meta_specs.rs
@@ -72,11 +72,7 @@ impl MetaSlot {
         &&& perms.vtable_ptr.is_init()
     }
 
-    /// The `slot_owners`/`obligations` transition of claiming an unused slot,
-    /// *agnostic to where the extracted slot perm ends up*. Says nothing about
-    /// `regions.slots` — callers pin the permission location separately with
-    /// [`slot_perm_extracted_spec`] (perm handed out, slot removed) or
-    /// [`slot_perm_reparked_spec`] (perm re-parked, domain preserved).
+    /// The `slot_owners`/`obligations` transition of claiming an unused slot.
     pub open spec fn get_from_unused_spec(
         paddr: Paddr,
         as_unique: bool,
@@ -89,21 +85,15 @@ impl MetaSlot {
             pre.inv(),
     {
         let idx = frame_to_index(paddr);
+        let pre_owner = pre.slot_owners[idx];
+        let post_owner = post.slot_owners[idx];
         {
-            &&& post.slot_owners.dom() =~= pre.slot_owners.dom()
-            &&& MetaSlot::get_from_unused_inner_perms_spec(
-                as_unique,
-                post.slot_owners[idx].inner_perms,
-            )
-            &&& post.slot_owners[idx].usage == PageUsage::Frame
-            &&& post.slot_owners[idx].slot_vaddr == pre.slot_owners[idx].slot_vaddr
-            &&& post.slot_owners[idx].paths_in_pt == pre.slot_owners[idx].paths_in_pt
-            &&& forall|i: usize| i != idx ==> (#[trigger] post.slot_owners[i] == pre.slot_owners[i])
-            &&& pre.slot_owners[idx].inner_perms.ref_count.value()
-                == REF_COUNT_UNUSED
-            // Linear-drop pilot: claiming an unused slot doesn't mint or
-            // redeem segment obligations.
-
+            &&& pre_owner.inner_perms.ref_count.value() == REF_COUNT_UNUSED
+            &&& MetaSlot::get_from_unused_inner_perms_spec(as_unique, post_owner.inner_perms)
+            &&& post_owner.usage == PageUsage::Frame
+            &&& post_owner.slot_vaddr == pre_owner.slot_vaddr
+            &&& post_owner.paths_in_pt == pre_owner.paths_in_pt
+            &&& post =~= pre.insert_slot_owner(paddr, post_owner)
         }
     }
 
@@ -134,17 +124,6 @@ impl MetaSlot {
             &&& forall|i: usize| i != idx ==> (#[trigger] post.slot_owners[i] == pre.slot_owners[i])
             &&& pre.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNUSED
         }
-    }
-
-    /// Permission-location clause: the slot perm was *extracted* (handed back to
-    /// the caller via an out-param), so `regions.slots` loses it. Pairs with
-    /// [`get_from_unused_spec`] to describe [`crate::mm::frame::MetaSlot::get_from_unused`].
-    pub open spec fn slot_perm_extracted_spec(
-        paddr: Paddr,
-        pre: MetaRegionOwners,
-        post: MetaRegionOwners,
-    ) -> bool {
-        post.slots =~= pre.slots.remove(frame_to_index(paddr))
     }
 
     /// Permission-location clause: the extracted slot perm was *re-parked* into

--- a/ostd/src/mm/frame/meta.rs
+++ b/ostd/src/mm/frame/meta.rs
@@ -374,51 +374,39 @@ impl MetaSlot {
     /// ## Safety
     /// - This function returns an error if `paddr` does not correspond to a valid slot or the slot is in use.
     /// - Accesses to the slot itself are gated by atomic checks, avoiding data races.
-    // FIXME: No need to give out the slot permission under the current `&mut MetaRegionOwners` design.
     #[verus_spec(res =>
         with Tracked(regions): Tracked<&mut MetaRegionOwners>
         requires
             old(regions).inv(),
         ensures
-            // Helper: on success, `regions.slots` loses the extracted slot
-            // (caller is responsible for re-parking it via `sync_slot_perm`
-            // to restore `regions.inv()`). On Err, regions is left intact
-            // and the inv is preserved.
             res is Err ==> *final(regions) == *old(regions),
-            res matches Ok((res, perm)) ==> {
-                &&& Self::get_from_unused_perm_spec(paddr, metadata, as_unique_ptr, res, perm@)
-                &&& perm@.value().wf(final(regions).slot_owners[frame_to_index(paddr)])
-                // The returned perm is exactly the slot perm that was extracted
-                // from `regions.slots`. Lets callers re-park via `sync_slot_perm`
-                // and recover `final.slots == old.slots`.
-                &&& perm@ == old(regions).slots[frame_to_index(paddr)]
+            res matches Ok(res) ==> {
+                &&& res.addr() == frame_to_meta(paddr)
+                &&& final(regions).inv()
                 &&& Self::get_from_unused_spec(paddr, as_unique_ptr, *old(regions), *final(regions))
-                // The extracted slot perm is handed back via the out-param, so it
-                // leaves `regions.slots` (caller re-parks it via `sync_slot_perm`).
-                &&& Self::slot_perm_extracted_spec(paddr, *old(regions), *final(regions))
             },
             !has_safe_slot(paddr) ==> res is Err,
-            // Linear-drop pilot: claiming an unused slot doesn't mint or
-            // redeem segment or frame obligations on any path.
-            final(regions).frame_obligations == old(regions).frame_obligations,
     )]
     pub(super) fn get_from_unused<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf>(
         paddr: Paddr,
         metadata: M,
         as_unique_ptr: bool,
-    ) -> Result<(PPtr<Self>, Tracked<PointsTo<MetaSlot>>), GetFrameError> {
+    ) -> Result<PPtr<Self>, GetFrameError> {
         let slot = get_slot(paddr)?;
 
         proof {
             regions.inv_implies_correct_addr(paddr);
         }
-
-        let tracked mut slot_own = regions.slot_owners.tracked_remove(frame_to_index(paddr));
-        let tracked mut slot_perm = regions.slots.tracked_remove(frame_to_index(paddr));
+        let ghost idx = frame_to_index(paddr);
+        let tracked slot_perm = regions.slots.tracked_borrow(idx);
+        let tracked slot_own = regions.slot_owners.tracked_borrow_mut(idx);
+        proof {
+            axiom_mmio_usage_iff_mmio_paddr(*slot_own);
+        }
 
         // `Acquire` pairs with the `Release` in `drop_last_in_place` and ensures the metadata
         // initialization won't be reordered before this memory compare-and-exchange.
-        let last_ref_cnt = slot.borrow(Tracked(&slot_perm)).ref_count.compare_exchange(
+        let last_ref_cnt = slot.borrow(Tracked(slot_perm)).ref_count.compare_exchange(
             Tracked(&mut slot_own.inner_perms.ref_count),
             REF_COUNT_UNUSED,
             0,
@@ -433,9 +421,6 @@ impl MetaSlot {
 
         if let Err(err) = last_ref_cnt {
             proof {
-                let idx = frame_to_index(paddr);
-                regions.slot_owners.tracked_insert(idx, slot_own);
-                regions.slots.tracked_insert(idx, slot_perm);
                 // CAS failure leaves `ref_count` unchanged (value + id), so the
                 // re-parked slot is exactly the original — region state intact.
                 vstd_extra::auxiliary::axiom_permission_u64_ext_eq(
@@ -455,12 +440,16 @@ impl MetaSlot {
         };
 
         if as_unique_ptr {
-            slot.borrow(Tracked(&slot_perm)).ref_count.store(
+            // No one can create a `Frame` instance directly from the page
+            // address, so `Relaxed` is fine here.
+            slot.borrow(Tracked(slot_perm)).ref_count.store(
                 Tracked(&mut slot_own.inner_perms.ref_count),
                 REF_COUNT_UNIQUE,
             );
         } else {
-            slot.borrow(Tracked(&slot_perm)).ref_count.store(
+            // `Release` is used to ensure that the metadata initialization
+            // won't be reordered after this memory store.
+            slot.borrow(Tracked(slot_perm)).ref_count.store(
                 Tracked(&mut slot_own.inner_perms.ref_count),
                 1,
             );
@@ -468,10 +457,10 @@ impl MetaSlot {
 
         proof {
             slot_own.usage = PageUsage::Frame;
-            regions.slot_owners.tracked_insert(frame_to_index(paddr), slot_own);
+            axiom_mmio_usage_iff_mmio_paddr(*slot_own);
         }
 
-        Ok((slot, Tracked(slot_perm)))
+        Ok(slot)
     }
 
     /// Gets another owning pointer to the metadata slot from the given page.

--- a/ostd/src/mm/frame/mod.rs
+++ b/ostd/src/mm/frame/mod.rs
@@ -220,9 +220,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Frame<M> {
             final(regions).inv(),
             r matches Ok(res) ==> {
                 &&& res.ptr.addr() == frame_to_meta(paddr)
-                &&& MetaSlot::get_from_unused_spec(paddr, false, *old(regions), *final(regions))
-                &&& MetaSlot::slot_perm_reparked_spec(paddr, *old(regions), *final(regions))
-                &&& MetaSlot::live_frame_obligations_ok_spec(paddr, *old(regions), *final(regions))
+                &&& Self::from_unused_spec(paddr, *old(regions), *final(regions))
             },
             !has_safe_slot(paddr) ==> r is Err,
             r is Err ==> *final(regions) == *old(regions)
@@ -233,14 +231,14 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Frame<M> {
         if let Err(err) = from_unused {
             Err(err)
         } else {
-            let (ptr, Tracked(perm)) = from_unused.unwrap();
+            let ptr = from_unused.unwrap();
             proof {
                 let ghost idx = frame_to_index(paddr);
                 assert(frame_to_index(paddr) < max_meta_slots());
                 assert(regions.slot_owners.contains_key(idx));
-                regions.sync_slot_perm(idx, &perm);
                 // Mint the pending-Drop obligation for the new live value.
                 let tracked _ = regions.tracked_mint_frame_obligation(idx);
+                assert(Self::from_unused_spec(paddr, *old(regions), *regions));
             }
             Ok(Self { ptr, _marker: PhantomData })
         }

--- a/ostd/src/mm/frame/unique.rs
+++ b/ostd/src/mm/frame/unique.rs
@@ -88,12 +88,11 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrame<M> {
             proof_with!(|= Tracked(None));
             Err(err)
         } else {
-            let (ptr, Tracked(slot_perm)) = from_unused.unwrap();
-            let ghost idx = frame_to_index(paddr);
+            let ptr = from_unused.unwrap();
 
             proof_decl! {
-                regions.slots.tracked_insert(idx, slot_perm);
                 let tracked owner = UniqueFrameOwner::<M>::tracked_from_unused_owner(regions, paddr);
+                let ghost idx = frame_to_index(paddr);
             }
             proof {
                 // The freshly-created live value owes a Drop: mint it.

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -39,39 +39,44 @@ use vstd::cell::pcell_maybe_uninit;
 use vstd::prelude::*;
 
 use vstd::atomic::PAtomicU8;
-
 use vstd_extra::array_ptr;
 use vstd_extra::cast_ptr::*;
 use vstd_extra::drop_tracking::{Drop as VerifiedDrop, TrackDrop};
 use vstd_extra::ghost_tree::*;
 use vstd_extra::ownership::*;
 
-use crate::mm::frame::allocator::FrameAllocOptions;
-use crate::mm::frame::meta::{
-    META_SLOT_SIZE,
-    mapping::{frame_to_meta, meta_to_frame},
+use crate::mm::frame::{
+    allocator::FrameAllocOptions,
+    meta::{
+        META_SLOT_SIZE, MetaSlot, REF_COUNT_MAX, REF_COUNT_UNUSED,
+        mapping::{frame_to_meta, meta_to_frame},
+    },
 };
-use crate::mm::frame::meta::{MetaSlot, REF_COUNT_MAX, REF_COUNT_UNUSED};
-use crate::mm::frame::{AnyFrameMeta, Frame};
-use crate::mm::kspace::VMALLOC_BASE_VADDR;
+
 use crate::mm::page_table::*;
-use crate::mm::{Paddr, Vaddr, kspace::LINEAR_MAPPING_BASE_VADDR, paddr_to_vaddr};
-use crate::specs::mm::frame::meta_owners::{MetaSlotOwner, MetaSlotStorage, Metadata};
-use crate::specs::mm::frame::{
-    mapping::{frame_to_index, lemma_frame_to_index_injective},
-    meta_region_owners::MetaRegionOwners,
+use crate::mm::{Paddr, Vaddr};
+use crate::specs::mm::{
+    frame::{
+        mapping::{frame_to_index, lemma_frame_to_index_injective},
+        meta_owners::{MetaSlotOwner, MetaSlotStorage, Metadata},
+        meta_region_owners::MetaRegionOwners,
+    },
+    page_table::node::owners::*,
 };
-use crate::specs::mm::page_table::node::owners::*;
 
 use core::{marker::PhantomData, ops::Deref, sync::atomic::Ordering};
 
-use super::nr_subpage_per_huge;
+use super::{PageTableConfig, PageTableEntryTrait, nr_subpage_per_huge};
 
 use crate::{
     mm::{
-        page_table::{load_pte, store_pte},
+        PagingConstsTrait,
+        PagingLevel,
         //        FrameAllocOptions, Infallible,
         //        VmReader,
+        frame::{Frame, FrameRef, meta::AnyFrameMeta},
+        paddr_to_vaddr,
+        page_table::{load_pte, store_pte},
     },
     specs::task::InAtomicMode,
 };


### PR DESCRIPTION
I find that the `PointsTo` output of  `MetaSlot::get_from_unused` is not used anywhere, so this new design may be cleaner. @SNoAnd You may have to alter the definition in embedding accordingly, but that may be a low priority.