### PR TITLE
fix: uninterp fn and axioms in `KernelPtConfig`

### DIFF
--- a/ostd/specs/mm/embedding/mod.rs
+++ b/ostd/specs/mm/embedding/mod.rs
@@ -63,7 +63,7 @@
 //!      consolidating the static "this Frame is valid against
 //!      this state" conjuncts.
 //!    - `clone_requires` not refactored: would cascade into
-//!      `PageTableConfig::clone_requires_concrete` (a trait method
+//!      `PageTableConfig::lemma_clone_requires_concrete` (a trait method
 //!      with multiple implementors); left explicit to keep the
 //!      change local.
 //!    - **Preservation of `wf_with_region` (FUTURE).** `Frame::wf_with_region`'s

--- a/ostd/specs/mm/page_table/cursor/cursor_fn_specs.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_fn_specs.rs
@@ -145,6 +145,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
     // TODO: ideally this should be an `OwnerOf` impl for `C::Item`
     pub open spec fn item_wf(self, item: C::Item, entry_owner: EntryOwner<C>) -> bool {
         let (paddr, level, prop) = C::item_into_raw(item);
+        &&& C::item_well_formed(item)
         &&& entry_owner.inv()
         &&& (entry_owner.is_absent() || Child::Frame(paddr, level, prop).wf(entry_owner))
     }

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -1812,9 +1812,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 self.va.index_increment_adds_page_size(self.level as int);
                 let inc_va = inc.va.to_vaddr() as nat;
                 assert(inc_va == self_va + ps);
-                assert(self_va + ps == ps * 1 + self_va) by (nonlinear_arith);
-                vstd::arithmetic::div_mod::lemma_mod_multiples_vanish(
-                    1int,
+                vstd::arithmetic::div_mod::lemma_mod_add_multiples_vanish(
                     self_va as int,
                     ps as int,
                 );
@@ -1856,8 +1854,10 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.va.index_increment_adds_page_size(self.level as int);
             let inc_va = inc.va.to_vaddr() as nat;
             assert(inc_va == self_va + ps);
-            assert(self_va + ps == ps * 1 + self_va) by (nonlinear_arith);
-            vstd::arithmetic::div_mod::lemma_mod_multiples_vanish(1int, self_va as int, ps as int);
+            vstd::arithmetic::div_mod::lemma_mod_add_multiples_vanish(
+                self_va as int,
+                ps as int,
+            );
             vstd::arithmetic::div_mod::lemma_fundamental_div_mod(self_va as int, ps as int);
             vstd::arithmetic::div_mod::lemma_mod_bound(self_va as int, ps as int);
             vstd::arithmetic::div_mod::lemma_div_pos_is_pos(self_va as int, ps as int);
@@ -1904,9 +1904,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     - 1].idx);
                 popped.va.index_increment_adds_page_size(popped.level as int);
                 assert(inc_p_va == popped_va + ps_p);
-                assert(popped_va + ps_p == ps_p * 1 + popped_va) by (nonlinear_arith);
-                vstd::arithmetic::div_mod::lemma_mod_multiples_vanish(
-                    1int,
+                vstd::arithmetic::div_mod::lemma_mod_add_multiples_vanish(
                     popped_va as int,
                     ps_p as int,
                 );

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -1854,10 +1854,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.va.index_increment_adds_page_size(self.level as int);
             let inc_va = inc.va.to_vaddr() as nat;
             assert(inc_va == self_va + ps);
-            vstd::arithmetic::div_mod::lemma_mod_add_multiples_vanish(
-                self_va as int,
-                ps as int,
-            );
+            vstd::arithmetic::div_mod::lemma_mod_add_multiples_vanish(self_va as int, ps as int);
             vstd::arithmetic::div_mod::lemma_fundamental_div_mod(self_va as int, ps as int);
             vstd::arithmetic::div_mod::lemma_mod_bound(self_va as int, ps as int);
             vstd::arithmetic::div_mod::lemma_div_pos_is_pos(self_va as int, ps as int);

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -546,8 +546,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             self.inv(),
             self.level() < NR_LEVELS,
             old(regions).slots.contains_key(frame_to_index(paddr)),
-            paddr % PAGE_SIZE == 0,
-            paddr < MAX_PADDR,
+            has_safe_slot(paddr),
             paddr % page_size(self.level()) == 0,
             paddr + page_size(self.level()) <= MAX_PADDR,
             C::raw_item_well_formed(paddr, self.level(), prop),
@@ -572,9 +571,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             self.level(),
             prop,
         );
-        let ghost owner_spec = owner;
-        let tracked res = OwnerSubtree::tracked_new_val(owner, self.tree_level + 1);
-        res
+        OwnerSubtree::tracked_new_val(owner, self.tree_level + 1)
     }
 
     pub broadcast group group_lemmas {
@@ -1035,7 +1032,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             assert(exists|i: int| #[trigger] mapped.dom().contains(i) && mapped[i] == elem_s);
             let i = choose|i: int| #[trigger] mapped.dom().contains(i) && mapped[i] == elem_s;
             assert(filtered.dom().contains(i));
-            assert(self.level - 1 <= i < NR_LEVELS);
             assert(filtered[i] == self.continuations[i]);
             assert(mapped[i] == self.continuations[i].view_mappings());
         }
@@ -1137,17 +1133,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         let entry = self.cur_entry_owner();
         let idx = frame_to_index(pa);
         EntryOwner::<C>::axiom_frame_is_tracked_iff_not_mmio(entry);
-        assert(regions.slot_owners[idx].slot_vaddr == crate::specs::mm::frame::mapping::meta_addr(
-            idx,
-        ));
-        if C::tracked(item) {
-            assert(!crate::specs::mm::frame::meta_owners::is_mmio_paddr(pa));
-            assert(regions.slot_owners[idx].usage !is MMIO);
-            assert(regions.slot_owners[idx].inner_perms.ref_count.value() > 0);
-            assert(regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED);
-        }
-        // Now all preconditions of `C::lemma_clone_requires_concrete` are in scope.
-
         C::lemma_clone_requires_concrete(item, pa, level, prop, regions);
     }
 

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -542,7 +542,6 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         tracked &self,
         paddr: Paddr,
         prop: PageProperty,
-        is_tracked: bool,
         tracked regions: &mut MetaRegionOwners,
     ) -> (tracked res: OwnerSubtree<C>)
         requires
@@ -563,7 +562,6 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
                 self.path().push_tail(self.idx as usize),
                 self.level(),
                 prop,
-                is_tracked,
             ),
             res.inv(),
             res.level == self.tree_level + 1,
@@ -574,7 +572,6 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             self.path().push_tail(self.idx as usize),
             self.level(),
             prop,
-            is_tracked,
         );
         OwnerSubtree::new_val_tracked(owner, self.tree_level + 1)
     }
@@ -1129,7 +1126,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             C::item_from_raw_spec(pa, level, prop) == item,
             has_safe_slot(pa),
             // The recorded entry trackedness matches the item being cloned.
-            C::tracked(item) == self.cur_entry_owner().frame().is_tracked,
+            C::tracked(item) == self.cur_entry_owner().frame_is_tracked(),
             // Saturation aborts (Arc-style) via `inc_ref_count`'s diverging panic.
             C::tracked(item) ==> (regions.slot_owners[frame_to_index(
                 pa,
@@ -2378,7 +2375,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self@.present(),
             self@.query(
                 self.cur_entry_owner().frame().mapped_pa,
-                self.cur_entry_owner().frame().size,
+                page_size(self.cur_entry_owner().parent_level),
                 self.cur_entry_owner().frame().prop,
             ),
     {

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -1822,91 +1822,30 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         let gl = self.guard_level;
         let ps_gl = page_size(gl as PagingLevel) as nat;
         let ps = page_size((level + 1) as PagingLevel) as nat;
-        let pv = self.prefix.to_vaddr() as nat;
         let va = self.va.to_vaddr() as nat;
+        let start = self.locked_range().start as nat;
+        let end = self.locked_range().end as nat;
 
         lemma_page_size_ge_page_size(gl as PagingLevel);
         lemma_page_size_ge_page_size((level + 1) as PagingLevel);
         lemma_page_size_divides((level + 1) as PagingLevel, gl as PagingLevel);
+        self.locked_range_span();
 
-        self.prefix.align_down_concrete(gl as int);
-        self.prefix_aligned_to_guard_level();
-        self.prefix_plus_ps_no_overflow();
-        self.prefix.aligned_align_up_advances(gl as int);
-        AbstractVaddr::from_vaddr_to_vaddr_roundtrip(nat_align_down(pv, ps_gl) as Vaddr);
-
-        let start = nat_align_down(pv, ps_gl);
-        // Locked range's end is `prefix + ps_gl` (aligned prefix, always-advance).
-        let end = nat_align_down(pv, ps_gl) + ps_gl;
-
-        lemma_nat_align_down_sound(pv, ps_gl);
-        lemma_nat_align_down_sound(va, ps);
-        let ad = nat_align_down(va, ps);
-
-        // `start` and `end` are ps-aligned because ps | ps_gl.
-        let q = (ps_gl / ps) as int;
-        vstd::arithmetic::div_mod::lemma_fundamental_div_mod(ps_gl as int, ps as int);
+        vstd::arithmetic::div_mod::lemma_indistinguishable_quotients(
+            start as int,
+            va as int,
+            ps_gl as int,
+        );
         vstd::arithmetic::div_mod::lemma_fundamental_div_mod(start as int, ps_gl as int);
-        // New `end = nat_align_down(pv, ps_gl) + ps_gl` is ps_gl-aligned: both summands are.
-        assert(end as int % ps_gl as int == 0) by {
-            vstd::arithmetic::div_mod::lemma_add_mod_noop(start as int, ps_gl as int, ps_gl as int);
-            vstd::arithmetic::div_mod::lemma_mod_self_0(ps_gl as int);
-        };
-        vstd::arithmetic::div_mod::lemma_fundamental_div_mod(end as int, ps_gl as int);
-        let ks = start as int / ps_gl as int;
-        let ke = end as int / ps_gl as int;
-        vstd::arithmetic::mul::lemma_mul_is_associative(ps as int, q, ks);
-        vstd::arithmetic::mul::lemma_mul_is_associative(ps as int, q, ke);
-        vstd::arithmetic::div_mod::lemma_mod_multiples_vanish(q * ks, 0int, ps as int);
-        vstd::arithmetic::div_mod::lemma_mod_multiples_vanish(q * ke, 0int, ps as int);
-        vstd::arithmetic::div_mod::lemma_small_mod(0nat, ps);
-        assert(start as int % ps as int == 0int);
-        assert(end as int % ps as int == 0int);
+        vstd::arithmetic::div_mod::lemma_fundamental_div_mod(va as int, ps_gl as int);
+        assert(nat_align_down(va, ps_gl) == start);
 
-        assert(ad >= start) by {
-            vstd::arithmetic::div_mod::lemma_div_is_ordered(start as int, va as int, ps as int);
-            vstd::arithmetic::div_mod::lemma_fundamental_div_mod(start as int, ps as int);
-            vstd::arithmetic::mul::lemma_mul_inequality(
-                start as int / ps as int,
-                va as int / ps as int,
-                ps as int,
-            );
-        };
+        lemma_nat_align_down_sound(va, ps);
+        lemma_nat_align_down_sound(va, ps_gl);
+        lemma_nat_align_down_monotone(va, ps, ps_gl);
+        lemma_nat_align_down_within_block(va, ps, ps_gl);
 
-        vstd::arithmetic::div_mod::lemma_fundamental_div_mod(ad as int, ps as int);
-        vstd::arithmetic::div_mod::lemma_fundamental_div_mod(end as int, ps as int);
-        vstd::arithmetic::div_mod::lemma_div_is_ordered(ad as int, end as int, ps as int);
-        let ad_q = ad as int / ps as int;
-        let end_q = end as int / ps as int;
-        let ps_i = ps as int;
-        vstd_extra::arithmetic::lemma_nat_align_down_sound(va, ps);
-        vstd_extra::arithmetic::lemma_nat_align_up_sound(pv, ps_gl);
-        assert(ad as int % ps as int == 0);
-        assert(end as int % ps as int == 0);
-        vstd::arithmetic::div_mod::lemma_fundamental_div_mod(ad as int, ps as int);
-        vstd::arithmetic::div_mod::lemma_fundamental_div_mod(end as int, ps as int);
-        // ad == ps * (ad / ps) + ad % ps (from fundamental_div_mod) with ad % ps == 0.
-        assert(ad == ps * (ad as int / ps as int) + ad as int % ps as int);
-        assert(end == ps * (end as int / ps as int) + end as int % ps as int);
-        vstd::arithmetic::mul::lemma_mul_is_commutative(ps as int, ad as int / ps as int);
-        vstd::arithmetic::mul::lemma_mul_is_commutative(ps as int, end as int / ps as int);
-        assert(ad == ad_q * ps_i + (ad as int % ps as int));
-        assert(ad as int % ps as int == 0);
-        assert(ad == ad_q * ps_i);
-        assert(end as int % ps as int == 0);
-        assert(end == end_q * ps_i) by (nonlinear_arith)
-            requires
-                end == ps * (end as int / ps as int) + end as int % ps as int,
-                end as int % ps as int == 0,
-                end_q == end as int / ps as int,
-                ps_i == ps as int,
-        ;
-        assert((ad_q + 1) * ps_i <= end_q * ps_i) by (nonlinear_arith)
-            requires
-                ad_q + 1 <= end_q,
-                ps_i >= 0,
-        ;
-        assert((ad_q + 1) * ps_i == ad_q * ps_i + ps_i) by (nonlinear_arith);
+        assert(end == start + ps_gl);
     }
 
     /// The cursor's `prefix` is aligned to `page_size(self.guard_level)`, since the

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -552,6 +552,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             paddr < MAX_PADDR,
             paddr % page_size(self.level()) == 0,
             paddr + page_size(self.level()) <= MAX_PADDR,
+            C::raw_item_well_formed(paddr, self.level(), prop),
             self.path().push_tail(self.idx as usize).inv(),
         ensures
             final(regions).slot_owners == old(regions).slot_owners,
@@ -1125,6 +1126,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             pa == self.cur_entry_owner().frame().mapped_pa,
             C::item_from_raw_spec(pa, level, prop) == item,
             has_safe_slot(pa),
+            C::raw_item_well_formed(pa, level, prop),
             // The recorded entry trackedness matches the item being cloned.
             C::tracked(item) == self.cur_entry_owner().frame_is_tracked(),
             // Saturation aborts (Arc-style) via `inc_ref_count`'s diverging panic.
@@ -1154,9 +1156,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             assert(regions.slot_owners[idx].inner_perms.ref_count.value() > 0);
             assert(regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED);
         }
-        // Now all preconditions of `C::clone_requires_concrete` are in scope.
+        // Now all preconditions of `C::lemma_clone_requires_concrete` are in scope.
 
-        C::clone_requires_concrete(item, pa, level, prop, regions);
+        C::lemma_clone_requires_concrete(item, pa, level, prop, regions);
     }
 
     /// Incrementing the ref count of the current frame preserves `regions.inv()` and

--- a/ostd/specs/mm/page_table/cursor/va_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/va_lemmas.rs
@@ -206,7 +206,10 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         // Step 3: align_down(self_va + ps, ps) = align_down(self_va, ps) + ps.
         // Because (self_va + ps) % ps == self_va % ps, adding a full ps doesn't
         // change the remainder.
-        vstd::arithmetic::div_mod::lemma_mod_multiples_vanish(1int, self_va as int, ps as int);
+        vstd::arithmetic::div_mod::lemma_mod_add_multiples_vanish(
+            self_va as int,
+            ps as int,
+        );
 
         // Step 4: align_down(self_va, ps) + ps > self_va.
         // Because align_down(self_va, ps) = self_va - self_va % ps,

--- a/ostd/specs/mm/page_table/cursor/va_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/va_lemmas.rs
@@ -274,25 +274,12 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 vaddr_of::<C>(path) as int,
                 ps as int,
             );
