### PR TITLE
toolchain: Align `Cargo.toml` and sync dv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "loongArch64"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "236e72a07bb26b68662f7cc9dcb58cea50cf5e3d8b698e1b51ff7c36d633dd92"
+dependencies = [
+ "bit_field",
+ "bitflags 2.9.1",
+]
+
+[[package]]
 name = "minicov"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +300,7 @@ dependencies = [
  "iced-x86",
  "inherit-methods-macro",
  "log",
+ "loongArch64",
  "minicov",
  "multiboot2",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "verified_libs/bitflags",
     "verified_libs/vstd_extra",
@@ -17,16 +18,35 @@ exclude = [
     "tests",
     "osdk",
 ]
-resolver = "2"
+
+[workspace.lints.rust]
+unsafe_op_in_unsafe_fn = "warn"
+
+[workspace.lints.clippy]
+allow_attributes = "warn"
+
+# Cargo only looks at the profile settings 
+# in the Cargo.toml manifest at the root of the workspace
+
+[profile.dev]
+panic = "unwind"
 
 [profile.release]
-overflow-checks = true
-lto = "fat"
-codegen-units = 1
+lto = "thin"
+panic = "unwind"
 
-[profile.release.build-override]
-opt-level = 3
-incremental = false
+# Release profile configuration with Link Time Optimization (LTO) enabled.
+#
+# This profile is optimized for maximum runtime performance, 
+# (achieving a 2% reduction in latency for the getpid system call).
+# However, enabling LTO significantly increases compilation times,
+# approximately doubling them compared to when LTO is not enabled.
+[profile.release-lto]
+inherits = "release"
+lto = true
+# lto can only be enabled when panic strategy is abort
+panic = "abort"
+# set codegen-units as the smallest number
 codegen-units = 1
 
 [workspace.dependencies]

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -8,25 +8,6 @@ readme = "README.md"
 repository = "https://github.com/asterinas/asterinas"
 documentation = "https://asterinas.github.io/api-docs"
 
-[lib]
-crate-type = ["rlib"]
-name = "ostd"
-# for cargo
-# path = "src/.dummy.rs"
-path = "src/lib.rs"
-
-[features]
-verus = []
-verify = ["verus"]
-alloc = []
-allow_panic = []
-default = ["verify", "alloc"]
-
-[package.metadata.verus]
-path = "src/lib.rs"
-verify = true
-# check_lifetime = false
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 # Settings for publishing docs in docs.rs
@@ -89,3 +70,20 @@ unwinding = { version = "=0.2.5", default-features = false, features = ["fde-gnu
 riscv = { version = "0.11.1", features = ["s-mode"] }
 sbi-rt = "0.0.3"
 fdt = { version = "0.1.5", features = ["pretty-printing"] }
+
+[lib]
+crate-type = ["rlib"]
+name = "ostd"
+path = "src/lib.rs"
+
+[features]
+# default = ["cvm_guest"]
+default = ["alloc"]
+alloc = []
+allow_panic = []
+# The guest OS support for Confidential VMs (CVMs), e.g., Intel TDX
+cvm_guest = ["dep:tdx-guest", "dep:iced-x86"]
+coverage = ["minicov"]
+
+[package.metadata.verus]
+verify = true

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -38,7 +38,6 @@ num-traits = { version = "0.2", default-features = false }
 ostd-pod = { path = "../verified_libs/ostd-pod" }
 spin = "0.9.4"
 smallvec = "1.13.2"
-# unwinding = { version = "=0.2.5", default-features = false, features = ["fde-gnu-eh-frame-hdr", "hide-trace", "panic", "personality", "unwinder"] }
 volatile = "0.6.1"
 bitvec = { version = "1.0", default-features = false, features = ["alloc"] }
 
@@ -70,20 +69,26 @@ unwinding = { version = "=0.2.5", default-features = false, features = ["fde-gnu
 riscv = { version = "0.11.1", features = ["s-mode"] }
 sbi-rt = "0.0.3"
 fdt = { version = "0.1.5", features = ["pretty-printing"] }
+unwinding = { version = "=0.2.5", default-features = false, features = ["fde-gnu-eh-frame-hdr", "hide-trace", "panic", "personality", "unwinder"] }
+
+[target.loongarch64-unknown-none-softfloat.dependencies]
+loongArch64 = "0.2.5"
+fdt = { version = "0.1.5", features = ["pretty-printing"] }
+
+[features]
+# default = ["cvm_guest"]
+default = []
+# The guest OS support for Confidential VMs (CVMs), e.g., Intel TDX
+cvm_guest = ["dep:tdx-guest", "dep:iced-x86"]
+coverage = ["minicov"]
+
+[lints]
+workspace = true
+
+[package.metadata.verus]
+verify = true
 
 [lib]
 crate-type = ["rlib"]
 name = "ostd"
 path = "src/lib.rs"
-
-[features]
-# default = ["cvm_guest"]
-default = ["alloc"]
-alloc = []
-allow_panic = []
-# The guest OS support for Confidential VMs (CVMs), e.g., Intel TDX
-cvm_guest = ["dep:tdx-guest", "dep:iced-x86"]
-coverage = ["minicov"]
-
-[package.metadata.verus]
-verify = true

--- a/ostd/Cargo.toml
+++ b/ostd/Cargo.toml
@@ -87,8 +87,3 @@ workspace = true
 
 [package.metadata.verus]
 verify = true
-
-[lib]
-crate-type = ["rlib"]
-name = "ostd"
-path = "src/lib.rs"

--- a/verified_libs/bitflags/Cargo.toml
+++ b/verified_libs/bitflags/Cargo.toml
@@ -6,18 +6,9 @@ edition = "2021"
 [lib]
 crate-type = ["rlib"]
 name = "bitflags"
-# for cargo
-# path = "src/.dummy.rs"
 path = "src/lib.rs"
-
-[features]
-verus = []
-verify = ["verus"]
-alloc = []
-default = ["verify", "alloc"]
 
 [package.metadata.verus]
-path = "src/lib.rs"
 verify = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/verified_libs/bitflags/Cargo.toml
+++ b/verified_libs/bitflags/Cargo.toml
@@ -3,11 +3,6 @@ name = "bitflags"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
-crate-type = ["rlib"]
-name = "bitflags"
-path = "src/lib.rs"
-
 [package.metadata.verus]
 verify = true
 

--- a/verified_libs/ostd-pod/Cargo.toml
+++ b/verified_libs/ostd-pod/Cargo.toml
@@ -10,8 +10,6 @@ repository = "https://github.com/asterinas/pod"
 [lib]
 crate-type = ["rlib"]
 name = "ostd_pod"
-# for cargo
-# path = "src/.dummy.rs"
 path = "src/lib.rs"# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -19,12 +17,5 @@ path = "src/lib.rs"# See more keys and their definitions at https://doc.rust-lan
 vstd = { workspace = true }
 vstd_extra = { path = "../vstd_extra" }
 
-[features]
-verus = []
-verify = ["verus"]
-# default = ["derive"]
-# derive = ["ostd-pod-derive"]
-
 [package.metadata.verus]
-path = "src/lib.rs"
 verify = true

--- a/verified_libs/ostd-pod/Cargo.toml
+++ b/verified_libs/ostd-pod/Cargo.toml
@@ -7,15 +7,21 @@ description = "A marker trait for plain old data (POD)"
 readme = "README.md"
 repository = "https://github.com/asterinas/pod"
 
-[lib]
-crate-type = ["rlib"]
-name = "ostd_pod"
-path = "src/lib.rs"# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 # ostd-pod-derive = { path = "derive", optional = true, version = "0.1.1" }
 vstd = { workspace = true }
 vstd_extra = { path = "../vstd_extra" }
 
+[features]
+# default = ["derive"]
+# derive = ["ostd-pod-derive"]
+
 [package.metadata.verus]
 verify = true
+
+[lib]
+crate-type = ["rlib"]
+name = "ostd_pod"
+path = "src/lib.rs"

--- a/verified_libs/vstd_extra/Cargo.toml
+++ b/verified_libs/vstd_extra/Cargo.toml
@@ -3,11 +3,6 @@ name = "vstd_extra"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
-crate-type = ["rlib"]
-name = "vstd_extra"
-path = "src/lib.rs"
-
 [package.metadata.verus]
 verify = true
 

--- a/verified_libs/vstd_extra/Cargo.toml
+++ b/verified_libs/vstd_extra/Cargo.toml
@@ -6,21 +6,10 @@ edition = "2021"
 [lib]
 crate-type = ["rlib"]
 name = "vstd_extra"
-# for cargo
-# path = "src/.dummy.rs"
 path = "src/lib.rs"
-
-[features]
-verus = []
-verify = ["verus"]
-alloc = []
-default = ["verify", "alloc"]
 
 [package.metadata.verus]
-path = "src/lib.rs"
 verify = true
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 vstd = { workspace = true }


### PR DESCRIPTION
The verus target is only decided by `cargo.metadata.verus` now.