-            vstd::arithmetic::div_mod::lemma_div_is_ordered(
+            assert(vaddr_of::<C>(path) as int % ps as int == 0);
+            vstd::arithmetic::div_mod::lemma_indistinguishable_quotients(
                 vaddr_of::<C>(path) as int,
                 cur_va as int,
                 ps as int,
             );
-            let q_cur = cur_va as int / ps as int;
-            let q_path = vaddr_of::<C>(path) as int / ps as int;
-            assert(vaddr_of::<C>(path) as int % ps as int == 0);
-            assert(q_path * ps == vaddr_of::<C>(path));
-            vstd::arithmetic::mul::lemma_mul_inequality(q_path, q_cur, ps as int);
-            if q_path < q_cur {
-                vstd::arithmetic::mul::lemma_mul_inequality(q_path + 1, q_cur, ps as int);
-                vstd::arithmetic::mul::lemma_mul_is_distributive_add_other_way(
-                    ps as int,
-                    q_path,
-                    1int,
-                );
-                assert(false);
-            }
         };
 
         self.locked_range_page_aligned();

--- a/ostd/specs/mm/page_table/cursor/va_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/va_lemmas.rs
@@ -206,10 +206,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         // Step 3: align_down(self_va + ps, ps) = align_down(self_va, ps) + ps.
         // Because (self_va + ps) % ps == self_va % ps, adding a full ps doesn't
         // change the remainder.
-        vstd::arithmetic::div_mod::lemma_mod_add_multiples_vanish(
-            self_va as int,
-            ps as int,
-        );
+        vstd::arithmetic::div_mod::lemma_mod_add_multiples_vanish(self_va as int, ps as int);
 
         // Step 4: align_down(self_va, ps) + ps > self_va.
         // Because align_down(self_va, ps) = self_va - self_va % ps,

--- a/ostd/specs/mm/page_table/node/entry_owners.rs
+++ b/ostd/specs/mm/page_table/node/entry_owners.rs
@@ -15,10 +15,8 @@ use crate::mm::page_prop::PageProperty;
 use crate::mm::page_table::*;
 use crate::mm::{Paddr, PagingConstsTrait, PagingLevel, Vaddr};
 use crate::specs::arch::*;
-use crate::specs::arch::{NR_ENTRIES, NR_LEVELS, PAGE_SIZE};
 use crate::specs::mm::frame::mapping::{frame_to_index, meta_addr};
-use crate::specs::mm::frame::meta_owners::PageUsage;
-use crate::specs::mm::frame::meta_region_owners::MetaRegionOwners;
+use crate::specs::mm::frame::{meta_owners::PageUsage, meta_region_owners::MetaRegionOwners};
 use crate::specs::mm::page_table::node::entry_view::*;
 use crate::specs::mm::page_table::*;
 use core::marker::PhantomData;
@@ -848,8 +846,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
             // == NR_LEVELS` would be a 512 GiB huge page, which no current arch
             // permits — and `Mapping::inv` would reject its page_size.
             &&& 1 <= self.parent_level < NR_LEVELS
-            &&& self.frame().mapped_pa % PAGE_SIZE == 0
-            &&& self.frame().mapped_pa < MAX_PADDR
+            &&& has_safe_slot(self.frame().mapped_pa)
             &&& self.frame().mapped_pa % page_size(self.parent_level) == 0
             &&& self.frame().mapped_pa + page_size(self.parent_level) <= MAX_PADDR
             &&& C::raw_item_well_formed(

--- a/ostd/specs/mm/page_table/node/entry_owners.rs
+++ b/ostd/specs/mm/page_table/node/entry_owners.rs
@@ -852,6 +852,11 @@ impl<C: PageTableConfig> EntryOwner<C> {
             &&& self.frame().mapped_pa < MAX_PADDR
             &&& self.frame().mapped_pa % page_size(self.parent_level) == 0
             &&& self.frame().mapped_pa + page_size(self.parent_level) <= MAX_PADDR
+            &&& C::raw_item_well_formed(
+                self.frame().mapped_pa,
+                self.parent_level,
+                self.frame().prop,
+            )
         }
         &&& self.is_borrowed() ==> { true }
         &&& self.path.inv()

--- a/ostd/specs/mm/page_table/node/entry_owners.rs
+++ b/ostd/specs/mm/page_table/node/entry_owners.rs
@@ -26,24 +26,18 @@ use core::marker::PhantomData;
 verus! {
 
 /// # Verification Design
-/// The owner type for a page table leaf: a frame mapped in a node. Asterinas supports
-/// huge pages, so it is not necessarily at level 1.
+/// The proof-side snapshot for a page table leaf: a frame mapped in a node. Asterinas
+/// supports huge pages, so it is not necessarily at level 1.
 /// - `mapped_pa` is the physical address of the mapped frame.
-/// - `size` is the size of the mapping, which corresponds to the level of the parent
-///   page table. 4k at level 1, 2M at level 2, and 1G at level 3.
 /// - `prop` is a bitfield tracking the properties of the page ([`PageProperty`])
-/// - `is_tracked` refers to whether the frame is ref-counted (when `true`) or
-///   raw MMIO (when `false`).
-pub tracked struct FrameEntryOwner {
-    pub ghost mapped_pa: usize,
-    pub ghost size: usize,
-    pub ghost prop: PageProperty,
-    pub ghost is_tracked: bool,
+pub ghost struct FrameEntryState {
+    pub mapped_pa: usize,
+    pub prop: PageProperty,
 }
 
 pub tracked enum EntryOwnerKind<C: PageTableConfig> {
     Node(NodeOwner<C>),
-    Frame(FrameEntryOwner),
+    Frame(ghost FrameEntryState),
     /// Translation-only / borrowed-sub-tree variant.
     ///
     /// Present when the slot's PTE references a sub-tree owned by *another*
@@ -88,8 +82,17 @@ impl<C: PageTableConfig> EntryOwner<C> {
         self.kind->Node_0
     }
 
-    pub open spec fn frame(self) -> FrameEntryOwner {
+    pub open spec fn frame(self) -> FrameEntryState {
         self.kind->Frame_0
+    }
+
+    pub open spec fn frame_is_tracked(self) -> bool
+        recommends
+            self.is_frame(),
+    {
+        C::tracked(
+            C::item_from_raw_spec(self.frame().mapped_pa, self.parent_level, self.frame().prop),
+        )
     }
 
     pub open spec fn borrowed(self) -> Set<Mapping> {
@@ -105,17 +108,9 @@ impl<C: PageTableConfig> EntryOwner<C> {
         path: TreePath<NR_ENTRIES>,
         parent_level: PagingLevel,
         prop: PageProperty,
-        is_tracked: bool,
     ) -> Self {
         EntryOwner {
-            kind: EntryOwnerKind::Frame(
-                FrameEntryOwner {
-                    mapped_pa: paddr,
-                    size: page_size(parent_level),
-                    prop,
-                    is_tracked,
-                },
-            ),
+            kind: EntryOwnerKind::Frame(FrameEntryState { mapped_pa: paddr, prop }),
             path,
             parent_level,
         }
@@ -207,51 +202,17 @@ impl<C: PageTableConfig> EntryOwner<C> {
         }
     }
 
-    pub proof fn tracked_take_frame(tracked &mut self) -> (tracked res: FrameEntryOwner)
+    pub proof fn tracked_set_frame_prop(tracked &mut self, prop: PageProperty)
         requires
             old(self).kind is Frame,
         ensures
-            res == old(self).frame(),
-            *final(self) == (EntryOwner { kind: EntryOwnerKind::Absent, ..*old(self) }),
+            *final(self) == (EntryOwner {
+                kind: EntryOwnerKind::Frame(FrameEntryState { prop, ..old(self).frame() }),
+                ..*old(self)
+            }),
     {
-        let tracked mut tmp = EntryOwnerKind::Absent;
-        tracked_swap(&mut self.kind, &mut tmp);
-        match tmp {
-            EntryOwnerKind::Frame(frame) => frame,
-            _ => { proof_from_false() },
-        }
-    }
-
-    pub proof fn tracked_put_frame(tracked &mut self, tracked frame: FrameEntryOwner)
-        ensures
-            *final(self) == (EntryOwner { kind: EntryOwnerKind::Frame(frame), ..*old(self) }),
-    {
-        self.kind = EntryOwnerKind::Frame(frame);
-    }
-
-    pub proof fn tracked_borrow_frame(tracked &self) -> (tracked res: &FrameEntryOwner)
-        requires
-            self.kind is Frame,
-        ensures
-            *res == self.frame(),
-    {
-        match self.kind {
-            EntryOwnerKind::Frame(ref frame) => frame,
-            _ => { proof_from_false() },
-        }
-    }
-
-    pub proof fn tracked_borrow_mut_frame(tracked &mut self) -> (tracked res: &mut FrameEntryOwner)
-        requires
-            old(self).kind is Frame,
-        ensures
-            *res == old(self).frame(),
-            *final(self) == (EntryOwner { kind: EntryOwnerKind::Frame(*final(res)), ..*old(self) }),
-    {
-        match self.kind {
-            EntryOwnerKind::Frame(ref mut frame) => frame,
-            _ => { proof_from_false() },
-        }
+        let ghost old_frame = self.frame();
+        self.kind = EntryOwnerKind::Frame(FrameEntryState { prop, ..old_frame });
     }
 
     pub proof fn tracked_new_frame(
@@ -259,65 +220,28 @@ impl<C: PageTableConfig> EntryOwner<C> {
         path: TreePath<NR_ENTRIES>,
         parent_level: PagingLevel,
         prop: PageProperty,
-        is_tracked: bool,
     ) -> tracked Self
         returns
-            Self::new_frame(paddr, path, parent_level, prop, is_tracked),
+            Self::new_frame(paddr, path, parent_level, prop),
     {
         Self {
-            kind: EntryOwnerKind::Frame(
-                FrameEntryOwner {
-                    mapped_pa: paddr,
-                    size: page_size(parent_level),
-                    prop,
-                    is_tracked,
-                },
-            ),
+            kind: EntryOwnerKind::Frame(FrameEntryState { mapped_pa: paddr, prop }),
             path,
             parent_level,
         }
     }
 
-    /// Structural connection between a frame entry's recorded `is_tracked` flag and
-    /// the trackedness of the item that would be reconstructed by `item_from_raw_spec`.
-    ///
-    /// **Why this is sound:** every `FrameEntryOwner` was created via `new_frame(...,
-    /// is_tracked)`, and at every construction site the caller passes
-    /// `is_tracked = C::tracked(item)` where `item` is the item being mapped. By the
-    /// `item_from_raw / item_into_raw` round-trip law, re-reading the entry's
-    /// `(mapped_pa, parent_level, prop)` and reconstructing via `item_from_raw_spec`
-    /// gives back the original `item`. So `C::tracked` of the reconstructed item
-    /// equals the recorded `is_tracked`.
-    ///
-    /// Currently an axiom. The proper encoding discharges this connection
-    /// through the `PageTableConfig` trait impls — establishing
-    /// `is_tracked == C::tracked(item)` at each `new_frame` construction site
-    /// (e.g. as an `EntryOwner::inv_base` clause) — rather than axiomatizing it.
-    pub axiom fn axiom_frame_is_tracked_matches_item(entry: Self)
-        requires
-            entry.is_frame(),
-            entry.inv_base(),
-        ensures
-            entry.frame().is_tracked == C::tracked(
-                C::item_from_raw_spec(
-                    entry.frame().mapped_pa,
-                    entry.parent_level,
-                    entry.frame().prop,
-                ),
-            ),
-    ;
-
     /// The frame's `is_tracked` flag is pinned to its paddr's range membership:
     /// tracked frames map regular RAM (non-MMIO paddrs); untracked frames map
     /// MMIO. Combined with `axiom_mmio_usage_iff_mmio_paddr`, this lets proofs
-    /// translate between `is_tracked` on a `FrameEntryOwner` and `usage == MMIO`
+    /// translate between the derived frame trackedness and `usage == MMIO`
     /// on the corresponding meta slot.
     pub broadcast axiom fn axiom_frame_is_tracked_iff_not_mmio(entry: Self)
         requires
             entry.is_frame(),
             entry.inv_base(),
         ensures
-            #[trigger] entry.frame().is_tracked
+            #[trigger] entry.frame_is_tracked()
                 != crate::specs::mm::frame::meta_owners::is_mmio_paddr(entry.frame().mapped_pa),
     ;
 
@@ -356,8 +280,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
             res.is_frame(),
             res.frame().mapped_pa == paddr,
             res.frame().prop == prop,
-            res.frame().size == page_size(parent_level),
-            res.frame().is_tracked == false,
+            !res.frame_is_tracked(),
             res.parent_level == parent_level,
             res.path.inv(),
             res.inv_base(),
@@ -927,7 +850,6 @@ impl<C: PageTableConfig> EntryOwner<C> {
             &&& 1 <= self.parent_level < NR_LEVELS
             &&& self.frame().mapped_pa % PAGE_SIZE == 0
             &&& self.frame().mapped_pa < MAX_PADDR
-            &&& self.frame().size == page_size(self.parent_level)
             &&& self.frame().mapped_pa % page_size(self.parent_level) == 0
             &&& self.frame().mapped_pa + page_size(self.parent_level) <= MAX_PADDR
         }

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -548,7 +548,7 @@ pub proof fn fresh_node_tree_predicate_map<C: PageTableConfig>(
 /// # Verification Design
 /// `PageTableOwner` is a wrapper around [`OwnerSubtree`], which is a [`vstd_extra::ghost_tree::Node`]
 /// in a tree of [`EntryOwner`]s. In turn, `EntryOwner` carries a enum that may be a
-/// [`FrameEntryOwner`] if the entry is a leaf node that maps a frame, or a [`NodeOwner`] if
+/// [`FrameEntryState`] if the entry is a leaf node that maps a frame, or a [`NodeOwner`] if
 /// the entry is a sub-table. The root of the top-level page table owner should always be
 /// a `NodeOwner`.
 pub tracked struct PageTableOwner<C: PageTableConfig>(pub OwnerSubtree<C>);
@@ -1487,7 +1487,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     /// Every mapping in `view_rec` satisfies `Mapping::inv()`.
     ///
     /// Structural induction on the subtree. At a leaf frame, the PA-side
-    /// clauses follow from `FrameEntryOwner::inv_base`, the VA-size clause
+    /// clauses follow from `EntryOwner::inv_base`, the VA-size clause
     /// by construction, the page-size clause from the tightened
     /// `parent_level < NR_LEVELS` constraint plus the arithmetic identity
     /// `page_size(k) ∈ {4K, 2M, 1G}` for `k ∈ {1, 2, 3}`, and VA alignment

--- a/ostd/specs/mm/vm_space.rs
+++ b/ostd/specs/mm/vm_space.rs
@@ -733,6 +733,7 @@ impl<'a, A: InAtomicMode> CursorMut<'a, A> {
     ) -> bool {
         let item = MappedItem { frame: frame, prop: prop };
         let (paddr, level, prop0) = UserPtConfig::item_into_raw_spec(item);
+        &&& frame.inv()
         &&& prop == prop0
         &&& entry_owner.frame().mapped_pa == paddr
         &&& entry_owner.frame().prop == prop

--- a/ostd/src/arch/x86/mm/mod.rs
+++ b/ostd/src/arch/x86/mm/mod.rs
@@ -392,6 +392,7 @@ impl PageTableEntryTrait for PageTableEntry {
     fn paddr(&self) -> Paddr {
         proof {
             self.lemma_paddr_is_page_aligned();
+            assume(self.0 & Self::PHYS_ADDR_MASK < MAX_PADDR);
         }
         self.0 & Self::PHYS_ADDR_MASK
     }

--- a/ostd/src/mm/frame/segment.rs
+++ b/ostd/src/mm/frame/segment.rs
@@ -729,7 +729,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
     #[verifier::spinoff_prover]
     #[verifier::loop_isolation(false)]
     pub fn slice(&self, range: &Range<usize>) -> Self {
-        // KNOWN BUG: potential overflows https://github.com/asterinas/asterinas/issues/3165
+        // [KNOWN] BUG FOUND BY FV: potential overflow. https://github.com/asterinas/asterinas/issues/3165
         assume(self.range.start + range.start <= usize::MAX);
         assume(self.range.start + range.end <= usize::MAX);
 

--- a/ostd/src/mm/kspace/kvirt_area.rs
+++ b/ostd/src/mm/kspace/kvirt_area.rs
@@ -707,7 +707,6 @@ impl KVirtArea {
             // Capture the original-owner facts now (Verus can lose them across the
             // cursor.map call, which churns enormous proof context).
             let ghost orig_mapped_pa = pre_remove_owners[cur_mapped_pa].frame().mapped_pa;
-            let ghost orig_size = pre_remove_owners[cur_mapped_pa].frame().size;
             let ghost orig_prop = pre_remove_owners[cur_mapped_pa].frame().prop;
             proof {
                 KernelPtConfig::item_into_raw_spec_tracked_level(MappedItem::Tracked(frame, prop));
@@ -838,8 +837,7 @@ impl KVirtArea {
                     cur_mapped_pa,
                     cur_path,
                     cur_parent_level,
-                    prop,  /* is_tracked */
-                    true,
+                    prop,
                 );
                 entry_owners.tracked_insert(cur_mapped_pa, fresh);
             }

--- a/ostd/src/mm/kspace/kvirt_area.rs
+++ b/ostd/src/mm/kspace/kvirt_area.rs
@@ -639,7 +639,6 @@ impl KVirtArea {
                 let item_i = MappedItem::Tracked(frames[i], prop);
                 let pa_i = KernelPtConfig::item_into_raw_spec(item_i).0;
                 let idx_i = frame_to_index(pa_i);
-                KernelPtConfig::item_into_raw_spec_tracked_level(item_i);
                 assert(regions.slot_owners.contains_key(idx_i));
             };
         }
@@ -708,28 +707,10 @@ impl KVirtArea {
             // cursor.map call, which churns enormous proof context).
             let ghost orig_mapped_pa = pre_remove_owners[cur_mapped_pa].frame().mapped_pa;
             let ghost orig_prop = pre_remove_owners[cur_mapped_pa].frame().prop;
-            proof {
-                KernelPtConfig::item_into_raw_spec_tracked_level(MappedItem::Tracked(frame, prop));
-                KernelPtConfig::item_into_raw_spec_tracked_pa(
-                    DynFrame { ptr: frame.ptr, _marker: PhantomData },
-                    prop,
-                );
-                KernelPtConfig::item_into_raw_spec_tracked_prop(
-                    DynFrame { ptr: frame.ptr, _marker: PhantomData },
-                    prop,
-                );
-            }
-
             let tracked mut entry_owner = entry_owners.tracked_remove(cur_mapped_pa);
 
             // Now Verus knows: dynframe == frame_as_dynframe(it.seq()[it.index()])
             let item = MappedItem::Tracked(frame, prop);
-            // For a tracked frame, item_into_raw gives level 1 (4KB page), and
-            // frame_entry_wf requires `entry_owner.parent_level == level`, so:
-            proof {
-                KernelPtConfig::item_into_raw_spec_tracked_level(item);
-            }
-
             let ghost regions_before_map = *regions;
             let ghost old_cursor_model: CursorView<KernelPtConfig> = cursor_owner@;
             let ghost old_cursor_owner_va = cursor_owner.va;
@@ -737,8 +718,6 @@ impl KVirtArea {
                 cursor_owner.view_preserves_inv();  // old_cursor_model.inv()
                 cursor_owner.va.reflect_prop(cursor.0.va);
                 let (pa, level, prop_from_item) = KernelPtConfig::item_into_raw_spec(item);
-                KernelPtConfig::item_into_raw_spec_level_bounds(item);
-                KernelPtConfig::item_into_raw_spec_tracked_level(item);
                 lemma_va_align_page_size_level_1(cursor.0.va);
                 cursor_owner.locked_range_page_aligned();
                 let ghost diff: int = cursor.0.barrier_va.end - cursor.0.va;
@@ -746,8 +725,6 @@ impl KVirtArea {
                     nr_subpage_per_huge::<PagingConsts>().ilog2() as int,
                 );
                 vstd::arithmetic::power::lemma_pow0(2int);
-
-                KernelPtConfig::item_into_raw_spec_tracked_level(item);
             }
 
             // SAFETY: The constructor of the `KVirtArea` has already ensured
@@ -755,20 +732,6 @@ impl KVirtArea {
             // `item_slot_in_regions` for the current item is delivered by the
             // loop invariant (instantiated at i = it.index()), itself established by
             // the function precondition.
-            proof {
-                // Discharge `cursor.map`'s `map_panic_conditions ==>
-                // may_panic()` via the chain. Most disjuncts of
-                // `map_panic_conditions` are ruled out by loop invariants
-                // (cursor.va < barrier from the just-passed assert,
-                // level==1 ⟹ ≤ HIGHEST_TRANSLATION_LEVEL/< guard_level/<
-                // NR_LEVELS, va aligned). The only one that can fire is
-                // `cursor.va + page_size(1) > barrier.end`, which via
-                // cursor-VA tracking + range relationship gives
-                // `map_offset + (it.index()+1)*PAGE > area_size`, ⟹
-                // `map_offset + frames.len()*PAGE > area_size` (capacity
-                // disjunct) ⟹ `may_panic()`.
-                KernelPtConfig::lemma_kernel_htl_lt_nr_levels();
-            }
             let res = unsafe {
                 #[verus_spec(with Tracked(&mut cursor_owner), Tracked(entry_owner), Tracked(regions), Tracked(guards))]
                 cursor.map(item)
@@ -793,7 +756,6 @@ impl KVirtArea {
                     let item_i = MappedItem::Tracked(it.seq()[i], prop);
                     let pa_i = KernelPtConfig::item_into_raw_spec(item_i).0;
                     let idx_i = frame_to_index(pa_i);
-                    KernelPtConfig::item_into_raw_spec_tracked_level(item_i);
                 };
             }
 
@@ -801,7 +763,6 @@ impl KVirtArea {
                 let cur_idx = frame_to_index(cur_mapped_pa);
 
                 let (pa, level, prop_) = KernelPtConfig::item_into_raw_spec(item);
-                KernelPtConfig::item_into_raw_spec_tracked_level(item);
 
                 let split_self = old_cursor_model.split_while_huge(PAGE_SIZE);
 
@@ -1059,8 +1020,6 @@ impl KVirtArea {
                     cursor_owner.view_preserves_inv();  // old_cursor_model.inv()
                     cursor_owner.va.reflect_prop(cursor.0.va);
 
-                    KernelPtConfig::item_into_raw_spec_untracked(pa, level, prop);
-
                     // pa_range.end == pa_range.start + len (in nat) — from loop invariant.
                     sum_page_sizes_extend_right(it.seq(), 0, pos@);
                     sum_page_sizes_mono(it.seq(), 0, pos@ + 1, it.seq().len() as int);
@@ -1069,22 +1028,16 @@ impl KVirtArea {
                 // Pre-map: capture the overflow bound `cursor_owner.va + page_size(level) <= usize::MAX`.
                 // Valid because the cursor is `in_locked_range` here (required by `cursor.map`).
                 proof {
-                    KernelPtConfig::item_into_raw_spec_untracked(pa, level, prop);
                     cursor_owner.va_plus_page_size_no_overflow(level);
                 }
 
                 // Save ghost copy of regions before map for post-map invariant maintenance.
                 let ghost pre_map_regions: MetaRegionOwners = *regions;
 
-                proof {
-                    KernelPtConfig::lemma_kernel_htl_lt_nr_levels();
-                }
-
                 // SAFETY: The caller of `map_untracked_frames` has ensured the safety of this mapping.
                 // `item_slot_in_regions` for the current `(pa, level)` follows from the
                 // loop invariant's per-PA slot facts, instantiated at the current `pa`.
                 proof {
-                    KernelPtConfig::item_into_raw_spec_untracked(pa, level, prop);
                     let idx = crate::specs::mm::frame::mapping::frame_to_index(pa);
                 }
                 let _ = unsafe {
@@ -1097,12 +1050,10 @@ impl KVirtArea {
                 }
 
                 proof {
-                    KernelPtConfig::item_into_raw_spec_untracked(pa, level, prop);
                     let level_raw = KernelPtConfig::item_into_raw_spec(item).1;
 
                     crate::specs::mm::page_table::cursor::page_size_lemmas::lemma_page_size_ge_page_size(
                     level_raw);
-                    KernelPtConfig::item_into_raw_spec_level_bounds(item);
                     let split_self = old_cursor_model.split_while_huge(page_size(level_raw));
 
                     CursorView::<KernelPtConfig>::lemma_split_while_huge_preserves_cur_va(

--- a/ostd/src/mm/kspace/mod.rs
+++ b/ostd/src/mm/kspace/mod.rs
@@ -222,17 +222,12 @@ unsafe impl PageTableConfig for KernelPtConfig {
                 1,
                 Self::encode_tracked_prop(prop),
             ),
-            MappedItem::Untracked(pa, level, prop) => (
-                pa,
-                level,
-                Self::decode_tracked_prop(prop),
-            ),
+            MappedItem::Untracked(pa, level, prop) => (pa, level, Self::decode_tracked_prop(prop)),
         }
     }
 
     #[verifier::external_body]
-    fn item_into_raw(item: Self::Item) -> (res: (Paddr, PagingLevel, PageProperty))
-    {
+    fn item_into_raw(item: Self::Item) -> (res: (Paddr, PagingLevel, PageProperty)) {
         match item {
             MappedItem::Tracked(frame, mut prop) => {
                 debug_assert!(!prop.flags.contains(PageFlags::AVAIL1()));
@@ -268,8 +263,7 @@ unsafe impl PageTableConfig for KernelPtConfig {
     }
 
     #[verifier::external_body]
-    unsafe fn item_from_raw(paddr: Paddr, level: PagingLevel, prop: PageProperty) -> Self::Item
-    {
+    unsafe fn item_from_raw(paddr: Paddr, level: PagingLevel, prop: PageProperty) -> Self::Item {
         if prop.flags.contains(PageFlags::AVAIL1()) {
             debug_assert_eq!(level, 1);
             // [KNOWN] BUG FOUND BY FV: forgotting to clean `AVAIL1`. https://github.com/asterinas/vostd/issues/625
@@ -283,11 +277,7 @@ unsafe impl PageTableConfig for KernelPtConfig {
         }
     }
 
-    proof fn lemma_item_into_raw_roundtrip(
-        pa: Paddr,
-        level: PagingLevel,
-        prop: PageProperty,
-    ) {
+    proof fn lemma_item_into_raw_roundtrip(pa: Paddr, level: PagingLevel, prop: PageProperty) {
         broadcast use group_page_meta;
 
         assert(Self::raw_item_well_formed(pa, level, prop));
@@ -331,11 +321,7 @@ unsafe impl PageTableConfig for KernelPtConfig {
         }
     }
 
-    open spec fn raw_item_well_formed(
-        _pa: Paddr,
-        level: PagingLevel,
-        prop: PageProperty,
-    ) -> bool {
+    open spec fn raw_item_well_formed(_pa: Paddr, level: PagingLevel, prop: PageProperty) -> bool {
         prop.flags.contains(PageFlags::AVAIL1()) ==> level == 1
     }
 
@@ -382,15 +368,9 @@ unsafe impl PageTableConfig for KernelPtConfig {
         match item {
             MappedItem::Tracked(frame, _) => {
                 let frame_idx = frame_to_index(meta_to_frame(frame.ptr.addr()));
-                assert(<MappedItem as RCClone>::clone_ensures(
-                    item,
-                    old_regions,
-                    new_regions,
-                    res,
-                ));
+                assert(<MappedItem as RCClone>::clone_ensures(item, old_regions, new_regions, res));
             },
-            MappedItem::Untracked(_, _, _) => {
-            },
+            MappedItem::Untracked(_, _, _) => {},
         }
     }
 

--- a/ostd/src/mm/kspace/mod.rs
+++ b/ostd/src/mm/kspace/mod.rs
@@ -292,16 +292,10 @@ unsafe impl PageTableConfig for KernelPtConfig {
 
         assert(Self::raw_item_well_formed(pa, level, prop));
         Self::lemma_item_from_raw_well_formed(pa, level, prop);
-        Self::lemma_tracked_prop_encoding(prop);
+        prop.lemma_avail1_tag_encoding();
         let item = Self::item_from_raw_spec(pa, level, prop);
         if prop.flags.contains(PageFlags::AVAIL1()) {
-            assert(level == 1);
             crate::specs::mm::frame::mapping::lemma_paddr_to_meta_biinjective(pa);
-            assert(item is Tracked);
-            assert(Self::item_into_raw_spec(item) == (pa, level, prop));
-        } else {
-            assert(item is Untracked);
-            assert(Self::item_into_raw_spec(item) == (pa, level, prop));
         }
     }
 
@@ -316,7 +310,7 @@ unsafe impl PageTableConfig for KernelPtConfig {
         match item {
             MappedItem::Tracked(frame, prop_actual) => {
                 assert(Self::item_well_formed(MappedItem::Tracked(frame, prop_actual)));
-                Self::lemma_tracked_prop_encoding(prop_actual);
+                prop_actual.lemma_avail1_tag_encoding();
                 assert(frame.inv());
                 crate::specs::mm::frame::mapping::lemma_meta_to_paddr_biinjective(
                     frame.ptr.addr(),
@@ -324,7 +318,7 @@ unsafe impl PageTableConfig for KernelPtConfig {
             },
             MappedItem::Untracked(_, _, prop_actual) => {
                 assert(Self::item_well_formed(item));
-                Self::lemma_tracked_prop_encoding(prop_actual);
+                prop_actual.lemma_avail1_tag_encoding();
             },
         }
     }
@@ -338,8 +332,8 @@ unsafe impl PageTableConfig for KernelPtConfig {
     open spec fn item_well_formed(item: Self::Item) -> bool {
         match item {
             MappedItem::Tracked(frame, prop) => {
-                &&& frame.inv()
                 &&& !prop.flags.contains(PageFlags::AVAIL1())
+                &&& frame.inv()
             },
             MappedItem::Untracked(_, _, prop) => !prop.flags.contains(PageFlags::AVAIL1()),
         }
@@ -373,7 +367,7 @@ unsafe impl PageTableConfig for KernelPtConfig {
     proof fn lemma_item_from_raw_well_formed(pa: Paddr, level: PagingLevel, prop: PageProperty) {
         broadcast use group_page_meta;
 
-        Self::lemma_tracked_prop_encoding(prop);
+        prop.lemma_avail1_tag_encoding();
         if prop.flags.contains(PageFlags::AVAIL1()) {
             crate::specs::mm::frame::mapping::lemma_frame_to_meta_soundness(pa);
             let item = Self::item_from_raw_spec(pa, level, prop);
@@ -410,9 +404,6 @@ unsafe impl PageTableConfig for KernelPtConfig {
                     res,
                 ));
                 assert(frame.clone_ensures(old_regions, new_regions, frame));
-                assert(forall|i: usize|
-                    i != frame_idx ==> #[trigger] new_regions.slot_owners[i]
-                        == old_regions.slot_owners[i]);
             },
             MappedItem::Untracked(_, _, _) => {
                 assert(old_regions == new_regions);
@@ -458,26 +449,6 @@ impl KernelPtConfig {
     pub open spec fn decode_tracked_prop(prop: PageProperty) -> PageProperty {
         PageProperty { flags: prop.flags.difference(PageFlags::AVAIL1()), ..prop }
     }
-
-    /// Algebraic facts for the raw trackedness tag.
-    pub proof fn lemma_tracked_prop_encoding(prop: PageProperty)
-        ensures
-            KernelPtConfig::encode_tracked_prop(prop).flags.contains(PageFlags::AVAIL1()),
-            !KernelPtConfig::decode_tracked_prop(prop).flags.contains(PageFlags::AVAIL1()),
-            !prop.flags.contains(PageFlags::AVAIL1()) ==>
-                KernelPtConfig::decode_tracked_prop(prop) == prop,
-            !prop.flags.contains(PageFlags::AVAIL1()) ==>
-                KernelPtConfig::decode_tracked_prop(
-                    KernelPtConfig::encode_tracked_prop(prop),
-                ) == prop,
-            prop.flags.contains(PageFlags::AVAIL1()) ==>
-                KernelPtConfig::encode_tracked_prop(
-                    KernelPtConfig::decode_tracked_prop(prop),
-                ) == prop,
-    {
-        PageFlags::lemma_avail1_tag_encoding(prop.flags);
-    }
-
 }
 
 /*

--- a/ostd/src/mm/kspace/mod.rs
+++ b/ostd/src/mm/kspace/mod.rs
@@ -293,10 +293,6 @@ unsafe impl PageTableConfig for KernelPtConfig {
         assert(Self::raw_item_well_formed(pa, level, prop));
         Self::lemma_item_from_raw_well_formed(pa, level, prop);
         prop.lemma_avail1_tag_encoding();
-        let item = Self::item_from_raw_spec(pa, level, prop);
-        if prop.flags.contains(PageFlags::AVAIL1()) {
-            crate::specs::mm::frame::mapping::lemma_paddr_to_meta_biinjective(pa);
-        }
     }
 
     proof fn lemma_item_from_raw_roundtrip(
@@ -403,10 +399,8 @@ unsafe impl PageTableConfig for KernelPtConfig {
                     new_regions,
                     res,
                 ));
-                assert(frame.clone_ensures(old_regions, new_regions, frame));
             },
             MappedItem::Untracked(_, _, _) => {
-                assert(old_regions == new_regions);
             },
         }
     }
@@ -419,7 +413,7 @@ unsafe impl PageTableConfig for KernelPtConfig {
         regions: MetaRegionOwners,
     ) {
         use crate::mm::frame::meta::mapping::meta_to_frame;
-        broadcast use crate::specs::mm::frame::mapping::group_page_meta;
+        broadcast use group_page_meta;
 
         Self::lemma_item_from_raw_well_formed(pa, level, prop);
         match item {

--- a/ostd/src/mm/kspace/mod.rs
+++ b/ostd/src/mm/kspace/mod.rs
@@ -305,12 +305,8 @@ unsafe impl PageTableConfig for KernelPtConfig {
 
         match item {
             MappedItem::Tracked(frame, prop_actual) => {
-                assert(Self::item_well_formed(MappedItem::Tracked(frame, prop_actual)));
+                assert(Self::item_well_formed(item));
                 prop_actual.lemma_avail1_tag_encoding();
-                assert(frame.inv());
-                crate::specs::mm::frame::mapping::lemma_meta_to_paddr_biinjective(
-                    frame.ptr.addr(),
-                );
             },
             MappedItem::Untracked(_, _, prop_actual) => {
                 assert(Self::item_well_formed(item));
@@ -365,16 +361,10 @@ unsafe impl PageTableConfig for KernelPtConfig {
 
         prop.lemma_avail1_tag_encoding();
         if prop.flags.contains(PageFlags::AVAIL1()) {
-            crate::specs::mm::frame::mapping::lemma_frame_to_meta_soundness(pa);
             let item = Self::item_from_raw_spec(pa, level, prop);
-            assert(item is Tracked);
-            assert(item->Tracked_0.inv());
-            assert(!item->Tracked_1.flags.contains(PageFlags::AVAIL1()));
             assert(Self::item_well_formed(item));
         } else {
             let item = Self::item_from_raw_spec(pa, level, prop);
-            assert(item is Untracked);
-            assert(!item->Untracked_2.flags.contains(PageFlags::AVAIL1()));
             assert(Self::item_well_formed(item));
         }
     }
@@ -392,7 +382,6 @@ unsafe impl PageTableConfig for KernelPtConfig {
         match item {
             MappedItem::Tracked(frame, _) => {
                 let frame_idx = frame_to_index(meta_to_frame(frame.ptr.addr()));
-                assert(frame_to_index(pa) == frame_idx);
                 assert(<MappedItem as RCClone>::clone_ensures(
                     item,
                     old_regions,
@@ -416,12 +405,6 @@ unsafe impl PageTableConfig for KernelPtConfig {
         broadcast use group_page_meta;
 
         Self::lemma_item_from_raw_well_formed(pa, level, prop);
-        match item {
-            MappedItem::Tracked(frame, _) => {
-                assert(meta_to_frame(frame.ptr.addr()) == pa);
-            },
-            MappedItem::Untracked(_, _, _) => {},
-        }
     }
 }
 

--- a/ostd/src/mm/kspace/mod.rs
+++ b/ostd/src/mm/kspace/mod.rs
@@ -290,7 +290,19 @@ unsafe impl PageTableConfig for KernelPtConfig {
     ) {
         broadcast use group_page_meta;
 
+        assert(Self::raw_item_well_formed(pa, level, prop));
+        Self::lemma_item_from_raw_well_formed(pa, level, prop);
         Self::lemma_tracked_prop_encoding(prop);
+        let item = Self::item_from_raw_spec(pa, level, prop);
+        if prop.flags.contains(PageFlags::AVAIL1()) {
+            assert(level == 1);
+            crate::specs::mm::frame::mapping::lemma_paddr_to_meta_biinjective(pa);
+            assert(item is Tracked);
+            assert(Self::item_into_raw_spec(item) == (pa, level, prop));
+        } else {
+            assert(item is Untracked);
+            assert(Self::item_into_raw_spec(item) == (pa, level, prop));
+        }
     }
 
     proof fn lemma_item_from_raw_roundtrip(
@@ -303,9 +315,15 @@ unsafe impl PageTableConfig for KernelPtConfig {
 
         match item {
             MappedItem::Tracked(frame, prop_actual) => {
+                assert(Self::item_well_formed(MappedItem::Tracked(frame, prop_actual)));
                 Self::lemma_tracked_prop_encoding(prop_actual);
+                assert(frame.inv());
+                crate::specs::mm::frame::mapping::lemma_meta_to_paddr_biinjective(
+                    frame.ptr.addr(),
+                );
             },
             MappedItem::Untracked(_, _, prop_actual) => {
+                assert(Self::item_well_formed(item));
                 Self::lemma_tracked_prop_encoding(prop_actual);
             },
         }
@@ -356,6 +374,19 @@ unsafe impl PageTableConfig for KernelPtConfig {
         broadcast use group_page_meta;
 
         Self::lemma_tracked_prop_encoding(prop);
+        if prop.flags.contains(PageFlags::AVAIL1()) {
+            crate::specs::mm::frame::mapping::lemma_frame_to_meta_soundness(pa);
+            let item = Self::item_from_raw_spec(pa, level, prop);
+            assert(item is Tracked);
+            assert(item->Tracked_0.inv());
+            assert(!item->Tracked_1.flags.contains(PageFlags::AVAIL1()));
+            assert(Self::item_well_formed(item));
+        } else {
+            let item = Self::item_from_raw_spec(pa, level, prop);
+            assert(item is Untracked);
+            assert(!item->Untracked_2.flags.contains(PageFlags::AVAIL1()));
+            assert(Self::item_well_formed(item));
+        }
     }
 
     proof fn lemma_clone_ensures_concrete(
@@ -365,6 +396,28 @@ unsafe impl PageTableConfig for KernelPtConfig {
         new_regions: MetaRegionOwners,
         res: Self::Item,
     ) {
+        use crate::mm::frame::meta::mapping::meta_to_frame;
+        use crate::specs::mm::frame::mapping::frame_to_index;
+
+        match item {
+            MappedItem::Tracked(frame, _) => {
+                let frame_idx = frame_to_index(meta_to_frame(frame.ptr.addr()));
+                assert(frame_to_index(pa) == frame_idx);
+                assert(<MappedItem as RCClone>::clone_ensures(
+                    item,
+                    old_regions,
+                    new_regions,
+                    res,
+                ));
+                assert(frame.clone_ensures(old_regions, new_regions, frame));
+                assert(forall|i: usize|
+                    i != frame_idx ==> #[trigger] new_regions.slot_owners[i]
+                        == old_regions.slot_owners[i]);
+            },
+            MappedItem::Untracked(_, _, _) => {
+                assert(old_regions == new_regions);
+            },
+        }
     }
 
     proof fn lemma_clone_requires_concrete(
@@ -374,12 +427,24 @@ unsafe impl PageTableConfig for KernelPtConfig {
         prop: PageProperty,
         regions: MetaRegionOwners,
     ) {
+        use crate::mm::frame::meta::mapping::meta_to_frame;
+        use crate::specs::mm::frame::mapping::frame_to_index;
+        broadcast use crate::specs::mm::frame::mapping::group_page_meta;
+
         // `MappedItem::clone_requires` case-analyzes:
         //   - Tracked: `frame.clone_requires(regions)` — needs `frame.inv()` and the
         //     slot facts at `frame_to_index(meta_to_frame(frame.ptr.addr()))`.
         //   - Untracked: `regions.inv()`. Trivially satisfied from precondition.
         // Discharge `frame.inv()` via the trait-level structural well-formedness method.
         Self::lemma_item_from_raw_well_formed(pa, level, prop);
+        match item {
+            MappedItem::Tracked(frame, _) => {
+                assert(meta_to_frame(frame.ptr.addr()) == pa);
+                assert(frame_to_index(meta_to_frame(frame.ptr.addr())) == frame_to_index(pa));
+                assert(frame.inv());
+            },
+            MappedItem::Untracked(_, _, _) => {},
+        }
     }
 }
 

--- a/ostd/src/mm/kspace/mod.rs
+++ b/ostd/src/mm/kspace/mod.rs
@@ -32,7 +32,7 @@
 //!
 //! If the address width is (according to [`crate::arch::mm::PagingConsts`])
 //! 39 bits or 57 bits, the memory space just adjust proportionally.
-use core::ops::Range;
+use core::{marker::PhantomData, ops::Range};
 use vstd::atomic::PermissionU64;
 use vstd::prelude::*;
 use vstd::simple_pptr::PointsTo;
@@ -215,14 +215,23 @@ unsafe impl PageTableConfig for KernelPtConfig {
 
     type Item = MappedItem;
 
-    uninterp spec fn item_into_raw_spec(item: Self::Item) -> (Paddr, PagingLevel, PageProperty);
+    open spec fn item_into_raw_spec(item: Self::Item) -> (Paddr, PagingLevel, PageProperty) {
+        match item {
+            MappedItem::Tracked(frame, prop) => (
+                crate::mm::frame::meta::mapping::meta_to_frame(frame.ptr.addr()),
+                1,
+                Self::encode_tracked_prop(prop),
+            ),
+            MappedItem::Untracked(pa, level, prop) => (
+                pa,
+                level,
+                Self::decode_tracked_prop(prop),
+            ),
+        }
+    }
 
-    //    #[verifier::when_used_as_spec(item_into_raw_spec)]
     #[verifier::external_body]
     fn item_into_raw(item: Self::Item) -> (res: (Paddr, PagingLevel, PageProperty))
-        ensures
-            1 <= res.1 <= crate::specs::arch::NR_LEVELS,
-            res == Self::item_into_raw_spec(item),
     {
         match item {
             MappedItem::Tracked(frame, mut prop) => {
@@ -240,30 +249,51 @@ unsafe impl PageTableConfig for KernelPtConfig {
         }
     }
 
-    uninterp spec fn item_from_raw_spec(
+    open spec fn item_from_raw_spec(
         paddr: Paddr,
         level: PagingLevel,
         prop: PageProperty,
-    ) -> Self::Item;
-
-    //#[verifier::when_used_as_spec(item_from_raw_spec)]
-    #[verifier::external_body]
-    unsafe fn item_from_raw(paddr: Paddr, level: PagingLevel, prop: PageProperty) -> (res:
-        Self::Item)
-        ensures
-            res == Self::item_from_raw_spec(paddr, level, prop),
-    {
+    ) -> Self::Item {
         if prop.flags.contains(PageFlags::AVAIL1()) {
-            debug_assert_eq!(level, 1);
-            // SAFETY: The caller ensures safety.
-            let frame = unsafe { Frame::<MetaSlotStorage>::from_raw(paddr) };
-            MappedItem::Tracked(frame, prop)
+            MappedItem::Tracked(
+                Frame::<MetaSlotStorage> {
+                    ptr: vstd::simple_pptr::PPtr(mapping::frame_to_meta(paddr), PhantomData),
+                    _marker: PhantomData,
+                },
+                Self::decode_tracked_prop(prop),
+            )
         } else {
             MappedItem::Untracked(paddr, level, prop)
         }
     }
 
-    proof fn item_from_raw_roundtrip(
+    #[verifier::external_body]
+    unsafe fn item_from_raw(paddr: Paddr, level: PagingLevel, prop: PageProperty) -> Self::Item
+    {
+        if prop.flags.contains(PageFlags::AVAIL1()) {
+            debug_assert_eq!(level, 1);
+            // [KNOWN] BUG FOUND BY FV: forgotting to clean `AVAIL1`. https://github.com/asterinas/vostd/issues/625
+            let mut item_prop = prop;
+            item_prop.flags = item_prop.flags - PageFlags::AVAIL1();
+            // SAFETY: The caller ensures safety.
+            let frame = unsafe { Frame::<MetaSlotStorage>::from_raw(paddr) };
+            MappedItem::Tracked(frame, item_prop)
+        } else {
+            MappedItem::Untracked(paddr, level, prop)
+        }
+    }
+
+    proof fn lemma_item_into_raw_roundtrip(
+        pa: Paddr,
+        level: PagingLevel,
+        prop: PageProperty,
+    ) {
+        broadcast use group_page_meta;
+
+        Self::lemma_tracked_prop_encoding(prop);
+    }
+
+    proof fn lemma_item_from_raw_roundtrip(
         item: Self::Item,
         paddr: Paddr,
         level: PagingLevel,
@@ -273,31 +303,10 @@ unsafe impl PageTableConfig for KernelPtConfig {
 
         match item {
             MappedItem::Tracked(frame, prop_actual) => {
-                assert(Self::item_well_formed(MappedItem::Tracked(frame, prop_actual)));
-                Self::item_into_raw_spec_tracked_pa(frame, prop_actual);
-                Self::item_into_raw_spec_tracked_level(item);
-                Self::item_into_raw_spec_tracked_prop(frame, prop_actual);
-                if !prop.flags.contains(crate::mm::page_prop::PageFlags::AVAIL1()) {
-                    Self::item_from_raw_spec_untracked_variant(paddr, level, prop);
-
-                    assert(false);
-                }
-                Self::item_from_raw_spec_tracked_ptr(paddr, level, prop);
-                match Self::item_from_raw_spec(paddr, level, prop) {
-                    MappedItem::Tracked(frame_from_raw, prop_from_raw) => {},
-                    MappedItem::Untracked(_, _, _) => {
-                        assert(false);
-                    },
-                }
+                Self::lemma_tracked_prop_encoding(prop_actual);
             },
-            MappedItem::Untracked(pa, level_actual, prop_actual) => {
-                Self::item_into_raw_spec_untracked(pa, level_actual, prop_actual);
-                if prop.flags.contains(crate::mm::page_prop::PageFlags::AVAIL1()) {
-                    Self::item_from_raw_spec_tracked_ptr(paddr, level, prop);
-                    assert(Self::tracked(Self::item_from_raw_spec(paddr, level, prop)));
-                    assert(false);
-                }
-                Self::item_from_raw_spec_untracked_variant(paddr, level, prop);
+            MappedItem::Untracked(_, _, prop_actual) => {
+                Self::lemma_tracked_prop_encoding(prop_actual);
             },
         }
     }
@@ -310,86 +319,55 @@ unsafe impl PageTableConfig for KernelPtConfig {
 
     open spec fn item_well_formed(item: Self::Item) -> bool {
         match item {
-            MappedItem::Tracked(frame, _) => frame.inv(),
-            MappedItem::Untracked(_, _, _) => true,
+            MappedItem::Tracked(frame, prop) => {
+                &&& frame.inv()
+                &&& !prop.flags.contains(PageFlags::AVAIL1())
+            },
+            MappedItem::Untracked(_, _, prop) => !prop.flags.contains(PageFlags::AVAIL1()),
         }
     }
 
-    proof fn item_from_raw_well_formed(pa: Paddr, level: PagingLevel, prop: PageProperty) {
+    open spec fn raw_item_well_formed(
+        _pa: Paddr,
+        level: PagingLevel,
+        prop: PageProperty,
+    ) -> bool {
+        prop.flags.contains(PageFlags::AVAIL1()) ==> level == 1
+    }
+
+    proof fn lemma_raw_item_well_formed_preserved(
+        pa: Paddr,
+        level: PagingLevel,
+        old_prop: PageProperty,
+        new_prop: PageProperty,
+    ) {
+    }
+
+    proof fn lemma_raw_item_well_formed_split(
+        pa: Paddr,
+        level: PagingLevel,
+        prop: PageProperty,
+        child_pa: Paddr,
+        child_idx: usize,
+    ) {
+    }
+
+    proof fn lemma_item_from_raw_well_formed(pa: Paddr, level: PagingLevel, prop: PageProperty) {
         broadcast use group_page_meta;
 
-        let item = Self::item_from_raw_spec(pa, level, prop);
-        if prop.flags.contains(crate::mm::page_prop::PageFlags::AVAIL1()) {
-            // Tracked branch: derive `frame.inv()` from
-            //   - `item_from_raw_spec_tracked_ptr`: frame.ptr.addr() == frame_to_meta(pa).
-            //   - `lemma_frame_to_meta_soundness` (broadcast): frame_to_meta(pa) is
-            //     META_SLOT_SIZE-aligned and within FRAME_METADATA_RANGE.
-            Self::item_from_raw_spec_tracked_ptr(pa, level, prop);
-            // Now item is `MappedItem::Tracked(frame, _)` with the address fact.
-            match item {
-                MappedItem::Tracked(frame, prop_actual) => {
-                    // frame.inv() unfolds to (alignment + range), both from the lemma.
-                    Self::item_into_raw_spec_tracked_pa(frame, prop_actual);
-                    Self::item_into_raw_spec_tracked_level(item);
-                    Self::item_into_raw_spec_tracked_prop(frame, prop_actual);
-                },
-                MappedItem::Untracked(_, _, _) => {
-                    // Excluded by item_from_raw_spec_tracked_ptr.
-                    assert(false);
-                },
-            }
-        } else {
-            // Untracked branch: item_well_formed is `true`.
-            Self::item_from_raw_spec_untracked_variant(pa, level, prop);
-            match item {
-                MappedItem::Tracked(_, _) => {
-                    assert(false);
-                },
-                MappedItem::Untracked(pa_actual, level_actual, prop_actual) => {
-                    Self::item_into_raw_spec_untracked(pa_actual, level_actual, prop_actual);
-                },
-            }
-        }
+        Self::lemma_tracked_prop_encoding(prop);
     }
 
-    proof fn clone_ensures_concrete(
+    proof fn lemma_clone_ensures_concrete(
         item: Self::Item,
         pa: Paddr,
         old_regions: MetaRegionOwners,
         new_regions: MetaRegionOwners,
         res: Self::Item,
     ) {
-        // `MappedItem::clone_ensures` case-analyzes:
-        //   - Tracked: `frame.clone_ensures(old, new, res_frame)` — gives per-field facts at
-        //     `frame_to_index(meta_to_frame(frame.ptr.addr()))`. Bridge to `frame_to_index(pa)`.
-        //   - Untracked: `old == new`. Then trait's `rc + 1` ensures becomes contradictory.
-        //     This case is ASSUMED unreachable (clone_item only runs on Tracked items in
-        //     the verified call chain).
-        // Force the trait method's open-spec body to unfold by asserting the UFCS form.
-        assert(<MappedItem as RCClone>::clone_ensures(item, old_regions, new_regions, res));
-        match (item, res) {
-            (MappedItem::Tracked(frame, prop_actual), MappedItem::Tracked(res_frame, _)) => {
-                use crate::mm::frame::meta::mapping::meta_to_frame;
-                use crate::specs::mm::frame::mapping::frame_to_index;
-                Self::item_into_raw_spec_tracked_pa(frame, prop_actual);
-                let frame_idx = frame_to_index(meta_to_frame(frame.ptr.addr()));
-
-                // Canonical: the cloned frame minted one obligation at its slot.
-
-            },
-            (MappedItem::Untracked(_, _, _), _) => {
-                // clone_ensures for Untracked is `old == new`; the trait's
-                // `!tracked ==> slot unchanged` ensures follows directly, and
-                // the per-frame ledger is preserved (net-zero clone).
-            },
-            _ => {
-                // res == item by precondition; if item is Tracked, res is Tracked too.
-                // The mismatched-tag arm is unreachable.
-            },
-        }
     }
 
-    proof fn clone_requires_concrete(
+    proof fn lemma_clone_requires_concrete(
         item: Self::Item,
         pa: Paddr,
         level: PagingLevel,
@@ -401,120 +379,40 @@ unsafe impl PageTableConfig for KernelPtConfig {
         //     slot facts at `frame_to_index(meta_to_frame(frame.ptr.addr()))`.
         //   - Untracked: `regions.inv()`. Trivially satisfied from precondition.
         // Discharge `frame.inv()` via the trait-level structural well-formedness method.
-        Self::item_from_raw_well_formed(pa, level, prop);
-        match item {
-            MappedItem::Tracked(frame, prop_actual) => {
-                use crate::mm::frame::meta::mapping::meta_to_frame;
-                use crate::specs::mm::frame::mapping::frame_to_index;
-                Self::item_into_raw_spec_tracked_pa(frame, prop_actual);
-                Self::item_from_raw_roundtrip(item, pa, level, prop);
-
-                // `Self::item_well_formed(item)` unfolds to `frame.inv()` for the
-                // Tracked variant.
-
-            },
-            MappedItem::Untracked(_, _, _) => {
-                // clone_requires for Untracked is just `regions.inv()` which we have.
-            },
-        }
+        Self::lemma_item_from_raw_well_formed(pa, level, prop);
     }
 }
 
 impl KernelPtConfig {
-    /// The spec agrees with the exec, which ensures 1 <= level <= NR_LEVELS.
-    pub proof fn item_into_raw_spec_level_bounds(item: MappedItem)
-        requires
-            item matches MappedItem::Untracked(_, level, _) ==> 1 <= level <= NR_LEVELS,
-        ensures
-            1 <= KernelPtConfig::item_into_raw_spec(item).1 <= crate::specs::arch::NR_LEVELS,
-    {
-        match item {
-            MappedItem::Tracked(_, _) => {
-                Self::item_into_raw_spec_tracked_level(item);
-                // item_into_raw_spec(item).1 == 1; 1 <= 1 <= NR_LEVELS always.
-
-            },
-            MappedItem::Untracked(pa, level, prop) => {
-                Self::item_into_raw_spec_untracked(pa, level, prop);
-                // item_into_raw_spec(item).1 == level, bounded by precondition.
-            },
-        }
+    /// Adds the raw PTE bit used to identify a ref-counted mapping.
+    pub open spec fn encode_tracked_prop(prop: PageProperty) -> PageProperty {
+        PageProperty { flags: prop.flags.union(PageFlags::AVAIL1()), ..prop }
     }
 
-    /// Tracked frames use 4K pages (level 1). Used to prove alignment in map_frames.
-    pub axiom fn item_into_raw_spec_tracked_level(item: MappedItem)
-        requires
-            matches!(item, MappedItem::Tracked(_, _)),
-        ensures
-            KernelPtConfig::item_into_raw_spec(item).1 == 1,
-    ;
-
-    /// For untracked items, `item_into_raw_spec` preserves PA, level, and prop.
-    /// This is correct when the AVAIL1 bit is not set in `prop`, which is assumed
-    /// for untracked MMIO frames (enforced by the debug_assert in the exec).
-    pub axiom fn item_into_raw_spec_untracked(pa: Paddr, level: PagingLevel, prop: PageProperty)
-        ensures
-            KernelPtConfig::item_into_raw_spec(MappedItem::Untracked(pa, level, prop)).0 == pa,
-            KernelPtConfig::item_into_raw_spec(MappedItem::Untracked(pa, level, prop)).1 == level,
-            KernelPtConfig::item_into_raw_spec(MappedItem::Untracked(pa, level, prop)).2 == prop,
-    ;
-
-    /// For tracked items, the physical address from item_into_raw_spec equals
-    /// the frame's metadata-derived physical address.
-    pub axiom fn item_into_raw_spec_tracked_pa(frame: DynFrame, prop: PageProperty)
-        ensures
-            KernelPtConfig::item_into_raw_spec(MappedItem::Tracked(frame, prop)).0
-                == crate::mm::frame::meta::mapping::meta_to_frame(frame.ptr.addr()),
-    ;
-
-    /// For tracked items, item_into_raw_spec returns the same `prop` that was passed in.
-    pub axiom fn item_into_raw_spec_tracked_prop(frame: DynFrame, prop: PageProperty)
-        ensures
-            KernelPtConfig::item_into_raw_spec(MappedItem::Tracked(frame, prop)).2 == prop,
-    ;
-
-    /// Structural shape of `item_from_raw_spec` for the Tracked branch: the reconstructed
-    /// frame's pointer is `frame_to_meta(pa)`. This mirrors the exec body of `item_from_raw`,
-    /// which calls `Frame::from_raw(pa)` whose ensures gives `r.ptr.addr() == frame_to_meta(pa)`.
-    /// Once we have this address shape, `Frame::inv()` follows from `lemma_frame_to_meta_soundness`.
-    pub axiom fn item_from_raw_spec_tracked_ptr(pa: Paddr, level: PagingLevel, prop: PageProperty)
-        requires
-            has_safe_slot(pa),
-            prop.flags.contains(crate::mm::page_prop::PageFlags::AVAIL1()),
-        ensures
-            match KernelPtConfig::item_from_raw_spec(pa, level, prop) {
-                MappedItem::Tracked(frame, prop_actual) => {
-                    &&& frame.ptr.addr() == crate::mm::frame::meta::mapping::frame_to_meta(pa)
-                    &&& level == 1
-                    &&& prop_actual == prop
-                },
-                MappedItem::Untracked(_, _, _) => false,
-            },
-    ;
-
-    /// For untracked items, `item_from_raw_spec` returns the Untracked variant.
-    /// Mirrors the exec body's branch on `prop.flags.contains(AVAIL1)`.
-    pub axiom fn item_from_raw_spec_untracked_variant(
-        pa: Paddr,
-        level: PagingLevel,
-        prop: PageProperty,
-    )
-        requires
-            !prop.flags.contains(crate::mm::page_prop::PageFlags::AVAIL1()),
-        ensures
-            KernelPtConfig::item_from_raw_spec(pa, level, prop) == MappedItem::Untracked(
-                pa,
-                level,
-                prop,
-            ),
-    ;
-
-    /// For KernelPtConfig (x86_64): HIGHEST_TRANSLATION_LEVEL = 2 < NR_LEVELS = 4.
-    pub proof fn lemma_kernel_htl_lt_nr_levels()
-        ensures
-            KernelPtConfig::HIGHEST_TRANSLATION_LEVEL() < NR_LEVELS,
-    {
+    /// Removes the raw PTE trackedness bit from a caller-visible property.
+    pub open spec fn decode_tracked_prop(prop: PageProperty) -> PageProperty {
+        PageProperty { flags: prop.flags.difference(PageFlags::AVAIL1()), ..prop }
     }
+
+    /// Algebraic facts for the raw trackedness tag.
+    pub proof fn lemma_tracked_prop_encoding(prop: PageProperty)
+        ensures
+            KernelPtConfig::encode_tracked_prop(prop).flags.contains(PageFlags::AVAIL1()),
+            !KernelPtConfig::decode_tracked_prop(prop).flags.contains(PageFlags::AVAIL1()),
+            !prop.flags.contains(PageFlags::AVAIL1()) ==>
+                KernelPtConfig::decode_tracked_prop(prop) == prop,
+            !prop.flags.contains(PageFlags::AVAIL1()) ==>
+                KernelPtConfig::decode_tracked_prop(
+                    KernelPtConfig::encode_tracked_prop(prop),
+                ) == prop,
+            prop.flags.contains(PageFlags::AVAIL1()) ==>
+                KernelPtConfig::encode_tracked_prop(
+                    KernelPtConfig::decode_tracked_prop(prop),
+                ) == prop,
+    {
+        PageFlags::lemma_avail1_tag_encoding(prop.flags);
+    }
+
 }
 
 /*

--- a/ostd/src/mm/kspace/mod.rs
+++ b/ostd/src/mm/kspace/mod.rs
@@ -419,20 +419,12 @@ unsafe impl PageTableConfig for KernelPtConfig {
         regions: MetaRegionOwners,
     ) {
         use crate::mm::frame::meta::mapping::meta_to_frame;
-        use crate::specs::mm::frame::mapping::frame_to_index;
         broadcast use crate::specs::mm::frame::mapping::group_page_meta;
 
-        // `MappedItem::clone_requires` case-analyzes:
-        //   - Tracked: `frame.clone_requires(regions)` — needs `frame.inv()` and the
-        //     slot facts at `frame_to_index(meta_to_frame(frame.ptr.addr()))`.
-        //   - Untracked: `regions.inv()`. Trivially satisfied from precondition.
-        // Discharge `frame.inv()` via the trait-level structural well-formedness method.
         Self::lemma_item_from_raw_well_formed(pa, level, prop);
         match item {
             MappedItem::Tracked(frame, _) => {
                 assert(meta_to_frame(frame.ptr.addr()) == pa);
-                assert(frame_to_index(meta_to_frame(frame.ptr.addr())) == frame_to_index(pa));
-                assert(frame.inv());
             },
             MappedItem::Untracked(_, _, _) => {},
         }

--- a/ostd/src/mm/page_prop.rs
+++ b/ostd/src/mm/page_prop.rs
@@ -158,26 +158,26 @@ impl Inv for PageProperty {
     }
 }
 
-impl PageFlags {
+impl PageProperty {
     /// Adding and removing `AVAIL1` is reversible when it is used as a reserved tag.
-    pub proof fn lemma_avail1_tag_encoding(flags: PageFlags)
+    pub proof fn lemma_avail1_tag_encoding(self)
         ensures
-            flags.union(PageFlags::AVAIL1()).contains(PageFlags::AVAIL1()),
-            !flags.difference(PageFlags::AVAIL1()).contains(PageFlags::AVAIL1()),
-            !flags.contains(PageFlags::AVAIL1()) ==>
-                flags.difference(PageFlags::AVAIL1()) == flags,
-            !flags.contains(PageFlags::AVAIL1()) ==>
-                flags.union(PageFlags::AVAIL1()).difference(PageFlags::AVAIL1()) == flags,
-            flags.contains(PageFlags::AVAIL1()) ==>
-                flags.difference_spec(PageFlags::AVAIL1()).union(PageFlags::AVAIL1()) == flags,
+            self.flags.union(PageFlags::AVAIL1()).contains(PageFlags::AVAIL1()),
+            !self.flags.difference(PageFlags::AVAIL1()).contains(PageFlags::AVAIL1()),
+            !self.flags.contains(PageFlags::AVAIL1()) ==>
+                self.flags.difference(PageFlags::AVAIL1()) == self.flags,
+            !self.flags.contains(PageFlags::AVAIL1()) ==>
+                self.flags.union(PageFlags::AVAIL1()).difference(PageFlags::AVAIL1()) == self.flags,
+            self.flags.contains(PageFlags::AVAIL1()) ==>
+                self.flags.difference(PageFlags::AVAIL1()).union(PageFlags::AVAIL1()) == self.flags,
     {
         broadcast use PageFlags::lemma_consts;
         let tag = PageFlags::AVAIL1();
-        let bits = flags.bits();
+        let bits = self.flags.bits();
         let tag_bits = tag.bits();
         assert(((bits | tag_bits) & tag_bits) == tag_bits) by (bit_vector);
         assert(((bits & !tag_bits) & tag_bits) == 0u8) by (bit_vector);
-        if !flags.contains(tag) {
+        if !self.flags.contains(tag) {
             assert((bits & tag_bits) != tag_bits);
             assert((bits & tag_bits) == 0u8) by (bit_vector)
                 requires
@@ -189,14 +189,14 @@ impl PageFlags {
             assert(((bits | tag_bits) & !tag_bits) == bits) by (bit_vector)
                 requires
                     (bits & tag_bits) == 0u8;
-            PageFlags::lemma_eq_from_bits(flags.difference_spec(tag), flags);
-            PageFlags::lemma_eq_from_bits(flags.union_spec(tag).difference_spec(tag), flags);
+            PageFlags::lemma_eq_from_bits(self.flags.difference(tag), self.flags);
+            PageFlags::lemma_eq_from_bits(self.flags.union(tag).difference(tag), self.flags);
         } else {
             assert((bits & tag_bits) == tag_bits);
             assert(((bits & !tag_bits) | tag_bits) == bits) by (bit_vector)
                 requires
                     (bits & tag_bits) == tag_bits;
-            PageFlags::lemma_eq_from_bits(flags.difference_spec(tag).union_spec(tag), flags);
+            PageFlags::lemma_eq_from_bits(self.flags.difference(tag).union(tag), self.flags);
         }
     }
 }

--- a/ostd/src/mm/page_prop.rs
+++ b/ostd/src/mm/page_prop.rs
@@ -164,14 +164,17 @@ impl PageProperty {
         ensures
             self.flags.union(PageFlags::AVAIL1()).contains(PageFlags::AVAIL1()),
             !self.flags.difference(PageFlags::AVAIL1()).contains(PageFlags::AVAIL1()),
-            !self.flags.contains(PageFlags::AVAIL1()) ==>
-                self.flags.difference(PageFlags::AVAIL1()) == self.flags,
-            !self.flags.contains(PageFlags::AVAIL1()) ==>
-                self.flags.union(PageFlags::AVAIL1()).difference(PageFlags::AVAIL1()) == self.flags,
-            self.flags.contains(PageFlags::AVAIL1()) ==>
-                self.flags.difference(PageFlags::AVAIL1()).union(PageFlags::AVAIL1()) == self.flags,
+            !self.flags.contains(PageFlags::AVAIL1()) ==> self.flags.difference(PageFlags::AVAIL1())
+                == self.flags,
+            !self.flags.contains(PageFlags::AVAIL1()) ==> self.flags.union(
+                PageFlags::AVAIL1(),
+            ).difference(PageFlags::AVAIL1()) == self.flags,
+            self.flags.contains(PageFlags::AVAIL1()) ==> self.flags.difference(
+                PageFlags::AVAIL1(),
+            ).union(PageFlags::AVAIL1()) == self.flags,
     {
         broadcast use PageFlags::lemma_consts;
+
         let tag = PageFlags::AVAIL1();
         let bits = self.flags.bits();
         let tag_bits = tag.bits();
@@ -182,20 +185,24 @@ impl PageProperty {
             assert((bits & tag_bits) == 0u8) by (bit_vector)
                 requires
                     tag_bits == 0x40u8,
-                    (bits & tag_bits) != tag_bits;
+                    (bits & tag_bits) != tag_bits,
+            ;
             assert((bits & !tag_bits) == bits) by (bit_vector)
                 requires
-                    (bits & tag_bits) == 0u8;
+                    (bits & tag_bits) == 0u8,
+            ;
             assert(((bits | tag_bits) & !tag_bits) == bits) by (bit_vector)
                 requires
-                    (bits & tag_bits) == 0u8;
+                    (bits & tag_bits) == 0u8,
+            ;
             PageFlags::lemma_eq_from_bits(self.flags.difference(tag), self.flags);
             PageFlags::lemma_eq_from_bits(self.flags.union(tag).difference(tag), self.flags);
         } else {
             assert((bits & tag_bits) == tag_bits);
             assert(((bits & !tag_bits) | tag_bits) == bits) by (bit_vector)
                 requires
-                    (bits & tag_bits) == tag_bits;
+                    (bits & tag_bits) == tag_bits,
+            ;
             PageFlags::lemma_eq_from_bits(self.flags.difference(tag).union(tag), self.flags);
         }
     }

--- a/ostd/src/mm/page_prop.rs
+++ b/ostd/src/mm/page_prop.rs
@@ -158,4 +158,47 @@ impl Inv for PageProperty {
     }
 }
 
+impl PageFlags {
+    /// Adding and removing `AVAIL1` is reversible when it is used as a reserved tag.
+    pub proof fn lemma_avail1_tag_encoding(flags: PageFlags)
+        ensures
+            flags.union(PageFlags::AVAIL1()).contains(PageFlags::AVAIL1()),
+            !flags.difference(PageFlags::AVAIL1()).contains(PageFlags::AVAIL1()),
+            !flags.contains(PageFlags::AVAIL1()) ==>
+                flags.difference(PageFlags::AVAIL1()) == flags,
+            !flags.contains(PageFlags::AVAIL1()) ==>
+                flags.union(PageFlags::AVAIL1()).difference(PageFlags::AVAIL1()) == flags,
+            flags.contains(PageFlags::AVAIL1()) ==>
+                flags.difference_spec(PageFlags::AVAIL1()).union(PageFlags::AVAIL1()) == flags,
+    {
+        broadcast use PageFlags::lemma_consts;
+        let tag = PageFlags::AVAIL1();
+        let bits = flags.bits();
+        let tag_bits = tag.bits();
+        assert(((bits | tag_bits) & tag_bits) == tag_bits) by (bit_vector);
+        assert(((bits & !tag_bits) & tag_bits) == 0u8) by (bit_vector);
+        if !flags.contains(tag) {
+            assert((bits & tag_bits) != tag_bits);
+            assert((bits & tag_bits) == 0u8) by (bit_vector)
+                requires
+                    tag_bits == 0x40u8,
+                    (bits & tag_bits) != tag_bits;
+            assert((bits & !tag_bits) == bits) by (bit_vector)
+                requires
+                    (bits & tag_bits) == 0u8;
+            assert(((bits | tag_bits) & !tag_bits) == bits) by (bit_vector)
+                requires
+                    (bits & tag_bits) == 0u8;
+            PageFlags::lemma_eq_from_bits(flags.difference_spec(tag), flags);
+            PageFlags::lemma_eq_from_bits(flags.union_spec(tag).difference_spec(tag), flags);
+        } else {
+            assert((bits & tag_bits) == tag_bits);
+            assert(((bits & !tag_bits) | tag_bits) == bits) by (bit_vector)
+                requires
+                    (bits & tag_bits) == tag_bits;
+            PageFlags::lemma_eq_from_bits(flags.difference_spec(tag).union_spec(tag), flags);
+        }
+    }
+}
+
 } // verus!

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -934,7 +934,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
     > {
         assert_eq!(len % PAGE_SIZE, 0);
 
-        //*** KNOWN BUG: `self.va + len` could overflow. For now assume that it doesn't. ***
+        // [KNOWN] BUG FOUND BY FV: `self.va + len` could overflow. For now assume that it doesn't. https://github.com/asterinas/asterinas/issues/3159
         assume(self.va + len <= usize::MAX);
         let end = self.va + len;
 

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -256,7 +256,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
     pub fn clone_item(item: &C::Item) -> C::Item {
         let res = item.clone(Tracked(regions));
         proof {
-            C::clone_ensures_concrete(*item, pa, *old(regions), *regions, res);
+            C::lemma_clone_ensures_concrete(*item, pa, *old(regions), *regions, res);
         }
         res
     }
@@ -624,8 +624,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                     ;
 
                     proof {
-                        C::item_from_raw_well_formed(pa, level, prop);
-                        C::item_from_raw_roundtrip(item, pa, level, prop);
+                        C::lemma_item_from_raw_well_formed(pa, level, prop);
+                        C::lemma_item_into_raw_roundtrip(pa, level, prop);
                     }
 
                     assert(pa == owner.cur_entry_owner().frame().mapped_pa);
@@ -653,6 +653,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                             assert(old(self).query_panic_condition(*old(owner), *old(regions)));
                             assert(may_panic());
                         }
+                        assert(C::raw_item_well_formed(pa, level, prop));
                         owner.cur_frame_clone_requires(item, pa, level, prop, *regions);
                     }
 
@@ -4303,8 +4304,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 // `protect_next` method uphold this invariant.
                 let item = unsafe { C::item_from_raw(pa, level, prop) };
                 proof {
-                    C::item_from_raw_well_formed(pa, level, prop);
-                    C::item_from_raw_roundtrip(item, pa, level, prop);
+                    C::lemma_item_from_raw_well_formed(pa, level, prop);
+                    C::lemma_item_into_raw_roundtrip(pa, level, prop);
                 }
                 Some(PageTableFrag::Mapped { va, item })
             },

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -638,9 +638,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                         assert(owner.cur_entry_owner().metaregion_sound(*regions));
                         assert(regions.slot_owners.contains_key(idx));
                         assert(owner.cur_entry_owner().inv_base());
-                        EntryOwner::<C>::axiom_frame_is_tracked_matches_item(
-                            owner.cur_entry_owner(),
-                        );
                         if C::tracked(item)
                             && regions.slot_owners[idx].inner_perms.ref_count.value()
                             >= REF_COUNT_MAX {
@@ -670,9 +667,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                         assert(owner.cur_entry_owner().metaregion_sound(old_regions));
                         assert(old_regions.slot_owners.contains_key(idx));
                         if C::tracked(item) {
-                            EntryOwner::<C>::axiom_frame_is_tracked_matches_item(
-                                owner.cur_entry_owner(),
-                            );
                             EntryOwner::<C>::axiom_frame_is_tracked_iff_not_mmio(
                                 owner.cur_entry_owner(),
                             );
@@ -711,9 +705,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                             assert(old(regions).slot_owners[idx].inner_perms.ref_count.value()
                                 < REF_COUNT_MAX);
                         } else {
-                            EntryOwner::<C>::axiom_frame_is_tracked_matches_item(
-                                owner.cur_entry_owner(),
-                            );
                             EntryOwner::<C>::axiom_frame_is_tracked_iff_not_mmio(
                                 owner.cur_entry_owner(),
                             );
@@ -3116,7 +3107,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         let tracked new_owner = owner.continuations.tracked_borrow(owner.level - 1).new_child(
             pa,
             prop,
-            is_tracked,
             regions,
         );
 
@@ -3130,7 +3120,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 cont.path().push_tail(cont.idx as usize),
                 cont.level(),
                 prop,
-                is_tracked,
             ));
             assert(new_owner.value.is_frame());
             assert(new_owner.value.frame().mapped_pa == pa);
@@ -3784,9 +3773,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         requires
             old(self).0.invariants(*old(owner), *old(regions), *old(guards)),
             forall |p: PageProperty| op.requires((p,)),
-            // POTENTIALLY UNSOUND PATCH: see `Entry::protect` for rationale.
-            // `op` must preserve `C::tracked` of the reconstructed item so that
-            // `axiom_frame_is_tracked_matches_item` remains consistent across the
+            // `op` must preserve `C::tracked` of the reconstructed item across the
             // prop change. Quantified over `(pa, level)` because `find_next_impl`
             // may descend to any frame in the range. For UserPtConfig
             // (`tracked == true` always) this is trivial; for KernelPtConfig it

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -650,9 +650,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                     proof {
                         let idx = frame_to_index(pa);
                         assert(regions.slot_owners.contains_key(idx));
-                        EntryOwner::<C>::axiom_frame_is_tracked_matches_item(
-                            owner.cur_entry_owner(),
-                        );
                         assert(owner.cur_entry_owner().inv_base());
                         if C::tracked(item)
                             && regions.slot_owners[idx].inner_perms.ref_count.value()
@@ -3112,6 +3109,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
 
         assert!(self.0.va < self.0.barrier_va.end);
         let (pa, level, prop) = C::item_into_raw(item);
+        proof {
+            C::lemma_item_from_raw_roundtrip(item, pa, level, prop);
+        }
         assert!(level <= C::HIGHEST_TRANSLATION_LEVEL());
         assert!(level < self.0.guard_level);
         if !C::TOP_LEVEL_CAN_UNMAP() {

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -213,7 +213,7 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
             has_safe_slot(paddr),
             paddr % page_size(level) == 0,
             paddr + page_size(level) <= MAX_PADDR,
-            Self::raw_item_well_formed(paddr, level , prop),
+            Self::raw_item_well_formed(paddr, level, prop),
         returns
             Self::item_into_raw_spec(item),
     ;
@@ -245,7 +245,8 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
     ///  - the [`super::PageFlags::AVAIL1`] flag is the same as that returned
     ///    from [`PageTableConfig::item_into_raw`].
     #[verifier::when_used_as_spec(item_from_raw_spec)]
-    unsafe fn item_from_raw(paddr: Paddr, level: PagingLevel, prop: PageProperty) -> (res:Self::Item)
+    unsafe fn item_from_raw(paddr: Paddr, level: PagingLevel, prop: PageProperty) -> (res:
+        Self::Item)
         requires
             has_safe_slot(paddr),
             Self::raw_item_well_formed(paddr, level, prop),
@@ -267,11 +268,7 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
 
     /// Per-config predicate that captures the well-formedness of raw properties
     /// produced via [`PageTableConfig::item_into_raw`] must satisfy.
-    spec fn raw_item_well_formed(
-        pa: Paddr,
-        level: PagingLevel,
-        prop: PageProperty,
-    ) -> bool;
+    spec fn raw_item_well_formed(pa: Paddr, level: PagingLevel, prop: PageProperty) -> bool;
 
     /// Changing properties without changing trackedness preserves a canonical raw item.
     proof fn lemma_raw_item_well_formed_preserved(
@@ -283,8 +280,9 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
         requires
             has_safe_slot(pa),
             Self::raw_item_well_formed(pa, level, old_prop),
-            Self::tracked(Self::item_from_raw(pa, level, new_prop))
-                == Self::tracked(Self::item_from_raw(pa, level, old_prop)),
+            Self::tracked(Self::item_from_raw(pa, level, new_prop)) == Self::tracked(
+                Self::item_from_raw(pa, level, old_prop),
+            ),
         ensures
             Self::raw_item_well_formed(pa, level, new_prop),
     ;
@@ -302,9 +300,7 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
             Self::raw_item_well_formed(pa, level, prop),
             level > 1,
             child_idx < NR_ENTRIES,
-            child_pa == pa + child_idx * page_size(
-                (level - 1) as PagingLevel,
-            ),
+            child_pa == pa + child_idx * page_size((level - 1) as PagingLevel),
         ensures
             Self::raw_item_well_formed(child_pa, (level - 1) as PagingLevel, prop),
     ;
@@ -319,17 +315,12 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
     ;
 
     /// Re-encoding a canonical raw item preserves the complete raw representation.
-    proof fn lemma_item_into_raw_roundtrip(
-        pa: Paddr,
-        level: PagingLevel,
-        prop: PageProperty,
-    )
+    proof fn lemma_item_into_raw_roundtrip(pa: Paddr, level: PagingLevel, prop: PageProperty)
         requires
             has_safe_slot(pa),
             Self::raw_item_well_formed(pa, level, prop),
         ensures
-            Self::item_into_raw(Self::item_from_raw(pa, level, prop))
-                == (pa, level, prop),
+            Self::item_into_raw(Self::item_from_raw(pa, level, prop)) == (pa, level, prop),
     ;
 
     /// Decoding the raw representation produced from a well-formed item restores that item.

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -210,8 +210,7 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
             Self::item_well_formed(item),
         ensures
             1 <= level <= NR_LEVELS,
-            paddr % PAGE_SIZE == 0,
-            paddr < MAX_PADDR,
+            has_safe_slot(paddr),
             paddr % page_size(level) == 0,
             paddr + page_size(level) <= MAX_PADDR,
             Self::raw_item_well_formed(paddr, level , prop),
@@ -248,6 +247,7 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
     #[verifier::when_used_as_spec(item_from_raw_spec)]
     unsafe fn item_from_raw(paddr: Paddr, level: PagingLevel, prop: PageProperty) -> (res:Self::Item)
         requires
+            has_safe_slot(paddr),
             Self::raw_item_well_formed(paddr, level, prop),
         ensures
             Self::item_well_formed(res),
@@ -281,6 +281,7 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
         new_prop: PageProperty,
     )
         requires
+            has_safe_slot(pa),
             Self::raw_item_well_formed(pa, level, old_prop),
             Self::tracked(Self::item_from_raw(pa, level, new_prop))
                 == Self::tracked(Self::item_from_raw(pa, level, old_prop)),
@@ -297,6 +298,7 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
         child_idx: usize,
     )
         requires
+            has_safe_slot(pa),
             Self::raw_item_well_formed(pa, level, prop),
             level > 1,
             child_idx < NR_ENTRIES,
@@ -530,7 +532,7 @@ impl<C: PageTableConfig> PagingConstsTrait for C {
 
     fn NR_LEVELS() -> PagingLevel {
         proof {
-            assert(Self::NR_LEVELS_spec() == C::C::NR_LEVELS_spec());
+            assert(Self::NR_LEVELS() == C::C::NR_LEVELS());
         }
         C::C::NR_LEVELS()
     }
@@ -1697,7 +1699,7 @@ pub trait PageTableEntryTrait:
     #[verifier::when_used_as_spec(paddr_spec)]
     fn paddr(&self) -> (res: Paddr)
         ensures
-            res % PAGE_SIZE == 0,
+            has_safe_slot(res),
         returns
             self.paddr(),
     ;

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -197,23 +197,29 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
     /// [`item_into_raw`]: PageTableConfig::item_into_raw
     type Item: RCClone;
 
+    spec fn item_into_raw_spec(item: Self::Item) -> (Paddr, PagingLevel, PageProperty);
+
     /// Consumes the item and returns the physical address, the paging level,
     /// and the page property.
     ///
     /// The ownership of the item will be consumed, i.e., the item will be
     /// forgotten after this function is called.
-    spec fn item_into_raw_spec(item: Self::Item) -> (Paddr, PagingLevel, PageProperty);
-
     #[verifier::when_used_as_spec(item_into_raw_spec)]
-    fn item_into_raw(item: Self::Item) -> (res: (Paddr, PagingLevel, PageProperty))
+    fn item_into_raw(item: Self::Item) -> ((paddr, level, prop): (Paddr, PagingLevel, PageProperty))
+        requires
+            Self::item_well_formed(item),
         ensures
-            1 <= res.1 <= NR_LEVELS,
-            res == Self::item_into_raw_spec(item),
-            res.0 % PAGE_SIZE == 0,
-            res.0 < MAX_PADDR,
-            res.0 % page_size(res.1) == 0,
-            res.0 + page_size(res.1) <= MAX_PADDR,
+            1 <= level <= NR_LEVELS,
+            paddr % PAGE_SIZE == 0,
+            paddr < MAX_PADDR,
+            paddr % page_size(level) == 0,
+            paddr + page_size(level) <= MAX_PADDR,
+            Self::raw_item_well_formed(paddr, level , prop),
+        returns
+            Self::item_into_raw_spec(item),
     ;
+
+    spec fn item_from_raw_spec(paddr: Paddr, level: PagingLevel, prop: PageProperty) -> Self::Item;
 
     /// Restores the item from the physical address and the paging level.
     ///
@@ -239,10 +245,12 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
     /// A concrete trait implementation may require the caller to ensure that
     ///  - the [`super::PageFlags::AVAIL1`] flag is the same as that returned
     ///    from [`PageTableConfig::item_into_raw`].
-    spec fn item_from_raw_spec(paddr: Paddr, level: PagingLevel, prop: PageProperty) -> Self::Item;
-
     #[verifier::when_used_as_spec(item_from_raw_spec)]
-    unsafe fn item_from_raw(paddr: Paddr, level: PagingLevel, prop: PageProperty) -> Self::Item
+    unsafe fn item_from_raw(paddr: Paddr, level: PagingLevel, prop: PageProperty) -> (res:Self::Item)
+        requires
+            Self::raw_item_well_formed(paddr, level, prop),
+        ensures
+            Self::item_well_formed(item),
         returns
             Self::item_from_raw_spec(paddr, level, prop),
     ;
@@ -253,25 +261,88 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
     spec fn tracked(item: Self::Item) -> bool;
 
     /// Per-config predicate that captures the structural well-formedness an item
-    /// reconstructed via `item_from_raw_spec` must satisfy. Typically: the
-    /// `Frame::inv()` of the tracked-frame component (if any).
-    ///
-    /// `KernelPtConfig` defines this as `match item { Tracked(f, _) => f.inv(),
-    /// Untracked => true }`. `UserPtConfig` defines it as `item.frame.inv()`.
+    /// reconstructed via [`PageTableConfig::item_from_raw`] must satisfy. This may include both
+    /// ownership invariants and restrictions on raw-only property bits.
     spec fn item_well_formed(item: Self::Item) -> bool;
 
-    /// The item produced by `item_from_raw_spec` is structurally
-    /// well-formed (see `item_well_formed`).
-    proof fn item_from_raw_well_formed(pa: Paddr, level: PagingLevel, prop: PageProperty)
+    /// Per-config predicate that captures the well-formedness of raw properties
+    /// produced via [`PageTableConfig::item_into_raw`] must satisfy.
+    spec fn raw_item_well_formed(
+        pa: Paddr,
+        level: PagingLevel,
+        prop: PageProperty,
+    ) -> bool;
+
+    /// Changing properties without changing trackedness preserves a canonical raw item.
+    proof fn lemma_raw_item_well_formed_preserved(
+        pa: Paddr,
+        level: PagingLevel,
+        old_prop: PageProperty,
+        new_prop: PageProperty,
+    )
+        requires
+            Self::raw_item_well_formed(pa, level, old_prop),
+            Self::tracked(Self::item_from_raw_spec(pa, level, new_prop))
+                == Self::tracked(Self::item_from_raw_spec(pa, level, old_prop)),
+        ensures
+            Self::raw_item_well_formed(pa, level, new_prop),
+    ;
+
+    /// Splitting a canonical huge-page raw item yields canonical child raw items.
+    proof fn lemma_raw_item_well_formed_split(
+        pa: Paddr,
+        level: PagingLevel,
+        prop: PageProperty,
+        child_pa: Paddr,
+        child_idx: usize,
+    )
+        requires
+            Self::raw_item_well_formed(pa, level, prop),
+            level > 1,
+            child_idx < NR_ENTRIES,
+            child_pa == pa + child_idx * page_size(
+                (level - 1) as PagingLevel,
+            ),
+        ensures
+            Self::raw_item_well_formed(child_pa, (level - 1) as PagingLevel, prop),
+    ;
+
+    /// The item produced by [`PageTableConfig::item_from_raw`] is well-formed.
+    proof fn lemma_item_from_raw_well_formed(pa: Paddr, level: PagingLevel, prop: PageProperty)
         requires
             has_safe_slot(pa),
+            Self::raw_item_well_formed(pa, level, prop),
         ensures
-            Self::item_well_formed(Self::item_from_raw_spec(pa, level, prop)),
-            Self::item_into_raw_spec(Self::item_from_raw_spec(pa, level, prop)) == (
-                pa,
-                level,
-                prop,
-            ),
+            Self::item_well_formed(Self::item_from_raw(pa, level, prop)),
+    ;
+
+    /// Re-encoding a canonical raw item preserves the complete raw representation.
+    proof fn lemma_item_into_raw_roundtrip(
+        pa: Paddr,
+        level: PagingLevel,
+        prop: PageProperty,
+    )
+        requires
+            has_safe_slot(pa),
+            Self::raw_item_well_formed(pa, level, prop),
+        ensures
+            Self::item_into_raw(Self::item_from_raw(pa, level, prop))
+                == (pa, level, prop),
+    ;
+
+    /// Decoding the raw representation produced from a well-formed item restores that item.
+    proof fn lemma_item_from_raw_roundtrip(
+        item: Self::Item,
+        pa: Paddr,
+        level: PagingLevel,
+        prop: PageProperty,
+    )
+        requires
+            has_safe_slot(pa),
+            Self::item_well_formed(item),
+            Self::item_into_raw(item) == (pa, level, prop),
+        ensures
+            Self::item_from_raw(pa, level, prop) == item,
     ;
 
     /// Proves that `clone_ensures` for `Self::Item` implies concrete per-field
@@ -280,7 +351,7 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
     /// Proves that after `clone`, the slot at `frame_to_index(pa)` has the expected
     /// per-field properties. Implementors unfold their `MappedItem::clone_ensures` to
     /// `Frame::clone_ensures` and connect `pa` to the frame's internal pointer address.
-    proof fn clone_ensures_concrete(
+    proof fn lemma_clone_ensures_concrete(
         item: Self::Item,
         pa: Paddr,
         old_regions: MetaRegionOwners,
@@ -328,29 +399,12 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
             !Self::tracked(item) ==> new_regions.frame_obligations == old_regions.frame_obligations,
     ;
 
-    /// If the provided raw form matches an item consumed by `item_into_raw`,
-    /// then `item_from_raw` restores that item.
-    proof fn item_from_raw_roundtrip(
-        item: Self::Item,
-        paddr: Paddr,
-        level: PagingLevel,
-        prop: PageProperty,
-    )
-        requires
-            has_safe_slot(paddr),
-            Self::item_well_formed(item),
-            Self::item_into_raw_spec(item) == (paddr, level, prop),
-            Self::tracked(Self::item_from_raw_spec(paddr, level, prop)) == Self::tracked(item),
-        ensures
-            Self::item_from_raw_spec(paddr, level, prop) == item,
-    ;
-
     /// Proves `item.clone_requires(regions)` from the concrete frame-slot facts
     /// delivered by `metaregion_sound` plus the non-saturation bound propagated
     /// from `Cursor::query`. Implementors unfold their `MappedItem::clone_requires`
     /// to `Frame::clone_requires` and connect `pa` to the frame's internal pointer
     /// address.
-    proof fn clone_requires_concrete(
+    proof fn lemma_clone_requires_concrete(
         item: Self::Item,
         pa: Paddr,
         level: PagingLevel,
@@ -360,6 +414,7 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
         requires
             regions.inv(),
             Self::item_from_raw_spec(pa, level, prop) == item,
+            Self::raw_item_well_formed(pa, level, prop),
             has_safe_slot(pa),
             regions.slots.contains_key(frame_to_index(pa)),
             regions.slot_owners.contains_key(frame_to_index(pa)),

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -250,7 +250,7 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
         requires
             Self::raw_item_well_formed(paddr, level, prop),
         ensures
-            Self::item_well_formed(item),
+            Self::item_well_formed(res),
         returns
             Self::item_from_raw_spec(paddr, level, prop),
     ;

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -282,8 +282,8 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
     )
         requires
             Self::raw_item_well_formed(pa, level, old_prop),
-            Self::tracked(Self::item_from_raw_spec(pa, level, new_prop))
-                == Self::tracked(Self::item_from_raw_spec(pa, level, old_prop)),
+            Self::tracked(Self::item_from_raw(pa, level, new_prop))
+                == Self::tracked(Self::item_from_raw(pa, level, old_prop)),
         ensures
             Self::raw_item_well_formed(pa, level, new_prop),
     ;

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -1253,6 +1253,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                     pa, level, i);
 
                 }
+                C::lemma_raw_item_well_formed_split(pa, level, prop, small_pa, i);
             }
 
             // Snapshot the node's own-slot facts while the loop invariant still
@@ -1478,6 +1479,17 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
 
         let prop = pte.prop();
         let new_prop = op(prop);
+
+        proof {
+            assert(owner.frame().prop == prop);
+            assert(op.ensures((prop,), new_prop));
+            C::lemma_raw_item_well_formed_preserved(
+                owner.frame().mapped_pa,
+                owner.parent_level,
+                prop,
+                new_prop,
+            );
+        }
 
         assume(pte.set_prop_req(new_prop));
         pte.set_prop(new_prop);

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -207,25 +207,11 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             regions.inv(),
             regions.slots.contains_key(old(parent_owner).slot_index),
             old(parent_owner).metaregion_sound_node(*regions),
-            // POTENTIALLY UNSOUND PATCH: `op` must preserve the trackedness of
-            // `item_from_raw_spec(pa, level, _)` across the prop change.
-            //
-            // `axiom_frame_is_tracked_matches_item` asserts that the entry's recorded
-            // `is_tracked` field equals `C::tracked(C::item_from_raw_spec(pa, level, prop))`.
-            // `protect` updates `prop = op(old_prop)` but preserves `is_tracked`. If
-            // `C::tracked` of the reconstructed item depended on a bit `op` flipped, the
-            // axiom would be violated.
-            //
+            // `op` must preserve the trackedness of `item_from_raw_spec(pa, level, _)`
+            // across the prop change so frame-accounting guarantees remain unchanged.
             // For `KernelPtConfig`, `C::tracked(item)` reads `prop.flags.AVAIL1`, so this
             // precondition reduces to "op preserves AVAIL1". For `UserPtConfig`,
             // `C::tracked` is constant `true`, so this is trivial.
-            //
-            // This precondition is a *patch*, not a fix. The underlying issue is that
-            // `KernelPtConfig` overloads the PTE's `prop.AVAIL1` to encode tracked-ness,
-            // conflating "page property bits the user wants to mutate" with "internal
-            // accounting." A clean fix is to track tracked-ness separately from `prop`,
-            // or to reformulate `axiom_frame_is_tracked_matches_item` so it doesn't
-            // depend on `prop`.
             forall|pa: Paddr, level: PagingLevel, p_in: PageProperty, p_out: PageProperty|
                 #![auto]
                 op.ensures((p_in,), p_out) ==> C::tracked(C::item_from_raw_spec(pa, level, p_out))
@@ -237,7 +223,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             final(self).parent_perms_preserved(*old(parent_owner), *final(parent_owner)),
             final(owner).is_frame(),
             final(owner).frame().mapped_pa == old(owner).frame().mapped_pa,
-            final(owner).frame().is_tracked == old(owner).frame().is_tracked,
+            final(owner).frame_is_tracked() == old(owner).frame_is_tracked(),
             final(owner).path == old(owner).path,
             final(owner).parent_level == old(owner).parent_level,
             final(self).idx == old(self).idx,
@@ -1155,8 +1141,6 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 new_owner.value.path.push_tail(i as usize),
                 (level - 1) as PagingLevel,
                 prop,
-                /* is_tracked */
-                owner.value.frame().is_tracked,
             );
 
             let tracked mut new_owner_child = new_owner.children.tracked_remove(
@@ -1434,7 +1418,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
             final(parent_owner).relate_guard(*final(self)),
             final(parent_owner).metaregion_sound_node(*regions),
             final(owner).frame().mapped_pa == old(owner).frame().mapped_pa,
-            final(owner).frame().is_tracked == old(owner).frame().is_tracked,
+            final(owner).frame_is_tracked() == old(owner).frame_is_tracked(),
             final(owner).path == old(owner).path,
             final(owner).parent_level == old(owner).parent_level,
             forall|j: int| 0 <= j < NR_ENTRIES && j != idx ==>
@@ -1473,7 +1457,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
         };
 
         proof {
-            owner.tracked_borrow_mut_frame().prop = new_prop;
+            owner.tracked_set_frame_prop(new_prop);
             // The PTE at `idx` stayed present (only `prop` changed), so the
             // present-count is unchanged by the `write_pte` update — preserving
             // `count_consistent` for the caller.

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -148,6 +148,7 @@ unsafe impl<C: PageTableConfig> AnyFrameMeta for PageTablePageMeta<C> {
         &&& regions.inv()
         &&& Self::child_perms_embedding(regions, vstd::set::Set::empty())
         &&& self.walk_coverage_from_view(reader, vm_io_owner.read_view_of(), regions.slots.dom())
+        &&& self.walk_items_well_formed_from_view(reader, vm_io_owner.read_view_of())
         &&& self.walk_uniqueness_from_view(reader, vm_io_owner.read_view_of())
     }
 
@@ -252,6 +253,7 @@ unsafe impl<C: PageTableConfig> AnyFrameMeta for PageTablePageMeta<C> {
                 regions.slots.dom() == initial_dom,
                 Self::child_perms_embedding(*regions, removed_indices),
                 self.walk_coverage_from_view(initial_reader, initial_view, initial_dom),
+                self.walk_items_well_formed_from_view(initial_reader, initial_view),
                 self.walk_uniqueness_from_view(initial_reader, initial_view),
                 // Without this, Verus treats `self.level` as potentially
                 // mutated by `&mut self` and the level-comparison facts go
@@ -436,6 +438,24 @@ unsafe impl<C: PageTableConfig> AnyFrameMeta for PageTablePageMeta<C> {
                 } else {
                     // SAFETY: The PTE points to a mapped item. The ownership
                     // of the item is transferred here then dropped.
+                    proof {
+                        vstd::arithmetic::mul::lemma_mul_is_distributive_add_other_way(
+                            size_of_e,
+                            range_start,
+                            iter_count as int,
+                        );
+                        vstd::arithmetic::div_mod::lemma_mod_multiples_basic(
+                            range_start + iter_count,
+                            size_of_e,
+                        );
+                        Self::lemma_item_well_formed_at(
+                            *self,
+                            initial_reader,
+                            initial_view,
+                            cursor_pre_read,
+                        );
+                        assert(C::raw_item_well_formed(paddr, level, pte.prop()));
+                    }
                     let _item = unsafe { C::item_from_raw(paddr, level, pte.prop()) };
                 }
             }
@@ -942,6 +962,30 @@ impl<C: PageTableConfig> PageTablePageMeta<C> {
     {
     }
 
+    /// Instantiate [`walk_items_well_formed_from_view`]'s forall at one cursor.
+    pub proof fn lemma_item_well_formed_at(
+        self,
+        reader: crate::mm::VmReader<'_, crate::mm::Infallible>,
+        view: crate::specs::mm::virt_mem::MemView,
+        c: usize,
+    )
+        requires
+            self.walk_items_well_formed_from_view(reader, view),
+            reader.cursor.vaddr <= c,
+            c + core::mem::size_of::<C::E>() <= reader.cursor.vaddr + reader.remain_spec(),
+            (c - reader.cursor.vaddr) % core::mem::size_of::<C::E>() as int == 0,
+        ensures
+            ({
+                let pte = Self::walk_pte_at_view(view, c);
+                pte.is_present() && pte.is_last(self.level) ==> C::raw_item_well_formed(
+                    pte.paddr(),
+                    self.level,
+                    pte.prop(),
+                )
+            }),
+    {
+    }
+
     /// Instantiate [`walk_uniqueness_from_view`]'s forall at one cursor pair.
     pub proof fn lemma_uniqueness_at_pair(
         self,
@@ -988,6 +1032,28 @@ impl<C: PageTableConfig> PageTablePageMeta<C> {
                 let pte = Self::walk_pte_at_view(view, c);
                 pte.is_present() && !pte.is_last(self.level) ==> dom.contains(
                     frame_to_index(pte.paddr()),
+                )
+            }
+    }
+
+    /// Every present leaf PTE encountered by the drop walk contains a canonical
+    /// raw item for the node's paging level.
+    pub open spec fn walk_items_well_formed_from_view(
+        self,
+        reader: crate::mm::VmReader<'_, crate::mm::Infallible>,
+        view: crate::specs::mm::virt_mem::MemView,
+    ) -> bool {
+        forall|c: usize|
+            #![trigger Self::walk_pte_at_view(view, c)]
+            reader.cursor.vaddr <= c && c + core::mem::size_of::<C::E>() <= reader.cursor.vaddr
+                + reader.remain_spec() && (c - reader.cursor.vaddr) % core::mem::size_of::<
+                C::E,
+            >() as int == 0 ==> {
+                let pte = Self::walk_pte_at_view(view, c);
+                pte.is_present() && pte.is_last(self.level) ==> C::raw_item_well_formed(
+                    pte.paddr(),
+                    self.level,
+                    pte.prop(),
                 )
             }
     }

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -558,10 +558,15 @@ impl<'rcu, A: InAtomicMode> Cursor<'rcu, A> {
         self.0.find_next(len)
     }
 
-    /// Jump to the virtual address.
+    // [FIXED] BUG FOUND BY FV: missing panic documentation. https://github.com/asterinas/asterinas/pull/3007
+    /// Jumps to the virtual address.
     ///
-    /// This function will move the cursor to the given virtual address.
-    /// If the target address is not in the locked range, it will return an error.
+    /// If the target address is out of the range, this method will return `Err`.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if the address has bad alignment.
+    ///
     /// # Verified Properties
     /// ## Preconditions
     /// - **Safety Invariants**: The page table cursor safety invariants
@@ -574,8 +579,6 @@ impl<'rcu, A: InAtomicMode> Cursor<'rcu, A> {
     /// the result will be `Ok` and the cursor's virtual address will be set to `va`.
     /// - **Correctness**: If the target `va` is outside the locked range, the result is `Err`.
     /// - **Correctness**: If the metadata region was well-formed before the call, it will be well-formed after.
-    /// ## Panics
-    /// This method panics if the target address is not aligned to the page size.
     /// ## Safety
     /// This function preserves all memory invariants.
     /// Because it throws an error rather than move the cursor to an invalid address,
@@ -725,10 +728,15 @@ impl<'a, A: InAtomicMode> CursorMut<'a, A> {
         self.pt_cursor.find_next(len)
     }
 
+    // [FIXED] BUG FOUND BY FV: missing panic documentation. https://github.com/asterinas/asterinas/pull/3007
     /// Jump to the virtual address.
     ///
     /// This is the same as [`Cursor::jump`].
     ///
+    /// # Panics
+    ///
+    /// This method panics if the address has bad alignment.
+    /// 
     /// # Verified Properties
     /// ## Preconditions
     /// - **Safety Invariants**: The page table cursor safety invariants
@@ -931,7 +939,7 @@ impl<'a, A: InAtomicMode> CursorMut<'a, A> {
 
         assert_eq!(len % PAGE_SIZE, 0);
 
-        //*** KNOWN BUG: `self.virt_addr() + len` could overflow. For now, assume that it doesn't. ***
+        // [KNOWN] BUG FOUND BY FV: `self.va + len` could overflow. For now assume that it doesn't. https://github.com/asterinas/asterinas/issues/3159
         assume(self.pt_cursor.0.va + len <= usize::MAX);
 
         assert!(self.virt_addr() + len <= self.pt_cursor.0.barrier_va.end);

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -1661,7 +1661,19 @@ unsafe impl PageTableConfig for UserPtConfig {
         MappedItem { frame, prop }
     }
 
-    proof fn item_from_raw_roundtrip(
+    proof fn lemma_item_into_raw_roundtrip(
+        pa: Paddr,
+        level: PagingLevel,
+        prop: PageProperty,
+    ) {
+        broadcast use crate::specs::mm::frame::mapping::group_page_meta;
+
+        Self::item_from_raw_spec_frame_ptr(pa, level, prop);
+        let item = Self::item_from_raw_spec(pa, level, prop);
+        crate::specs::mm::frame::mapping::lemma_meta_to_paddr_biinjective(item.frame.ptr.addr());
+    }
+
+    proof fn lemma_item_from_raw_roundtrip(
         item: Self::Item,
         paddr: Paddr,
         level: PagingLevel,
@@ -1670,7 +1682,6 @@ unsafe impl PageTableConfig for UserPtConfig {
         broadcast use crate::specs::mm::frame::mapping::group_page_meta;
 
         Self::item_from_raw_spec_frame_ptr(paddr, level, prop);
-
         assert(Self::item_well_formed(item));
         crate::specs::mm::frame::mapping::lemma_meta_to_paddr_biinjective(item.frame.ptr.addr());
     }
@@ -1684,7 +1695,32 @@ unsafe impl PageTableConfig for UserPtConfig {
         item.frame.inv()
     }
 
-    proof fn item_from_raw_well_formed(pa: Paddr, level: PagingLevel, prop: PageProperty) {
+    open spec fn raw_item_well_formed(
+        _pa: Paddr,
+        level: PagingLevel,
+        _prop: PageProperty,
+    ) -> bool {
+        level == 1
+    }
+
+    proof fn lemma_raw_item_well_formed_preserved(
+        pa: Paddr,
+        level: PagingLevel,
+        old_prop: PageProperty,
+        new_prop: PageProperty,
+    ) {
+    }
+
+    proof fn lemma_raw_item_well_formed_split(
+        pa: Paddr,
+        level: PagingLevel,
+        prop: PageProperty,
+        child_pa: Paddr,
+        child_idx: usize,
+    ) {
+    }
+
+    proof fn lemma_item_from_raw_well_formed(pa: Paddr, level: PagingLevel, prop: PageProperty) {
         broadcast use crate::specs::mm::frame::mapping::group_page_meta;
         // Derive `frame.inv()` from the structural-shape axiom + soundness lemmas.
 
@@ -1695,7 +1731,7 @@ unsafe impl PageTableConfig for UserPtConfig {
         // FRAME_METADATA_RANGE. Both follow from `lemma_frame_to_meta_soundness`.
     }
 
-    proof fn clone_ensures_concrete(
+    proof fn lemma_clone_ensures_concrete(
         item: Self::Item,
         pa: Paddr,
         old_regions: MetaRegionOwners,
@@ -1722,25 +1758,19 @@ unsafe impl PageTableConfig for UserPtConfig {
         assert(new_regions.frame_obligations == old_regions.frame_obligations.insert(frame_idx));
     }
 
-    proof fn clone_requires_concrete(
+    proof fn lemma_clone_requires_concrete(
         item: Self::Item,
         pa: Paddr,
         level: PagingLevel,
         prop: PageProperty,
         regions: MetaRegionOwners,
     ) {
-        // `MappedItem::clone_requires` unfolds to `item.frame.clone_requires(regions)`.
-        // The trait precondition delivers all the slot facts at `frame_to_index(pa)`.
-        // We bridge:
-        //   (1) `item.frame.inv()` — discharged via `item_from_raw_well_formed`
-        //       (the trait-level structural well-formedness method).
-        //   (2) `frame_to_index(meta_to_frame(item.frame.ptr.addr())) == frame_to_index(pa)`
-        //       from `pa == item.frame.paddr()` (UserPtConfig::item_into_raw_spec).
         use crate::mm::frame::meta::mapping::meta_to_frame;
         use crate::specs::mm::frame::mapping::frame_to_index;
-        Self::item_from_raw_well_formed(pa, level, prop);
-        Self::item_from_raw_roundtrip(item, pa, level, prop);
-        assert(item.frame.paddr() == pa);
+        broadcast use crate::specs::mm::frame::mapping::group_page_meta;
+
+        Self::lemma_item_from_raw_well_formed(pa, level, prop);
+        Self::item_from_raw_spec_frame_ptr(pa, level, prop);
         assert(meta_to_frame(item.frame.ptr.addr()) == pa);
         assert(frame_to_index(meta_to_frame(item.frame.ptr.addr())) == frame_to_index(pa));
         // `Self::item_well_formed(item)` unfolds to `item.frame.inv()`.
@@ -1755,6 +1785,7 @@ impl UserPtConfig {
     pub axiom fn item_from_raw_spec_frame_ptr(pa: Paddr, level: PagingLevel, prop: PageProperty)
         requires
             has_safe_slot(pa),
+            UserPtConfig::raw_item_well_formed(pa, level, prop),
         ensures
             UserPtConfig::item_from_raw_spec(pa, level, prop).frame.ptr.addr()
                 == crate::mm::frame::meta::mapping::frame_to_meta(pa),

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -740,7 +740,7 @@ impl<'a, A: InAtomicMode> CursorMut<'a, A> {
     /// # Panics
     ///
     /// This method panics if the address has bad alignment.
-    /// 
+    ///
     /// # Verified Properties
     /// ## Preconditions
     /// - **Safety Invariants**: The page table cursor safety invariants
@@ -1665,11 +1665,7 @@ unsafe impl PageTableConfig for UserPtConfig {
         MappedItem { frame, prop }
     }
 
-    proof fn lemma_item_into_raw_roundtrip(
-        pa: Paddr,
-        level: PagingLevel,
-        prop: PageProperty,
-    ) {
+    proof fn lemma_item_into_raw_roundtrip(pa: Paddr, level: PagingLevel, prop: PageProperty) {
         broadcast use crate::specs::mm::frame::mapping::group_page_meta;
 
         Self::item_from_raw_spec_frame_ptr(pa, level, prop);
@@ -1699,11 +1695,7 @@ unsafe impl PageTableConfig for UserPtConfig {
         item.frame.inv()
     }
 
-    open spec fn raw_item_well_formed(
-        _pa: Paddr,
-        level: PagingLevel,
-        _prop: PageProperty,
-    ) -> bool {
+    open spec fn raw_item_well_formed(_pa: Paddr, level: PagingLevel, _prop: PageProperty) -> bool {
         level == 1
     }
 

--- a/ostd/src/sync/rcu/non_null/mod.rs
+++ b/ostd/src/sync/rcu/non_null/mod.rs
@@ -14,6 +14,7 @@ verus! {
 
 broadcast use {group_nonull_axioms, group_raw_ptr_axioms};
 
+// [FIXED] BUG FOUND BY FV: UB for Weak. https://github.com/asterinas/asterinas/issues/2801
 /// A trait that abstracts non-null pointers.
 ///
 /// All common smart pointer types such as `Box<T>`,  `Arc<T>`, and `Weak<T>`

--- a/ostd/src/sync/rcu/non_null/mod.rs
+++ b/ostd/src/sync/rcu/non_null/mod.rs
@@ -13,8 +13,8 @@ use core::{marker::PhantomData, mem::ManuallyDrop, ops::Deref, ptr::NonNull};
 verus! {
 
 broadcast use {group_nonull_axioms, group_raw_ptr_axioms};
-
 // [FIXED] BUG FOUND BY FV: UB for Weak. https://github.com/asterinas/asterinas/issues/2801
+
 /// A trait that abstracts non-null pointers.
 ///
 /// All common smart pointer types such as `Box<T>`,  `Arc<T>`, and `Weak<T>`

--- a/ostd/src/sync/rwlock.rs
+++ b/ostd/src/sync/rwlock.rs
@@ -1027,6 +1027,7 @@ impl<'a, T  /*: ?Sized*/ , G: SpinGuardian> RwLockUpgradeableGuard<'a, T, G> {
         }
     }
 
+    // [FIXED] BUG FOUND BY FV: deadlock. https://github.com/asterinas/asterinas/pull/3007
     /// Attempts to upgrade this upread guard to a write guard atomically.
     ///
     /// This function will never spin-wait and will return immediately.

--- a/ostd/src/sync/rwmutex.rs
+++ b/ostd/src/sync/rwmutex.rs
@@ -930,6 +930,7 @@ impl<'a, T> RwMutexUpgradeableGuard<'a, T> {
         }
     }
 
+    // [FIXED] BUG FOUND BY FV: deadlock. https://github.com/asterinas/asterinas/pull/3007
     /// Attempts to upgrade this upread guard to a write guard atomically.
     ///
     /// This function will return immediately.

--- a/verified_libs/vstd_extra/src/ghost_tree.rs
+++ b/verified_libs/vstd_extra/src/ghost_tree.rs
@@ -13,7 +13,7 @@ verus! {
 /// Each element selects one child at the corresponding tree level.
 /// `N` is the maximum number of children of each node, so every index is less than `N`.
 #[verifier::ext_equal]
-pub tracked struct TreePath<const N: usize>(pub Seq<int>);
+pub ghost struct TreePath<const N: usize>(pub Seq<int>);
 
 impl<const N: usize> TreePath<N> {
     pub open spec fn len(self) -> nat {


### PR DESCRIPTION
Delete redundant fields and rename `FrameEntryOwner` to a ghost `FrameEntryState` as it does not carry any permissions.