### PR TITLE
refactor `Node`: fix breaking changes and optimize the library

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,9 +17,9 @@ Other components like `kernel`, `osdk`, `test`, and `docs` shall be ignored duri
 - `git submodule update --init --recursive`: initialize required submodules.
 - `make verus` or `cargo dv bootstrap`: fetch and build the configured Verus toolchain under `tools/`.
   - `make verus update` or `cargo dv bootstrap --upgrade`: needed if there is compilation errors which might be caused by toolchain updates.
-- `make` or `cargo dv verify --targets ostd`: verify the main `ostd` target.
+- `make` or `cargo dv verify`: verify the whole target.
 - `cargo dv verify --targets ostd -- --verify-only-module <module_path>`: verify only a specific module, for example `sync::rwlock`.
-- `cargo dv compile --targets vstd_extra`: compile and verify the `vstd_extra` library independently.
+- `cargo dv verify --targets vstd_extra`: compile and verify the `vstd_extra` library independently.
 - `make fmt`: format Verus/Rust sources using the project formatter.
 - `make doc`: verify and generate API documentation in `doc/`.
 - `make clean`: remove Cargo and generated documentation artifacts.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,7 +587,7 @@ version = "0.0.0-2026-05-17-0151"
 
 [[package]]
 name = "verus_builtin_macros"
-version = "0.0.0-2026-06-14-0213"
+version = "0.0.0-2026-07-12-0122"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -638,7 +638,7 @@ checksum = "af8ca9a5d4debca0633e697c88269395493cebf2e10db21ca2dbde37c1356452"
 
 [[package]]
 name = "vstd"
-version = "0.0.0-2026-06-14-0213"
+version = "0.0.0-2026-07-12-0122"
 dependencies = [
  "verus_builtin",
  "verus_builtin_macros",

--- a/ostd/specs/mm/embedding/kvirt_store.rs
+++ b/ostd/specs/mm/embedding/kvirt_store.rs
@@ -125,7 +125,7 @@ pub axiom fn query_embedded<'rcu>(
         old(regions).inv(),
         old(kernel_pt).inv(),
         old(kernel_pt).metaregion_sound(*old(regions)),
-        old(kernel_pt).0.value.node().relate_guard(root_guard),
+        old(kernel_pt).0.value().node().relate_guard(root_guard),
         !(KVirtArea { range }).query_panic_condition(
             KVirtAreaOwner { pt_owner: *old(kernel_pt) },
             addr,
@@ -166,7 +166,7 @@ impl KVmStore {
                 addr,
                 old(self).regions,
             ),
-            old(self).kernel_pt.0.value.node().relate_guard(root_guard),
+            old(self).kernel_pt.0.value().node().relate_guard(root_guard),
         ensures
             final(self).inv(),
             final(self).kvirt_areas == old(self).kvirt_areas,

--- a/ostd/specs/mm/embedding/vm_space.rs
+++ b/ostd/specs/mm/embedding/vm_space.rs
@@ -22,7 +22,7 @@ verus! {
 /// extracts from `regions.slots` (the root is owned by the page table,
 /// not parked in the free pool).
 pub open spec fn vm_space_root_idx(owner: VmSpaceOwner) -> usize {
-    frame_to_index(owner.page_table_owner.value.meta_slot_paddr()->0)
+    frame_to_index(owner.page_table_owner.value().meta_slot_paddr()->0)
 }
 
 // =============================================================================

--- a/ostd/specs/mm/mod.rs
+++ b/ostd/specs/mm/mod.rs
@@ -48,7 +48,7 @@ impl GlobalMemOwner {
     /// The set of mappings in the page table is determined by
     /// [`PageTableOwner::view_rec`](crate::specs::mm::page_table::owners::PageTableOwner::view_rec).
     pub closed spec fn page_table_mappings(self) -> Set<Mapping> {
-        self.pt.view_rec(self.pt.0.value.path)
+        self.pt.view_rec(self.pt.0.value().path)
     }
 
     /// Top-level property: the page table mappings are disjoint in the virtual address space.
@@ -123,7 +123,7 @@ impl GlobalMemOwner {
             self.invariants(),
     {
         let pt = self.pt;
-        let root_path = pt.0.value.path;
+        let root_path = pt.0.value().path;
 
         assert forall|m1: Mapping, m2: Mapping|
             self.page_table_mappings() has m1 && self.page_table_mappings() has m2 && m1

--- a/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
@@ -189,8 +189,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 0 <= j < NR_ENTRIES && !(C::TOP_LEVEL_INDEX_RANGE().start <= j
                     < C::TOP_LEVEL_INDEX_RANGE().end) ==> (#[trigger] self.continuations[NR_LEVELS
                     - 1].children[j]) is Some ==> (self.continuations[NR_LEVELS
-                    - 1].children[j].unwrap().value.is_borrowed() || self.continuations[NR_LEVELS
-                    - 1].children[j].unwrap().value.is_absent()));
+                    - 1].children[j].unwrap().value().is_borrowed() || self.continuations[NR_LEVELS
+                    - 1].children[j].unwrap().value().is_absent()));
         }
     }
 
@@ -210,11 +210,11 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             owner0.continuations[owner0.level - 1].children[owner0.continuations[owner0.level
                 - 1].idx as int] is Some,
             owner0.continuations[owner0.level - 1].children[owner0.continuations[owner0.level
-                - 1].idx as int]->0.value.is_absent(),
+                - 1].idx as int]->0.value().is_absent(),
             self.continuations[self.level - 1].children[self.continuations[self.level
                 - 1].idx as int] is Some,
             self.continuations[self.level - 1].children[self.continuations[self.level
-                - 1].idx as int]->0.value.is_node(),
+                - 1].idx as int]->0.value().is_node(),
             // Non-idx children and path preserved
             self.continuations[self.level - 1].path() == owner0.continuations[owner0.level
                 - 1].path(),
@@ -314,7 +314,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             forall|i: int|
                 0 <= i < NR_ENTRIES ==> #[trigger] self.continuations[self.level
                     - 1].children[i] is Some && self.continuations[self.level
-                    - 1].children[i]->0.value.is_absent(),
+                    - 1].children[i]->0.value().is_absent(),
         ensures
             self.cur_entry_owner().is_absent(),
     {
@@ -331,19 +331,19 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 == self.continuations[i].idx,
     {
         if i == 3 && j == 2 {
-            self.continuations[3].path().push_tail_property_index(
+            self.continuations[3].path().lemma_push_tail_index(
                 self.continuations[3].idx as usize,
             );
-            self.continuations[3].path().push_tail_property_len(self.continuations[3].idx as usize);
+            self.continuations[3].path().lemma_push_tail_len(self.continuations[3].idx as usize);
         } else if i == 3 && j == 1 {
             let p3 = self.continuations[3].path();
             let p2 = self.continuations[2].path();
             let idx3 = self.continuations[3].idx as usize;
             let idx2 = self.continuations[2].idx as usize;
-            p3.push_tail_property_index(idx3);
-            p3.push_tail_property_len(idx3);
-            p2.push_tail_property_index(idx2);
-            p2.push_tail_property_len(idx2);
+            p3.lemma_push_tail_index(idx3);
+            p3.lemma_push_tail_len(idx3);
+            p2.lemma_push_tail_index(idx2);
+            p2.lemma_push_tail_len(idx2);
             assert(p3.len() < p2.len());
             assert(self.continuations[1].path() == p2.push_tail(idx2));
             assert(p2.push_tail(idx2).index(p3.len() as int) == p2.index(p3.len() as int));
@@ -354,40 +354,40 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             let idx3 = self.continuations[3].idx as usize;
             let idx2 = self.continuations[2].idx as usize;
             let idx1 = self.continuations[1].idx as usize;
-            p3.push_tail_property_index(idx3);
-            p3.push_tail_property_len(idx3);
-            p2.push_tail_property_index(idx2);
-            p2.push_tail_property_len(idx2);
-            p1.push_tail_property_index(idx1);
-            p1.push_tail_property_len(idx1);
+            p3.lemma_push_tail_index(idx3);
+            p3.lemma_push_tail_len(idx3);
+            p2.lemma_push_tail_index(idx2);
+            p2.lemma_push_tail_len(idx2);
+            p1.lemma_push_tail_index(idx1);
+            p1.lemma_push_tail_len(idx1);
             assert(p3.len() < p2.len());
             assert(p3.len() < p1.len());
             assert(p1.push_tail(idx1).index(p3.len() as int) == p1.index(p3.len() as int));
             assert(p2.push_tail(idx2).index(p3.len() as int) == p2.index(p3.len() as int));
         } else if i == 2 && j == 1 {
-            self.continuations[2].path().push_tail_property_index(
+            self.continuations[2].path().lemma_push_tail_index(
                 self.continuations[2].idx as usize,
             );
-            self.continuations[2].path().push_tail_property_len(self.continuations[2].idx as usize);
+            self.continuations[2].path().lemma_push_tail_len(self.continuations[2].idx as usize);
         } else if i == 2 && j == 0 {
             let p2 = self.continuations[2].path();
             let p1 = self.continuations[1].path();
             let idx2 = self.continuations[2].idx as usize;
             let idx1 = self.continuations[1].idx as usize;
-            p2.push_tail_property_index(idx2);
-            p2.push_tail_property_len(idx2);
-            p1.push_tail_property_index(idx1);
-            p1.push_tail_property_len(idx1);
+            p2.lemma_push_tail_index(idx2);
+            p2.lemma_push_tail_len(idx2);
+            p1.lemma_push_tail_index(idx1);
+            p1.lemma_push_tail_len(idx1);
             assert(p2.len() < p1.len());
             assert(self.continuations[0].path() == p1.push_tail(idx1));
             assert(p1.push_tail(idx1).index(p2.len() as int) == p1.index(p2.len() as int));
             assert(p1 == p2.push_tail(idx2));
             assert(p2.push_tail(idx2).index(p2.len() as int) == idx2);
         } else if i == 1 && j == 0 {
-            self.continuations[1].path().push_tail_property_index(
+            self.continuations[1].path().lemma_push_tail_index(
                 self.continuations[1].idx as usize,
             );
-            self.continuations[1].path().push_tail_property_len(self.continuations[1].idx as usize);
+            self.continuations[1].path().lemma_push_tail_len(self.continuations[1].idx as usize);
         }
     }
 

--- a/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
@@ -73,7 +73,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 let new_child = other.continuations[self.level
                     - 1].children[other.continuations[self.level - 1].idx as int]->0;
                 let new_path = other.continuations[self.level - 1].path().push_tail(
-                    other.continuations[self.level - 1].idx as usize,
+                    other.continuations[self.level - 1].idx as int,
                 );
                 new_child.subtree_satisfies(
                     new_path,
@@ -106,7 +106,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     #![trigger o_cont.children[j]]
                     0 <= j < o_cont.children.len()
                         && o_cont.children[j] is Some implies o_cont.children[j].unwrap().subtree_satisfies(
-                o_cont.path().push_tail(j as usize), f) by {
+                o_cont.path().push_tail(j), f) by {
                     if j != idx {
                         assert(o_cont.children[j] == s_cont.children[j]);
                         s_cont.inv_children_unroll(j);
@@ -228,7 +228,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     - 1].idx as int]->0,
             ).view_rec(
                 self.continuations[self.level - 1].path().push_tail(
-                    self.continuations[self.level - 1].idx as usize,
+                    self.continuations[self.level - 1].idx as int,
                 ),
             ) =~= Set::<Mapping>::empty(),
         ensures
@@ -244,14 +244,14 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         assert(cont.view_mappings() == cont0.view_mappings()) by {
             cont0.inv_children_unroll(idx);
             PageTableOwner(cont0.children[idx].unwrap()).view_rec_absent_empty(
-                cont0.path().push_tail(idx as usize),
+                cont0.path().push_tail(idx as int),
             );
             assert forall|m: Mapping|
                 cont.view_mappings().contains(m) implies cont0.view_mappings().contains(m) by {
                 let j = choose|j: int|
                     0 <= j < cont.children.len() && #[trigger] cont.children[j] is Some
                         && PageTableOwner(cont.children[j].unwrap()).view_rec(
-                        cont.path().push_tail(j as usize),
+                        cont.path().push_tail(j),
                     ).contains(m);
                 if j == idx {
                     // cont.children[idx]'s view_rec == empty (from precondition)
@@ -265,7 +265,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 let j = choose|j: int|
                     0 <= j < cont0.children.len() && #[trigger] cont0.children[j] is Some
                         && PageTableOwner(cont0.children[j].unwrap()).view_rec(
-                        cont0.path().push_tail(j as usize),
+                        cont0.path().push_tail(j),
                     ).contains(m);
                 if j == idx {
                     // cont0.children[idx] is absent, view_rec is empty
@@ -332,14 +332,14 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
     {
         if i == 3 && j == 2 {
             self.continuations[3].path().lemma_push_tail_index(
-                self.continuations[3].idx as usize,
+                self.continuations[3].idx as int,
             );
-            self.continuations[3].path().lemma_push_tail_len(self.continuations[3].idx as usize);
+            self.continuations[3].path().lemma_push_tail_len(self.continuations[3].idx as int);
         } else if i == 3 && j == 1 {
             let p3 = self.continuations[3].path();
             let p2 = self.continuations[2].path();
-            let idx3 = self.continuations[3].idx as usize;
-            let idx2 = self.continuations[2].idx as usize;
+            let idx3 = self.continuations[3].idx as int;
+            let idx2 = self.continuations[2].idx as int;
             p3.lemma_push_tail_index(idx3);
             p3.lemma_push_tail_len(idx3);
             p2.lemma_push_tail_index(idx2);
@@ -351,9 +351,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             let p3 = self.continuations[3].path();
             let p2 = self.continuations[2].path();
             let p1 = self.continuations[1].path();
-            let idx3 = self.continuations[3].idx as usize;
-            let idx2 = self.continuations[2].idx as usize;
-            let idx1 = self.continuations[1].idx as usize;
+            let idx3 = self.continuations[3].idx as int;
+            let idx2 = self.continuations[2].idx as int;
+            let idx1 = self.continuations[1].idx as int;
             p3.lemma_push_tail_index(idx3);
             p3.lemma_push_tail_len(idx3);
             p2.lemma_push_tail_index(idx2);
@@ -366,14 +366,14 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             assert(p2.push_tail(idx2).index(p3.len() as int) == p2.index(p3.len() as int));
         } else if i == 2 && j == 1 {
             self.continuations[2].path().lemma_push_tail_index(
-                self.continuations[2].idx as usize,
+                self.continuations[2].idx as int,
             );
-            self.continuations[2].path().lemma_push_tail_len(self.continuations[2].idx as usize);
+            self.continuations[2].path().lemma_push_tail_len(self.continuations[2].idx as int);
         } else if i == 2 && j == 0 {
             let p2 = self.continuations[2].path();
             let p1 = self.continuations[1].path();
-            let idx2 = self.continuations[2].idx as usize;
-            let idx1 = self.continuations[1].idx as usize;
+            let idx2 = self.continuations[2].idx as int;
+            let idx1 = self.continuations[1].idx as int;
             p2.lemma_push_tail_index(idx2);
             p2.lemma_push_tail_len(idx2);
             p1.lemma_push_tail_index(idx1);
@@ -385,9 +385,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             assert(p2.push_tail(idx2).index(p2.len() as int) == idx2);
         } else if i == 1 && j == 0 {
             self.continuations[1].path().lemma_push_tail_index(
-                self.continuations[1].idx as usize,
+                self.continuations[1].idx as int,
             );
-            self.continuations[1].path().lemma_push_tail_len(self.continuations[1].idx as usize);
+            self.continuations[1].path().lemma_push_tail_len(self.continuations[1].idx as int);
         }
     }
 

--- a/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
@@ -75,7 +75,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 let new_path = other.continuations[self.level - 1].path().push_tail(
                     other.continuations[self.level - 1].idx as usize,
                 );
-                new_child.tree_predicate_map(
+                new_child.subtree_satisfies(
                     new_path,
                     PageTableOwner::<C>::metaregion_sound_pred(regions),
                 )
@@ -105,7 +105,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 assert forall|j: int|
                     #![trigger o_cont.children[j]]
                     0 <= j < o_cont.children.len()
-                        && o_cont.children[j] is Some implies o_cont.children[j].unwrap().tree_predicate_map(
+                        && o_cont.children[j] is Some implies o_cont.children[j].unwrap().subtree_satisfies(
                 o_cont.path().push_tail(j as usize), f) by {
                     if j != idx {
                         assert(o_cont.children[j] == s_cont.children[j]);

--- a/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
@@ -27,6 +27,8 @@ use core::ops::Range;
 
 verus! {
 
+broadcast use group_ghost_tree_lemmas;
+
 impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
     pub proof fn protect_preserves_cursor_inv_metaregion(
         self,
@@ -331,19 +333,11 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 == self.continuations[i].idx,
     {
         if i == 3 && j == 2 {
-            self.continuations[3].path().lemma_push_tail_index(
-                self.continuations[3].idx as int,
-            );
-            self.continuations[3].path().lemma_push_tail_len(self.continuations[3].idx as int);
         } else if i == 3 && j == 1 {
             let p3 = self.continuations[3].path();
             let p2 = self.continuations[2].path();
             let idx3 = self.continuations[3].idx as int;
             let idx2 = self.continuations[2].idx as int;
-            p3.lemma_push_tail_index(idx3);
-            p3.lemma_push_tail_len(idx3);
-            p2.lemma_push_tail_index(idx2);
-            p2.lemma_push_tail_len(idx2);
             assert(p3.len() < p2.len());
             assert(self.continuations[1].path() == p2.push_tail(idx2));
             assert(p2.push_tail(idx2)[p3.len() as int] == p2[p3.len() as int]);
@@ -354,40 +348,22 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             let idx3 = self.continuations[3].idx as int;
             let idx2 = self.continuations[2].idx as int;
             let idx1 = self.continuations[1].idx as int;
-            p3.lemma_push_tail_index(idx3);
-            p3.lemma_push_tail_len(idx3);
-            p2.lemma_push_tail_index(idx2);
-            p2.lemma_push_tail_len(idx2);
-            p1.lemma_push_tail_index(idx1);
-            p1.lemma_push_tail_len(idx1);
             assert(p3.len() < p2.len());
             assert(p3.len() < p1.len());
             assert(p1.push_tail(idx1)[p3.len() as int] == p1[p3.len() as int]);
             assert(p2.push_tail(idx2)[p3.len() as int] == p2[p3.len() as int]);
         } else if i == 2 && j == 1 {
-            self.continuations[2].path().lemma_push_tail_index(
-                self.continuations[2].idx as int,
-            );
-            self.continuations[2].path().lemma_push_tail_len(self.continuations[2].idx as int);
         } else if i == 2 && j == 0 {
             let p2 = self.continuations[2].path();
             let p1 = self.continuations[1].path();
             let idx2 = self.continuations[2].idx as int;
             let idx1 = self.continuations[1].idx as int;
-            p2.lemma_push_tail_index(idx2);
-            p2.lemma_push_tail_len(idx2);
-            p1.lemma_push_tail_index(idx1);
-            p1.lemma_push_tail_len(idx1);
             assert(p2.len() < p1.len());
             assert(self.continuations[0].path() == p1.push_tail(idx1));
             assert(p1.push_tail(idx1)[p2.len() as int] == p1[p2.len() as int]);
             assert(p1 == p2.push_tail(idx2));
             assert(p2.push_tail(idx2)[p2.len() as int] == idx2);
         } else if i == 1 && j == 0 {
-            self.continuations[1].path().lemma_push_tail_index(
-                self.continuations[1].idx as int,
-            );
-            self.continuations[1].path().lemma_push_tail_len(self.continuations[1].idx as int);
         }
     }
 

--- a/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_fn_lemmas.rs
@@ -327,7 +327,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             i < NR_LEVELS,
         ensures
             self.continuations[j].path().len() as int > self.continuations[i].path().len(),
-            self.continuations[j].path().index(self.continuations[i].path().len() as int)
+            self.continuations[j].path()[self.continuations[i].path().len() as int]
                 == self.continuations[i].idx,
     {
         if i == 3 && j == 2 {
@@ -346,7 +346,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             p2.lemma_push_tail_len(idx2);
             assert(p3.len() < p2.len());
             assert(self.continuations[1].path() == p2.push_tail(idx2));
-            assert(p2.push_tail(idx2).index(p3.len() as int) == p2.index(p3.len() as int));
+            assert(p2.push_tail(idx2)[p3.len() as int] == p2[p3.len() as int]);
         } else if i == 3 && j == 0 {
             let p3 = self.continuations[3].path();
             let p2 = self.continuations[2].path();
@@ -362,8 +362,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             p1.lemma_push_tail_len(idx1);
             assert(p3.len() < p2.len());
             assert(p3.len() < p1.len());
-            assert(p1.push_tail(idx1).index(p3.len() as int) == p1.index(p3.len() as int));
-            assert(p2.push_tail(idx2).index(p3.len() as int) == p2.index(p3.len() as int));
+            assert(p1.push_tail(idx1)[p3.len() as int] == p1[p3.len() as int]);
+            assert(p2.push_tail(idx2)[p3.len() as int] == p2[p3.len() as int]);
         } else if i == 2 && j == 1 {
             self.continuations[2].path().lemma_push_tail_index(
                 self.continuations[2].idx as int,
@@ -380,9 +380,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             p1.lemma_push_tail_len(idx1);
             assert(p2.len() < p1.len());
             assert(self.continuations[0].path() == p1.push_tail(idx1));
-            assert(p1.push_tail(idx1).index(p2.len() as int) == p1.index(p2.len() as int));
+            assert(p1.push_tail(idx1)[p2.len() as int] == p1[p2.len() as int]);
             assert(p1 == p2.push_tail(idx2));
-            assert(p2.push_tail(idx2).index(p2.len() as int) == idx2);
+            assert(p2.push_tail(idx2)[p2.len() as int] == idx2);
         } else if i == 1 && j == 0 {
             self.continuations[1].path().lemma_push_tail_index(
                 self.continuations[1].idx as int,

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -27,8 +27,8 @@ verus! {
 /// Paths obtained by push_tail with different indices are different
 pub proof fn push_tail_different_indices_different_paths(
     path: TreePath<NR_ENTRIES>,
-    i: usize,
-    j: usize,
+    i: int,
+    j: int,
 )
     requires
         path.inv(),
@@ -40,8 +40,8 @@ pub proof fn push_tail_different_indices_different_paths(
 {
     path.lemma_push_tail_len(i);
     path.lemma_push_tail_len(j);
-    assert(path.push_tail(i).index(path.len() as int) == i as usize);
-    assert(path.push_tail(j).index(path.len() as int) == j as usize);
+    assert(path.push_tail(i).index(path.len() as int) == i);
+    assert(path.push_tail(j).index(path.len() as int) == j);
     if path.push_tail(i) == path.push_tail(j) {
         assert(i == j);  // Contradiction
     }
@@ -64,7 +64,7 @@ pub proof fn different_length_different_paths(
 }
 
 /// A path obtained by push_tail has greater length than the original
-pub proof fn push_tail_increases_length(path: TreePath<NR_ENTRIES>, i: usize)
+pub proof fn push_tail_increases_length(path: TreePath<NR_ENTRIES>, i: int)
     requires
         path.inv(),
         0 <= i < NR_ENTRIES,
@@ -135,14 +135,14 @@ pub proof fn subtree_unlock_upgrade<'rcu, C: PageTableConfig>(
             #![trigger subtree.children()[i]]
             0 <= i < subtree.children().len()
                 && subtree.children()[i] is Some implies subtree.children()[i].unwrap().subtree_satisfies(
-        path.push_tail(i as usize), h) by {
+        path.push_tail(i), h) by {
             let child = subtree.children()[i].unwrap();
             subtree.lemma_map_unroll_once(path, f, i);
             subtree.lemma_map_unroll_once(path, g, i);
 
             PageTableOwner::<C>(subtree).pt_inv_unroll(i);
-            let child_path = path.push_tail(i as usize);
-            path.lemma_push_tail_len(i as usize);
+            let child_path = path.push_tail(i);
+            path.lemma_push_tail_len(i);
 
             assert(child_path != excepted_path) by {
                 if excepted_path.len() <= path.len() {
@@ -169,7 +169,7 @@ pub proof fn subtree_unlock_upgrade<'rcu, C: PageTableConfig>(
             #![trigger subtree.children()[i]]
             0 <= i < subtree.children().len()
                 && subtree.children()[i] is Some implies subtree.children()[i].unwrap().subtree_satisfies(
-        path.push_tail(i as usize), h) by {
+        path.push_tail(i), h) by {
             PageTableOwner::<C>(subtree).pt_inv_non_node(i);
         };
     }
@@ -378,14 +378,14 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
         old_cont.inv_children_rel_unroll(old_cont.idx as int);
         let child_subtree = old_cont.children[old_cont.idx as int].unwrap();
-        let child_path = old_cont.path().push_tail(old_cont.idx as usize);
+        let child_path = old_cont.path().push_tail(old_cont.idx as int);
         assert(child_cont.children == child_subtree.children());
         assert(child_cont.path() == child_path);
         assert(child_subtree.value().is_node());
         assert(child_path.len() < INC_LEVELS - 1) by {
             assert(old_cont.tree_level < INC_LEVELS - 1);
             assert(old_cont.entry_own.inv_base());
-            old_cont.path().lemma_push_tail_len(old_cont.idx as usize);
+            old_cont.path().lemma_push_tail_len(old_cont.idx as int);
         };
         old_cont.inv_children_unroll(old_cont.idx as int);
         let pto = PageTableOwner(child_subtree);
@@ -398,7 +398,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     #![auto]
                     0 <= j < child_cont.children.len() && child_cont.children[j] is Some
                         && PageTableOwner(child_cont.children[j].unwrap()).view_rec(
-                        child_cont.path().push_tail(j as usize),
+                        child_cont.path().push_tail(j),
                     ).contains(m);
                 assert(pto.0.children()[j] is Some);
                 assert(pto.0.children()[j] == child_cont.children[j]);
@@ -412,7 +412,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     #![trigger pto.0.children()[j]]
                     0 <= j < pto.0.children().len() && pto.0.children()[j] is Some && PageTableOwner(
                         pto.0.children()[j].unwrap(),
-                    ).view_rec(child_path.push_tail(j as usize)).contains(m);
+                    ).view_rec(child_path.push_tail(j)).contains(m);
                 assert(child_cont.children[j] == pto.0.children()[j]);
                 assert(child_cont.children[j] is Some);
             };
@@ -446,7 +446,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 assert(old_cont.view_mappings_take_child_spec().contains(m));
                 let child_subtree = old_cont.children[old_cont.idx as int].unwrap();
                 assert(PageTableOwner(child_subtree).view_rec(
-                    old_cont.path().push_tail(old_cont.idx as usize),
+                    old_cont.path().push_tail(old_cont.idx as int),
                 ).contains(m));
                 assert(self.continuations[self.level - 1].view_mappings().contains(m));
             } else if i == self.level - 1 {
@@ -525,10 +525,10 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 Some(gc.value()),
             ));
             assert(gc.value().path.len() == child.entry_own.node().tree_level + 1);
-            assert(gc.value().path == child.entry_own.path.push_tail(0usize));
+            assert(gc.value().path == child.entry_own.path.push_tail(0));
             assert(child.entry_own.inv_base());
-            child.entry_own.path.lemma_push_tail_len(0usize);
-            assert(child.entry_own.path.push_tail(0usize).len() == child.entry_own.path.len() + 1);
+            child.entry_own.path.lemma_push_tail_len(0);
+            assert(child.entry_own.path.push_tail(0).len() == child.entry_own.path.len() + 1);
         };
 
         assert(child.tree_level == child.entry_own.node().tree_level);
@@ -552,7 +552,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     j,
                     Some(child.children[j].unwrap().value()),
                 )
-                &&& child.children[j].unwrap().value().path == child.path().push_tail(j as usize)
+                &&& child.children[j].unwrap().value().path == child.path().push_tail(j)
             } by {
                 let gc = child.children[j].unwrap();
                 assert(child.children[j] == child_node.children()[j]);
@@ -628,7 +628,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     Some(modified_cont.children[i].unwrap().value()),
                 )
                 &&& modified_cont.children[i].unwrap().value().path == modified_cont.path().push_tail(
-                    i as usize,
+                    i,
                 )
             } by {
                 assert(i != modified_cont.idx);
@@ -668,7 +668,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             &&& new_owner.continuations[2].guard.inner.inner@.ptr.addr()
                 != new_owner.continuations[3].guard.inner.inner@.ptr.addr()
             &&& new_owner.continuations[2].path() == new_owner.continuations[3].path().push_tail(
-                new_owner.continuations[3].idx as usize,
+                new_owner.continuations[3].idx as int,
             )
             &&& <EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
                 new_owner.continuations[3].entry_own,
@@ -691,7 +691,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     // path consistency: child.path() == modified_cont.path().push_tail(modified_cont.idx)
                     assert(new_owner.continuations[2].path()
                         == new_owner.continuations[3].path().push_tail(
-                        new_owner.continuations[3].idx as usize,
+                        new_owner.continuations[3].idx as int,
                     )) by {
                         assert(modified_cont.path() == old_cont.path());
                         assert(modified_cont.idx == old_cont.idx);
@@ -723,7 +723,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             &&& new_owner.continuations[1].guard.inner.inner@.ptr.addr()
                 != new_owner.continuations[3].guard.inner.inner@.ptr.addr()
             &&& new_owner.continuations[1].path() == new_owner.continuations[2].path().push_tail(
-                new_owner.continuations[2].idx as usize,
+                new_owner.continuations[2].idx as int,
             )
             &&& <EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
                 new_owner.continuations[2].entry_own,
@@ -751,7 +751,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     // path: child.path() == modified_cont.path().push_tail(modified_cont.idx)
                     assert(new_owner.continuations[1].path()
                         == new_owner.continuations[2].path().push_tail(
-                        new_owner.continuations[2].idx as usize,
+                        new_owner.continuations[2].idx as int,
                     )) by {
                         assert(modified_cont.path() == old_cont.path());
                         assert(modified_cont.idx == old_cont.idx);
@@ -790,7 +790,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             &&& new_owner.continuations[0].guard.inner.inner@.ptr.addr()
                 != new_owner.continuations[3].guard.inner.inner@.ptr.addr()
             &&& new_owner.continuations[0].path() == new_owner.continuations[1].path().push_tail(
-                new_owner.continuations[1].idx as usize,
+                new_owner.continuations[1].idx as int,
             )
             &&& <EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
                 new_owner.continuations[1].entry_own,
@@ -831,13 +831,13 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 assert(new_owner.va.index[0] == child.idx);
 
                 // path consistency: child.path() == modified_cont.path().push_tail(modified_cont.idx)
-                assert(child.path() == modified_cont.path().push_tail(modified_cont.idx as usize))
+                assert(child.path() == modified_cont.path().push_tail(modified_cont.idx as int))
                     by {
                     assert(modified_cont.path() == old_cont.path());
                     assert(modified_cont.idx == old_cont.idx);
                     old_cont.inv_children_rel_unroll(old_cont.idx as int);
                     assert(child.entry_own.path == old_cont.path().push_tail(
-                        old_cont.idx as usize,
+                        old_cont.idx as int,
                     ));
                 };
 
@@ -895,7 +895,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
         let cur_entry = self.cur_entry_owner();
         let cur_entry_addr = cur_entry.node().meta_addr_self();
-        let cur_entry_path = old_cont.path().push_tail(old_cont.idx as usize);
+        let cur_entry_path = old_cont.path().push_tail(old_cont.idx as int);
         self.cont_entries_metaregion(regions);
 
         assert forall|i: int|
@@ -915,7 +915,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
                 assert(cur_entry_path.len() == old_cont.tree_level + 1) by {
                     old_cont.inv_children_rel_unroll(old_cont.idx as int);
-                    old_cont.entry_own.path.lemma_push_tail_len(old_cont.idx as usize);
+                    old_cont.entry_own.path.lemma_push_tail_len(old_cont.idx as int);
                 };
                 assert(cont_i.tree_level <= old_cont.tree_level) by {
                     if self.level == 1 {
@@ -953,19 +953,19 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     #![trigger child_cont.children[j]]
                     0 <= j < child_cont.children.len()
                         && child_cont.children[j] is Some implies child_cont.children[j].unwrap().subtree_satisfies(
-                child_cont.path().push_tail(j as usize), h) by {
+                child_cont.path().push_tail(j), h) by {
                     let gc = child_cont.children[j].unwrap();
-                    let gc_path = child_cont.path().push_tail(j as usize);
+                    let gc_path = child_cont.path().push_tail(j);
                     child_cont.inv_children_unroll(j);
                     child_cont.inv_children_rel_unroll(j);
-                    child_cont.path().lemma_push_tail_len(j as usize);
+                    child_cont.path().lemma_push_tail_len(j);
 
                     let child_subtree = old_cont.children[old_cont.idx as int].unwrap();
                     child_subtree.lemma_map_unroll_once(cur_entry_path, f, j);
                     child_subtree.lemma_map_unroll_once(cur_entry_path, g_except, j);
 
                     assert(child_cont.path() == cur_entry_path);
-                    assert(gc_path == cur_entry_path.push_tail(j as usize));
+                    assert(gc_path == cur_entry_path.push_tail(j));
                     assert(cur_entry_path.len() < gc_path.len());
                     child_cont.pt_inv_children_unroll(j);
                     subtree_unlock_upgrade(
@@ -984,24 +984,24 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     #![trigger modified_cont.children[j]]
                     0 <= j < modified_cont.children.len()
                         && modified_cont.children[j] is Some implies modified_cont.children[j].unwrap().subtree_satisfies(
-                modified_cont.path().push_tail(j as usize), h) by {
+                modified_cont.path().push_tail(j), h) by {
                     assert(j != old_cont.idx as int);
                     assert(modified_cont.children[j] == old_cont.children[j]);
                     let sibling = old_cont.children[j].unwrap();
-                    let sibling_path = old_cont.path().push_tail(j as usize);
+                    let sibling_path = old_cont.path().push_tail(j);
                     old_cont.inv_children_unroll(j);
                     old_cont.inv_children_rel_unroll(j);
-                    old_cont.path().lemma_push_tail_len(j as usize);
+                    old_cont.path().lemma_push_tail_len(j);
 
                     push_tail_different_indices_different_paths(
                         old_cont.path(),
-                        j as usize,
-                        old_cont.idx,
+                        j,
+                        old_cont.idx as int,
                     );
                     // `cur_entry_path.len() <= sibling_path.len()` previously had its own
                     // `by { ... }` block at depth 3; inline its facts instead.
                     old_cont.inv_children_rel_unroll(old_cont.idx as int);
-                    old_cont.path().lemma_push_tail_len(old_cont.idx as usize);
+                    old_cont.path().lemma_push_tail_len(old_cont.idx as int);
                     assert(cur_entry_path.len() <= sibling_path.len());
                     old_cont.pt_inv_children_unroll(j);
                     subtree_unlock_upgrade(
@@ -1017,44 +1017,44 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 assert(new_owner.continuations[i] == self.continuations[i]);
                 let cont_i = self.continuations[i];
 
-                old_cont.entry_own.path.lemma_push_tail_len(old_cont.idx as usize);
+                old_cont.entry_own.path.lemma_push_tail_len(old_cont.idx as int);
                 if i == self.level {
-                    assert(old_cont.path() == cont_i.path().push_tail(cont_i.idx as usize));
-                    cont_i.entry_own.path.lemma_push_tail_len(cont_i.idx as usize);
+                    assert(old_cont.path() == cont_i.path().push_tail(cont_i.idx as int));
+                    cont_i.entry_own.path.lemma_push_tail_len(cont_i.idx as int);
                 } else if i == self.level + 1 {
                     let cont_sl = self.continuations[self.level as int];
-                    assert(old_cont.path() == cont_sl.path().push_tail(cont_sl.idx as usize));
-                    assert(cont_sl.path() == cont_i.path().push_tail(cont_i.idx as usize));
-                    cont_i.entry_own.path.lemma_push_tail_len(cont_i.idx as usize);
-                    cont_i.path().push_tail(cont_i.idx as usize).lemma_push_tail_len(
-                        cont_sl.idx as usize,
+                    assert(old_cont.path() == cont_sl.path().push_tail(cont_sl.idx as int));
+                    assert(cont_sl.path() == cont_i.path().push_tail(cont_i.idx as int));
+                    cont_i.entry_own.path.lemma_push_tail_len(cont_i.idx as int);
+                    cont_i.path().push_tail(cont_i.idx as int).lemma_push_tail_len(
+                        cont_sl.idx as int,
                     );
                 } else {
                     let cont_sl = self.continuations[self.level as int];
                     let cont_sl1 = self.continuations[self.level + 1];
-                    assert(old_cont.path() == cont_sl.path().push_tail(cont_sl.idx as usize));
-                    assert(cont_sl.path() == cont_sl1.path().push_tail(cont_sl1.idx as usize));
-                    assert(cont_sl1.path() == cont_i.path().push_tail(cont_i.idx as usize));
-                    cont_i.entry_own.path.lemma_push_tail_len(cont_i.idx as usize);
-                    cont_i.path().push_tail(cont_i.idx as usize).lemma_push_tail_len(
-                        cont_sl1.idx as usize,
+                    assert(old_cont.path() == cont_sl.path().push_tail(cont_sl.idx as int));
+                    assert(cont_sl.path() == cont_sl1.path().push_tail(cont_sl1.idx as int));
+                    assert(cont_sl1.path() == cont_i.path().push_tail(cont_i.idx as int));
+                    cont_i.entry_own.path.lemma_push_tail_len(cont_i.idx as int);
+                    cont_i.path().push_tail(cont_i.idx as int).lemma_push_tail_len(
+                        cont_sl1.idx as int,
                     );
-                    cont_sl1.path().push_tail(cont_sl1.idx as usize).lemma_push_tail_len(
-                        cont_sl.idx as usize,
+                    cont_sl1.path().push_tail(cont_sl1.idx as int).lemma_push_tail_len(
+                        cont_sl.idx as int,
                     );
                 }
-                assert(cur_entry_path.index(cont_i.tree_level as int) == cont_i.idx as usize);
+                assert(cur_entry_path.index(cont_i.tree_level as int) == cont_i.idx as int);
 
                 assert forall|j: int|
                     #![trigger cont_i.children[j]]
                     0 <= j < cont_i.children.len()
                         && cont_i.children[j] is Some implies cont_i.children[j].unwrap().subtree_satisfies(
-                cont_i.path().push_tail(j as usize), h) by {
+                cont_i.path().push_tail(j), h) by {
                     let child_sub = cont_i.children[j].unwrap();
-                    let child_path = cont_i.path().push_tail(j as usize);
+                    let child_path = cont_i.path().push_tail(j);
                     cont_i.inv_children_unroll(j);
                     cont_i.inv_children_rel_unroll(j);
-                    cont_i.path().lemma_push_tail_len(j as usize);
+                    cont_i.path().lemma_push_tail_len(j);
 
                     assert(child_path.index(cont_i.tree_level as int) == j as usize);
                     assert(j != cont_i.idx);
@@ -1140,7 +1140,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             assert forall|j: int|
                 0 <= j
                     < child_subtree.children().len() implies match #[trigger] child_subtree.children()[j] {
-                Some(ch) => ch.subtree_satisfies(child_cont.path().push_tail(j as usize), f),
+                Some(ch) => ch.subtree_satisfies(child_cont.path().push_tail(j), f),
                 None => true,
             } by {
                 child_subtree.lemma_map_unroll_once(child_cont.path(), f, j);
@@ -1152,7 +1152,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             assert forall|j: int|
                 0 <= j < modified_cont.children.len()
                     && #[trigger] modified_cont.children[j] is Some implies modified_cont.children[j].unwrap().subtree_satisfies(
-            modified_cont.path().push_tail(j as usize), f) by {
+            modified_cont.path().push_tail(j), f) by {
                 assert(j != old_cont.idx as int);
                 assert(modified_cont.children[j] == old_cont.children[j]);
             };
@@ -1279,8 +1279,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             }
         };
 
-        assert(child.path() == cont.path().push_tail(cont.idx as usize));
-        assert(child.entry_own.path == new_cont.path().push_tail(cont.idx as usize));
+        assert(child.path() == cont.path().push_tail(cont.idx as int));
+        assert(child.entry_own.path == new_cont.path().push_tail(cont.idx as int));
         assert(<EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
             new_cont.entry_own,
             cont.idx as int,
@@ -1345,7 +1345,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     Some(new_cont.children[i].unwrap().value()),
                 )
                 &&& new_cont.children[i].unwrap().value().path == new_cont.path().push_tail(
-                    i as usize,
+                    i,
                 )
             } by {
                 if i == cont.idx {
@@ -1386,7 +1386,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             &&& new_owner.continuations[2].guard.inner.inner@.ptr.addr()
                 != new_owner.continuations[3].guard.inner.inner@.ptr.addr()
             &&& new_owner.continuations[2].path() == new_owner.continuations[3].path().push_tail(
-                new_owner.continuations[3].idx as usize,
+                new_owner.continuations[3].idx as int,
             )
             &&& <EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
                 new_owner.continuations[3].entry_own,
@@ -1416,7 +1416,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             &&& new_owner.continuations[1].guard.inner.inner@.ptr.addr()
                 != new_owner.continuations[3].guard.inner.inner@.ptr.addr()
             &&& new_owner.continuations[1].path() == new_owner.continuations[2].path().push_tail(
-                new_owner.continuations[2].idx as usize,
+                new_owner.continuations[2].idx as int,
             )
             &&& <EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
                 new_owner.continuations[2].entry_own,
@@ -1621,7 +1621,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             &&& r.continuations[2].guard.inner.inner@.ptr.addr()
                 != r.continuations[3].guard.inner.inner@.ptr.addr()
             &&& r.continuations[2].path() == r.continuations[3].path().push_tail(
-                r.continuations[3].idx as usize,
+                r.continuations[3].idx as int,
             )
         });
 
@@ -1636,7 +1636,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             &&& r.continuations[1].guard.inner.inner@.ptr.addr()
                 != r.continuations[3].guard.inner.inner@.ptr.addr()
             &&& r.continuations[1].path() == r.continuations[2].path().push_tail(
-                r.continuations[2].idx as usize,
+                r.continuations[2].idx as int,
             )
         });
 
@@ -1653,7 +1653,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             &&& r.continuations[0].guard.inner.inner@.ptr.addr()
                 != r.continuations[3].guard.inner.inner@.ptr.addr()
             &&& r.continuations[0].path() == r.continuations[1].path().push_tail(
-                r.continuations[1].idx as usize,
+                r.continuations[1].idx as int,
             )
         });
     }
@@ -2178,7 +2178,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
         assert(child.all_some());
         assert(parent.all_but_index_some());
-        assert(child.path() == parent.path().push_tail(parent.idx as usize));
+        assert(child.path() == parent.path().push_tail(parent.idx as int));
 
         assert(child_subtree.inv()) by {
             assert(child_subtree.inv_node());
@@ -2237,7 +2237,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     #![auto]
                     0 <= j < r.children.len() && r.children[j] is Some && PageTableOwner(
                         r.children[j].unwrap(),
-                    ).view_rec(r.path().push_tail(j as usize)).contains(m);
+                    ).view_rec(r.path().push_tail(j)).contains(m);
                 assert(p.children[j] is Some);
             };
             assert forall|m: Mapping|
@@ -2246,7 +2246,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     #![auto]
                     0 <= j < p.children.len() && p.children[j] is Some && PageTableOwner(
                         p.children[j].unwrap(),
-                    ).view_rec(p.path().push_tail(j as usize)).contains(m);
+                    ).view_rec(p.path().push_tail(j)).contains(m);
                 assert(r.children[j] is Some);
             };
         };
@@ -2328,7 +2328,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         #![auto]
                         0 <= i < old_cont.children.len() && old_cont.children[i] is Some
                             && PageTableOwner(old_cont.children[i].unwrap()).view_rec(
-                            old_cont.path().push_tail(i as usize),
+                            old_cont.path().push_tail(i),
                         ).contains(m);
                     assert(new_cont.children[i] is Some);
                 };
@@ -2340,7 +2340,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         #![auto]
                         0 <= i < new_cont.children.len() && new_cont.children[i] is Some
                             && PageTableOwner(new_cont.children[i].unwrap()).view_rec(
-                            new_cont.path().push_tail(i as usize),
+                            new_cont.path().push_tail(i),
                         ).contains(m);
                     assert(old_cont.children[i] is Some);
                 };

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -27,11 +27,7 @@ verus! {
 broadcast use group_ghost_tree_lemmas;
 
 /// Paths obtained by push_tail with different indices are different
-pub proof fn push_tail_different_indices_different_paths(
-    path: TreePath<NR_ENTRIES>,
-    i: int,
-    j: int,
-)
+pub proof fn push_tail_different_indices_different_paths(path: TreePath<NR_ENTRIES>, i: int, j: int)
     requires
         path.inv(),
         0 <= i < NR_ENTRIES,
@@ -132,9 +128,9 @@ pub proof fn subtree_unlock_upgrade<'rcu, C: PageTableConfig>(
     if subtree.level() < INC_LEVELS - 1 && subtree.value().is_node() {
         assert forall|i: int|
             #![trigger subtree.children()[i]]
-            0 <= i < subtree.children().len()
-                && subtree.has_child(i) implies subtree.child(i).subtree_satisfies(
-        path.push_tail(i), h) by {
+            0 <= i < subtree.children().len() && subtree.has_child(i) implies subtree.child(
+            i,
+        ).subtree_satisfies(path.push_tail(i), h) by {
             let child = subtree.child(i);
             subtree.lemma_subtree_satisfies_unroll_once(path, f, i);
             subtree.lemma_subtree_satisfies_unroll_once(path, g, i);
@@ -165,9 +161,9 @@ pub proof fn subtree_unlock_upgrade<'rcu, C: PageTableConfig>(
         // has no children to recurse into.
         assert forall|i: int|
             #![trigger subtree.children()[i]]
-            0 <= i < subtree.children().len()
-                && subtree.has_child(i) implies subtree.child(i).subtree_satisfies(
-        path.push_tail(i), h) by {
+            0 <= i < subtree.children().len() && subtree.has_child(i) implies subtree.child(
+            i,
+        ).subtree_satisfies(path.push_tail(i), h) by {
             PageTableOwner::<C>(subtree).pt_inv_non_node(i);
         };
     }
@@ -624,9 +620,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     i,
                     Some(modified_cont.children[i].unwrap().value()),
                 )
-                &&& modified_cont.children[i].unwrap().value().path == modified_cont.path().push_tail(
-                    i,
-                )
+                &&& modified_cont.children[i].unwrap().value().path
+                    == modified_cont.path().push_tail(i)
             } by {
                 assert(i != modified_cont.idx);
                 assert(modified_cont.children[i] == old_cont.children[i]);
@@ -778,7 +773,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             )
         }) by {
             if new_owner.level == 1 {
-
                 // parent_level == 2: from inv_children_rel on old_cont
                 assert(child.entry_own.parent_level == 2) by {
                     old_cont.inv_children_rel_unroll(old_cont.idx as int);
@@ -791,9 +785,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     assert(modified_cont.path() == old_cont.path());
                     assert(modified_cont.idx == old_cont.idx);
                     old_cont.inv_children_rel_unroll(old_cont.idx as int);
-                    assert(child.entry_own.path == old_cont.path().push_tail(
-                        old_cont.idx as int,
-                    ));
+                    assert(child.entry_own.path == old_cont.path().push_tail(old_cont.idx as int));
                 };
 
                 // PTE consistency: from old_cont.inv_children_rel at idx
@@ -1018,8 +1010,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     j,
                     None,
                 ),
-            } by {
-            };
+            } by {};
         };
         assert forall|j: int|
             0 <= j < NR_ENTRIES implies match #[trigger] child_subtree.children()[j] {
@@ -1043,8 +1034,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         assert(child_cont.map_children(f)) by {
             assert forall|j: int|
                 0 <= j < child_cont.children.len()
-                    && #[trigger] child_cont.children[j] is Some implies child_cont.children[j]
-                .unwrap().subtree_satisfies(child_cont.path().push_tail(j), f) by {
+                    && #[trigger] child_cont.children[j] is Some implies child_cont.children[j].unwrap().subtree_satisfies(
+            child_cont.path().push_tail(j), f) by {
                 assert(child_subtree.has_child(j));
                 child_subtree.lemma_subtree_satisfies_unroll_once(child_cont.path(), f, j);
                 assert(child_subtree.child(j) == child_cont.children[j].unwrap());
@@ -1202,7 +1193,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 ));
             };
         };
-        assert forall|j: int| 0 <= j < NR_ENTRIES implies match #[trigger] child_node.children()[j] {
+        assert forall|j: int|
+            0 <= j < NR_ENTRIES implies match #[trigger] child_node.children()[j] {
             Some(ch) => ch.inv(),
             None => true,
         } by {
@@ -1232,9 +1224,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     i,
                     Some(new_cont.children[i].unwrap().value()),
                 )
-                &&& new_cont.children[i].unwrap().value().path == new_cont.path().push_tail(
-                    i,
-                )
+                &&& new_cont.children[i].unwrap().value().path == new_cont.path().push_tail(i)
             } by {
                 if i == cont.idx {
                     assert(new_cont.children[i].unwrap() == child_node);

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -134,9 +134,9 @@ pub proof fn subtree_unlock_upgrade<'rcu, C: PageTableConfig>(
         assert forall|i: int|
             #![trigger subtree.children()[i]]
             0 <= i < subtree.children().len()
-                && subtree.children()[i] is Some implies subtree.children()[i].unwrap().subtree_satisfies(
+                && subtree.has_child(i) implies subtree.child(i).subtree_satisfies(
         path.push_tail(i), h) by {
-            let child = subtree.children()[i].unwrap();
+            let child = subtree.child(i);
             subtree.lemma_map_unroll_once(path, f, i);
             subtree.lemma_map_unroll_once(path, g, i);
 
@@ -168,7 +168,7 @@ pub proof fn subtree_unlock_upgrade<'rcu, C: PageTableConfig>(
         assert forall|i: int|
             #![trigger subtree.children()[i]]
             0 <= i < subtree.children().len()
-                && subtree.children()[i] is Some implies subtree.children()[i].unwrap().subtree_satisfies(
+                && subtree.has_child(i) implies subtree.child(i).subtree_satisfies(
         path.push_tail(i), h) by {
             PageTableOwner::<C>(subtree).pt_inv_non_node(i);
         };
@@ -400,7 +400,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         && PageTableOwner(child_cont.children[j].unwrap()).view_rec(
                         child_cont.path().push_tail(j),
                     ).contains(m);
-                assert(pto.0.children()[j] is Some);
+                assert(pto.0.has_child(j));
                 assert(pto.0.children()[j] == child_cont.children[j]);
                 assert(pto.view_rec(child_path).contains(m));
             };
@@ -410,8 +410,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 ) implies #[trigger] child_cont.view_mappings().contains(m) by {
                 let j = choose|j: int|
                     #![trigger pto.0.children()[j]]
-                    0 <= j < pto.0.children().len() && pto.0.children()[j] is Some && PageTableOwner(
-                        pto.0.children()[j].unwrap(),
+                    0 <= j < pto.0.children().len() && pto.0.has_child(j) && PageTableOwner(
+                        pto.0.child(j),
                     ).view_rec(child_path.push_tail(j)).contains(m);
                 assert(child_cont.children[j] == pto.0.children()[j]);
                 assert(child_cont.children[j] is Some);

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -40,8 +40,6 @@ pub proof fn push_tail_different_indices_different_paths(
     ensures
         path.push_tail(i) != path.push_tail(j),
 {
-    path.lemma_push_tail_len(i);
-    path.lemma_push_tail_len(j);
     assert(path.push_tail(i)[path.len() as int] == i);
     assert(path.push_tail(j)[path.len() as int] == j);
     if path.push_tail(i) == path.push_tail(j) {
@@ -144,7 +142,6 @@ pub proof fn subtree_unlock_upgrade<'rcu, C: PageTableConfig>(
 
             PageTableOwner::<C>(subtree).pt_inv_unroll(i);
             let child_path = path.push_tail(i);
-            path.lemma_push_tail_len(i);
 
             assert(child_path != excepted_path) by {
                 if excepted_path.len() <= path.len() {
@@ -383,11 +380,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         let child_path = old_cont.path().push_tail(old_cont.idx as int);
         assert(child_cont.children == child_subtree.children());
         assert(child_cont.path() == child_path);
-        assert(child_subtree.value().is_node());
         assert(child_path.len() < INC_LEVELS - 1) by {
             assert(old_cont.tree_level < INC_LEVELS - 1);
             assert(old_cont.entry_own.inv_base());
-            old_cont.path().lemma_push_tail_len(old_cont.idx as int);
         };
         old_cont.inv_children_unroll(old_cont.idx as int);
         let pto = PageTableOwner(child_subtree);
@@ -503,10 +498,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         );
 
         old_cont.inv_children_rel_unroll(old_cont.idx as int);
-        assert(child.children == child_node.children());
-        assert(child.entry_own == child_node.value());
-        assert(child.tree_level == child_node.level());
-        assert(child.path() == child_node.value().path);
 
         assert(self.va.index.contains_key(self.level - 2));
 
@@ -520,7 +511,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 Some(gc.value()),
             ));
             assert(child.entry_own.inv_base());
-            child.entry_own.path.lemma_push_tail_len(0);
         };
 
         assert(child.inv_children()) by {
@@ -553,9 +543,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 PageTableOwner(child_node).pt_inv_unroll(j);
                 assert(gc == child_node.child(j));
                 assert(PageTableOwner::<C>::pt_edge_at(child_node, j));
-                assert(gc.value().parent_level == child.level());
-                assert(gc.level() == child.tree_level + 1);
-                assert(gc.value().path.len() == child.entry_own.node().tree_level + 1);
                 assert(gc.value().match_pte(
                     child.entry_own.node().children_perm.value()[j],
                     child.entry_own.node().level,
@@ -664,12 +651,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 old_cont.pt_inv_children_unroll(i);
             };
         };
-        assert(modified_cont.entry_own.is_node());
-        assert(modified_cont.entry_own.node().relate_guard(modified_cont.guard));
-        assert(modified_cont.tree_level == INC_LEVELS - modified_cont.level() - 1);
-        assert(modified_cont.tree_level < INC_LEVELS - 1);
-        assert(modified_cont.path().len() == modified_cont.tree_level);
-        assert(modified_cont.inv());
 
         assert(new_owner.level <= 4 ==> {
             &&& new_owner.continuations.contains_key(3)

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -137,8 +137,8 @@ pub proof fn subtree_unlock_upgrade<'rcu, C: PageTableConfig>(
                 && subtree.has_child(i) implies subtree.child(i).subtree_satisfies(
         path.push_tail(i), h) by {
             let child = subtree.child(i);
-            subtree.lemma_map_unroll_once(path, f, i);
-            subtree.lemma_map_unroll_once(path, g, i);
+            subtree.lemma_subtree_satisfies_unroll_once(path, f, i);
+            subtree.lemma_subtree_satisfies_unroll_once(path, g, i);
 
             PageTableOwner::<C>(subtree).pt_inv_unroll(i);
             let child_path = path.push_tail(i);
@@ -942,8 +942,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     child_cont.path().lemma_push_tail_len(j);
 
                     let child_subtree = old_cont.children[old_cont.idx as int].unwrap();
-                    child_subtree.lemma_map_unroll_once(cur_entry_path, f, j);
-                    child_subtree.lemma_map_unroll_once(cur_entry_path, g_except, j);
+                    child_subtree.lemma_subtree_satisfies_unroll_once(cur_entry_path, f, j);
+                    child_subtree.lemma_subtree_satisfies_unroll_once(cur_entry_path, g_except, j);
 
                     assert(child_cont.path() == cur_entry_path);
                     assert(gc_path == cur_entry_path.push_tail(j));
@@ -1122,7 +1122,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 Some(ch) => ch.subtree_satisfies(child_cont.path().push_tail(j), f),
                 None => true,
             } by {
-                child_subtree.lemma_map_unroll_once(child_cont.path(), f, j);
+                child_subtree.lemma_subtree_satisfies_unroll_once(child_cont.path(), f, j);
             };
         };
 

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -500,21 +500,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         );
 
         old_cont.inv_children_rel_unroll(old_cont.idx as int);
-        assert(child.entry_own == child_node.value());
-        assert(child.entry_own == self.cur_entry_owner());
         assert(child.children == child_node.children());
-        assert(child.tree_level == old_cont.tree_level + 1);
 
         assert(self.va.index.contains_key(self.level - 2));
-        assert(child.idx == self.va.index[self.level - 2] as usize);
-
-        assert(child.entry_own.path.len() == old_cont.entry_own.node().tree_level + 1);
-        assert(old_cont.entry_own.node().tree_level == old_cont.tree_level) by {
-            assert(old_cont.tree_level == INC_LEVELS - old_cont.level() - 1);
-        };
-        assert(child.entry_own.path.len() == child.tree_level) by {
-            assert(child.tree_level == old_cont.tree_level + 1);
-        };
 
         assert(child.entry_own.node().tree_level == child.entry_own.path.len()) by {
             assert(child.children[0] is Some);
@@ -524,15 +512,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 0,
                 Some(gc.value()),
             ));
-            assert(gc.value().path.len() == child.entry_own.node().tree_level + 1);
-            assert(gc.value().path == child.entry_own.path.push_tail(0));
             assert(child.entry_own.inv_base());
             child.entry_own.path.lemma_push_tail_len(0);
-            assert(child.entry_own.path.push_tail(0).len() == child.entry_own.path.len() + 1);
         };
-
-        assert(child.tree_level == child.entry_own.node().tree_level);
-        assert(child.tree_level == INC_LEVELS - child.level() - 1);
 
         assert(child.inv_children()) by {
             assert forall|j: int|
@@ -555,7 +537,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 &&& child.children[j].unwrap().value().path == child.path().push_tail(j)
             } by {
                 let gc = child.children[j].unwrap();
-                assert(child.children[j] == child_node.children()[j]);
                 assert(<EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
                     child.entry_own,
                     j,

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -38,8 +38,8 @@ pub proof fn push_tail_different_indices_different_paths(
     ensures
         path.push_tail(i) != path.push_tail(j),
 {
-    path.push_tail_property(i);
-    path.push_tail_property(j);
+    path.lemma_push_tail_len(i);
+    path.lemma_push_tail_len(j);
     assert(path.push_tail(i).index(path.len() as int) == i as usize);
     assert(path.push_tail(j).index(path.len() as int) == j as usize);
     if path.push_tail(i) == path.push_tail(j) {
@@ -71,7 +71,7 @@ pub proof fn push_tail_increases_length(path: TreePath<NR_ENTRIES>, i: usize)
     ensures
         path.push_tail(i).len() > path.len(),
 {
-    path.push_tail_property(i);
+    path.lemma_push_tail_len(i);
 }
 
 /// Upgrade `node_unlocked_except` to `node_unlocked` on a subtree where the excepted
@@ -98,7 +98,7 @@ pub proof fn subtree_unlock_upgrade<'rcu, C: PageTableConfig>(
         regions.slot_owners[frame_to_index(meta_to_frame(excepted_addr))].paths_in_pt
             == set![excepted_path],
         // Structural path == value path
-        path == subtree.value.path,
+        path == subtree.value().path,
         path.inv(),
         // excepted_path does not match this subtree root
         path != excepted_path,
@@ -109,40 +109,40 @@ pub proof fn subtree_unlock_upgrade<'rcu, C: PageTableConfig>(
             0 <= k < path.len() && #[trigger] excepted_path.index(k) != path.index(k)),
     ensures
         subtree.tree_predicate_map(path, CursorOwner::<'rcu, C>::node_unlocked(guards)),
-    decreases INC_LEVELS - subtree.level,
+    decreases INC_LEVELS - subtree.level(),
 {
     let f = PageTableOwner::<C>::metaregion_sound_pred(regions);
     let g = CursorOwner::<'rcu, C>::node_unlocked_except(guards, excepted_addr);
     let h = CursorOwner::<'rcu, C>::node_unlocked(guards);
 
-    assert(f(subtree.value, path));
-    assert(g(subtree.value, path));
-    if subtree.value.is_node() {
-        if subtree.value.node().meta_addr_self() == excepted_addr {
+    assert(f(subtree.value(), path));
+    assert(g(subtree.value(), path));
+    if subtree.value().is_node() {
+        if subtree.value().node().meta_addr_self() == excepted_addr {
             // addr == excepted_addr contradicts path != excepted_path
             // via metaregion_sound's singleton paths_in_pt.
             let idx = frame_to_index(meta_to_frame(excepted_addr));
-            assert(subtree.value.metaregion_sound(regions));
-            assert(regions.slot_owners[idx].paths_in_pt == set![subtree.value.path]);
-            assert(set![subtree.value.path].contains(excepted_path));
+            assert(subtree.value().metaregion_sound(regions));
+            assert(regions.slot_owners[idx].paths_in_pt == set![subtree.value().path]);
+            assert(set![subtree.value().path].contains(excepted_path));
             assert(false);
         }
     }
-    assert(h(subtree.value, path));
+    assert(h(subtree.value(), path));
 
-    if subtree.level < INC_LEVELS - 1 && subtree.value.is_node() {
+    if subtree.level() < INC_LEVELS - 1 && subtree.value().is_node() {
         assert forall|i: int|
-            #![trigger subtree.children[i]]
-            0 <= i < subtree.children.len()
-                && subtree.children[i] is Some implies subtree.children[i].unwrap().tree_predicate_map(
+            #![trigger subtree.children()[i]]
+            0 <= i < subtree.children().len()
+                && subtree.children()[i] is Some implies subtree.children()[i].unwrap().tree_predicate_map(
         path.push_tail(i as usize), h) by {
-            let child = subtree.children[i].unwrap();
-            subtree.map_unroll_once(path, f, i);
-            subtree.map_unroll_once(path, g, i);
+            let child = subtree.children()[i].unwrap();
+            subtree.lemma_map_unroll_once(path, f, i);
+            subtree.lemma_map_unroll_once(path, g, i);
 
             PageTableOwner::<C>(subtree).pt_inv_unroll(i);
             let child_path = path.push_tail(i as usize);
-            path.push_tail_property(i as usize);
+            path.lemma_push_tail_len(i as usize);
 
             assert(child_path != excepted_path) by {
                 if excepted_path.len() <= path.len() {
@@ -162,13 +162,13 @@ pub proof fn subtree_unlock_upgrade<'rcu, C: PageTableConfig>(
                 excepted_path,
             );
         };
-    } else if subtree.level < INC_LEVELS - 1 && !subtree.value.is_node() {
+    } else if subtree.level() < INC_LEVELS - 1 && !subtree.value().is_node() {
         // Non-node: pt_inv gives children[i] is None, so tree_predicate_map
         // has no children to recurse into.
         assert forall|i: int|
-            #![trigger subtree.children[i]]
-            0 <= i < subtree.children.len()
-                && subtree.children[i] is Some implies subtree.children[i].unwrap().tree_predicate_map(
+            #![trigger subtree.children()[i]]
+            0 <= i < subtree.children().len()
+                && subtree.children()[i] is Some implies subtree.children()[i].unwrap().tree_predicate_map(
         path.push_tail(i as usize), h) by {
             PageTableOwner::<C>(subtree).pt_inv_non_node(i);
         };
@@ -379,13 +379,13 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         old_cont.inv_children_rel_unroll(old_cont.idx as int);
         let child_subtree = old_cont.children[old_cont.idx as int].unwrap();
         let child_path = old_cont.path().push_tail(old_cont.idx as usize);
-        assert(child_cont.children == child_subtree.children);
+        assert(child_cont.children == child_subtree.children());
         assert(child_cont.path() == child_path);
-        assert(child_subtree.value.is_node());
+        assert(child_subtree.value().is_node());
         assert(child_path.len() < INC_LEVELS - 1) by {
             assert(old_cont.tree_level < INC_LEVELS - 1);
             assert(old_cont.entry_own.inv_base());
-            old_cont.path().push_tail_property(old_cont.idx as usize);
+            old_cont.path().lemma_push_tail_len(old_cont.idx as usize);
         };
         old_cont.inv_children_unroll(old_cont.idx as int);
         let pto = PageTableOwner(child_subtree);
@@ -400,8 +400,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         && PageTableOwner(child_cont.children[j].unwrap()).view_rec(
                         child_cont.path().push_tail(j as usize),
                     ).contains(m);
-                assert(pto.0.children[j] is Some);
-                assert(pto.0.children[j] == child_cont.children[j]);
+                assert(pto.0.children()[j] is Some);
+                assert(pto.0.children()[j] == child_cont.children[j]);
                 assert(pto.view_rec(child_path).contains(m));
             };
             assert forall|m: Mapping|
@@ -409,11 +409,11 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     m,
                 ) implies #[trigger] child_cont.view_mappings().contains(m) by {
                 let j = choose|j: int|
-                    #![trigger pto.0.children[j]]
-                    0 <= j < pto.0.children.len() && pto.0.children[j] is Some && PageTableOwner(
-                        pto.0.children[j].unwrap(),
+                    #![trigger pto.0.children()[j]]
+                    0 <= j < pto.0.children().len() && pto.0.children()[j] is Some && PageTableOwner(
+                        pto.0.children()[j].unwrap(),
                     ).view_rec(child_path.push_tail(j as usize)).contains(m);
-                assert(child_cont.children[j] == pto.0.children[j]);
+                assert(child_cont.children[j] == pto.0.children()[j]);
                 assert(child_cont.children[j] is Some);
             };
         };
@@ -500,9 +500,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         );
 
         old_cont.inv_children_rel_unroll(old_cont.idx as int);
-        assert(child.entry_own == child_node.value);
+        assert(child.entry_own == child_node.value());
         assert(child.entry_own == self.cur_entry_owner());
-        assert(child.children == child_node.children);
+        assert(child.children == child_node.children());
         assert(child.tree_level == old_cont.tree_level + 1);
 
         assert(self.va.index.contains_key(self.level - 2));
@@ -522,12 +522,12 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             assert(<EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
                 child.entry_own,
                 0,
-                Some(gc.value),
+                Some(gc.value()),
             ));
-            assert(gc.value.path.len() == child.entry_own.node().tree_level + 1);
-            assert(gc.value.path == child.entry_own.path.push_tail(0usize));
+            assert(gc.value().path.len() == child.entry_own.node().tree_level + 1);
+            assert(gc.value().path == child.entry_own.path.push_tail(0usize));
             assert(child.entry_own.inv_base());
-            child.entry_own.path.push_tail_property(0usize);
+            child.entry_own.path.lemma_push_tail_len(0usize);
             assert(child.entry_own.path.push_tail(0usize).len() == child.entry_own.path.len() + 1);
         };
 
@@ -538,28 +538,28 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             assert forall|j: int|
                 0 <= j < child.children.len()
                     && #[trigger] child.children[j] is Some implies child.children[j].unwrap().inv() by {
-                assert(child.children[j] == child_node.children[j]);
+                assert(child.children[j] == child_node.children()[j]);
                 old_cont.inv_children_unroll(old_cont.idx as int);
             };
         };
         assert(child.inv_children_rel()) by {
             assert forall|j: int|
                 0 <= j < NR_ENTRIES && #[trigger] child.children[j] is Some implies {
-                &&& child.children[j].unwrap().value.parent_level == child.level()
-                &&& child.children[j].unwrap().level == child.tree_level + 1
+                &&& child.children[j].unwrap().value().parent_level == child.level()
+                &&& child.children[j].unwrap().level() == child.tree_level + 1
                 &&& <EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
                     child.entry_own,
                     j,
-                    Some(child.children[j].unwrap().value),
+                    Some(child.children[j].unwrap().value()),
                 )
-                &&& child.children[j].unwrap().value.path == child.path().push_tail(j as usize)
+                &&& child.children[j].unwrap().value().path == child.path().push_tail(j as usize)
             } by {
                 let gc = child.children[j].unwrap();
-                assert(child.children[j] == child_node.children[j]);
+                assert(child.children[j] == child_node.children()[j]);
                 assert(<EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
                     child.entry_own,
                     j,
-                    Some(gc.value),
+                    Some(gc.value()),
                 ));
                 child.inv_children_unroll(j);
             };
@@ -620,14 +620,14 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         assert(modified_cont.inv_children_rel()) by {
             assert forall|i: int|
                 0 <= i < NR_ENTRIES && #[trigger] modified_cont.children[i] is Some implies {
-                &&& modified_cont.children[i].unwrap().value.parent_level == modified_cont.level()
-                &&& modified_cont.children[i].unwrap().level == modified_cont.tree_level + 1
+                &&& modified_cont.children[i].unwrap().value().parent_level == modified_cont.level()
+                &&& modified_cont.children[i].unwrap().level() == modified_cont.tree_level + 1
                 &&& <EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
                     modified_cont.entry_own,
                     i,
-                    Some(modified_cont.children[i].unwrap().value),
+                    Some(modified_cont.children[i].unwrap().value()),
                 )
-                &&& modified_cont.children[i].unwrap().value.path == modified_cont.path().push_tail(
+                &&& modified_cont.children[i].unwrap().value().path == modified_cont.path().push_tail(
                     i as usize,
                 )
             } by {
@@ -915,7 +915,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
                 assert(cur_entry_path.len() == old_cont.tree_level + 1) by {
                     old_cont.inv_children_rel_unroll(old_cont.idx as int);
-                    old_cont.entry_own.path.push_tail_property(old_cont.idx as usize);
+                    old_cont.entry_own.path.lemma_push_tail_len(old_cont.idx as usize);
                 };
                 assert(cont_i.tree_level <= old_cont.tree_level) by {
                     if self.level == 1 {
@@ -958,11 +958,11 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     let gc_path = child_cont.path().push_tail(j as usize);
                     child_cont.inv_children_unroll(j);
                     child_cont.inv_children_rel_unroll(j);
-                    child_cont.path().push_tail_property(j as usize);
+                    child_cont.path().lemma_push_tail_len(j as usize);
 
                     let child_subtree = old_cont.children[old_cont.idx as int].unwrap();
-                    child_subtree.map_unroll_once(cur_entry_path, f, j);
-                    child_subtree.map_unroll_once(cur_entry_path, g_except, j);
+                    child_subtree.lemma_map_unroll_once(cur_entry_path, f, j);
+                    child_subtree.lemma_map_unroll_once(cur_entry_path, g_except, j);
 
                     assert(child_cont.path() == cur_entry_path);
                     assert(gc_path == cur_entry_path.push_tail(j as usize));
@@ -991,7 +991,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     let sibling_path = old_cont.path().push_tail(j as usize);
                     old_cont.inv_children_unroll(j);
                     old_cont.inv_children_rel_unroll(j);
-                    old_cont.path().push_tail_property(j as usize);
+                    old_cont.path().lemma_push_tail_len(j as usize);
 
                     push_tail_different_indices_different_paths(
                         old_cont.path(),
@@ -1001,7 +1001,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     // `cur_entry_path.len() <= sibling_path.len()` previously had its own
                     // `by { ... }` block at depth 3; inline its facts instead.
                     old_cont.inv_children_rel_unroll(old_cont.idx as int);
-                    old_cont.path().push_tail_property(old_cont.idx as usize);
+                    old_cont.path().lemma_push_tail_len(old_cont.idx as usize);
                     assert(cur_entry_path.len() <= sibling_path.len());
                     old_cont.pt_inv_children_unroll(j);
                     subtree_unlock_upgrade(
@@ -1017,16 +1017,16 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 assert(new_owner.continuations[i] == self.continuations[i]);
                 let cont_i = self.continuations[i];
 
-                old_cont.entry_own.path.push_tail_property(old_cont.idx as usize);
+                old_cont.entry_own.path.lemma_push_tail_len(old_cont.idx as usize);
                 if i == self.level {
                     assert(old_cont.path() == cont_i.path().push_tail(cont_i.idx as usize));
-                    cont_i.entry_own.path.push_tail_property(cont_i.idx as usize);
+                    cont_i.entry_own.path.lemma_push_tail_len(cont_i.idx as usize);
                 } else if i == self.level + 1 {
                     let cont_sl = self.continuations[self.level as int];
                     assert(old_cont.path() == cont_sl.path().push_tail(cont_sl.idx as usize));
                     assert(cont_sl.path() == cont_i.path().push_tail(cont_i.idx as usize));
-                    cont_i.entry_own.path.push_tail_property(cont_i.idx as usize);
-                    cont_i.path().push_tail(cont_i.idx as usize).push_tail_property(
+                    cont_i.entry_own.path.lemma_push_tail_len(cont_i.idx as usize);
+                    cont_i.path().push_tail(cont_i.idx as usize).lemma_push_tail_len(
                         cont_sl.idx as usize,
                     );
                 } else {
@@ -1035,11 +1035,11 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     assert(old_cont.path() == cont_sl.path().push_tail(cont_sl.idx as usize));
                     assert(cont_sl.path() == cont_sl1.path().push_tail(cont_sl1.idx as usize));
                     assert(cont_sl1.path() == cont_i.path().push_tail(cont_i.idx as usize));
-                    cont_i.entry_own.path.push_tail_property(cont_i.idx as usize);
-                    cont_i.path().push_tail(cont_i.idx as usize).push_tail_property(
+                    cont_i.entry_own.path.lemma_push_tail_len(cont_i.idx as usize);
+                    cont_i.path().push_tail(cont_i.idx as usize).lemma_push_tail_len(
                         cont_sl1.idx as usize,
                     );
-                    cont_sl1.path().push_tail(cont_sl1.idx as usize).push_tail_property(
+                    cont_sl1.path().push_tail(cont_sl1.idx as usize).lemma_push_tail_len(
                         cont_sl.idx as usize,
                     );
                 }
@@ -1054,7 +1054,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     let child_path = cont_i.path().push_tail(j as usize);
                     cont_i.inv_children_unroll(j);
                     cont_i.inv_children_rel_unroll(j);
-                    cont_i.path().push_tail_property(j as usize);
+                    cont_i.path().lemma_push_tail_len(j as usize);
 
                     assert(child_path.index(cont_i.tree_level as int) == j as usize);
                     assert(j != cont_i.idx);
@@ -1093,36 +1093,41 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
         let f = PageTableOwner::<C>::metaregion_sound_pred(regions);
         let child_subtree = child_cont.as_subtree();
+        OwnerSubtree::<C>::lemma_new_properties(
+            child_cont.entry_own,
+            child_cont.tree_level,
+            child_cont.children,
+        );
 
         assert(child_subtree.inv_children()) by {
             assert forall|j: int|
-                0 <= j < NR_ENTRIES implies match #[trigger] child_subtree.children[j] {
+                0 <= j < NR_ENTRIES implies match #[trigger] child_subtree.children()[j] {
                 Some(ch) => {
-                    &&& ch.level == child_subtree.level + 1
+                    &&& ch.level() == child_subtree.level() + 1
                     &&& <EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
-                        child_subtree.value,
+                        child_subtree.value(),
                         j,
-                        Some(ch.value),
+                        Some(ch.value()),
                     )
                 },
                 None => <EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
-                    child_subtree.value,
+                    child_subtree.value(),
                     j,
                     None,
                 ),
             } by {
                 assert(child_cont.children[j] is Some);
                 let ch = child_cont.children[j].unwrap();
-                assert(ch.level == child_cont.tree_level + 1);
+                assert(ch.level() == child_cont.tree_level + 1);
                 assert(<EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
                     child_cont.entry_own,
                     j,
-                    Some(ch.value),
+                    Some(ch.value()),
                 ));
             };
         };
         assert forall|j: int|
-            0 <= j < NR_ENTRIES implies match #[trigger] child_subtree.children[j] {
+            0 <= j < NR_ENTRIES implies match #[trigger] child_subtree.children()[j] {
             Some(ch) => ch.inv(),
             None => true,
         } by {
@@ -1131,14 +1136,14 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
         // Pre-prove tree_predicate_map for child_subtree (f)
         assert(child_subtree.tree_predicate_map(child_cont.path(), f)) by {
-            assert(f(child_subtree.value, child_cont.path()));
+            assert(f(child_subtree.value(), child_cont.path()));
             assert forall|j: int|
                 0 <= j
-                    < child_subtree.children.len() implies match #[trigger] child_subtree.children[j] {
+                    < child_subtree.children().len() implies match #[trigger] child_subtree.children()[j] {
                 Some(ch) => ch.tree_predicate_map(child_cont.path().push_tail(j as usize), f),
                 None => true,
             } by {
-                child_subtree.map_unroll_once(child_cont.path(), f, j);
+                child_subtree.lemma_map_unroll_once(child_cont.path(), f, j);
             };
         };
 
@@ -1239,11 +1244,12 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         let (new_cont, _) = cont.restore(child);
         let new_owner = self.pop_level_owner().0;
 
-        let child_node = OwnerSubtree {
-            value: child.entry_own,
-            level: child.tree_level,
-            children: child.children,
-        };
+        let child_node = OwnerSubtree::new(child.entry_own, child.tree_level, child.children);
+        OwnerSubtree::<C>::lemma_new_properties(
+            child.entry_own,
+            child.tree_level,
+            child.children,
+        );
 
         let nc = self.continuations.insert(self.level as int, new_cont).remove(self.level - 1);
         assert(new_owner.continuations == nc);
@@ -1283,32 +1289,32 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
         assert(child_node.inv_children()) by {
             assert forall|j: int|
-                0 <= j < NR_ENTRIES implies match #[trigger] child_node.children[j] {
+                0 <= j < NR_ENTRIES implies match #[trigger] child_node.children()[j] {
                 Some(ch) => {
-                    &&& ch.level == child_node.level + 1
+                    &&& ch.level() == child_node.level() + 1
                     &&& <EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
-                        child_node.value,
+                        child_node.value(),
                         j,
-                        Some(ch.value),
+                        Some(ch.value()),
                     )
                 },
                 None => <EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
-                    child_node.value,
+                    child_node.value(),
                     j,
                     None,
                 ),
             } by {
                 assert(child.children[j] is Some);
                 let ch = child.children[j].unwrap();
-                assert(ch.level == child.tree_level + 1);
+                assert(ch.level() == child.tree_level + 1);
                 assert(<EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
                     child.entry_own,
                     j,
-                    Some(ch.value),
+                    Some(ch.value()),
                 ));
             };
         };
-        assert forall|j: int| 0 <= j < NR_ENTRIES implies match #[trigger] child_node.children[j] {
+        assert forall|j: int| 0 <= j < NR_ENTRIES implies match #[trigger] child_node.children()[j] {
             Some(ch) => ch.inv(),
             None => true,
         } by {
@@ -1331,14 +1337,14 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         assert(new_cont.inv_children_rel()) by {
             assert forall|i: int|
                 0 <= i < NR_ENTRIES && #[trigger] new_cont.children[i] is Some implies {
-                &&& new_cont.children[i].unwrap().value.parent_level == new_cont.level()
-                &&& new_cont.children[i].unwrap().level == new_cont.tree_level + 1
+                &&& new_cont.children[i].unwrap().value().parent_level == new_cont.level()
+                &&& new_cont.children[i].unwrap().level() == new_cont.tree_level + 1
                 &&& <EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
                     new_cont.entry_own,
                     i,
-                    Some(new_cont.children[i].unwrap().value),
+                    Some(new_cont.children[i].unwrap().value()),
                 )
-                &&& new_cont.children[i].unwrap().value.path == new_cont.path().push_tail(
+                &&& new_cont.children[i].unwrap().value().path == new_cont.path().push_tail(
                     i as usize,
                 )
             } by {
@@ -1446,11 +1452,12 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         let child = self.continuations[self.level - 1];
         let cont = self.continuations[self.level as int];
         let (new_cont, _guard) = cont.restore(child);
-        let child_node = OwnerSubtree {
-            value: child.entry_own,
-            level: child.tree_level,
-            children: child.children,
-        };
+        let child_node = OwnerSubtree::new(child.entry_own, child.tree_level, child.children);
+        OwnerSubtree::<C>::lemma_new_properties(
+            child.entry_own,
+            child.tree_level,
+            child.children,
+        );
 
         self.pop_level_owner_preserves_inv();
 
@@ -1474,9 +1481,14 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
         let child_addr = child.entry_own.node().meta_addr_self();
         let child_subtree = child.as_subtree();
+        OwnerSubtree::<C>::lemma_new_properties(
+            child.entry_own,
+            child.tree_level,
+            child.children,
+        );
 
         assert forall|j: int|
-            0 <= j < NR_ENTRIES implies match #[trigger] child_subtree.children[j] {
+            0 <= j < NR_ENTRIES implies match #[trigger] child_subtree.children()[j] {
             Some(ch) => ch.inv(),
             None => true,
         } by {
@@ -2158,6 +2170,11 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         let (restored_parent, _) = parent.restore(child);
         let popped = self.pop_level_owner().0;
         let child_subtree = child.as_subtree();
+        OwnerSubtree::<C>::lemma_new_properties(
+            child.entry_own,
+            child.tree_level,
+            child.children,
+        );
 
         assert(child.all_some());
         assert(parent.all_but_index_some());
@@ -2166,17 +2183,17 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         assert(child_subtree.inv()) by {
             assert(child_subtree.inv_node());
             assert forall|i: int|
-                0 <= i < NR_ENTRIES implies match #[trigger] child_subtree.children[i] {
+                0 <= i < NR_ENTRIES implies match #[trigger] child_subtree.children()[i] {
                 Some(ch) => {
-                    &&& ch.level == child_subtree.level + 1
+                    &&& ch.level() == child_subtree.level() + 1
                     &&& <EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
-                        child_subtree.value,
+                        child_subtree.value(),
                         i,
-                        Some(ch.value),
+                        Some(ch.value()),
                     )
                 },
                 None => <EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
-                    child_subtree.value,
+                    child_subtree.value(),
                     i,
                     None,
                 ),
@@ -2185,13 +2202,13 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 assert(<EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
                     child.entry_own,
                     i,
-                    Some(ch.value),
+                    Some(ch.value()),
                 ));
             };
             assert(child_subtree.inv_children());
 
             assert forall|i: int|
-                0 <= i < NR_ENTRIES implies match #[trigger] child_subtree.children[i] {
+                0 <= i < NR_ENTRIES implies match #[trigger] child_subtree.children()[i] {
                 Some(ch) => ch.inv(),
                 None => true,
             } by {

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -40,8 +40,8 @@ pub proof fn push_tail_different_indices_different_paths(
 {
     path.lemma_push_tail_len(i);
     path.lemma_push_tail_len(j);
-    assert(path.push_tail(i).index(path.len() as int) == i);
-    assert(path.push_tail(j).index(path.len() as int) == j);
+    assert(path.push_tail(i)[path.len() as int] == i);
+    assert(path.push_tail(j)[path.len() as int] == j);
     if path.push_tail(i) == path.push_tail(j) {
         assert(i == j);  // Contradiction
     }
@@ -106,7 +106,7 @@ pub proof fn subtree_unlock_upgrade<'rcu, C: PageTableConfig>(
         // excepted_path.len() <= path.len() it can't be a descendant; otherwise
         // it must diverge at some index below path.len())
         excepted_path.len() <= path.len() || (exists|k: int|
-            0 <= k < path.len() && #[trigger] excepted_path.index(k) != path.index(k)),
+            0 <= k < path.len() && #[trigger] excepted_path[k] != path[k]),
     ensures
         subtree.subtree_satisfies(path, CursorOwner::<'rcu, C>::node_unlocked(guards)),
     decreases INC_LEVELS - subtree.level(),
@@ -148,8 +148,8 @@ pub proof fn subtree_unlock_upgrade<'rcu, C: PageTableConfig>(
                 if excepted_path.len() <= path.len() {
                 } else {
                     let k = choose|k: int|
-                        0 <= k < path.len() && #[trigger] excepted_path.index(k) != path.index(k);
-                    assert(child_path.index(k) == path.index(k));
+                        0 <= k < path.len() && #[trigger] excepted_path[k] != path[k];
+                    assert(child_path[k] == path[k]);
                 }
             };
 
@@ -1043,7 +1043,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         cont_sl.idx as int,
                     );
                 }
-                assert(cur_entry_path.index(cont_i.tree_level as int) == cont_i.idx as int);
+                assert(cur_entry_path[cont_i.tree_level as int] == cont_i.idx as int);
 
                 assert forall|j: int|
                     #![trigger cont_i.children[j]]
@@ -1056,11 +1056,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     cont_i.inv_children_rel_unroll(j);
                     cont_i.path().lemma_push_tail_len(j);
 
-                    assert(child_path.index(cont_i.tree_level as int) == j as usize);
+                    assert(child_path[cont_i.tree_level as int] == j as usize);
                     assert(j != cont_i.idx);
-                    assert(child_path.index(cont_i.tree_level as int) != cur_entry_path.index(
-                        cont_i.tree_level as int,
-                    ));
+                    assert(child_path[cont_i.tree_level as int] != cur_entry_path[cont_i.tree_level as int]);
                     assert(cont_i.tree_level < child_path.len());
                     cont_i.pt_inv_children_unroll(j);
                     subtree_unlock_upgrade(

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -90,8 +90,8 @@ pub proof fn subtree_unlock_upgrade<'rcu, C: PageTableConfig>(
     requires
         subtree.inv(),
         PageTableOwner::<C>(subtree).pt_inv(),
-        subtree.tree_predicate_map(path, PageTableOwner::<C>::metaregion_sound_pred(regions)),
-        subtree.tree_predicate_map(
+        subtree.subtree_satisfies(path, PageTableOwner::<C>::metaregion_sound_pred(regions)),
+        subtree.subtree_satisfies(
             path,
             CursorOwner::<'rcu, C>::node_unlocked_except(guards, excepted_addr),
         ),
@@ -108,7 +108,7 @@ pub proof fn subtree_unlock_upgrade<'rcu, C: PageTableConfig>(
         excepted_path.len() <= path.len() || (exists|k: int|
             0 <= k < path.len() && #[trigger] excepted_path.index(k) != path.index(k)),
     ensures
-        subtree.tree_predicate_map(path, CursorOwner::<'rcu, C>::node_unlocked(guards)),
+        subtree.subtree_satisfies(path, CursorOwner::<'rcu, C>::node_unlocked(guards)),
     decreases INC_LEVELS - subtree.level(),
 {
     let f = PageTableOwner::<C>::metaregion_sound_pred(regions);
@@ -134,7 +134,7 @@ pub proof fn subtree_unlock_upgrade<'rcu, C: PageTableConfig>(
         assert forall|i: int|
             #![trigger subtree.children()[i]]
             0 <= i < subtree.children().len()
-                && subtree.children()[i] is Some implies subtree.children()[i].unwrap().tree_predicate_map(
+                && subtree.children()[i] is Some implies subtree.children()[i].unwrap().subtree_satisfies(
         path.push_tail(i as usize), h) by {
             let child = subtree.children()[i].unwrap();
             subtree.lemma_map_unroll_once(path, f, i);
@@ -163,12 +163,12 @@ pub proof fn subtree_unlock_upgrade<'rcu, C: PageTableConfig>(
             );
         };
     } else if subtree.level() < INC_LEVELS - 1 && !subtree.value().is_node() {
-        // Non-node: pt_inv gives children[i] is None, so tree_predicate_map
+        // Non-node: pt_inv gives children[i] is None, so subtree_satisfies
         // has no children to recurse into.
         assert forall|i: int|
             #![trigger subtree.children()[i]]
             0 <= i < subtree.children().len()
-                && subtree.children()[i] is Some implies subtree.children()[i].unwrap().tree_predicate_map(
+                && subtree.children()[i] is Some implies subtree.children()[i].unwrap().subtree_satisfies(
         path.push_tail(i as usize), h) by {
             PageTableOwner::<C>(subtree).pt_inv_non_node(i);
         };
@@ -952,7 +952,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 assert forall|j: int|
                     #![trigger child_cont.children[j]]
                     0 <= j < child_cont.children.len()
-                        && child_cont.children[j] is Some implies child_cont.children[j].unwrap().tree_predicate_map(
+                        && child_cont.children[j] is Some implies child_cont.children[j].unwrap().subtree_satisfies(
                 child_cont.path().push_tail(j as usize), h) by {
                     let gc = child_cont.children[j].unwrap();
                     let gc_path = child_cont.path().push_tail(j as usize);
@@ -983,7 +983,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 assert forall|j: int|
                     #![trigger modified_cont.children[j]]
                     0 <= j < modified_cont.children.len()
-                        && modified_cont.children[j] is Some implies modified_cont.children[j].unwrap().tree_predicate_map(
+                        && modified_cont.children[j] is Some implies modified_cont.children[j].unwrap().subtree_satisfies(
                 modified_cont.path().push_tail(j as usize), h) by {
                     assert(j != old_cont.idx as int);
                     assert(modified_cont.children[j] == old_cont.children[j]);
@@ -1048,7 +1048,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 assert forall|j: int|
                     #![trigger cont_i.children[j]]
                     0 <= j < cont_i.children.len()
-                        && cont_i.children[j] is Some implies cont_i.children[j].unwrap().tree_predicate_map(
+                        && cont_i.children[j] is Some implies cont_i.children[j].unwrap().subtree_satisfies(
                 cont_i.path().push_tail(j as usize), h) by {
                     let child_sub = cont_i.children[j].unwrap();
                     let child_path = cont_i.path().push_tail(j as usize);
@@ -1134,13 +1134,13 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             child_cont.inv_children_unroll(j);
         };
 
-        // Pre-prove tree_predicate_map for child_subtree (f)
-        assert(child_subtree.tree_predicate_map(child_cont.path(), f)) by {
+        // Pre-prove subtree_satisfies for child_subtree (f)
+        assert(child_subtree.subtree_satisfies(child_cont.path(), f)) by {
             assert(f(child_subtree.value(), child_cont.path()));
             assert forall|j: int|
                 0 <= j
                     < child_subtree.children().len() implies match #[trigger] child_subtree.children()[j] {
-                Some(ch) => ch.tree_predicate_map(child_cont.path().push_tail(j as usize), f),
+                Some(ch) => ch.subtree_satisfies(child_cont.path().push_tail(j as usize), f),
                 None => true,
             } by {
                 child_subtree.lemma_map_unroll_once(child_cont.path(), f, j);
@@ -1151,7 +1151,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         assert(modified_cont.map_children(f)) by {
             assert forall|j: int|
                 0 <= j < modified_cont.children.len()
-                    && #[trigger] modified_cont.children[j] is Some implies modified_cont.children[j].unwrap().tree_predicate_map(
+                    && #[trigger] modified_cont.children[j] is Some implies modified_cont.children[j].unwrap().subtree_satisfies(
             modified_cont.path().push_tail(j as usize), f) by {
                 assert(j != old_cont.idx as int);
                 assert(modified_cont.children[j] == old_cont.children[j]);

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -744,9 +744,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             if new_owner.level <= 2 {
                 if self.level == 3 {
                     assert(self.va.index.contains_key(1));
-                    assert(new_owner.continuations[1].guard == guard);
-                    assert(new_owner.continuations[2] == modified_cont);
-                    assert(modified_cont.guard == old_cont.guard);
 
                     assert(new_owner.continuations[1].guard.inner.inner@.ptr.addr()
                         != new_owner.continuations[2].guard.inner.inner@.ptr.addr()) by {
@@ -809,36 +806,12 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             )
         }) by {
             if new_owner.level == 1 {
-                // self.level == 2, new_level == 1
-                assert(new_owner.continuations[0].guard == guard);
-                assert(new_owner.continuations[1] == modified_cont);
-                assert(modified_cont.guard == old_cont.guard);
-
-                // Guard distinctness from precondition
-                assert(self.continuations[1].guard.inner.inner@.ptr.addr()
-                    != guard.inner.inner@.ptr.addr());
-                assert(self.continuations[2].guard.inner.inner@.ptr.addr()
-                    != guard.inner.inner@.ptr.addr());
-                assert(self.continuations[3].guard.inner.inner@.ptr.addr()
-                    != guard.inner.inner@.ptr.addr());
-
-                // child.level() == 1: from tree_level arithmetic
-                // old_cont = continuations[1], old_cont.level() == 2 (from self.inv() level <= 2)
-                assert(old_cont.level() == 2);
-                // child.tree_level == old_cont.tree_level + 1
-                // old_cont.tree_level == INC_LEVELS - 2 - 1 == 2
-                // child.tree_level == 3
-                // child.level() == INC_LEVELS - child.tree_level - 1 == 5 - 3 - 1 == 1
-                assert(child.tree_level == INC_LEVELS - child.level() - 1);
 
                 // parent_level == 2: from inv_children_rel on old_cont
                 assert(child.entry_own.parent_level == 2) by {
                     old_cont.inv_children_rel_unroll(old_cont.idx as int);
                     assert(child.entry_own.parent_level == old_cont.level());
                 };
-
-                // idx match
-                assert(new_owner.va.index[0] == child.idx);
 
                 // path consistency: child.path() == modified_cont.path().push_tail(modified_cont.idx)
                 assert(child.path() == modified_cont.path().push_tail(modified_cont.idx as int))
@@ -927,17 +900,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     old_cont.inv_children_rel_unroll(old_cont.idx as int);
                     old_cont.entry_own.path.lemma_push_tail_len(old_cont.idx as int);
                 };
-                assert(cont_i.tree_level <= old_cont.tree_level) by {
-                    if self.level == 1 {
-                        assert(old_cont.level() == 1);
-                    } else if self.level == 2 {
-                        assert(old_cont.level() == 2);
-                    } else if self.level == 3 {
-                        assert(old_cont.level() == 3);
-                    } else {
-                        assert(old_cont.level() == 4);
-                    }
-                };
                 assert(false);
             }
         };
@@ -968,7 +930,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     let gc_path = child_cont.path().push_tail(j);
                     child_cont.inv_children_unroll(j);
                     child_cont.inv_children_rel_unroll(j);
-                    child_cont.path().lemma_push_tail_len(j);
 
                     let child_subtree = old_cont.children[old_cont.idx as int].unwrap();
                     child_subtree.lemma_subtree_satisfies_unroll_once(cur_entry_path, f, j);
@@ -1001,7 +962,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     let sibling_path = old_cont.path().push_tail(j);
                     old_cont.inv_children_unroll(j);
                     old_cont.inv_children_rel_unroll(j);
-                    old_cont.path().lemma_push_tail_len(j);
 
                     push_tail_different_indices_different_paths(
                         old_cont.path(),
@@ -1011,7 +971,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     // `cur_entry_path.len() <= sibling_path.len()` previously had its own
                     // `by { ... }` block at depth 3; inline its facts instead.
                     old_cont.inv_children_rel_unroll(old_cont.idx as int);
-                    old_cont.path().lemma_push_tail_len(old_cont.idx as int);
                     assert(cur_entry_path.len() <= sibling_path.len());
                     old_cont.pt_inv_children_unroll(j);
                     subtree_unlock_upgrade(
@@ -1027,18 +986,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 assert(new_owner.continuations[i] == self.continuations[i]);
                 let cont_i = self.continuations[i];
 
-                old_cont.entry_own.path.lemma_push_tail_len(old_cont.idx as int);
                 if i == self.level {
                     assert(old_cont.path() == cont_i.path().push_tail(cont_i.idx as int));
-                    cont_i.entry_own.path.lemma_push_tail_len(cont_i.idx as int);
                 } else if i == self.level + 1 {
-                    let cont_sl = self.continuations[self.level as int];
-                    assert(old_cont.path() == cont_sl.path().push_tail(cont_sl.idx as int));
-                    assert(cont_sl.path() == cont_i.path().push_tail(cont_i.idx as int));
-                    cont_i.entry_own.path.lemma_push_tail_len(cont_i.idx as int);
-                    cont_i.path().push_tail(cont_i.idx as int).lemma_push_tail_len(
-                        cont_sl.idx as int,
-                    );
                 } else {
                     let cont_sl = self.continuations[self.level as int];
                     let cont_sl1 = self.continuations[self.level + 1];
@@ -1064,7 +1014,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     let child_path = cont_i.path().push_tail(j);
                     cont_i.inv_children_unroll(j);
                     cont_i.inv_children_rel_unroll(j);
-                    cont_i.path().lemma_push_tail_len(j);
 
                     assert(child_path[cont_i.tree_level as int] == j as usize);
                     assert(j != cont_i.idx);
@@ -1102,13 +1051,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         let f = PageTableOwner::<C>::metaregion_sound_pred(regions);
         let child_subtree = child_cont.as_subtree();
         let child_node = old_cont.children[old_cont.idx as int].unwrap();
-        OwnerSubtree::<C>::lemma_new_properties(
-            child_cont.entry_own,
-            child_cont.tree_level,
-            child_cont.children,
-        );
-        assert(child_subtree.value() == child_node.value());
-        assert(child_subtree.level() == child_node.level());
         assert(child_subtree.children() =~= child_node.children());
         OwnerSubtree::<C>::lemma_ext_equal(child_subtree, child_node);
         assert(self.continuations[self.level - 1].map_children(f));
@@ -1468,11 +1410,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         let cont = self.continuations[self.level as int];
         let (new_cont, _guard) = cont.restore(child);
         let child_node = OwnerSubtree::new(child.entry_own, child.tree_level, child.children);
-        OwnerSubtree::<C>::lemma_new_properties(
-            child.entry_own,
-            child.tree_level,
-            child.children,
-        );
 
         self.pop_level_owner_preserves_inv();
 
@@ -1496,11 +1433,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
         let child_addr = child.entry_own.node().meta_addr_self();
         let child_subtree = child.as_subtree();
-        OwnerSubtree::<C>::lemma_new_properties(
-            child.entry_own,
-            child.tree_level,
-            child.children,
-        );
 
         assert forall|j: int|
             0 <= j < NR_ENTRIES implies match #[trigger] child_subtree.children()[j] {
@@ -1748,12 +1680,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             assert(self.index() == k);
             if self.guard_level < NR_LEVELS {
                 // Pop to parent. Parent is at guard_level + 1 with popped_too_high.
-                assert(self.level < NR_LEVELS);
                 self.pop_level_owner_preserves_inv();
-                let popped = self.pop_level_owner().0;
-                // popped.popped_too_high == true, so move_forward on popped
-                // does inc_index().zero_below_level(). VA increases.
-                // k == NR_ENTRIES - 1 here, so the parent idx advances.
             } else {
                 // `level == guard_level == NR_LEVELS && index+1 == NR_ENTRIES`
                 // is unreachable: `cursor_top_idx_strict_lt_nr_entries` derives
@@ -1763,12 +1690,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 assert(false);
             }
         } else if self.level + 1 < self.guard_level {
-            assert(self.level < NR_LEVELS);
             self.pop_level_owner_preserves_inv();
             self.pop_level_owner().0.move_forward_increases_va();
         } else {
-            assert(self.level < NR_LEVELS);
-            assert(self.guard_level == self.level + 1);
             self.in_locked_range_guard_index_eq_prefix();
             let k = self.prefix.index[self.guard_level - 1];
             assert(self.va.index[self.level as int] == k);
@@ -1779,9 +1703,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 assert(popped.move_forward_owner_spec() == popped.inc_index().zero_below_level());
                 popped.inc_and_zero_increases_va();
             } else {
-                // k == NR_ENTRIES - 1: popped state at guard_level wraps. move_forward
-                // pops further (if guard_level < NR_LEVELS). VA still increases
-                // because the parent entry advances.
             }
         }
     }
@@ -1942,25 +1863,13 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             popped.max_steps_partial_eq(self, lp1);
             Self::max_steps_subtree_positive(lp1);
 
-            assert(self.continuations[self.level - 1].idx + 1 == NR_ENTRIES);
-            assert((NR_ENTRIES - self.continuations[self.level - 1].idx - 1) as nat == 0nat);
             assert(Self::max_steps_subtree(l) * 0nat == 0) by (nonlinear_arith);
-            assert(self.max_steps_partial(l) == self.max_steps_partial(lp1));
-            assert(popped.level == (self.level + 1) as u8);
-            assert(popped.max_steps() == self.max_steps_partial(lp1) + Self::max_steps_subtree(
-                lp1,
-            ));
             assert(self.max_steps() == self.max_steps_partial(lp1) + Self::max_steps_subtree(l));
             if !popped.popped_too_high {
                 popped.move_forward_owner_decreases_steps();
                 assert(popped.move_forward_owner_spec().max_steps() + Self::max_steps_subtree(lp1)
                     <= popped.max_steps());
                 assert(self.move_forward_owner_spec() == popped.move_forward_owner_spec());
-                // Stitch: popped.move_forward.max_steps + subtree(lp1) ≤ popped.max_steps
-                //                                          == self.max_steps_partial(lp1) + subtree(lp1)
-                //   ⟹ popped.move_forward.max_steps ≤ self.max_steps_partial(lp1)
-                //   ⟹ popped.move_forward.max_steps + st_l ≤ self.max_steps_partial(lp1) + st_l
-                //                                          == self.max_steps()
                 assert(popped.move_forward_owner_spec().max_steps() <= self.max_steps_partial(lp1));
                 assert(self.move_forward_owner_spec().max_steps() + st_l <= self.max_steps());
             } else {
@@ -2330,9 +2239,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
             let old_cont = self.continuations[self.level - 1];
             let new_cont = old_cont.inc_index();
-            assert(new_cont.children == old_cont.children);
-            assert(new_cont.entry_own == old_cont.entry_own);
-            assert(new_cont.path() == old_cont.path());
 
             assert(new_cont.view_mappings() == old_cont.view_mappings()) by {
                 assert forall|m: Mapping|

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -24,6 +24,8 @@ use core::ops::Range;
 
 verus! {
 
+broadcast use group_ghost_tree_lemmas;
+
 /// Paths obtained by push_tail with different indices are different
 pub proof fn push_tail_different_indices_different_paths(
     path: TreePath<NR_ENTRIES>,
@@ -493,6 +495,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
         let old_cont = self.continuations[self.level - 1];
         old_cont.inv_children_unroll(old_cont.idx as int);
+        old_cont.pt_inv_children_unroll(old_cont.idx as int);
         let child_node = old_cont.children[old_cont.idx as int].unwrap();
         let (child, modified_cont) = old_cont.make_cont(
             self.va.index[self.level - 2] as usize,
@@ -501,10 +504,14 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
         old_cont.inv_children_rel_unroll(old_cont.idx as int);
         assert(child.children == child_node.children());
+        assert(child.entry_own == child_node.value());
+        assert(child.tree_level == child_node.level());
+        assert(child.path() == child_node.value().path);
 
         assert(self.va.index.contains_key(self.level - 2));
 
         assert(child.entry_own.node().tree_level == child.entry_own.path.len()) by {
+            PageTableOwner(child_node).pt_inv_unroll(0);
             assert(child.children[0] is Some);
             let gc = child.children[0].unwrap();
             assert(<EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
@@ -529,6 +536,12 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 0 <= j < NR_ENTRIES && #[trigger] child.children[j] is Some implies {
                 &&& child.children[j].unwrap().value().parent_level == child.level()
                 &&& child.children[j].unwrap().level() == child.tree_level + 1
+                &&& child.children[j].unwrap().value().path.len()
+                    == child.entry_own.node().tree_level + 1
+                &&& child.children[j].unwrap().value().match_pte(
+                    child.entry_own.node().children_perm.value()[j],
+                    child.entry_own.node().level,
+                )
                 &&& <EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
                     child.entry_own,
                     j,
@@ -537,6 +550,17 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 &&& child.children[j].unwrap().value().path == child.path().push_tail(j)
             } by {
                 let gc = child.children[j].unwrap();
+                PageTableOwner(child_node).pt_inv_unroll(j);
+                assert(gc == child_node.child(j));
+                assert(PageTableOwner::<C>::pt_edge_at(child_node, j));
+                assert(gc.value().parent_level == child.level());
+                assert(gc.level() == child.tree_level + 1);
+                assert(gc.value().path.len() == child.entry_own.node().tree_level + 1);
+                assert(gc.value().match_pte(
+                    child.entry_own.node().children_perm.value()[j],
+                    child.entry_own.node().level,
+                ));
+                assert(gc.value().path == child.path().push_tail(j));
                 assert(<EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
                     child.entry_own,
                     j,
@@ -545,17 +569,23 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 child.inv_children_unroll(j);
             };
         };
+        assert(child.pt_inv_children()) by {
+            assert forall|j: int|
+                0 <= j < child.children.len()
+                    && #[trigger] child.children[j] is Some implies PageTableOwner(
+                child.children[j].unwrap(),
+            ).pt_inv() by {
+                PageTableOwner(child_node).pt_inv_unroll(j);
+                assert(child.children[j].unwrap() == child_node.child(j));
+            };
+        };
+        assert(child.inv());
 
         assert(new_owner.continuations[new_owner.level - 1].all_some()) by {
             assert(new_owner.continuations[new_owner.level - 1] == child);
             assert forall|j: int| 0 <= j < NR_ENTRIES implies child.children[j] is Some by {
-                if child.children[j] is None {
-                    assert(<EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
-                        child.entry_own,
-                        j,
-                        None,
-                    ));
-                }
+                PageTableOwner(child_node).pt_inv_unroll(j);
+                assert(child_node.has_child(j));
             };
         };
 
@@ -603,6 +633,12 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 0 <= i < NR_ENTRIES && #[trigger] modified_cont.children[i] is Some implies {
                 &&& modified_cont.children[i].unwrap().value().parent_level == modified_cont.level()
                 &&& modified_cont.children[i].unwrap().level() == modified_cont.tree_level + 1
+                &&& modified_cont.children[i].unwrap().value().path.len()
+                    == modified_cont.entry_own.node().tree_level + 1
+                &&& modified_cont.children[i].unwrap().value().match_pte(
+                    modified_cont.entry_own.node().children_perm.value()[i],
+                    modified_cont.entry_own.node().level,
+                )
                 &&& <EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
                     modified_cont.entry_own,
                     i,
@@ -617,11 +653,23 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 assert(old_cont.inv_children_rel());
             };
         };
+        assert(modified_cont.pt_inv_children()) by {
+            assert forall|i: int|
+                0 <= i < modified_cont.children.len()
+                    && #[trigger] modified_cont.children[i] is Some implies PageTableOwner(
+                modified_cont.children[i].unwrap(),
+            ).pt_inv() by {
+                assert(i != modified_cont.idx);
+                assert(modified_cont.children[i] == old_cont.children[i]);
+                old_cont.pt_inv_children_unroll(i);
+            };
+        };
         assert(modified_cont.entry_own.is_node());
         assert(modified_cont.entry_own.node().relate_guard(modified_cont.guard));
         assert(modified_cont.tree_level == INC_LEVELS - modified_cont.level() - 1);
         assert(modified_cont.tree_level < INC_LEVELS - 1);
         assert(modified_cont.path().len() == modified_cont.tree_level);
+        assert(modified_cont.inv());
 
         assert(new_owner.level <= 4 ==> {
             &&& new_owner.continuations.contains_key(3)
@@ -1072,11 +1120,20 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
         let f = PageTableOwner::<C>::metaregion_sound_pred(regions);
         let child_subtree = child_cont.as_subtree();
+        let child_node = old_cont.children[old_cont.idx as int].unwrap();
         OwnerSubtree::<C>::lemma_new_properties(
             child_cont.entry_own,
             child_cont.tree_level,
             child_cont.children,
         );
+        assert(child_subtree.value() == child_node.value());
+        assert(child_subtree.level() == child_node.level());
+        assert(child_subtree.children() =~= child_node.children());
+        OwnerSubtree::<C>::lemma_ext_equal(child_subtree, child_node);
+        assert(self.continuations[self.level - 1].map_children(f));
+        assert(old_cont.map_children(f));
+        assert(old_cont.children[old_cont.idx as int] is Some);
+        assert(child_subtree.subtree_satisfies(child_cont.path(), f));
 
         assert(child_subtree.inv_children()) by {
             assert forall|j: int|
@@ -1113,19 +1170,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             child_cont.inv_children_unroll(j);
         };
 
-        // Pre-prove subtree_satisfies for child_subtree (f)
-        assert(child_subtree.subtree_satisfies(child_cont.path(), f)) by {
-            assert(f(child_subtree.value(), child_cont.path()));
-            assert forall|j: int|
-                0 <= j
-                    < child_subtree.children().len() implies match #[trigger] child_subtree.children()[j] {
-                Some(ch) => ch.subtree_satisfies(child_cont.path().push_tail(j), f),
-                None => true,
-            } by {
-                child_subtree.lemma_subtree_satisfies_unroll_once(child_cont.path(), f, j);
-            };
-        };
-
         // Pre-prove map_children for modified_cont (f)
         assert(modified_cont.map_children(f)) by {
             assert forall|j: int|
@@ -1134,6 +1178,17 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             modified_cont.path().push_tail(j), f) by {
                 assert(j != old_cont.idx as int);
                 assert(modified_cont.children[j] == old_cont.children[j]);
+            };
+        };
+
+        assert(child_cont.map_children(f)) by {
+            assert forall|j: int|
+                0 <= j < child_cont.children.len()
+                    && #[trigger] child_cont.children[j] is Some implies child_cont.children[j]
+                .unwrap().subtree_satisfies(child_cont.path().push_tail(j), f) by {
+                assert(child_subtree.has_child(j));
+                child_subtree.lemma_subtree_satisfies_unroll_once(child_cont.path(), f, j);
+                assert(child_subtree.child(j) == child_cont.children[j].unwrap());
             };
         };
 

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -71,7 +71,6 @@ pub proof fn push_tail_increases_length(path: TreePath<NR_ENTRIES>, i: int)
     ensures
         path.push_tail(i).len() > path.len(),
 {
-    path.lemma_push_tail_len(i);
 }
 
 /// Upgrade `node_unlocked_except` to `node_unlocked` on a subtree where the excepted
@@ -541,12 +540,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             } by {
                 let gc = child.children[j].unwrap();
                 PageTableOwner(child_node).pt_inv_unroll(j);
-                assert(gc == child_node.child(j));
-                assert(PageTableOwner::<C>::pt_edge_at(child_node, j));
-                assert(gc.value().match_pte(
-                    child.entry_own.node().children_perm.value()[j],
-                    child.entry_own.node().level,
-                ));
                 assert(gc.value().path == child.path().push_tail(j));
                 assert(<EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
                     child.entry_own,
@@ -689,22 +682,11 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             if new_owner.level <= 3 {
                 if self.level == 4 {
                     assert(self.va.index.contains_key(2));
-                    assert(new_owner.continuations[2].guard == guard);
-                    assert(new_owner.continuations[3] == modified_cont);
-                    assert(modified_cont.guard == old_cont.guard);
-                    // guard distinctness
-                    assert(new_owner.continuations[2].guard.inner.inner@.ptr.addr()
-                        != new_owner.continuations[3].guard.inner.inner@.ptr.addr()) by {
-                        assert(self.continuations[self.level - 1].guard.inner.inner@.ptr.addr()
-                            != guard.inner.inner@.ptr.addr());
-                    };
                     // path consistency: child.path() == modified_cont.path().push_tail(modified_cont.idx)
                     assert(new_owner.continuations[2].path()
                         == new_owner.continuations[3].path().push_tail(
                         new_owner.continuations[3].idx as int,
                     )) by {
-                        assert(modified_cont.path() == old_cont.path());
-                        assert(modified_cont.idx == old_cont.idx);
                         old_cont.inv_children_rel_unroll(old_cont.idx as int);
                     };
                     // PTE consistency: from old_cont.inv_children_rel at idx
@@ -745,16 +727,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 if self.level == 3 {
                     assert(self.va.index.contains_key(1));
 
-                    assert(new_owner.continuations[1].guard.inner.inner@.ptr.addr()
-                        != new_owner.continuations[2].guard.inner.inner@.ptr.addr()) by {
-                        assert(self.continuations[2].guard.inner.inner@.ptr.addr()
-                            != guard.inner.inner@.ptr.addr());
-                    };
-                    assert(new_owner.continuations[1].guard.inner.inner@.ptr.addr()
-                        != new_owner.continuations[3].guard.inner.inner@.ptr.addr()) by {
-                        assert(self.continuations[3].guard.inner.inner@.ptr.addr()
-                            != guard.inner.inner@.ptr.addr());
-                    };
                     // path: child.path() == modified_cont.path().push_tail(modified_cont.idx)
                     assert(new_owner.continuations[1].path()
                         == new_owner.continuations[2].path().push_tail(
@@ -898,7 +870,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
                 assert(cur_entry_path.len() == old_cont.tree_level + 1) by {
                     old_cont.inv_children_rel_unroll(old_cont.idx as int);
-                    old_cont.entry_own.path.lemma_push_tail_len(old_cont.idx as int);
                 };
                 assert(false);
             }
@@ -935,9 +906,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     child_subtree.lemma_subtree_satisfies_unroll_once(cur_entry_path, f, j);
                     child_subtree.lemma_subtree_satisfies_unroll_once(cur_entry_path, g_except, j);
 
-                    assert(child_cont.path() == cur_entry_path);
-                    assert(gc_path == cur_entry_path.push_tail(j));
-                    assert(cur_entry_path.len() < gc_path.len());
                     child_cont.pt_inv_children_unroll(j);
                     subtree_unlock_upgrade(
                         gc,
@@ -949,15 +917,11 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     );
                 };
             } else if i == self.level - 1 {
-                assert(new_owner.continuations[i] == modified_cont);
-                assert(modified_cont.path() == old_cont.path());
                 assert forall|j: int|
                     #![trigger modified_cont.children[j]]
                     0 <= j < modified_cont.children.len()
                         && modified_cont.children[j] is Some implies modified_cont.children[j].unwrap().subtree_satisfies(
                 modified_cont.path().push_tail(j), h) by {
-                    assert(j != old_cont.idx as int);
-                    assert(modified_cont.children[j] == old_cont.children[j]);
                     let sibling = old_cont.children[j].unwrap();
                     let sibling_path = old_cont.path().push_tail(j);
                     old_cont.inv_children_unroll(j);
@@ -971,7 +935,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     // `cur_entry_path.len() <= sibling_path.len()` previously had its own
                     // `by { ... }` block at depth 3; inline its facts instead.
                     old_cont.inv_children_rel_unroll(old_cont.idx as int);
-                    assert(cur_entry_path.len() <= sibling_path.len());
                     old_cont.pt_inv_children_unroll(j);
                     subtree_unlock_upgrade(
                         sibling,
@@ -990,18 +953,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     assert(old_cont.path() == cont_i.path().push_tail(cont_i.idx as int));
                 } else if i == self.level + 1 {
                 } else {
-                    let cont_sl = self.continuations[self.level as int];
-                    let cont_sl1 = self.continuations[self.level + 1];
-                    assert(old_cont.path() == cont_sl.path().push_tail(cont_sl.idx as int));
-                    assert(cont_sl.path() == cont_sl1.path().push_tail(cont_sl1.idx as int));
-                    assert(cont_sl1.path() == cont_i.path().push_tail(cont_i.idx as int));
-                    cont_i.entry_own.path.lemma_push_tail_len(cont_i.idx as int);
-                    cont_i.path().push_tail(cont_i.idx as int).lemma_push_tail_len(
-                        cont_sl1.idx as int,
-                    );
-                    cont_sl1.path().push_tail(cont_sl1.idx as int).lemma_push_tail_len(
-                        cont_sl.idx as int,
-                    );
                 }
                 assert(cur_entry_path[cont_i.tree_level as int] == cont_i.idx as int);
 
@@ -1015,10 +966,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     cont_i.inv_children_unroll(j);
                     cont_i.inv_children_rel_unroll(j);
 
-                    assert(child_path[cont_i.tree_level as int] == j as usize);
-                    assert(j != cont_i.idx);
-                    assert(child_path[cont_i.tree_level as int] != cur_entry_path[cont_i.tree_level as int]);
-                    assert(cont_i.tree_level < child_path.len());
                     cont_i.pt_inv_children_unroll(j);
                     subtree_unlock_upgrade(
                         child_sub,
@@ -1053,9 +1000,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         let child_node = old_cont.children[old_cont.idx as int].unwrap();
         assert(child_subtree.children() =~= child_node.children());
         OwnerSubtree::<C>::lemma_ext_equal(child_subtree, child_node);
-        assert(self.continuations[self.level - 1].map_children(f));
-        assert(old_cont.map_children(f));
-        assert(old_cont.children[old_cont.idx as int] is Some);
         assert(child_subtree.subtree_satisfies(child_cont.path(), f));
 
         assert(child_subtree.inv_children()) by {
@@ -1075,14 +1019,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     None,
                 ),
             } by {
-                assert(child_cont.children[j] is Some);
-                let ch = child_cont.children[j].unwrap();
-                assert(ch.level() == child_cont.tree_level + 1);
-                assert(<EntryOwner<C> as TreeNodeValue<NR_LEVELS>>::rel_children(
-                    child_cont.entry_own,
-                    j,
-                    Some(ch.value()),
-                ));
             };
         };
         assert forall|j: int|
@@ -1545,59 +1481,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             }
         };
 
-        assert(r.continuations[r.level - 1].all_some());
-        assert(r.level <= 4 ==> {
-            &&& r.continuations.contains_key(3)
-            &&& r.continuations[3].inv()
-            &&& r.continuations[3].level() == 4
-            &&& r.continuations[3].entry_own.parent_level == 5
-            &&& r.in_locked_range() ==> r.va.index[3] == r.continuations[3].idx
-        });
-
-        assert(r.level <= 3 ==> {
-            &&& r.continuations.contains_key(2)
-            &&& r.continuations[2].inv()
-            &&& r.continuations[2].level() == 3
-            &&& r.continuations[2].entry_own.parent_level == 4
-            &&& r.in_locked_range() ==> r.va.index[2] == r.continuations[2].idx
-            &&& r.continuations[2].guard.inner.inner@.ptr.addr()
-                != r.continuations[3].guard.inner.inner@.ptr.addr()
-            &&& r.continuations[2].path() == r.continuations[3].path().push_tail(
-                r.continuations[3].idx as int,
-            )
-        });
-
-        assert(r.level <= 2 ==> {
-            &&& r.continuations.contains_key(1)
-            &&& r.continuations[1].inv()
-            &&& r.continuations[1].level() == 2
-            &&& r.continuations[1].entry_own.parent_level == 3
-            &&& r.in_locked_range() ==> r.va.index[1] == r.continuations[1].idx
-            &&& r.continuations[1].guard.inner.inner@.ptr.addr()
-                != r.continuations[2].guard.inner.inner@.ptr.addr()
-            &&& r.continuations[1].guard.inner.inner@.ptr.addr()
-                != r.continuations[3].guard.inner.inner@.ptr.addr()
-            &&& r.continuations[1].path() == r.continuations[2].path().push_tail(
-                r.continuations[2].idx as int,
-            )
-        });
-
-        assert(r.level == 1 ==> {
-            &&& r.continuations.contains_key(0)
-            &&& r.continuations[0].inv()
-            &&& r.continuations[0].level() == 1
-            &&& r.continuations[0].entry_own.parent_level == 2
-            &&& r.in_locked_range() ==> r.va.index[0] == r.continuations[0].idx
-            &&& r.continuations[0].guard.inner.inner@.ptr.addr()
-                != r.continuations[1].guard.inner.inner@.ptr.addr()
-            &&& r.continuations[0].guard.inner.inner@.ptr.addr()
-                != r.continuations[2].guard.inner.inner@.ptr.addr()
-            &&& r.continuations[0].guard.inner.inner@.ptr.addr()
-                != r.continuations[3].guard.inner.inner@.ptr.addr()
-            &&& r.continuations[0].path() == r.continuations[1].path().push_tail(
-                r.continuations[1].idx as int,
-            )
-        });
     }
 
     pub proof fn tracked_pop_level_owner(tracked &mut self) -> (tracked guard: PageTableGuard<
@@ -1765,9 +1648,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             popped2.max_steps_partial_eq(self, lp1);
             Self::max_steps_subtree_positive(lp1);
 
-            // Bookkeeping (mirrors the main lemma at lines 1683-1695):
-            assert(self.continuations[self.level - 1].idx + 1 == NR_ENTRIES);
-            assert((NR_ENTRIES - self.continuations[self.level - 1].idx - 1) as nat == 0nat);
             assert(Self::max_steps_subtree(l) * 0nat == 0) by (nonlinear_arith);
             assert(self.max_steps_partial(l) == self.max_steps_partial(lp1));
             assert(popped2.level == lp1 as u8);

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -1202,11 +1202,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         let new_owner = self.pop_level_owner().0;
 
         let child_node = OwnerSubtree::new(child.entry_own, child.tree_level, child.children);
-        OwnerSubtree::<C>::lemma_new_properties(
-            child.entry_own,
-            child.tree_level,
-            child.children,
-        );
 
         let nc = self.continuations.insert(self.level as int, new_cont).remove(self.level - 1);
         assert(new_owner.continuations == nc);
@@ -2094,14 +2089,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         let (restored_parent, _) = parent.restore(child);
         let popped = self.pop_level_owner().0;
         let child_subtree = child.as_subtree();
-        OwnerSubtree::<C>::lemma_new_properties(
-            child.entry_own,
-            child.tree_level,
-            child.children,
-        );
-
-        assert(child.all_some());
-        assert(parent.all_but_index_some());
         assert(child.path() == parent.path().push_tail(parent.idx as int));
 
         assert(child_subtree.inv()) by {

--- a/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
@@ -84,7 +84,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 #![trigger cont.children[j]]
                 0 <= j < cont.children.len()
                     && cont.children[j] is Some implies cont.children[j].unwrap().subtree_satisfies(
-            cont.path().push_tail(j), combined) by {
+                cont.path().push_tail(j),
+                combined,
+            ) by {
                 cont.inv_children_unroll(j);
                 OwnerSubtree::lemma_subtree_satisfies_implies_and(
                     cont.children[j].unwrap(),
@@ -282,7 +284,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 #![trigger cont.children[j]]
                 0 <= j < cont.children.len()
                     && cont.children[j] is Some implies cont.children[j].unwrap().subtree_satisfies(
-            cont.path().push_tail(j), g) by {
+                cont.path().push_tail(j),
+                g,
+            ) by {
                 cont.inv_children_unroll(j);
                 cont.pt_inv_children_unroll(j);
                 cont.inv_children_rel_unroll(j);

--- a/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
@@ -84,11 +84,11 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 #![trigger cont.children[j]]
                 0 <= j < cont.children.len()
                     && cont.children[j] is Some implies cont.children[j].unwrap().subtree_satisfies(
-            cont.path().push_tail(j as usize), combined) by {
+            cont.path().push_tail(j), combined) by {
                 cont.inv_children_unroll(j);
                 OwnerSubtree::lemma_map_implies_and(
                     cont.children[j].unwrap(),
-                    cont.path().push_tail(j as usize),
+                    cont.path().push_tail(j),
                     f,
                     guard,
                     combined,
@@ -282,12 +282,12 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 #![trigger cont.children[j]]
                 0 <= j < cont.children.len()
                     && cont.children[j] is Some implies cont.children[j].unwrap().subtree_satisfies(
-            cont.path().push_tail(j as usize), g) by {
+            cont.path().push_tail(j), g) by {
                 cont.inv_children_unroll(j);
                 cont.pt_inv_children_unroll(j);
                 cont.inv_children_rel_unroll(j);
                 let child = cont.children[j].unwrap();
-                let child_path = cont.path().push_tail(j as usize);
+                let child_path = cont.path().push_tail(j);
                 // child.value.path == child_path (inv_children_rel) and
                 // child.value.path.inv() (EntryOwner::inv_base).
                 // L1: pt_inv ⟹ tree-wide path correctness.

--- a/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
@@ -57,9 +57,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
     /// Pointwise conjunction of two tree-wide predicates: if `self.map_full_tree(f)`
     /// and `self.map_full_tree(guard)` hold, then `self.map_full_tree(f && guard)`
-    /// holds. A thin wrapper around `OwnerSubtree::map_implies_and` applied per
+    /// holds. A thin wrapper around `OwnerSubtree::lemma_map_implies_and` applied per
     /// continuation + per child; extracted so callers don't have to re-derive
-    /// the same nested `assert forall ... by { map_implies_and(...) }` block.
+    /// the same nested `assert forall ... by { lemma_map_implies_and(...) }` block.
     pub proof fn and_map_full_tree(
         self,
         f: spec_fn(EntryOwner<C>, TreePath<NR_ENTRIES>) -> bool,
@@ -86,7 +86,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     && cont.children[j] is Some implies cont.children[j].unwrap().tree_predicate_map(
             cont.path().push_tail(j as usize), combined) by {
                 cont.inv_children_unroll(j);
-                OwnerSubtree::map_implies_and(
+                OwnerSubtree::lemma_map_implies_and(
                     cont.children[j].unwrap(),
                     cont.path().push_tail(j as usize),
                     f,
@@ -459,7 +459,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 owner_before_replace.cur_subtree(),
             )@.mappings,
             PageTableOwner(owner_before_replace.cur_subtree())@.mappings == set![target],
-            owner_before_replace.cur_subtree().value.path == removed_path,
+            owner_before_replace.cur_subtree().value().path == removed_path,
             regions1.slots == regions0.slots,
             regions1.slot_owners.dom() =~= regions0.slot_owners.dom(),
             forall|i: usize|

--- a/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
@@ -83,7 +83,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             assert forall|j: int|
                 #![trigger cont.children[j]]
                 0 <= j < cont.children.len()
-                    && cont.children[j] is Some implies cont.children[j].unwrap().tree_predicate_map(
+                    && cont.children[j] is Some implies cont.children[j].unwrap().subtree_satisfies(
             cont.path().push_tail(j as usize), combined) by {
                 cont.inv_children_unroll(j);
                 OwnerSubtree::lemma_map_implies_and(
@@ -281,7 +281,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             assert forall|j: int|
                 #![trigger cont.children[j]]
                 0 <= j < cont.children.len()
-                    && cont.children[j] is Some implies cont.children[j].unwrap().tree_predicate_map(
+                    && cont.children[j] is Some implies cont.children[j].unwrap().subtree_satisfies(
             cont.path().push_tail(j as usize), g) by {
                 cont.inv_children_unroll(j);
                 cont.pt_inv_children_unroll(j);

--- a/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
@@ -57,9 +57,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
     /// Pointwise conjunction of two tree-wide predicates: if `self.map_full_tree(f)`
     /// and `self.map_full_tree(guard)` hold, then `self.map_full_tree(f && guard)`
-    /// holds. A thin wrapper around `OwnerSubtree::lemma_map_implies_and` applied per
+    /// holds. A thin wrapper around `OwnerSubtree::lemma_subtree_satisfies_implies_and` applied per
     /// continuation + per child; extracted so callers don't have to re-derive
-    /// the same nested `assert forall ... by { lemma_map_implies_and(...) }` block.
+    /// the same nested `assert forall ... by { lemma_subtree_satisfies_implies_and(...) }` block.
     pub proof fn and_map_full_tree(
         self,
         f: spec_fn(EntryOwner<C>, TreePath<NR_ENTRIES>) -> bool,
@@ -86,7 +86,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     && cont.children[j] is Some implies cont.children[j].unwrap().subtree_satisfies(
             cont.path().push_tail(j), combined) by {
                 cont.inv_children_unroll(j);
-                OwnerSubtree::lemma_map_implies_and(
+                OwnerSubtree::lemma_subtree_satisfies_implies_and(
                     cont.children[j].unwrap(),
                     cont.path().push_tail(j),
                     f,

--- a/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
@@ -397,41 +397,12 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         let va_path = self.va.to_path(lvl);
 
         self.va.to_path_len(lvl);
-        cont.path().lemma_push_tail_len(cont.idx as int);
         assert forall|k: int| 0 <= k < child_path.len() implies child_path[k]
             == va_path[k] by {
             self.va.to_path_index(lvl, k);
-            if lvl == 3 {
-                cont.path().lemma_push_tail_index(cont.idx as int);
-            } else if lvl == 2 {
-                cont.path().lemma_push_tail_index(cont.idx as int);
-                self.continuations[3].path().lemma_push_tail_index(
-                    self.continuations[3].idx as int,
-                );
-            } else if lvl == 1 {
-                cont.path().lemma_push_tail_index(cont.idx as int);
-                self.continuations[2].path().lemma_push_tail_index(
-                    self.continuations[2].idx as int,
-                );
-                self.continuations[3].path().lemma_push_tail_index(
-                    self.continuations[3].idx as int,
-                );
-            } else {
-                cont.path().lemma_push_tail_index(cont.idx as int);
-                self.continuations[1].path().lemma_push_tail_index(
-                    self.continuations[1].idx as int,
-                );
-                self.continuations[2].path().lemma_push_tail_index(
-                    self.continuations[2].idx as int,
-                );
-                self.continuations[3].path().lemma_push_tail_index(
-                    self.continuations[3].idx as int,
-                );
-            }
         };
 
         self.va.to_path_inv(lvl);
-        cont.path().lemma_push_tail_preserves_inv(cont.idx as int);
         AbstractVaddr::rec_vaddr_eq_if_indices_eq(child_path, va_path, 0);
         self.va.vaddr_range_from_path(lvl);
     }

--- a/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
@@ -34,7 +34,6 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
     {
         broadcast use {CursorContinuation::group_lemmas, PageTableOwner::group_lemmas};
 
-        self.as_subtree_properties();
         self.inv_children_unroll_all();
         self.as_subtree_inv();
         self.as_page_table_owner_pt_inv();
@@ -176,24 +175,6 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
 }
 
 impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
-    proof fn as_subtree_properties(self)
-        ensures
-            self.as_subtree().value() == self.entry_own,
-            self.as_subtree().level() == self.tree_level,
-            self.as_subtree().children() == self.children,
-    {
-    }
-
-    proof fn as_subtree_eq_implies_view_mappings_eq(self, other: Self)
-        requires
-            self.as_subtree() == other.as_subtree(),
-            self.path() == other.path(),
-        ensures
-            self.view_mappings() == other.view_mappings(),
-    {
-        self.as_subtree_properties();
-        other.as_subtree_properties();
-    }
 
     /// When a continuation has all_some and inv, its as_subtree() also has `TreeNode::inv()`.
     proof fn as_subtree_inv(self)
@@ -203,7 +184,6 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         ensures
             self.as_subtree().inv(),
     {
-        self.as_subtree_properties();
         self.inv_children_unroll_all();
     }
 
@@ -214,7 +194,6 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         ensures
             PageTableOwner(self.as_subtree()).pt_inv(),
     {
-        self.as_subtree_properties();
         self.as_subtree_inv();
         let st = self.as_subtree();
         let depth = (INC_LEVELS - st.level()) as nat;
@@ -669,7 +648,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         lemma_vaddr_of_eq_int::<C>(cont_i.path().push_tail(j));
 
                         old_cont.as_subtree_inv();
-                        old_cont.as_subtree_properties();
                         old_cont.as_page_table_owner_preserves_view_mappings();
                         PageTableOwner(old_cont.as_subtree()).view_rec_vaddr_range(
                             old_cont.path(),
@@ -722,7 +700,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
         if self.level == 4 {
             self.continuations[3].as_page_table_owner_preserves_view_mappings();
-            self.continuations[3].as_subtree_properties();
             self.inv_continuation(3);
             assert(self.view_mappings() == self.continuations[3].view_mappings());
             assert(self.as_page_table_owner().view_rec(self.continuations[3].path())
@@ -733,18 +710,15 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
             c2.as_page_table_owner_preserves_view_mappings();
             c2.as_subtree_inv();
-            c2.as_subtree_properties();
             c3.view_mappings_put_child(c2.as_subtree());
             c3.as_subtree_restore(c2);
 
             let l4 = c3.restore(c2).0;
-            l4.as_subtree_eq_implies_view_mappings_eq(c3.put_child(c2.as_subtree()));
             c2.as_page_table_owner_pt_inv();
 
             c2.inv_children_unroll_all();
             c3.inv_children_unroll_all();
             l4.as_page_table_owner_preserves_view_mappings();
-            l4.as_subtree_properties();
 
             assert(self.view_mappings() == self.continuations[2].view_mappings().union(
                 self.continuations[3].view_mappings(),
@@ -768,29 +742,24 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
             c1.as_page_table_owner_preserves_view_mappings();
             c1.as_subtree_inv();
-            c1.as_subtree_properties();
             c2.view_mappings_put_child(c1.as_subtree());
             c2.as_subtree_restore(c1);
 
             let l3 = c2.restore(c1).0;
-            l3.as_subtree_eq_implies_view_mappings_eq(c2.put_child(c1.as_subtree()));
             c1.as_page_table_owner_pt_inv();
 
             c1.inv_children_unroll_all();
             c2.inv_children_unroll_all();
             l3.as_page_table_owner_preserves_view_mappings();
             l3.as_subtree_inv();
-            l3.as_subtree_properties();
             c3.as_subtree_restore(l3);
             c3.view_mappings_put_child(l3.as_subtree());
 
             let l4 = c3.restore(l3).0;
-            l4.as_subtree_eq_implies_view_mappings_eq(c3.put_child(l3.as_subtree()));
             l3.as_page_table_owner_pt_inv();
 
             c3.inv_children_unroll_all();
             l4.as_page_table_owner_preserves_view_mappings();
-            l4.as_subtree_properties();
 
             assert(self.view_mappings() == c1.view_mappings().union(c2.view_mappings()).union(
                 c3.view_mappings(),
@@ -814,37 +783,30 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
             c0.as_page_table_owner_preserves_view_mappings();
             c0.as_subtree_inv();
-            c0.as_subtree_properties();
             c1.view_mappings_put_child(c0.as_subtree());
             c1.as_subtree_restore(c0);
             let l2 = c1.restore(c0).0;
-            l2.as_subtree_eq_implies_view_mappings_eq(c1.put_child(c0.as_subtree()));
             c0.as_page_table_owner_pt_inv();
 
             c0.inv_children_unroll_all();
             c1.inv_children_unroll_all();
             l2.as_page_table_owner_preserves_view_mappings();
             l2.as_subtree_inv();
-            l2.as_subtree_properties();
             c2.view_mappings_put_child(l2.as_subtree());
             c2.as_subtree_restore(l2);
             let l3 = c2.restore(l2).0;
-            l3.as_subtree_eq_implies_view_mappings_eq(c2.put_child(l2.as_subtree()));
             l2.as_page_table_owner_pt_inv();
 
             c2.inv_children_unroll_all();
             l3.as_page_table_owner_preserves_view_mappings();
             l3.as_subtree_inv();
-            l3.as_subtree_properties();
             c3.view_mappings_put_child(l3.as_subtree());
             c3.as_subtree_restore(l3);
             let l4 = c3.restore(l3).0;
-            l4.as_subtree_eq_implies_view_mappings_eq(c3.put_child(l3.as_subtree()));
             l3.as_page_table_owner_pt_inv();
 
             c3.inv_children_unroll_all();
             l4.as_page_table_owner_preserves_view_mappings();
-            l4.as_subtree_properties();
 
             assert(self.view_mappings() == c0.view_mappings().union(c1.view_mappings()).union(
                 c2.view_mappings(),
@@ -862,30 +824,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         }
     }
 
-    proof fn as_page_table_owner_root_properties(self)
-        requires
-            self.inv(),
-        ensures
-            self.as_page_table_owner().0.value() == self.continuations[3].entry_own,
-            self.as_page_table_owner().0.level() == self.continuations[3].tree_level,
-    {
-        if self.level == 4 {
-            self.continuations[3].as_subtree_properties();
-        } else if self.level == 3 {
-            let l4 = self.continuations[3].restore(self.continuations[2]).0;
-            l4.as_subtree_properties();
-        } else if self.level == 2 {
-            let l3 = self.continuations[2].restore(self.continuations[1]).0;
-            let l4 = self.continuations[3].restore(l3).0;
-            l4.as_subtree_properties();
-        } else {
-            let l2 = self.continuations[1].restore(self.continuations[0]).0;
-            let l3 = self.continuations[2].restore(l2).0;
-            let l4 = self.continuations[3].restore(l3).0;
-            l4.as_subtree_properties();
-        }
-    }
-
     /// Every mapping in the cursor view satisfies `Mapping::inv()`.
     ///
     /// Collapses the cursor view into a single-root `view_rec` and applies
@@ -898,7 +836,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             forall|m: Mapping| self.view_mappings().contains(m) ==> #[trigger] m.inv(),
     {
         self.as_page_table_owner_preserves_view_mappings();
-        self.as_page_table_owner_root_properties();
         let pto = self.as_page_table_owner();
         let root_path = self.continuations[3].path();
         self.inv_continuation(NR_LEVELS as int - 1);
@@ -920,7 +857,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     ==> set![4096usize, 2097152usize, 1073741824usize].contains(m.page_size),
     {
         self.as_page_table_owner_preserves_view_mappings();
-        self.as_page_table_owner_root_properties();
         let pto = self.as_page_table_owner();
         let root_path = self.continuations[3].path();
         self.inv_continuation(NR_LEVELS - 1);
@@ -943,7 +879,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self@.non_overlapping(),
     {
         self.as_page_table_owner_preserves_view_mappings();
-        self.as_page_table_owner_root_properties();
         let pto = self.as_page_table_owner();
         let root_path = self.continuations[3].path();
 

--- a/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
@@ -19,6 +19,8 @@ use crate::specs::mm::page_table::{AbstractVaddr, Mapping};
 
 verus! {
 
+broadcast use group_ghost_tree_lemmas;
+
 // ─── CursorContinuation mapping lemmas ───────────────────────────────────────
 impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
     pub proof fn as_page_table_owner_preserves_view_mappings(self)
@@ -180,11 +182,6 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             self.as_subtree().level() == self.tree_level,
             self.as_subtree().children() == self.children,
     {
-        OwnerSubtree::<C>::lemma_new_properties(
-            self.entry_own,
-            self.tree_level,
-            self.children,
-        );
     }
 
     proof fn as_subtree_eq_implies_view_mappings_eq(self, other: Self)

--- a/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
@@ -401,8 +401,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
         self.va.to_path_len(lvl);
         cont.path().lemma_push_tail_len(cont.idx as int);
-        assert forall|k: int| 0 <= k < child_path.len() implies child_path.index(k)
-            == va_path.index(k) by {
+        assert forall|k: int| 0 <= k < child_path.len() implies child_path[k]
+            == va_path[k] by {
             self.va.to_path_index(lvl, k);
             if lvl == 3 {
                 cont.path().lemma_push_tail_index(cont.idx as int);

--- a/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
@@ -32,6 +32,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
     {
         broadcast use {CursorContinuation::group_lemmas, PageTableOwner::group_lemmas};
 
+        self.as_subtree_properties();
         self.inv_children_unroll_all();
         self.as_subtree_inv();
         self.as_page_table_owner_pt_inv();
@@ -53,8 +54,8 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
                 ) implies #[trigger] self.view_mappings().contains(m) by {
                 let i = choose|i: int|
                     #![auto]
-                    0 <= i < pto.0.children.len() && pto.0.children[i] is Some && PageTableOwner(
-                        pto.0.children[i].unwrap(),
+                    0 <= i < pto.0.children().len() && pto.0.children()[i] is Some && PageTableOwner(
+                        pto.0.children()[i].unwrap(),
                     ).view_rec(self.path().push_tail(i as usize)).contains(m);
             };
         };
@@ -173,6 +174,30 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
 }
 
 impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
+    proof fn as_subtree_properties(self)
+        ensures
+            self.as_subtree().value() == self.entry_own,
+            self.as_subtree().level() == self.tree_level,
+            self.as_subtree().children() == self.children,
+    {
+        OwnerSubtree::<C>::lemma_new_properties(
+            self.entry_own,
+            self.tree_level,
+            self.children,
+        );
+    }
+
+    proof fn as_subtree_eq_implies_view_mappings_eq(self, other: Self)
+        requires
+            self.as_subtree() == other.as_subtree(),
+            self.path() == other.path(),
+        ensures
+            self.view_mappings() == other.view_mappings(),
+    {
+        self.as_subtree_properties();
+        other.as_subtree_properties();
+    }
+
     /// When a continuation has all_some and inv, its as_subtree() also has Node::inv().
     proof fn as_subtree_inv(self)
         requires
@@ -181,6 +206,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         ensures
             self.as_subtree().inv(),
     {
+        self.as_subtree_properties();
         self.inv_children_unroll_all();
     }
 
@@ -191,13 +217,14 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         ensures
             PageTableOwner(self.as_subtree()).pt_inv(),
     {
+        self.as_subtree_properties();
         self.as_subtree_inv();
         let st = self.as_subtree();
-        let depth = (INC_LEVELS - st.level) as nat;
+        let depth = (INC_LEVELS - st.level()) as nat;
         assert forall|i: int|
-            #![trigger st.children[i]]
+            #![trigger st.children()[i]]
             0 <= i < NR_ENTRIES implies PageTableOwner::<C>::pt_edge_at(st, i) && PageTableOwner(
-            st.children[i].unwrap(),
+            st.children()[i].unwrap(),
         ).pt_inv_at_depth((depth - 1) as nat) by {
             self.inv_children_rel_unroll(i);
             self.pt_inv_children_unroll(i);
@@ -215,7 +242,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.in_locked_range(),
         ensures
             ({
-                let subtree_va = vaddr_of::<C>(self.cur_subtree().value.path) as int;
+                let subtree_va = vaddr_of::<C>(self.cur_subtree().value().path) as int;
                 let size = page_size(self.level) as int;
                 PageTableOwner(self.cur_subtree())@.mappings == self@.mappings.filter(
                     |m: Mapping| subtree_va <= m.va_range.start < subtree_va + size,
@@ -225,7 +252,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         broadcast use {CursorContinuation::group_lemmas, CursorOwner::group_lemmas};
 
         let cur_subtree = self.cur_subtree();
-        let cur_path = cur_subtree.value.path;
+        let cur_path = cur_subtree.value().path;
         let subtree_va = vaddr_of::<C>(cur_path) as int;
         let size = page_size(self.level) as int;
 
@@ -340,7 +367,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         self.cur_subtree_eq_filtered_mappings_path();
         self.cur_va_in_cont_child_range(self.level - 1);
         self.va.to_path_vaddr_concrete(self.level - 1);
-        let cur_path = self.cur_subtree().value.path;
+        let cur_path = self.cur_subtree().value().path;
         let ps = page_size(self.level);
         lemma_vaddr_of_eq_int::<C>(cur_path);
         // Bridge nat_align_down's nat→usize cast (no wrap since
@@ -373,41 +400,41 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         let va_path = self.va.to_path(lvl);
 
         self.va.to_path_len(lvl);
-        cont.path().push_tail_property_len(cont.idx as usize);
+        cont.path().lemma_push_tail_len(cont.idx as usize);
         assert forall|k: int| 0 <= k < child_path.len() implies child_path.index(k)
             == va_path.index(k) by {
             self.va.to_path_index(lvl, k);
             if lvl == 3 {
-                cont.path().push_tail_property_index(cont.idx as usize);
+                cont.path().lemma_push_tail_index(cont.idx as usize);
             } else if lvl == 2 {
-                cont.path().push_tail_property_index(cont.idx as usize);
-                self.continuations[3].path().push_tail_property_index(
+                cont.path().lemma_push_tail_index(cont.idx as usize);
+                self.continuations[3].path().lemma_push_tail_index(
                     self.continuations[3].idx as usize,
                 );
             } else if lvl == 1 {
-                cont.path().push_tail_property_index(cont.idx as usize);
-                self.continuations[2].path().push_tail_property_index(
+                cont.path().lemma_push_tail_index(cont.idx as usize);
+                self.continuations[2].path().lemma_push_tail_index(
                     self.continuations[2].idx as usize,
                 );
-                self.continuations[3].path().push_tail_property_index(
+                self.continuations[3].path().lemma_push_tail_index(
                     self.continuations[3].idx as usize,
                 );
             } else {
-                cont.path().push_tail_property_index(cont.idx as usize);
-                self.continuations[1].path().push_tail_property_index(
+                cont.path().lemma_push_tail_index(cont.idx as usize);
+                self.continuations[1].path().lemma_push_tail_index(
                     self.continuations[1].idx as usize,
                 );
-                self.continuations[2].path().push_tail_property_index(
+                self.continuations[2].path().lemma_push_tail_index(
                     self.continuations[2].idx as usize,
                 );
-                self.continuations[3].path().push_tail_property_index(
+                self.continuations[3].path().lemma_push_tail_index(
                     self.continuations[3].idx as usize,
                 );
             }
         };
 
         self.va.to_path_inv(lvl);
-        cont.path().push_tail_preserves_inv(cont.idx as usize);
+        cont.path().lemma_push_tail_preserves_inv(cont.idx as usize);
         AbstractVaddr::rec_vaddr_eq_if_indices_eq(child_path, va_path, 0);
         self.va.vaddr_range_from_path(lvl);
     }
@@ -421,7 +448,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.level - 1 < lvl < NR_LEVELS,
         ensures
             ({
-                let subtree_va = vaddr(self.cur_subtree().value.path);
+                let subtree_va = vaddr(self.cur_subtree().value().path);
                 let idx_path_va = vaddr(
                     self.continuations[lvl].path().push_tail(self.continuations[lvl].idx as usize),
                 );
@@ -447,7 +474,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         let shift = self.va.leading_bits * 0x1_0000_0000_0000int;
 
         // Explicit chain: subtree_va + shift == nat_align_down(x, fine)
-        let subtree_va = vaddr(self.cur_subtree().value.path);
+        let subtree_va = vaddr(self.cur_subtree().value().path);
         assert(subtree_va == vaddr(self.va.to_path(self.level - 1)));
         assert(subtree_va + shift == nat_align_down(x, fine));
 
@@ -532,7 +559,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.view_mappings().contains(m),
             m.va_range.start <= self.cur_va() < m.va_range.end,
         ensures
-            PageTableOwner(self.cur_subtree()).view_rec(self.cur_subtree().value.path).contains(m),
+            PageTableOwner(self.cur_subtree()).view_rec(self.cur_subtree().value().path).contains(m),
     {
         broadcast use {CursorContinuation::group_lemmas, CursorOwner::group_lemmas};
 
@@ -674,6 +701,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         lemma_vaddr_of_eq_int::<C>(cont_i.path().push_tail(j as usize));
 
                         old_cont.as_subtree_inv();
+                        old_cont.as_subtree_properties();
                         old_cont.as_page_table_owner_preserves_view_mappings();
                         PageTableOwner(old_cont.as_subtree()).view_rec_vaddr_range(
                             old_cont.path(),
@@ -719,30 +747,36 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.as_page_table_owner().view_rec(self.continuations[3].path())
                 == self.view_mappings(),
             self.as_page_table_owner().0.inv(),
-            self.as_page_table_owner().0.level == self.continuations[3].tree_level,
+            self.as_page_table_owner().0.level() == self.continuations[3].tree_level,
             self.as_page_table_owner().pt_inv(),
     {
         broadcast use CursorOwner::group_lemmas;
 
         if self.level == 4 {
             self.continuations[3].as_page_table_owner_preserves_view_mappings();
+            self.continuations[3].as_subtree_properties();
             self.inv_continuation(3);
             assert(self.view_mappings() == self.continuations[3].view_mappings());
+            assert(self.as_page_table_owner().view_rec(self.continuations[3].path())
+                == self.view_mappings());
         } else if self.level == 3 {
             let c2 = self.continuations[2];
             let c3 = self.continuations[3];
 
             c2.as_page_table_owner_preserves_view_mappings();
             c2.as_subtree_inv();
+            c2.as_subtree_properties();
             c3.view_mappings_put_child(c2.as_subtree());
             c3.as_subtree_restore(c2);
 
             let l4 = c3.restore(c2).0;
+            l4.as_subtree_eq_implies_view_mappings_eq(c3.put_child(c2.as_subtree()));
             c2.as_page_table_owner_pt_inv();
 
             c2.inv_children_unroll_all();
             c3.inv_children_unroll_all();
             l4.as_page_table_owner_preserves_view_mappings();
+            l4.as_subtree_properties();
 
             assert(self.view_mappings() == self.continuations[2].view_mappings().union(
                 self.continuations[3].view_mappings(),
@@ -757,6 +791,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                             && #[trigger] self.continuations[i].view_mappings().contains(m);
                 };
             };
+            assert(self.as_page_table_owner().view_rec(self.continuations[3].path())
+                == self.view_mappings());
         } else if self.level == 2 {
             let c1 = self.continuations[1];
             let c2 = self.continuations[2];
@@ -764,24 +800,29 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
             c1.as_page_table_owner_preserves_view_mappings();
             c1.as_subtree_inv();
+            c1.as_subtree_properties();
             c2.view_mappings_put_child(c1.as_subtree());
             c2.as_subtree_restore(c1);
 
             let l3 = c2.restore(c1).0;
+            l3.as_subtree_eq_implies_view_mappings_eq(c2.put_child(c1.as_subtree()));
             c1.as_page_table_owner_pt_inv();
 
             c1.inv_children_unroll_all();
             c2.inv_children_unroll_all();
             l3.as_page_table_owner_preserves_view_mappings();
             l3.as_subtree_inv();
+            l3.as_subtree_properties();
             c3.as_subtree_restore(l3);
             c3.view_mappings_put_child(l3.as_subtree());
 
             let l4 = c3.restore(l3).0;
+            l4.as_subtree_eq_implies_view_mappings_eq(c3.put_child(l3.as_subtree()));
             l3.as_page_table_owner_pt_inv();
 
             c3.inv_children_unroll_all();
             l4.as_page_table_owner_preserves_view_mappings();
+            l4.as_subtree_properties();
 
             assert(self.view_mappings() == c1.view_mappings().union(c2.view_mappings()).union(
                 c3.view_mappings(),
@@ -794,6 +835,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                             && #[trigger] self.continuations[i].view_mappings().contains(m);
                 };
             };
+            assert(self.as_page_table_owner().view_rec(self.continuations[3].path())
+                == self.view_mappings());
         } else {
             // level == 1
             let c0 = self.continuations[0];
@@ -803,30 +846,37 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
             c0.as_page_table_owner_preserves_view_mappings();
             c0.as_subtree_inv();
+            c0.as_subtree_properties();
             c1.view_mappings_put_child(c0.as_subtree());
             c1.as_subtree_restore(c0);
             let l2 = c1.restore(c0).0;
+            l2.as_subtree_eq_implies_view_mappings_eq(c1.put_child(c0.as_subtree()));
             c0.as_page_table_owner_pt_inv();
 
             c0.inv_children_unroll_all();
             c1.inv_children_unroll_all();
             l2.as_page_table_owner_preserves_view_mappings();
             l2.as_subtree_inv();
+            l2.as_subtree_properties();
             c2.view_mappings_put_child(l2.as_subtree());
             c2.as_subtree_restore(l2);
             let l3 = c2.restore(l2).0;
+            l3.as_subtree_eq_implies_view_mappings_eq(c2.put_child(l2.as_subtree()));
             l2.as_page_table_owner_pt_inv();
 
             c2.inv_children_unroll_all();
             l3.as_page_table_owner_preserves_view_mappings();
             l3.as_subtree_inv();
+            l3.as_subtree_properties();
             c3.view_mappings_put_child(l3.as_subtree());
             c3.as_subtree_restore(l3);
             let l4 = c3.restore(l3).0;
+            l4.as_subtree_eq_implies_view_mappings_eq(c3.put_child(l3.as_subtree()));
             l3.as_page_table_owner_pt_inv();
 
             c3.inv_children_unroll_all();
             l4.as_page_table_owner_preserves_view_mappings();
+            l4.as_subtree_properties();
 
             assert(self.view_mappings() == c0.view_mappings().union(c1.view_mappings()).union(
                 c2.view_mappings(),
@@ -839,6 +889,32 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                             && #[trigger] self.continuations[i].view_mappings().contains(m);
                 };
             };
+            assert(self.as_page_table_owner().view_rec(self.continuations[3].path())
+                == self.view_mappings());
+        }
+    }
+
+    proof fn as_page_table_owner_root_properties(self)
+        requires
+            self.inv(),
+        ensures
+            self.as_page_table_owner().0.value() == self.continuations[3].entry_own,
+            self.as_page_table_owner().0.level() == self.continuations[3].tree_level,
+    {
+        if self.level == 4 {
+            self.continuations[3].as_subtree_properties();
+        } else if self.level == 3 {
+            let l4 = self.continuations[3].restore(self.continuations[2]).0;
+            l4.as_subtree_properties();
+        } else if self.level == 2 {
+            let l3 = self.continuations[2].restore(self.continuations[1]).0;
+            let l4 = self.continuations[3].restore(l3).0;
+            l4.as_subtree_properties();
+        } else {
+            let l2 = self.continuations[1].restore(self.continuations[0]).0;
+            let l3 = self.continuations[2].restore(l2).0;
+            let l4 = self.continuations[3].restore(l3).0;
+            l4.as_subtree_properties();
         }
     }
 
@@ -854,6 +930,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             forall|m: Mapping| self.view_mappings().contains(m) ==> #[trigger] m.inv(),
     {
         self.as_page_table_owner_preserves_view_mappings();
+        self.as_page_table_owner_root_properties();
         let pto = self.as_page_table_owner();
         let root_path = self.continuations[3].path();
         self.inv_continuation(NR_LEVELS as int - 1);
@@ -875,6 +952,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     ==> set![4096usize, 2097152usize, 1073741824usize].contains(m.page_size),
     {
         self.as_page_table_owner_preserves_view_mappings();
+        self.as_page_table_owner_root_properties();
         let pto = self.as_page_table_owner();
         let root_path = self.continuations[3].path();
         self.inv_continuation(NR_LEVELS - 1);
@@ -897,6 +975,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self@.non_overlapping(),
     {
         self.as_page_table_owner_preserves_view_mappings();
+        self.as_page_table_owner_root_properties();
         let pto = self.as_page_table_owner();
         let root_path = self.continuations[3].path();
 

--- a/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
@@ -20,8 +20,8 @@ use crate::specs::mm::page_table::{AbstractVaddr, Mapping};
 verus! {
 
 broadcast use group_ghost_tree_lemmas;
-
 // ─── CursorContinuation mapping lemmas ───────────────────────────────────────
+
 impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
     pub proof fn as_page_table_owner_preserves_view_mappings(self)
         requires
@@ -55,9 +55,10 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
                 ) implies #[trigger] self.view_mappings().contains(m) by {
                 let i = choose|i: int|
                     #![auto]
-                    0 <= i < pto.0.children().len() && pto.0.children()[i] is Some && PageTableOwner(
-                        pto.0.children()[i].unwrap(),
-                    ).view_rec(self.path().push_tail(i)).contains(m);
+                    0 <= i < pto.0.children().len() && pto.0.children()[i] is Some
+                        && PageTableOwner(pto.0.children()[i].unwrap()).view_rec(
+                        self.path().push_tail(i),
+                    ).contains(m);
             };
         };
     }
@@ -175,7 +176,6 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
 }
 
 impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
-
     /// When a continuation has all_some and inv, its as_subtree() also has `TreeNode::inv()`.
     proof fn as_subtree_inv(self)
         requires
@@ -376,8 +376,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         let va_path = self.va.to_path(lvl);
 
         self.va.to_path_len(lvl);
-        assert forall|k: int| 0 <= k < child_path.len() implies child_path[k]
-            == va_path[k] by {
+        assert forall|k: int| 0 <= k < child_path.len() implies child_path[k] == va_path[k] by {
             self.va.to_path_index(lvl, k);
         };
 
@@ -450,12 +449,10 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             j != self.index(),
             self.continuations[self.level - 1].children[j] is Some,
         ensures
-            vaddr(self.continuations[self.level - 1].path().push_tail(j))
-                + self.va.leading_bits * 0x1_0000_0000_0000int + page_size(
-                self.level as PagingLevel,
-            ) <= self.cur_va() || self.cur_va() < vaddr(
-                self.continuations[self.level - 1].path().push_tail(j),
-            ) + self.va.leading_bits * 0x1_0000_0000_0000int,
+            vaddr(self.continuations[self.level - 1].path().push_tail(j)) + self.va.leading_bits
+                * 0x1_0000_0000_0000int + page_size(self.level as PagingLevel) <= self.cur_va()
+                || self.cur_va() < vaddr(self.continuations[self.level - 1].path().push_tail(j))
+                + self.va.leading_bits * 0x1_0000_0000_0000int,
     {
         let cont = self.continuations[self.level - 1];
         let idx = self.index();
@@ -506,7 +503,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.view_mappings().contains(m),
             m.va_range.start <= self.cur_va() < m.va_range.end,
         ensures
-            PageTableOwner(self.cur_subtree()).view_rec(self.cur_subtree().value().path).contains(m),
+            PageTableOwner(self.cur_subtree()).view_rec(self.cur_subtree().value().path).contains(
+                m,
+            ),
     {
         broadcast use {CursorContinuation::group_lemmas, CursorOwner::group_lemmas};
 
@@ -637,12 +636,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         let sib_size = page_size(
                             (INC_LEVELS - cont_i.path().len() - 1) as PagingLevel,
                         );
-                        sibling_paths_disjoint::<C>(
-                            cont_i.path(),
-                            cont_i.idx as int,
-                            j,
-                            sib_size,
-                        );
+                        sibling_paths_disjoint::<C>(cont_i.path(), cont_i.idx as int, j, sib_size);
                         // Lift positional disjointness to canonical.
                         lemma_vaddr_of_eq_int::<C>(cont_i.path().push_tail(cont_i.idx as int));
                         lemma_vaddr_of_eq_int::<C>(cont_i.path().push_tail(j));

--- a/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
@@ -45,7 +45,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
                     #![auto]
                     0 <= i < self.children.len() && self.children[i] is Some && PageTableOwner(
                         self.children[i].unwrap(),
-                    ).view_rec(self.path().push_tail(i as usize)).contains(m);
+                    ).view_rec(self.path().push_tail(i)).contains(m);
                 assert(pto.view_rec(self.path()).contains(m));
             };
             assert forall|m: Mapping|
@@ -56,7 +56,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
                     #![auto]
                     0 <= i < pto.0.children().len() && pto.0.children()[i] is Some && PageTableOwner(
                         pto.0.children()[i].unwrap(),
-                    ).view_rec(self.path().push_tail(i as usize)).contains(m);
+                    ).view_rec(self.path().push_tail(i)).contains(m);
             };
         };
     }
@@ -78,7 +78,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             let i = choose|i: int|
                 0 <= i < self.children.len() && #[trigger] self.children[i] is Some
                     && PageTableOwner(self.children[i].unwrap()).view_rec(
-                    self.path().push_tail(i as usize),
+                    self.path().push_tail(i),
                 ).contains(m);
             assert(i != self.idx);
             assert(self.take_child().1.children[i] is Some);
@@ -93,34 +93,34 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
                 #![auto]
                 0 <= i < left.children.len() && left.children[i] is Some && PageTableOwner(
                     left.children[i].unwrap(),
-                ).view_rec(left.path().push_tail(i as usize)).contains(m);
+                ).view_rec(left.path().push_tail(i)).contains(m);
             if self.view_mappings_take_child_spec().contains(m) {
                 assert(PageTableOwner(self.children[self.idx as int].unwrap()).view_rec(
-                    self.path().push_tail(self.idx as usize),
+                    self.path().push_tail(self.idx as int),
                 ).contains(m));
                 let i = choose|i: int|
                     0 <= i < left.children.len() && #[trigger] left.children[i] is Some
                         && PageTableOwner(left.children[i].unwrap()).view_rec(
-                        left.path().push_tail(i as usize),
+                        left.path().push_tail(i),
                     ).contains(m);
                 assert(PageTableOwner(left.children[i as int].unwrap()).view_rec(
-                    left.path().push_tail(i as usize),
+                    left.path().push_tail(i),
                 ).contains(m));
 
                 PageTableOwner(self.children[self.idx as int].unwrap()).view_rec_vaddr_range(
-                    self.path().push_tail(self.idx as usize),
+                    self.path().push_tail(self.idx as int),
                     m,
                 );
                 PageTableOwner(left.children[i as int].unwrap()).view_rec_vaddr_range(
-                    left.path().push_tail(i as usize),
+                    left.path().push_tail(i),
                     m,
                 );
 
                 let size = page_size((INC_LEVELS - self.path().len() - 1) as PagingLevel);
                 // Positional disjointness; shift both sides by LEADING_BITS * 2^48.
-                sibling_paths_disjoint::<C>(self.path(), self.idx, i as usize, size);
-                lemma_vaddr_of_eq_int::<C>(self.path().push_tail(self.idx as usize));
-                lemma_vaddr_of_eq_int::<C>(self.path().push_tail(i as usize));
+                sibling_paths_disjoint::<C>(self.path(), self.idx as int, i, size);
+                lemma_vaddr_of_eq_int::<C>(self.path().push_tail(self.idx as int));
+                lemma_vaddr_of_eq_int::<C>(self.path().push_tail(i));
             }
         };
     }
@@ -133,26 +133,26 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         ensures
             self.put_child(child).view_mappings() == self.view_mappings() + PageTableOwner(
                 child,
-            ).view_rec(self.path().push_tail(self.idx as usize)),
+            ).view_rec(self.path().push_tail(self.idx as int)),
     {
         broadcast use CursorContinuation::group_lemmas;
 
         let def = self.put_child(child).view_mappings();
         let sum = self.view_mappings() + PageTableOwner(child).view_rec(
-            self.path().push_tail(self.idx as usize),
+            self.path().push_tail(self.idx as int),
         );
         assert forall|m: Mapping| sum.contains(m) implies def.contains(m) by {
             if self.view_mappings().contains(m) {
                 let i = choose|i: int|
                     0 <= i < self.children.len() && #[trigger] self.children[i] is Some
                         && PageTableOwner(self.children[i].unwrap()).view_rec(
-                        self.path().push_tail(i as usize),
+                        self.path().push_tail(i),
                     ).contains(m);
                 assert(self.put_child(child).children[i] == self.children[i]);
                 self.put_child(child).lemma_view_mappings_intro(m, i);
             } else {
                 assert(PageTableOwner(child).view_rec(
-                    self.path().push_tail(self.idx as usize),
+                    self.path().push_tail(self.idx as int),
                 ).contains(m));
                 assert(self.put_child(child).children[self.idx as int] == Some(child));
                 self.put_child(child).lemma_view_mappings_intro(m, self.idx as int);
@@ -164,7 +164,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
                     child,
                 ).children[i] is Some && PageTableOwner(
                     self.put_child(child).children[i].unwrap(),
-                ).view_rec(self.put_child(child).path().push_tail(i as usize)).contains(m);
+                ).view_rec(self.put_child(child).path().push_tail(i)).contains(m);
             if i == self.idx {
             } else {
                 assert(self.children[i] == self.put_child(child).children[i]);
@@ -293,11 +293,11 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 #![auto]
                 0 <= j < NR_ENTRIES && cont_i.children[j] is Some && PageTableOwner(
                     cont_i.children[j].unwrap(),
-                ).view_rec(cont_i.path().push_tail(j as usize)).contains(m);
+                ).view_rec(cont_i.path().push_tail(j)).contains(m);
 
             cont_i.inv_children_unroll(j);
             PageTableOwner(cont_i.children[j].unwrap()).view_rec_vaddr_range(
-                cont_i.path().push_tail(j as usize),
+                cont_i.path().push_tail(j),
                 m,
             );
 
@@ -306,30 +306,30 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     // cont_i.children[j] is exactly cur_subtree; m is already
                     // in subtree_mappings via view_rec at the same path.
                     assert(cont_i.children[j] == Some(cur_subtree));
-                    assert(cont_i.path().push_tail(j as usize) == cur_path);
+                    assert(cont_i.path().push_tail(j) == cur_path);
                     assert(subtree_mappings == PageTableOwner(cur_subtree).view_rec(cur_path));
                     assert(PageTableOwner(cur_subtree).view_rec(cur_path).contains(m));
                     assert(subtree_mappings.contains(m));
                 } else {
                     // Disjointness: sibling j's VA range doesn't overlap [subtree_va, subtree_va + page_size(level))
                     let sib_size = page_size((INC_LEVELS - cont.path().len() - 1) as PagingLevel);
-                    sibling_paths_disjoint::<C>(cont.path(), self.index(), j as usize, sib_size);
+                    sibling_paths_disjoint::<C>(cont.path(), self.index() as int, j, sib_size);
                     // Lift positional disjointness to canonical by adding
                     // the same leading_bits * 2^48 to both sides.
-                    lemma_vaddr_of_eq_int::<C>(cont.path().push_tail(self.index() as usize));
-                    lemma_vaddr_of_eq_int::<C>(cont.path().push_tail(j as usize));
+                    lemma_vaddr_of_eq_int::<C>(cont.path().push_tail(self.index() as int));
+                    lemma_vaddr_of_eq_int::<C>(cont.path().push_tail(j));
                     assert(false);  // contradiction from disjointness + filter
                 }
             } else {
-                if j as usize != cont_i.idx as usize {
+                if j as usize != cont_i.idx as int {
                     // Subtree VA range is contained in ancestor child range
                     self.subtree_va_in_ancestor_range(i);
 
                     // Sibling j is disjoint from cont_i.idx child
                     let sib_size = page_size((INC_LEVELS - cont_i.path().len() - 1) as PagingLevel);
-                    sibling_paths_disjoint::<C>(cont_i.path(), cont_i.idx, j as usize, sib_size);
-                    lemma_vaddr_of_eq_int::<C>(cont_i.path().push_tail(cont_i.idx as usize));
-                    lemma_vaddr_of_eq_int::<C>(cont_i.path().push_tail(j as usize));
+                    sibling_paths_disjoint::<C>(cont_i.path(), cont_i.idx as int, j, sib_size);
+                    lemma_vaddr_of_eq_int::<C>(cont_i.path().push_tail(cont_i.idx as int));
+                    lemma_vaddr_of_eq_int::<C>(cont_i.path().push_tail(j));
                     lemma_vaddr_of_eq_int::<C>(cur_path);
                     assert(false);  // contradiction
                 } else {
@@ -387,54 +387,54 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.in_locked_range(),
             self.level - 1 <= lvl < NR_LEVELS,
         ensures
-            vaddr(self.continuations[lvl].path().push_tail(self.continuations[lvl].idx as usize))
+            vaddr(self.continuations[lvl].path().push_tail(self.continuations[lvl].idx as int))
                 + self.va.leading_bits * 0x1_0000_0000_0000int <= self.cur_va(),
             self.cur_va() < vaddr(
-                self.continuations[lvl].path().push_tail(self.continuations[lvl].idx as usize),
+                self.continuations[lvl].path().push_tail(self.continuations[lvl].idx as int),
             ) + self.va.leading_bits * 0x1_0000_0000_0000int + page_size((lvl + 1) as PagingLevel),
-            vaddr(self.continuations[lvl].path().push_tail(self.continuations[lvl].idx as usize))
+            vaddr(self.continuations[lvl].path().push_tail(self.continuations[lvl].idx as int))
                 == vaddr(self.va.to_path(lvl)),
     {
         let cont = self.continuations[lvl];
-        let child_path = cont.path().push_tail(cont.idx as usize);
+        let child_path = cont.path().push_tail(cont.idx as int);
         let va_path = self.va.to_path(lvl);
 
         self.va.to_path_len(lvl);
-        cont.path().lemma_push_tail_len(cont.idx as usize);
+        cont.path().lemma_push_tail_len(cont.idx as int);
         assert forall|k: int| 0 <= k < child_path.len() implies child_path.index(k)
             == va_path.index(k) by {
             self.va.to_path_index(lvl, k);
             if lvl == 3 {
-                cont.path().lemma_push_tail_index(cont.idx as usize);
+                cont.path().lemma_push_tail_index(cont.idx as int);
             } else if lvl == 2 {
-                cont.path().lemma_push_tail_index(cont.idx as usize);
+                cont.path().lemma_push_tail_index(cont.idx as int);
                 self.continuations[3].path().lemma_push_tail_index(
-                    self.continuations[3].idx as usize,
+                    self.continuations[3].idx as int,
                 );
             } else if lvl == 1 {
-                cont.path().lemma_push_tail_index(cont.idx as usize);
+                cont.path().lemma_push_tail_index(cont.idx as int);
                 self.continuations[2].path().lemma_push_tail_index(
-                    self.continuations[2].idx as usize,
+                    self.continuations[2].idx as int,
                 );
                 self.continuations[3].path().lemma_push_tail_index(
-                    self.continuations[3].idx as usize,
+                    self.continuations[3].idx as int,
                 );
             } else {
-                cont.path().lemma_push_tail_index(cont.idx as usize);
+                cont.path().lemma_push_tail_index(cont.idx as int);
                 self.continuations[1].path().lemma_push_tail_index(
-                    self.continuations[1].idx as usize,
+                    self.continuations[1].idx as int,
                 );
                 self.continuations[2].path().lemma_push_tail_index(
-                    self.continuations[2].idx as usize,
+                    self.continuations[2].idx as int,
                 );
                 self.continuations[3].path().lemma_push_tail_index(
-                    self.continuations[3].idx as usize,
+                    self.continuations[3].idx as int,
                 );
             }
         };
 
         self.va.to_path_inv(lvl);
-        cont.path().lemma_push_tail_preserves_inv(cont.idx as usize);
+        cont.path().lemma_push_tail_preserves_inv(cont.idx as int);
         AbstractVaddr::rec_vaddr_eq_if_indices_eq(child_path, va_path, 0);
         self.va.vaddr_range_from_path(lvl);
     }
@@ -450,7 +450,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             ({
                 let subtree_va = vaddr(self.cur_subtree().value().path);
                 let idx_path_va = vaddr(
-                    self.continuations[lvl].path().push_tail(self.continuations[lvl].idx as usize),
+                    self.continuations[lvl].path().push_tail(self.continuations[lvl].idx as int),
                 );
                 &&& idx_path_va <= subtree_va
                 &&& subtree_va + page_size(self.level) <= idx_path_va + page_size(
@@ -480,7 +480,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
         // Explicit chain: idx_path_va + shift == nat_align_down(x, coarse)
         let idx_path_va = vaddr(
-            self.continuations[lvl].path().push_tail(self.continuations[lvl].idx as usize),
+            self.continuations[lvl].path().push_tail(self.continuations[lvl].idx as int),
         );
         assert(idx_path_va == vaddr(self.va.to_path(lvl)));
         assert(idx_path_va + shift == nat_align_down(x, coarse));
@@ -503,11 +503,11 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             j != self.index(),
             self.continuations[self.level - 1].children[j] is Some,
         ensures
-            vaddr(self.continuations[self.level - 1].path().push_tail(j as usize))
+            vaddr(self.continuations[self.level - 1].path().push_tail(j))
                 + self.va.leading_bits * 0x1_0000_0000_0000int + page_size(
                 self.level as PagingLevel,
             ) <= self.cur_va() || self.cur_va() < vaddr(
-                self.continuations[self.level - 1].path().push_tail(j as usize),
+                self.continuations[self.level - 1].path().push_tail(j),
             ) + self.va.leading_bits * 0x1_0000_0000_0000int,
     {
         let cont = self.continuations[self.level - 1];
@@ -519,7 +519,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
         // Sibling paths are separated by `page_size(self.level)` (child page size).
         let size = page_size((INC_LEVELS - cont.path().len() - 1) as PagingLevel);
-        sibling_paths_disjoint::<C>(cont.path(), idx, j as usize, size);
+        sibling_paths_disjoint::<C>(cont.path(), idx as int, j, size);
     }
 
     /// Children of higher-level continuations have VA ranges that don't include cur_va,
@@ -533,9 +533,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             j != self.continuations[i].idx,
             self.continuations[i].children[j] is Some,
         ensures
-            vaddr(self.continuations[i].path().push_tail(j as usize)) + self.va.leading_bits
+            vaddr(self.continuations[i].path().push_tail(j)) + self.va.leading_bits
                 * 0x1_0000_0000_0000int + page_size((i + 1) as PagingLevel) <= self.cur_va()
-                || self.cur_va() < vaddr(self.continuations[i].path().push_tail(j as usize))
+                || self.cur_va() < vaddr(self.continuations[i].path().push_tail(j))
                 + self.va.leading_bits * 0x1_0000_0000_0000int,
     {
         let cont = self.continuations[i];
@@ -546,7 +546,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
         // Siblings at this depth are separated by `page_size(i+1)` (child page size).
         let size = page_size((INC_LEVELS - cont.path().len() - 1) as PagingLevel);
-        sibling_paths_disjoint::<C>(cont.path(), cont.idx, j as usize, size);
+        sibling_paths_disjoint::<C>(cont.path(), cont.idx as int, j, size);
     }
 
     /// Any mapping that covers cur_va must come from the current subtree.
@@ -576,11 +576,11 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             #![auto]
             0 <= j < NR_ENTRIES && cont_i.children[j] is Some && PageTableOwner(
                 cont_i.children[j].unwrap(),
-            ).view_rec(cont_i.path().push_tail(j as usize)).contains(m);
+            ).view_rec(cont_i.path().push_tail(j)).contains(m);
 
         cont_i.inv_children_unroll(j);
         let child_j = cont_i.children[j].unwrap();
-        let path_j = cont_i.path().push_tail(j as usize);
+        let path_j = cont_i.path().push_tail(j);
         PageTableOwner(child_j).view_rec_vaddr_range(path_j, m);
         // Bridge view_rec_vaddr_range's canonical bounds to the
         // disjointness lemmas (also canonical after the refactor).
@@ -591,7 +591,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 self.subtree_va_ranges_disjoint(j);
             }
         } else {
-            if j as usize != cont_i.idx as usize {
+            if j as usize != cont_i.idx as int {
                 self.higher_level_children_disjoint(i, j);
             } else {
                 assert(cont_i.children[cont_i.idx as int] is None);
@@ -648,10 +648,10 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         #![auto]
                         0 <= j < NR_ENTRIES && cont_i.children[j] is Some && PageTableOwner(
                             cont_i.children[j].unwrap(),
-                        ).view_rec(cont_i.path().push_tail(j as usize)).contains(m);
+                        ).view_rec(cont_i.path().push_tail(j)).contains(m);
                     cont_i.inv_children_unroll(j);
                     PageTableOwner(cont_i.children[j].unwrap()).view_rec_vaddr_range(
-                        cont_i.path().push_tail(j as usize),
+                        cont_i.path().push_tail(j),
                         m,
                     );
 
@@ -659,14 +659,14 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         #![auto]
                         0 <= k < NR_ENTRIES && old_cont.children[k] is Some && PageTableOwner(
                             old_cont.children[k].unwrap(),
-                        ).view_rec(old_cont.path().push_tail(k as usize)).contains(m);
+                        ).view_rec(old_cont.path().push_tail(k)).contains(m);
                     old_cont.inv_children_unroll(k);
                     PageTableOwner(old_cont.children[k].unwrap()).view_rec_vaddr_range(
-                        old_cont.path().push_tail(k as usize),
+                        old_cont.path().push_tail(k),
                         m,
                     );
 
-                    if j as usize != cont_i.idx as usize {
+                    if j as usize != cont_i.idx as int {
                         old_self.cur_va_in_cont_child_range(level as int);
                         old_self.va.to_path_vaddr_concrete(level as int);
                         old_self.cur_va_in_cont_child_range(i);
@@ -692,13 +692,13 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                         );
                         sibling_paths_disjoint::<C>(
                             cont_i.path(),
-                            cont_i.idx,
-                            j as usize,
+                            cont_i.idx as int,
+                            j,
                             sib_size,
                         );
                         // Lift positional disjointness to canonical.
-                        lemma_vaddr_of_eq_int::<C>(cont_i.path().push_tail(cont_i.idx as usize));
-                        lemma_vaddr_of_eq_int::<C>(cont_i.path().push_tail(j as usize));
+                        lemma_vaddr_of_eq_int::<C>(cont_i.path().push_tail(cont_i.idx as int));
+                        lemma_vaddr_of_eq_int::<C>(cont_i.path().push_tail(j));
 
                         old_cont.as_subtree_inv();
                         old_cont.as_subtree_properties();

--- a/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/mapping_set_lemmas.rs
@@ -198,7 +198,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         other.as_subtree_properties();
     }
 
-    /// When a continuation has all_some and inv, its as_subtree() also has Node::inv().
+    /// When a continuation has all_some and inv, its as_subtree() also has `TreeNode::inv()`.
     proof fn as_subtree_inv(self)
         requires
             self.inv(),

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -893,9 +893,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.continuations[i].node_locked(guards1)
         } by {
             let cont_addr = self.continuations[i].guard.inner.inner@.ptr.addr();
-            assert(self.level - 1 <= i < NR_LEVELS);
-            assert(cont_addr != dropped_addr);
-            assert(self.continuations[i].node_locked(guards0));
             assert(guards0.guards.contains(cont_addr));
             assert(guards1.guards.contains(cont_addr));
         };
@@ -1063,7 +1060,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         assert(filtered.dom().contains(i));
         assert(filtered[i] == self.continuations[i]);
         assert(mapped.dom().contains(i));
-        assert(mapped[i] == self.continuations[i].view_mappings());
         assert(values.contains(mapped[i]));
         values.lemma_flatten_contains(m);
     }
@@ -1138,26 +1134,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             item.clone_requires(regions),
     {
         broadcast use crate::specs::mm::frame::meta_owners::axiom_mmio_usage_iff_mmio_paddr;
-        // Extract the frame-slot facts from metaregion_sound via path_metaregion_sound.
-
-        assert(self.path_metaregion_sound(regions));
-        assert(self.cur_entry_owner().metaregion_sound(regions));
         let entry = self.cur_entry_owner();
         let idx = frame_to_index(pa);
-        // Bridge `C::tracked(item)` to `usage != MMIO`: the entry's `is_tracked`
-        // is connected to its paddr's MMIO-ness by `axiom_frame_is_tracked_iff_not_mmio`,
-        // and `usage == MMIO` to the paddr by `axiom_mmio_usage_iff_mmio_paddr`.
         EntryOwner::<C>::axiom_frame_is_tracked_iff_not_mmio(entry);
-        assert(regions.slot_owners[idx].slot_vaddr == crate::specs::mm::frame::mapping::meta_addr(
-            idx,
-        ));
-        if C::tracked(item) {
-            assert(!crate::specs::mm::frame::meta_owners::is_mmio_paddr(pa));
-            assert(regions.slot_owners[idx].usage !is MMIO);
-            assert(regions.slot_owners[idx].inner_perms.ref_count.value() > 0);
-            assert(regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED);
-        }
-        // Now all preconditions of `C::clone_requires_concrete` are in scope.
 
         C::clone_requires_concrete(item, pa, level, prop, regions);
     }
@@ -1265,8 +1244,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         let path = new_subtree.value().path;
         let ps = page_size(level);
         let cont = self.continuations[self.level - 1];
-
-        cont.path().lemma_push_tail_len(cont.idx as int);
 
         // Bridge `nat_align_down(cur_va, ps) == vaddr_of::<C>(path) as Vaddr`:
         //   to_path_vaddr_concrete: vaddr(path) + va.leading_bits * 2^48 == nat_align_down(cur_va, ps)
@@ -2364,8 +2341,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         let pt_level = INC_LEVELS - path.len();
         let cont = self.continuations[self.level - 1];
 
-        cont.path().lemma_push_tail_len(cont.idx as int);
-
         let m = Mapping {
             va_range: Range {
                 start: vaddr_of::<C>(path) as int,
@@ -2867,8 +2842,6 @@ pub proof fn lemma_view_in_vaddr_range<'rcu, C: PageTableConfig>(owner: &CursorO
         cont.inv_children_rel_unroll(j);
         let child = PageTableOwner(cont.children[j].unwrap());
         let p = cont.path().push_tail(j);
-        cont.path().lemma_push_tail_len(j);
-        cont.path().lemma_push_tail_index(j);
         let pidx = p[0] as int;
         assert(start <= pidx < end) by {
             if i != NR_LEVELS - 1 {

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -2469,7 +2469,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     && #[trigger] cont.children[j] is Some implies cont.children[j].unwrap().subtree_satisfies(
             cont.path().push_tail(j), g) by {
                 cont.inv_children_unroll(j);
-                cont.children[j].unwrap().lemma_map_implies(cont.path().push_tail(j), f, g);
+                cont.children[j].unwrap().lemma_subtree_satisfies_implies(cont.path().push_tail(j), f, g);
             };
         };
         assert(other.path_metaregion_sound(regions1)) by {
@@ -2567,7 +2567,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
     }
 
     /// Transfers `metaregion_sound` when `raw_count` changed from 0 to 1 at one index.
-    /// Uses `lemma_map_implies_and` with the trivial `not_in_scope_pred`.
+    /// Uses `lemma_subtree_satisfies_implies_and` with the trivial `not_in_scope_pred`.
     pub proof fn metaregion_borrow_slot(
         self,
         regions0: MetaRegionOwners,
@@ -2648,7 +2648,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     && #[trigger] cont.children[j] is Some implies cont.children[j].unwrap().subtree_satisfies(
             cont.path().push_tail(j), g) by {
                 cont.inv_children_unroll(j);
-                cont.children[j].unwrap().lemma_map_implies_and(
+                cont.children[j].unwrap().lemma_subtree_satisfies_implies_and(
                     cont.path().push_tail(j),
                     f,
                     nsp,

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -187,7 +187,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         forall|i: int|
             #![trigger(self.children[i])]
             0 <= i < self.children.len() ==> self.children[i] is Some
-                ==> self.children[i]->0.tree_predicate_map(self.path().push_tail(i as usize), f)
+                ==> self.children[i]->0.subtree_satisfies(self.path().push_tail(i as usize), f)
     }
 
     // map_children_lift, map_children_lift_skip_idx, as_subtree_restore
@@ -2466,7 +2466,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             reveal(CursorContinuation::inv_children);
             assert forall|j: int|
                 0 <= j < NR_ENTRIES
-                    && #[trigger] cont.children[j] is Some implies cont.children[j].unwrap().tree_predicate_map(
+                    && #[trigger] cont.children[j] is Some implies cont.children[j].unwrap().subtree_satisfies(
             cont.path().push_tail(j as usize), g) by {
                 cont.inv_children_unroll(j);
                 cont.children[j].unwrap().lemma_map_implies(cont.path().push_tail(j as usize), f, g);
@@ -2635,7 +2635,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             reveal(CursorContinuation::inv_children);
             assert forall|j: int|
                 0 <= j < NR_ENTRIES
-                    && #[trigger] cont.children[j] is Some implies cont.children[j].unwrap().tree_predicate_map(
+                    && #[trigger] cont.children[j] is Some implies cont.children[j].unwrap().subtree_satisfies(
             cont.path().push_tail(j as usize), nsp) by {
                 cont.inv_children_unroll(j);
                 PageTableOwner::tree_not_in_scope(
@@ -2645,7 +2645,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             };
             assert forall|j: int|
                 0 <= j < NR_ENTRIES
-                    && #[trigger] cont.children[j] is Some implies cont.children[j].unwrap().tree_predicate_map(
+                    && #[trigger] cont.children[j] is Some implies cont.children[j].unwrap().subtree_satisfies(
             cont.path().push_tail(j as usize), g) by {
                 cont.inv_children_unroll(j);
                 cont.children[j].unwrap().lemma_map_implies_and(
@@ -2679,7 +2679,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
     ///
     /// ## Justification
     /// When the cursor descends into a subtree, each continuation's `entry_own`
-    /// was previously checked by `tree_predicate_map` in the parent's child
+    /// was previously checked by `subtree_satisfies` in the parent's child
     /// subtree.  After descent, `map_full_tree` only covers the siblings (the
     /// taken child is `None`), so the path entries' properties are no longer
     /// covered by `map_full_tree`.  However, `regions` is unchanged since

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -1134,6 +1134,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             item.clone_requires(regions),
     {
         broadcast use crate::specs::mm::frame::meta_owners::axiom_mmio_usage_iff_mmio_paddr;
+
         let entry = self.cur_entry_owner();
         let idx = frame_to_index(pa);
         EntryOwner::<C>::axiom_frame_is_tracked_iff_not_mmio(entry);
@@ -2418,7 +2419,11 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     && #[trigger] cont.children[j] is Some implies cont.children[j].unwrap().subtree_satisfies(
             cont.path().push_tail(j), g) by {
                 cont.inv_children_unroll(j);
-                cont.children[j].unwrap().lemma_subtree_satisfies_implies(cont.path().push_tail(j), f, g);
+                cont.children[j].unwrap().lemma_subtree_satisfies_implies(
+                    cont.path().push_tail(j),
+                    f,
+                    g,
+                );
             };
         };
         assert(other.path_metaregion_sound(regions1)) by {
@@ -2978,8 +2983,8 @@ pub proof fn lemma_view_in_vaddr_range_kernel<'rcu>(owner: CursorOwner<'rcu, Ker
         }
         child.view_rec_top_index_va_bound(p, m, end);
         // m.start ≥ index(0)·2^39 + lb·2^48 ≥ start·2^39 + lb·2^48 = bound.0.
-        assert(p[0] * 0x80_0000_0000int + lb * 0x1_0000_0000_0000int >= start
-            * 0x80_0000_0000int + lb * 0x1_0000_0000_0000int) by (nonlinear_arith)
+        assert(p[0] * 0x80_0000_0000int + lb * 0x1_0000_0000_0000int >= start * 0x80_0000_0000int
+            + lb * 0x1_0000_0000_0000int) by (nonlinear_arith)
             requires
                 start <= p[0],
         ;

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -1279,7 +1279,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.va.to_path_len(self.level - 1);
             self.va.to_path_inv(self.level - 1);
             self.cur_subtree_inv();
-            assert forall|i: int| 0 <= i < path.len() implies path.index(i) == va_path.index(i) by {
+            assert forall|i: int| 0 <= i < path.len() implies path[i] == va_path[i] by {
                 self.va.to_path_index(self.level - 1, i);
                 if self.level == 4 {
                     cont.path().lemma_push_tail_index(cont.idx as int);
@@ -2895,10 +2895,10 @@ pub proof fn lemma_view_in_vaddr_range<'rcu, C: PageTableConfig>(owner: &CursorO
         let p = cont.path().push_tail(j);
         cont.path().lemma_push_tail_len(j);
         cont.path().lemma_push_tail_index(j);
-        let pidx = p.index(0) as int;
+        let pidx = p[0] as int;
         assert(start <= pidx < end) by {
             if i != NR_LEVELS - 1 {
-                assert(cont.path().index(0) == owner.continuations[NR_LEVELS - 1].idx) by {
+                assert(cont.path()[0] == owner.continuations[NR_LEVELS - 1].idx) by {
                     owner.inv_continuation(NR_LEVELS - 1);
                     owner.continuations[NR_LEVELS - 1].path().lemma_push_tail_index(
                         owner.continuations[NR_LEVELS - 1].idx as int,
@@ -2970,24 +2970,24 @@ pub proof fn lemma_view_in_vaddr_range_user<'rcu>(
         let child = PageTableOwner(cont.children[j].unwrap());
         let p = cont.path().push_tail(j);
         cont.path().lemma_push_tail_index(j);
-        assert(0 <= p.index(0) < end) by {
+        assert(0 <= p[0] < end) by {
             if i == NR_LEVELS - 1 {
                 // Root continuation: `p == [j]`. A contributing child is a
                 // frame/node (borrowed/absent give an empty `view_rec`), hence
                 // neither borrowed nor absent; the cursor-inv top-level clause
                 // then forces `j ∈ [0, 256)`.
                 assert(cont.path().len() == 0);
-                assert(p.index(0) == j);
+                assert(p[0] == j);
                 assert(child.0.value().is_frame() || child.0.value().is_node());
                 assert(!child.0.value().is_borrowed());
                 assert(!child.0.value().is_absent());
             } else {
-                // Non-root continuation: `p.index(0) == cont.path().index(0)`,
+                // Non-root continuation: `p[0] == cont.path()[0]`,
                 // which (via the inv path chain) equals the root continuation's
                 // descended index, in `[0, 256)` by the cursor-inv idx clause.
                 assert(cont.path().len() > 0);
-                assert(p.index(0) == cont.path().index(0));
-                assert(cont.path().index(0) == owner.continuations[NR_LEVELS - 1].idx) by {
+                assert(p[0] == cont.path()[0]);
+                assert(cont.path()[0] == owner.continuations[NR_LEVELS - 1].idx) by {
                     owner.inv_continuation(NR_LEVELS - 1);
                     owner.continuations[NR_LEVELS - 1].path().lemma_push_tail_index(
                         owner.continuations[NR_LEVELS - 1].idx as int,
@@ -3063,12 +3063,12 @@ pub proof fn lemma_view_in_vaddr_range_kernel<'rcu>(owner: CursorOwner<'rcu, Ker
         let child = PageTableOwner(cont.children[j].unwrap());
         let p = cont.path().push_tail(j);
         cont.path().lemma_push_tail_index(j);
-        assert(start <= p.index(0) < end) by {
+        assert(start <= p[0] < end) by {
             if i == NR_LEVELS - 1 {
             } else {
-                // Non-root: `p.index(0) == cont.path().index(0) == root.idx ∈
+                // Non-root: `p[0] == cont.path()[0] == root.idx ∈
                 // [256, 512)` (path chain + cursor-inv idx clause).
-                assert(cont.path().index(0) == owner.continuations[NR_LEVELS - 1].idx) by {
+                assert(cont.path()[0] == owner.continuations[NR_LEVELS - 1].idx) by {
                     owner.inv_continuation(NR_LEVELS - 1);
                     owner.continuations[NR_LEVELS - 1].path().lemma_push_tail_index(
                         owner.continuations[NR_LEVELS - 1].idx as int,
@@ -3091,10 +3091,10 @@ pub proof fn lemma_view_in_vaddr_range_kernel<'rcu>(owner: CursorOwner<'rcu, Ker
         }
         child.view_rec_top_index_va_bound(p, m, end);
         // m.start ≥ index(0)·2^39 + lb·2^48 ≥ start·2^39 + lb·2^48 = bound.0.
-        assert(p.index(0) * 0x80_0000_0000int + lb * 0x1_0000_0000_0000int >= start
+        assert(p[0] * 0x80_0000_0000int + lb * 0x1_0000_0000_0000int >= start
             * 0x80_0000_0000int + lb * 0x1_0000_0000_0000int) by (nonlinear_arith)
             requires
-                start <= p.index(0),
+                start <= p[0],
         ;
     }
 }

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -2847,22 +2847,6 @@ pub proof fn lemma_view_in_vaddr_range<'rcu, C: PageTableConfig>(owner: &CursorO
             if i != NR_LEVELS - 1 {
                 assert(cont.path()[0] == owner.continuations[NR_LEVELS - 1].idx) by {
                     owner.inv_continuation(NR_LEVELS - 1);
-                    owner.continuations[NR_LEVELS - 1].path().lemma_push_tail_index(
-                        owner.continuations[NR_LEVELS - 1].idx as int,
-                    );
-                    if i == 2 {
-                    } else if i == 1 {
-                        owner.continuations[2].path().lemma_push_tail_index(
-                            owner.continuations[2].idx as int,
-                        );
-                    } else {
-                        owner.continuations[2].path().lemma_push_tail_index(
-                            owner.continuations[2].idx as int,
-                        );
-                        owner.continuations[1].path().lemma_push_tail_index(
-                            owner.continuations[1].idx as int,
-                        );
-                    }
                 }
             }
         }
@@ -2916,14 +2900,12 @@ pub proof fn lemma_view_in_vaddr_range_user<'rcu>(
         cont.inv_children_rel_unroll(j);
         let child = PageTableOwner(cont.children[j].unwrap());
         let p = cont.path().push_tail(j);
-        cont.path().lemma_push_tail_index(j);
         assert(0 <= p[0] < end) by {
             if i == NR_LEVELS - 1 {
             } else {
                 // Non-root continuation: `p[0] == cont.path()[0]`,
                 // which (via the inv path chain) equals the root continuation's
                 // descended index, in `[0, 256)` by the cursor-inv idx clause.
-                assert(cont.path().len() > 0);
                 assert(p[0] == cont.path()[0]);
                 assert(cont.path()[0] == owner.continuations[NR_LEVELS - 1].idx) by {
                     owner.inv_continuation(NR_LEVELS - 1);
@@ -2984,7 +2966,6 @@ pub proof fn lemma_view_in_vaddr_range_kernel<'rcu>(owner: CursorOwner<'rcu, Ker
         cont.inv_children_rel_unroll(j);
         let child = PageTableOwner(cont.children[j].unwrap());
         let p = cont.path().push_tail(j);
-        cont.path().lemma_push_tail_index(j);
         assert(start <= p[0] < end) by {
             if i == NR_LEVELS - 1 {
             } else {

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -41,6 +41,8 @@ use crate::specs::task::InAtomicMode;
 
 verus! {
 
+broadcast use group_ghost_tree_lemmas;
+
 pub tracked struct CursorContinuation<'rcu, C: PageTableConfig> {
     pub entry_own: EntryOwner<C>,
     pub ghost idx: usize,

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -116,10 +116,10 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
 
     pub open spec fn make_cont(self, idx: usize, guard: PageTableGuard<'rcu, C>) -> (Self, Self) {
         let child = Self {
-            entry_own: self.children[self.idx as int]->0.value,
+            entry_own: self.children[self.idx as int]->0.value(),
             tree_level: (self.tree_level + 1) as nat,
             idx: idx,
-            children: self.children[self.idx as int]->0.children,
+            children: self.children[self.idx as int]->0.children(),
             path: self.path.push_tail(self.idx as usize),
             guard: guard,
         };
@@ -142,11 +142,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
     ;
 
     pub open spec fn restore(self, child: Self) -> (Self, PageTableGuard<'rcu, C>) {
-        let child_node = OwnerSubtree {
-            value: child.entry_own,
-            level: child.tree_level,
-            children: child.children,
-        };
+        let child_node = OwnerSubtree::new(child.entry_own, child.tree_level, child.children);
         (
             Self { children: self.children.update(self.idx as int, Some(child_node)), ..self },
             child.guard,
@@ -166,10 +162,10 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         guard: PageTableGuard<'rcu, C>,
     ) -> Self {
         Self {
-            entry_own: owner_subtree.value,
+            entry_own: owner_subtree.value(),
             idx: idx,
-            tree_level: owner_subtree.level,
-            children: owner_subtree.children,
+            tree_level: owner_subtree.level(),
+            children: owner_subtree.children(),
             path: TreePath::new(Seq::empty()),
             guard: guard,
         }
@@ -237,14 +233,14 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         |i: int, child: Option<OwnerSubtree<C>>|
             {
                 child is Some ==> {
-                    &&& child->0.value.parent_level == self.level()
-                    &&& child->0.level == self.tree_level + 1
-                    &&& child->0.value.path.len() == self.entry_own.node().tree_level + 1
-                    &&& child->0.value.match_pte(
+                    &&& child->0.value().parent_level == self.level()
+                    &&& child->0.level() == self.tree_level + 1
+                    &&& child->0.value().path.len() == self.entry_own.node().tree_level + 1
+                    &&& child->0.value().match_pte(
                         self.entry_own.node().children_perm.value()[i],
                         self.entry_own.node().level,
                     )
-                    &&& child->0.value.path == self.path().push_tail(i as usize)
+                    &&& child->0.value().path == self.path().push_tail(i as usize)
                 }
             }
     }
@@ -278,14 +274,14 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             0 <= i < self.children.len(),
             self.children[i] is Some,
         ensures
-            self.children[i]->0.value.parent_level == self.level(),
-            self.children[i]->0.level == self.tree_level + 1,
-            self.children[i]->0.value.path.len() == self.entry_own.node().tree_level + 1,
-            self.children[i]->0.value.match_pte(
+            self.children[i]->0.value().parent_level == self.level(),
+            self.children[i]->0.level() == self.tree_level + 1,
+            self.children[i]->0.value().path.len() == self.entry_own.node().tree_level + 1,
+            self.children[i]->0.value().match_pte(
                 self.entry_own.node().children_perm.value()[i],
                 self.entry_own.node().level,
             ),
-            self.children[i]->0.value.path == self.path().push_tail(i as usize),
+            self.children[i]->0.value().path == self.path().push_tail(i as usize),
     {
         lemma_forall_seq_index(self.children, self.inv_children_rel_pred(), i);
     }
@@ -411,7 +407,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
     }
 
     pub open spec fn as_subtree(self) -> OwnerSubtree<C> {
-        OwnerSubtree { value: self.entry_own, level: self.tree_level, children: self.children }
+        OwnerSubtree::new(self.entry_own, self.tree_level, self.children)
     }
 
     pub open spec fn as_page_table_owner(self) -> PageTableOwner<C> {
@@ -517,14 +513,14 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             // The new child at idx is well-formed
             self.children[self.idx as int] is Some,
             self.children[self.idx as int]->0.inv(),
-            self.children[self.idx as int]->0.value.parent_level == self.level(),
-            self.children[self.idx as int]->0.value.path == self.path().push_tail(
+            self.children[self.idx as int]->0.value().parent_level == self.level(),
+            self.children[self.idx as int]->0.value().path == self.path().push_tail(
                 self.idx as usize,
             ),
-            self.children[self.idx as int]->0.level == self.tree_level + 1,
-            self.children[self.idx as int]->0.value.path.len() == self.entry_own.node().tree_level
+            self.children[self.idx as int]->0.level() == self.tree_level + 1,
+            self.children[self.idx as int]->0.value().path.len() == self.entry_own.node().tree_level
                 + 1,
-            self.children[self.idx as int]->0.value.match_pte(
+            self.children[self.idx as int]->0.value().match_pte(
                 self.entry_own.node().children_perm.value()[self.idx as int],
                 self.entry_own.node().level,
             ),
@@ -558,7 +554,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             final(regions).slot_owners == old(regions).slot_owners,
             final(regions).slots == old(regions).slots,
             // Allocating a child doesn't touch the segment obligation ledger.
-            res.value == EntryOwner::<C>::new_frame(
+            res.value() == EntryOwner::<C>::new_frame(
                 paddr,
                 self.path().push_tail(self.idx as usize),
                 self.level(),
@@ -566,8 +562,8 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
                 is_tracked,
             ),
             res.inv(),
-            res.level == self.tree_level + 1,
-            res == OwnerSubtree::new_val(res.value, res.level as nat),
+            res.level() == self.tree_level + 1,
+            res == OwnerSubtree::new_val(res.value(), res.level() as nat),
     {
         let tracked mut owner = EntryOwner::<C>::tracked_new_frame(
             paddr,
@@ -576,7 +572,10 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             prop,
             is_tracked,
         );
-        OwnerSubtree::new_val_tracked(owner, self.tree_level + 1)
+        let ghost owner_spec = owner;
+        let tracked res = OwnerSubtree::tracked_new_val(owner, self.tree_level + 1);
+        res.lemma_new_val_properties(owner_spec, self.tree_level + 1);
+        res
     }
 
     pub broadcast group group_lemmas {
@@ -640,8 +639,8 @@ impl<'rcu, C: PageTableConfig> Inv for CursorOwner<'rcu, C> {
             0 <= j < NR_ENTRIES && !(C::TOP_LEVEL_INDEX_RANGE().start <= j
                 < C::TOP_LEVEL_INDEX_RANGE().end) ==> self.continuations[NR_LEVELS
                 - 1].children[j] is Some ==> (self.continuations[NR_LEVELS
-                - 1].children[j].unwrap().value.is_borrowed() || self.continuations[NR_LEVELS
-                - 1].children[j].unwrap().value.is_absent())
+                - 1].children[j].unwrap().value().is_borrowed() || self.continuations[NR_LEVELS
+                - 1].children[j].unwrap().value().is_absent())
         &&& self.prefix.inv()
         &&& self.prefix.offset == 0
         &&& forall|i: int|
@@ -1091,7 +1090,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
     }
 
     pub open spec fn cur_entry_owner(self) -> EntryOwner<C> {
-        self.cur_subtree().value
+        self.cur_subtree().value()
     }
 
     pub open spec fn cur_subtree(self) -> OwnerSubtree<C> {
@@ -1247,12 +1246,12 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.in_locked_range(),
             level == self.level,
             new_subtree.inv(),
-            new_subtree.value.is_frame(),
-            new_subtree.value.path == self.continuations[self.level - 1].path().push_tail(
+            new_subtree.value().is_frame(),
+            new_subtree.value().path == self.continuations[self.level - 1].path().push_tail(
                 self.continuations[self.level - 1].idx as usize,
             ),
-            new_subtree.value.frame().mapped_pa == pa,
-            new_subtree.value.frame().prop == prop,
+            new_subtree.value().frame().mapped_pa == pa,
+            new_subtree.value().frame().prop == prop,
         ensures
             PageTableOwner(new_subtree)@.mappings
                 == set![Mapping {
@@ -1262,11 +1261,11 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 property: prop,
             }],
     {
-        let path = new_subtree.value.path;
+        let path = new_subtree.value().path;
         let ps = page_size(level);
         let cont = self.continuations[self.level - 1];
 
-        cont.path().push_tail_property_len(cont.idx as usize);
+        cont.path().lemma_push_tail_len(cont.idx as usize);
 
         // Bridge `nat_align_down(cur_va, ps) == vaddr_of::<C>(path) as Vaddr`:
         //   to_path_vaddr_concrete: vaddr(path) + va.leading_bits * 2^48 == nat_align_down(cur_va, ps)
@@ -1283,29 +1282,29 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             assert forall|i: int| 0 <= i < path.len() implies path.index(i) == va_path.index(i) by {
                 self.va.to_path_index(self.level - 1, i);
                 if self.level == 4 {
-                    cont.path().push_tail_property_index(cont.idx as usize);
+                    cont.path().lemma_push_tail_index(cont.idx as usize);
                 } else if self.level == 3 {
-                    cont.path().push_tail_property_index(cont.idx as usize);
-                    self.continuations[3].path().push_tail_property_index(
+                    cont.path().lemma_push_tail_index(cont.idx as usize);
+                    self.continuations[3].path().lemma_push_tail_index(
                         self.continuations[3].idx as usize,
                     );
                 } else if self.level == 2 {
-                    cont.path().push_tail_property_index(cont.idx as usize);
-                    self.continuations[2].path().push_tail_property_index(
+                    cont.path().lemma_push_tail_index(cont.idx as usize);
+                    self.continuations[2].path().lemma_push_tail_index(
                         self.continuations[2].idx as usize,
                     );
-                    self.continuations[3].path().push_tail_property_index(
+                    self.continuations[3].path().lemma_push_tail_index(
                         self.continuations[3].idx as usize,
                     );
                 } else {
-                    cont.path().push_tail_property_index(cont.idx as usize);
-                    self.continuations[1].path().push_tail_property_index(
+                    cont.path().lemma_push_tail_index(cont.idx as usize);
+                    self.continuations[1].path().lemma_push_tail_index(
                         self.continuations[1].idx as usize,
                     );
-                    self.continuations[2].path().push_tail_property_index(
+                    self.continuations[2].path().lemma_push_tail_index(
                         self.continuations[2].idx as usize,
                     );
-                    self.continuations[3].path().push_tail_property_index(
+                    self.continuations[3].path().lemma_push_tail_index(
                         self.continuations[3].idx as usize,
                     );
                 }
@@ -2316,7 +2315,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         self.cur_subtree_inv();
         let cur_va = self.cur_va();
         let cur_subtree = self.cur_subtree();
-        let cur_path = cur_subtree.value.path;
+        let cur_path = cur_subtree.value().path;
         PageTableOwner(cur_subtree).view_rec_absent_empty(cur_path);
 
         assert forall|m: Mapping| self.view_mappings().contains(m) implies !(m.va_range.start
@@ -2343,7 +2342,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         requires
             self.inv(),
             self.in_locked_range(),
-            PageTableOwner(self.cur_subtree()).view_rec(self.cur_subtree().value.path) =~= set![],
+            PageTableOwner(self.cur_subtree()).view_rec(self.cur_subtree().value().path) =~= set![],
         ensures
             !self@.present(),
     {
@@ -2386,12 +2385,12 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         self.cur_va_in_subtree_range();
         self.view_preserves_inv();
         let subtree = self.cur_subtree();
-        let path = subtree.value.path;
+        let path = subtree.value().path;
         let frame = self.cur_entry_owner().frame();
         let pt_level = INC_LEVELS - path.len();
         let cont = self.continuations[self.level - 1];
 
-        cont.path().push_tail_property_len(cont.idx as usize);
+        cont.path().lemma_push_tail_len(cont.idx as usize);
 
         let m = Mapping {
             va_range: Range {
@@ -2470,7 +2469,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     && #[trigger] cont.children[j] is Some implies cont.children[j].unwrap().tree_predicate_map(
             cont.path().push_tail(j as usize), g) by {
                 cont.inv_children_unroll(j);
-                cont.children[j].unwrap().map_implies(cont.path().push_tail(j as usize), f, g);
+                cont.children[j].unwrap().lemma_map_implies(cont.path().push_tail(j as usize), f, g);
             };
         };
         assert(other.path_metaregion_sound(regions1)) by {
@@ -2568,7 +2567,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
     }
 
     /// Transfers `metaregion_sound` when `raw_count` changed from 0 to 1 at one index.
-    /// Uses `map_implies_and` with the trivial `not_in_scope_pred`.
+    /// Uses `lemma_map_implies_and` with the trivial `not_in_scope_pred`.
     pub proof fn metaregion_borrow_slot(
         self,
         regions0: MetaRegionOwners,
@@ -2649,7 +2648,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     && #[trigger] cont.children[j] is Some implies cont.children[j].unwrap().tree_predicate_map(
             cont.path().push_tail(j as usize), g) by {
                 cont.inv_children_unroll(j);
-                cont.children[j].unwrap().map_implies_and(
+                cont.children[j].unwrap().lemma_map_implies_and(
                     cont.path().push_tail(j as usize),
                     f,
                     nsp,
@@ -2894,26 +2893,26 @@ pub proof fn lemma_view_in_vaddr_range<'rcu, C: PageTableConfig>(owner: &CursorO
         cont.inv_children_rel_unroll(j);
         let child = PageTableOwner(cont.children[j].unwrap());
         let p = cont.path().push_tail(j as usize);
-        cont.path().push_tail_property_len(j as usize);
-        cont.path().push_tail_property_index(j as usize);
+        cont.path().lemma_push_tail_len(j as usize);
+        cont.path().lemma_push_tail_index(j as usize);
         let pidx = p.index(0) as int;
         assert(start <= pidx < end) by {
             if i != NR_LEVELS - 1 {
                 assert(cont.path().index(0) == owner.continuations[NR_LEVELS - 1].idx) by {
                     owner.inv_continuation(NR_LEVELS - 1);
-                    owner.continuations[NR_LEVELS - 1].path().push_tail_property_index(
+                    owner.continuations[NR_LEVELS - 1].path().lemma_push_tail_index(
                         owner.continuations[NR_LEVELS - 1].idx,
                     );
                     if i == 2 {
                     } else if i == 1 {
-                        owner.continuations[2].path().push_tail_property_index(
+                        owner.continuations[2].path().lemma_push_tail_index(
                             owner.continuations[2].idx,
                         );
                     } else {
-                        owner.continuations[2].path().push_tail_property_index(
+                        owner.continuations[2].path().lemma_push_tail_index(
                             owner.continuations[2].idx,
                         );
-                        owner.continuations[1].path().push_tail_property_index(
+                        owner.continuations[1].path().lemma_push_tail_index(
                             owner.continuations[1].idx,
                         );
                     }
@@ -2970,7 +2969,7 @@ pub proof fn lemma_view_in_vaddr_range_user<'rcu>(
         cont.inv_children_rel_unroll(j);
         let child = PageTableOwner(cont.children[j].unwrap());
         let p = cont.path().push_tail(j as usize);
-        cont.path().push_tail_property_index(j as usize);
+        cont.path().lemma_push_tail_index(j as usize);
         assert(0 <= p.index(0) < end) by {
             if i == NR_LEVELS - 1 {
                 // Root continuation: `p == [j]`. A contributing child is a
@@ -2979,9 +2978,9 @@ pub proof fn lemma_view_in_vaddr_range_user<'rcu>(
                 // then forces `j ∈ [0, 256)`.
                 assert(cont.path().len() == 0);
                 assert(p.index(0) == j);
-                assert(child.0.value.is_frame() || child.0.value.is_node());
-                assert(!child.0.value.is_borrowed());
-                assert(!child.0.value.is_absent());
+                assert(child.0.value().is_frame() || child.0.value().is_node());
+                assert(!child.0.value().is_borrowed());
+                assert(!child.0.value().is_absent());
             } else {
                 // Non-root continuation: `p.index(0) == cont.path().index(0)`,
                 // which (via the inv path chain) equals the root continuation's
@@ -2990,19 +2989,19 @@ pub proof fn lemma_view_in_vaddr_range_user<'rcu>(
                 assert(p.index(0) == cont.path().index(0));
                 assert(cont.path().index(0) == owner.continuations[NR_LEVELS - 1].idx) by {
                     owner.inv_continuation(NR_LEVELS - 1);
-                    owner.continuations[NR_LEVELS - 1].path().push_tail_property_index(
+                    owner.continuations[NR_LEVELS - 1].path().lemma_push_tail_index(
                         owner.continuations[NR_LEVELS - 1].idx,
                     );
                     if i == 2 {
                     } else if i == 1 {
-                        owner.continuations[2].path().push_tail_property_index(
+                        owner.continuations[2].path().lemma_push_tail_index(
                             owner.continuations[2].idx,
                         );
                     } else {
-                        owner.continuations[2].path().push_tail_property_index(
+                        owner.continuations[2].path().lemma_push_tail_index(
                             owner.continuations[2].idx,
                         );
-                        owner.continuations[1].path().push_tail_property_index(
+                        owner.continuations[1].path().lemma_push_tail_index(
                             owner.continuations[1].idx,
                         );
                     }
@@ -3063,7 +3062,7 @@ pub proof fn lemma_view_in_vaddr_range_kernel<'rcu>(owner: CursorOwner<'rcu, Ker
         cont.inv_children_rel_unroll(j);
         let child = PageTableOwner(cont.children[j].unwrap());
         let p = cont.path().push_tail(j as usize);
-        cont.path().push_tail_property_index(j as usize);
+        cont.path().lemma_push_tail_index(j as usize);
         assert(start <= p.index(0) < end) by {
             if i == NR_LEVELS - 1 {
             } else {
@@ -3071,19 +3070,19 @@ pub proof fn lemma_view_in_vaddr_range_kernel<'rcu>(owner: CursorOwner<'rcu, Ker
                 // [256, 512)` (path chain + cursor-inv idx clause).
                 assert(cont.path().index(0) == owner.continuations[NR_LEVELS - 1].idx) by {
                     owner.inv_continuation(NR_LEVELS - 1);
-                    owner.continuations[NR_LEVELS - 1].path().push_tail_property_index(
+                    owner.continuations[NR_LEVELS - 1].path().lemma_push_tail_index(
                         owner.continuations[NR_LEVELS - 1].idx,
                     );
                     if i == 2 {
                     } else if i == 1 {
-                        owner.continuations[2].path().push_tail_property_index(
+                        owner.continuations[2].path().lemma_push_tail_index(
                             owner.continuations[2].idx,
                         );
                     } else {
-                        owner.continuations[2].path().push_tail_property_index(
+                        owner.continuations[2].path().lemma_push_tail_index(
                             owner.continuations[2].idx,
                         );
-                        owner.continuations[1].path().push_tail_property_index(
+                        owner.continuations[1].path().lemma_push_tail_index(
                             owner.continuations[1].idx,
                         );
                     }

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -1282,33 +1282,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.cur_subtree_inv();
             assert forall|i: int| 0 <= i < path.len() implies path[i] == va_path[i] by {
                 self.va.to_path_index(self.level - 1, i);
-                if self.level == 4 {
-                    cont.path().lemma_push_tail_index(cont.idx as int);
-                } else if self.level == 3 {
-                    cont.path().lemma_push_tail_index(cont.idx as int);
-                    self.continuations[3].path().lemma_push_tail_index(
-                        self.continuations[3].idx as int,
-                    );
-                } else if self.level == 2 {
-                    cont.path().lemma_push_tail_index(cont.idx as int);
-                    self.continuations[2].path().lemma_push_tail_index(
-                        self.continuations[2].idx as int,
-                    );
-                    self.continuations[3].path().lemma_push_tail_index(
-                        self.continuations[3].idx as int,
-                    );
-                } else {
-                    cont.path().lemma_push_tail_index(cont.idx as int);
-                    self.continuations[1].path().lemma_push_tail_index(
-                        self.continuations[1].idx as int,
-                    );
-                    self.continuations[2].path().lemma_push_tail_index(
-                        self.continuations[2].idx as int,
-                    );
-                    self.continuations[3].path().lemma_push_tail_index(
-                        self.continuations[3].idx as int,
-                    );
-                }
             };
             AbstractVaddr::rec_vaddr_eq_if_indices_eq(path, va_path, 0);
         };
@@ -2973,15 +2946,6 @@ pub proof fn lemma_view_in_vaddr_range_user<'rcu>(
         cont.path().lemma_push_tail_index(j);
         assert(0 <= p[0] < end) by {
             if i == NR_LEVELS - 1 {
-                // Root continuation: `p == [j]`. A contributing child is a
-                // frame/node (borrowed/absent give an empty `view_rec`), hence
-                // neither borrowed nor absent; the cursor-inv top-level clause
-                // then forces `j ∈ [0, 256)`.
-                assert(cont.path().len() == 0);
-                assert(p[0] == j);
-                assert(child.0.value().is_frame() || child.0.value().is_node());
-                assert(!child.0.value().is_borrowed());
-                assert(!child.0.value().is_absent());
             } else {
                 // Non-root continuation: `p[0] == cont.path()[0]`,
                 // which (via the inv path chain) equals the root continuation's
@@ -2990,22 +2954,6 @@ pub proof fn lemma_view_in_vaddr_range_user<'rcu>(
                 assert(p[0] == cont.path()[0]);
                 assert(cont.path()[0] == owner.continuations[NR_LEVELS - 1].idx) by {
                     owner.inv_continuation(NR_LEVELS - 1);
-                    owner.continuations[NR_LEVELS - 1].path().lemma_push_tail_index(
-                        owner.continuations[NR_LEVELS - 1].idx as int,
-                    );
-                    if i == 2 {
-                    } else if i == 1 {
-                        owner.continuations[2].path().lemma_push_tail_index(
-                            owner.continuations[2].idx as int,
-                        );
-                    } else {
-                        owner.continuations[2].path().lemma_push_tail_index(
-                            owner.continuations[2].idx as int,
-                        );
-                        owner.continuations[1].path().lemma_push_tail_index(
-                            owner.continuations[1].idx as int,
-                        );
-                    }
                 }
             }
         }
@@ -3071,22 +3019,6 @@ pub proof fn lemma_view_in_vaddr_range_kernel<'rcu>(owner: CursorOwner<'rcu, Ker
                 // [256, 512)` (path chain + cursor-inv idx clause).
                 assert(cont.path()[0] == owner.continuations[NR_LEVELS - 1].idx) by {
                     owner.inv_continuation(NR_LEVELS - 1);
-                    owner.continuations[NR_LEVELS - 1].path().lemma_push_tail_index(
-                        owner.continuations[NR_LEVELS - 1].idx as int,
-                    );
-                    if i == 2 {
-                    } else if i == 1 {
-                        owner.continuations[2].path().lemma_push_tail_index(
-                            owner.continuations[2].idx as int,
-                        );
-                    } else {
-                        owner.continuations[2].path().lemma_push_tail_index(
-                            owner.continuations[2].idx as int,
-                        );
-                        owner.continuations[1].path().lemma_push_tail_index(
-                            owner.continuations[1].idx as int,
-                        );
-                    }
                 }
             }
         }

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -120,7 +120,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             tree_level: (self.tree_level + 1) as nat,
             idx: idx,
             children: self.children[self.idx as int]->0.children(),
-            path: self.path.push_tail(self.idx as usize),
+            path: self.path.push_tail(self.idx as int),
             guard: guard,
         };
         let cont = Self { children: self.children.update(self.idx as int, None), ..self };
@@ -187,7 +187,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         forall|i: int|
             #![trigger(self.children[i])]
             0 <= i < self.children.len() ==> self.children[i] is Some
-                ==> self.children[i]->0.subtree_satisfies(self.path().push_tail(i as usize), f)
+                ==> self.children[i]->0.subtree_satisfies(self.path().push_tail(i), f)
     }
 
     // map_children_lift, map_children_lift_skip_idx, as_subtree_restore
@@ -240,7 +240,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
                         self.entry_own.node().children_perm.value()[i],
                         self.entry_own.node().level,
                     )
-                    &&& child->0.value().path == self.path().push_tail(i as usize)
+                    &&& child->0.value().path == self.path().push_tail(i)
                 }
             }
     }
@@ -281,7 +281,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
                 self.entry_own.node().children_perm.value()[i],
                 self.entry_own.node().level,
             ),
-            self.children[i]->0.value().path == self.path().push_tail(i as usize),
+            self.children[i]->0.value().path == self.path().push_tail(i),
     {
         lemma_forall_seq_index(self.children, self.inv_children_rel_pred(), i);
     }
@@ -331,7 +331,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         self.children.map(
             |i, child: Option<OwnerSubtree<C>>|
                 if child is Some {
-                    PageTableOwner(child->0).view_rec(self.path().push_tail(i as usize))
+                    PageTableOwner(child->0).view_rec(self.path().push_tail(i))
                 } else {
                     Set::empty()
                 },
@@ -346,7 +346,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
                     #![trigger self.children[i]]
                     0 <= i < self.children.len() && self.children[i] is Some && PageTableOwner(
                         self.children[i]->0,
-                    ).view_rec(self.path().push_tail(i as usize)).contains(m),
+                    ).view_rec(self.path().push_tail(i)).contains(m),
     {
         broadcast use vstd::seq_lib::group_seq_properties;
 
@@ -354,11 +354,11 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             #![trigger self.children[i]]
             0 <= i < self.children.len() && self.children[i] is Some && PageTableOwner(
                 self.children[i]->0,
-            ).view_rec(self.path().push_tail(i as usize)).contains(m) by {
+            ).view_rec(self.path().push_tail(i)).contains(m) by {
             let mapped = self.children.map(
                 |i, child: Option<OwnerSubtree<C>>|
                     if child is Some {
-                        PageTableOwner(child->0).view_rec(self.path().push_tail(i as usize))
+                        PageTableOwner(child->0).view_rec(self.path().push_tail(i))
                     } else {
                         Set::empty()
                     },
@@ -371,7 +371,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             let i = mapped.lemma_contains_to_index(elem_s);
             if self.children[i] is Some {
                 assert(mapped[i] == PageTableOwner(self.children[i]->0).view_rec(
-                    self.path().push_tail(i as usize),
+                    self.path().push_tail(i),
                 ));
             } else {
                 assert(mapped[i] == Set::<Mapping>::empty());
@@ -385,7 +385,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             0 <= i < self.children.len(),
             self.children[i] is Some,
             #[trigger] PageTableOwner(self.children[i]->0).view_rec(
-                self.path().push_tail(i as usize),
+                self.path().push_tail(i),
             ).contains(m),
         ensures
             self.view_mappings().contains(m),
@@ -395,7 +395,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         let mapped = self.children.map(
             |i, child: Option<OwnerSubtree<C>>|
                 if child is Some {
-                    PageTableOwner(child->0).view_rec(self.path().push_tail(i as usize))
+                    PageTableOwner(child->0).view_rec(self.path().push_tail(i))
                 } else {
                     Set::empty()
                 },
@@ -416,7 +416,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
 
     pub open spec fn view_mappings_take_child_spec(self) -> Set<Mapping> {
         PageTableOwner(self.children[self.idx as int]->0).view_rec(
-            self.path().push_tail(self.idx as usize),
+            self.path().push_tail(self.idx as int),
         )
     }
 
@@ -444,7 +444,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             entry.idx == idx,
             entry_own.is_node(),
             entry_own.node() == parent_owner,
-            child_value.path == entry_own.path.push_tail(idx),
+            child_value.path == entry_own.path.push_tail(idx as int),
             child_value.path.len() == parent_owner.tree_level + 1,
         ensures
             child_value.path.len() == parent_owner.tree_level + 1,
@@ -452,7 +452,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
                 parent_owner.children_perm.value()[idx as int],
                 parent_owner.level,
             ),
-            child_value.path == entry_own.path.push_tail(idx),
+            child_value.path == entry_own.path.push_tail(idx as int),
             child_value.parent_level == parent_owner.level,
     {
     }
@@ -515,7 +515,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             self.children[self.idx as int]->0.inv(),
             self.children[self.idx as int]->0.value().parent_level == self.level(),
             self.children[self.idx as int]->0.value().path == self.path().push_tail(
-                self.idx as usize,
+                self.idx as int,
             ),
             self.children[self.idx as int]->0.level() == self.tree_level + 1,
             self.children[self.idx as int]->0.value().path.len() == self.entry_own.node().tree_level
@@ -549,14 +549,14 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             paddr < MAX_PADDR,
             paddr % page_size(self.level()) == 0,
             paddr + page_size(self.level()) <= MAX_PADDR,
-            self.path().push_tail(self.idx as usize).inv(),
+            self.path().push_tail(self.idx as int).inv(),
         ensures
             final(regions).slot_owners == old(regions).slot_owners,
             final(regions).slots == old(regions).slots,
             // Allocating a child doesn't touch the segment obligation ledger.
             res.value() == EntryOwner::<C>::new_frame(
                 paddr,
-                self.path().push_tail(self.idx as usize),
+                self.path().push_tail(self.idx as int),
                 self.level(),
                 prop,
                 is_tracked,
@@ -567,7 +567,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
     {
         let tracked mut owner = EntryOwner::<C>::tracked_new_frame(
             paddr,
-            self.path().push_tail(self.idx as usize),
+            self.path().push_tail(self.idx as int),
             self.level(),
             prop,
             is_tracked,
@@ -714,7 +714,7 @@ impl<'rcu, C: PageTableConfig> Inv for CursorOwner<'rcu, C> {
                 != self.continuations[3].guard.inner.inner@.ptr.addr()
             // Path consistency: child path = parent path pushed with parent's index
             &&& self.continuations[2].path() == self.continuations[3].path().push_tail(
-                self.continuations[3].idx as usize,
+                self.continuations[3].idx as int,
             )
             // PTE consistency
             &&& self.continuations[2].entry_own.path.len()
@@ -738,7 +738,7 @@ impl<'rcu, C: PageTableConfig> Inv for CursorOwner<'rcu, C> {
                 != self.continuations[3].guard.inner.inner@.ptr.addr()
             // Path consistency: child path = parent path pushed with parent's index
             &&& self.continuations[1].path() == self.continuations[2].path().push_tail(
-                self.continuations[2].idx as usize,
+                self.continuations[2].idx as int,
             )
             // PTE consistency
             &&& self.continuations[1].entry_own.path.len()
@@ -764,7 +764,7 @@ impl<'rcu, C: PageTableConfig> Inv for CursorOwner<'rcu, C> {
                 != self.continuations[3].guard.inner.inner@.ptr.addr()
             // Path consistency: child path = parent path pushed with parent's index
             &&& self.continuations[0].path() == self.continuations[1].path().push_tail(
-                self.continuations[1].idx as usize,
+                self.continuations[1].idx as int,
             )
             // PTE consistency
             &&& self.continuations[0].entry_own.path.len()
@@ -1248,7 +1248,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             new_subtree.inv(),
             new_subtree.value().is_frame(),
             new_subtree.value().path == self.continuations[self.level - 1].path().push_tail(
-                self.continuations[self.level - 1].idx as usize,
+                self.continuations[self.level - 1].idx as int,
             ),
             new_subtree.value().frame().mapped_pa == pa,
             new_subtree.value().frame().prop == prop,
@@ -1265,7 +1265,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         let ps = page_size(level);
         let cont = self.continuations[self.level - 1];
 
-        cont.path().lemma_push_tail_len(cont.idx as usize);
+        cont.path().lemma_push_tail_len(cont.idx as int);
 
         // Bridge `nat_align_down(cur_va, ps) == vaddr_of::<C>(path) as Vaddr`:
         //   to_path_vaddr_concrete: vaddr(path) + va.leading_bits * 2^48 == nat_align_down(cur_va, ps)
@@ -1282,30 +1282,30 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             assert forall|i: int| 0 <= i < path.len() implies path.index(i) == va_path.index(i) by {
                 self.va.to_path_index(self.level - 1, i);
                 if self.level == 4 {
-                    cont.path().lemma_push_tail_index(cont.idx as usize);
+                    cont.path().lemma_push_tail_index(cont.idx as int);
                 } else if self.level == 3 {
-                    cont.path().lemma_push_tail_index(cont.idx as usize);
+                    cont.path().lemma_push_tail_index(cont.idx as int);
                     self.continuations[3].path().lemma_push_tail_index(
-                        self.continuations[3].idx as usize,
+                        self.continuations[3].idx as int,
                     );
                 } else if self.level == 2 {
-                    cont.path().lemma_push_tail_index(cont.idx as usize);
+                    cont.path().lemma_push_tail_index(cont.idx as int);
                     self.continuations[2].path().lemma_push_tail_index(
-                        self.continuations[2].idx as usize,
+                        self.continuations[2].idx as int,
                     );
                     self.continuations[3].path().lemma_push_tail_index(
-                        self.continuations[3].idx as usize,
+                        self.continuations[3].idx as int,
                     );
                 } else {
-                    cont.path().lemma_push_tail_index(cont.idx as usize);
+                    cont.path().lemma_push_tail_index(cont.idx as int);
                     self.continuations[1].path().lemma_push_tail_index(
-                        self.continuations[1].idx as usize,
+                        self.continuations[1].idx as int,
                     );
                     self.continuations[2].path().lemma_push_tail_index(
-                        self.continuations[2].idx as usize,
+                        self.continuations[2].idx as int,
                     );
                     self.continuations[3].path().lemma_push_tail_index(
-                        self.continuations[3].idx as usize,
+                        self.continuations[3].idx as int,
                     );
                 }
             };
@@ -2390,7 +2390,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         let pt_level = INC_LEVELS - path.len();
         let cont = self.continuations[self.level - 1];
 
-        cont.path().lemma_push_tail_len(cont.idx as usize);
+        cont.path().lemma_push_tail_len(cont.idx as int);
 
         let m = Mapping {
             va_range: Range {
@@ -2467,9 +2467,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             assert forall|j: int|
                 0 <= j < NR_ENTRIES
                     && #[trigger] cont.children[j] is Some implies cont.children[j].unwrap().subtree_satisfies(
-            cont.path().push_tail(j as usize), g) by {
+            cont.path().push_tail(j), g) by {
                 cont.inv_children_unroll(j);
-                cont.children[j].unwrap().lemma_map_implies(cont.path().push_tail(j as usize), f, g);
+                cont.children[j].unwrap().lemma_map_implies(cont.path().push_tail(j), f, g);
             };
         };
         assert(other.path_metaregion_sound(regions1)) by {
@@ -2636,20 +2636,20 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             assert forall|j: int|
                 0 <= j < NR_ENTRIES
                     && #[trigger] cont.children[j] is Some implies cont.children[j].unwrap().subtree_satisfies(
-            cont.path().push_tail(j as usize), nsp) by {
+            cont.path().push_tail(j), nsp) by {
                 cont.inv_children_unroll(j);
                 PageTableOwner::tree_not_in_scope(
                     cont.children[j].unwrap(),
-                    cont.path().push_tail(j as usize),
+                    cont.path().push_tail(j),
                 );
             };
             assert forall|j: int|
                 0 <= j < NR_ENTRIES
                     && #[trigger] cont.children[j] is Some implies cont.children[j].unwrap().subtree_satisfies(
-            cont.path().push_tail(j as usize), g) by {
+            cont.path().push_tail(j), g) by {
                 cont.inv_children_unroll(j);
                 cont.children[j].unwrap().lemma_map_implies_and(
-                    cont.path().push_tail(j as usize),
+                    cont.path().push_tail(j),
                     f,
                     nsp,
                     g,
@@ -2888,32 +2888,32 @@ pub proof fn lemma_view_in_vaddr_range<'rcu, C: PageTableConfig>(owner: &CursorO
         let j = choose|j: int|
             0 <= j < cont.children.len() && #[trigger] cont.children[j] is Some && PageTableOwner(
                 cont.children[j].unwrap(),
-            ).view_rec(cont.path().push_tail(j as usize)).contains(m);
+            ).view_rec(cont.path().push_tail(j)).contains(m);
         cont.pt_inv_children_unroll(j);
         cont.inv_children_rel_unroll(j);
         let child = PageTableOwner(cont.children[j].unwrap());
-        let p = cont.path().push_tail(j as usize);
-        cont.path().lemma_push_tail_len(j as usize);
-        cont.path().lemma_push_tail_index(j as usize);
+        let p = cont.path().push_tail(j);
+        cont.path().lemma_push_tail_len(j);
+        cont.path().lemma_push_tail_index(j);
         let pidx = p.index(0) as int;
         assert(start <= pidx < end) by {
             if i != NR_LEVELS - 1 {
                 assert(cont.path().index(0) == owner.continuations[NR_LEVELS - 1].idx) by {
                     owner.inv_continuation(NR_LEVELS - 1);
                     owner.continuations[NR_LEVELS - 1].path().lemma_push_tail_index(
-                        owner.continuations[NR_LEVELS - 1].idx,
+                        owner.continuations[NR_LEVELS - 1].idx as int,
                     );
                     if i == 2 {
                     } else if i == 1 {
                         owner.continuations[2].path().lemma_push_tail_index(
-                            owner.continuations[2].idx,
+                            owner.continuations[2].idx as int,
                         );
                     } else {
                         owner.continuations[2].path().lemma_push_tail_index(
-                            owner.continuations[2].idx,
+                            owner.continuations[2].idx as int,
                         );
                         owner.continuations[1].path().lemma_push_tail_index(
-                            owner.continuations[1].idx,
+                            owner.continuations[1].idx as int,
                         );
                     }
                 }
@@ -2964,12 +2964,12 @@ pub proof fn lemma_view_in_vaddr_range_user<'rcu>(
         let j = choose|j: int|
             0 <= j < cont.children.len() && #[trigger] cont.children[j] is Some && PageTableOwner(
                 cont.children[j].unwrap(),
-            ).view_rec(cont.path().push_tail(j as usize)).contains(m);
+            ).view_rec(cont.path().push_tail(j)).contains(m);
         cont.pt_inv_children_unroll(j);
         cont.inv_children_rel_unroll(j);
         let child = PageTableOwner(cont.children[j].unwrap());
-        let p = cont.path().push_tail(j as usize);
-        cont.path().lemma_push_tail_index(j as usize);
+        let p = cont.path().push_tail(j);
+        cont.path().lemma_push_tail_index(j);
         assert(0 <= p.index(0) < end) by {
             if i == NR_LEVELS - 1 {
                 // Root continuation: `p == [j]`. A contributing child is a
@@ -2990,19 +2990,19 @@ pub proof fn lemma_view_in_vaddr_range_user<'rcu>(
                 assert(cont.path().index(0) == owner.continuations[NR_LEVELS - 1].idx) by {
                     owner.inv_continuation(NR_LEVELS - 1);
                     owner.continuations[NR_LEVELS - 1].path().lemma_push_tail_index(
-                        owner.continuations[NR_LEVELS - 1].idx,
+                        owner.continuations[NR_LEVELS - 1].idx as int,
                     );
                     if i == 2 {
                     } else if i == 1 {
                         owner.continuations[2].path().lemma_push_tail_index(
-                            owner.continuations[2].idx,
+                            owner.continuations[2].idx as int,
                         );
                     } else {
                         owner.continuations[2].path().lemma_push_tail_index(
-                            owner.continuations[2].idx,
+                            owner.continuations[2].idx as int,
                         );
                         owner.continuations[1].path().lemma_push_tail_index(
-                            owner.continuations[1].idx,
+                            owner.continuations[1].idx as int,
                         );
                     }
                 }
@@ -3057,12 +3057,12 @@ pub proof fn lemma_view_in_vaddr_range_kernel<'rcu>(owner: CursorOwner<'rcu, Ker
         let j = choose|j: int|
             0 <= j < cont.children.len() && #[trigger] cont.children[j] is Some && PageTableOwner(
                 cont.children[j].unwrap(),
-            ).view_rec(cont.path().push_tail(j as usize)).contains(m);
+            ).view_rec(cont.path().push_tail(j)).contains(m);
         cont.pt_inv_children_unroll(j);
         cont.inv_children_rel_unroll(j);
         let child = PageTableOwner(cont.children[j].unwrap());
-        let p = cont.path().push_tail(j as usize);
-        cont.path().lemma_push_tail_index(j as usize);
+        let p = cont.path().push_tail(j);
+        cont.path().lemma_push_tail_index(j);
         assert(start <= p.index(0) < end) by {
             if i == NR_LEVELS - 1 {
             } else {
@@ -3071,19 +3071,19 @@ pub proof fn lemma_view_in_vaddr_range_kernel<'rcu>(owner: CursorOwner<'rcu, Ker
                 assert(cont.path().index(0) == owner.continuations[NR_LEVELS - 1].idx) by {
                     owner.inv_continuation(NR_LEVELS - 1);
                     owner.continuations[NR_LEVELS - 1].path().lemma_push_tail_index(
-                        owner.continuations[NR_LEVELS - 1].idx,
+                        owner.continuations[NR_LEVELS - 1].idx as int,
                     );
                     if i == 2 {
                     } else if i == 1 {
                         owner.continuations[2].path().lemma_push_tail_index(
-                            owner.continuations[2].idx,
+                            owner.continuations[2].idx as int,
                         );
                     } else {
                         owner.continuations[2].path().lemma_push_tail_index(
-                            owner.continuations[2].idx,
+                            owner.continuations[2].idx as int,
                         );
                         owner.continuations[1].path().lemma_push_tail_index(
-                            owner.continuations[1].idx,
+                            owner.continuations[1].idx as int,
                         );
                     }
                 }

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -574,7 +574,6 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         );
         let ghost owner_spec = owner;
         let tracked res = OwnerSubtree::tracked_new_val(owner, self.tree_level + 1);
-        res.lemma_new_val_properties(owner_spec, self.tree_level + 1);
         res
     }
 

--- a/ostd/specs/mm/page_table/cursor/split_while_huge_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/split_while_huge_lemmas.rs
@@ -18,6 +18,8 @@ use vstd_extra::arithmetic::*;
 
 verus! {
 
+broadcast use group_ghost_tree_lemmas;
+
 impl<C: PageTableConfig> CursorView<C> {
     /// After `split_if_mapped_huge_spec(new_size)`, a sub-mapping at `cur_va`
     /// still exists.  The witness is `split_index(m, new_size, k)` where
@@ -261,14 +263,6 @@ impl<C: PageTableConfig> CursorView<C> {
                 // Bounds: sub is within m's range.
                 vstd::arithmetic::mul::lemma_mul_nonnegative(k, ns);
                 vstd::arithmetic::mul::lemma_mul_inequality(k + 1, count, ns);
-                // (k+1)*ns <= count*ns = ps, so m.start + (k+1)*ns <= m.start + ps = m.end.
-                assert(sub.va_range.start >= m.va_range.start);
-                assert(sub.va_range.end <= m.va_range.end);
-                assert(sub.va_range.start <= sub.va_range.end);
-
-                assert(sub.pa_range.start >= m.pa_range.start);
-                assert(sub.pa_range.end <= m.pa_range.end);
-                assert(sub.pa_range.start <= sub.pa_range.end);
             }
         };
 
@@ -887,20 +881,9 @@ impl<C: PageTableConfig> CursorView<C> {
             vstd::arithmetic::mul::lemma_mul_nonnegative(k, ns);
             vstd::arithmetic::mul::lemma_mul_inequality(k + 1, count, ns);
 
-            assert(k as usize == k);
             let ku = k as usize;
             assert(e == Self::split_index(qm, new_size, ku));
             vstd::arithmetic::mul::lemma_mul_is_distributive_add(ns, k, 1int);
-
-            assert(e.va_range.start == qm.va_range.start + k * ns);
-            assert(e.va_range.start >= qm.va_range.start);
-            assert(e.va_range.end == qm.va_range.start + (k + 1) * ns);
-            assert(e.va_range.end <= qm.va_range.end);
-            assert(e.pa_range.start == qm.pa_range.start + k * ns);
-            assert(e.va_range.start - qm.va_range.start == k * ns);
-            assert(e.pa_range.start == (qm.pa_range.start + (e.va_range.start
-                - qm.va_range.start)) as Paddr);
-            assert(e.property == qm.property);
         }
     }
 
@@ -975,26 +958,6 @@ impl<C: PageTableConfig> CursorView<C> {
                         assert(m.inv());
                         assert(new_self.inv());
                         assert(p.inv());
-                        // Mapping::inv gives `start + page_size == end`.
-                        assert(m.va_range.start + m.page_size == m.va_range.end);
-                        assert(qm.va_range.start + qm.page_size == qm.va_range.end);
-                        // m's va offset within qm: at most qm.page_size - m.page_size <= qm.page_size.
-                        assert(m.va_range.start - qm.va_range.start <= qm.page_size - m.page_size);
-                        // pa-side chain in int arithmetic.
-                        assert(qm.pa_range.start + qm.page_size == qm.pa_range.end);
-                        assert(qm.pa_range.end <= MAX_PADDR);
-                        assert(p.pa_range.start == qm.pa_range.start + (p.va_range.start
-                            - qm.va_range.start));
-                        assert(m.pa_range.start == p.pa_range.start + (m.va_range.start
-                            - p.va_range.start));
-                        assert(m.pa_range.start == qm.pa_range.start + (m.va_range.start
-                            - qm.va_range.start));
-                        // No-overflow: sum <= qm.pa_range.end <= MAX_PADDR <= usize::MAX.
-                        assert(qm.pa_range.start + (m.va_range.start - qm.va_range.start)
-                            <= qm.pa_range.end);
-                        assert(m.pa_range.start == (qm.pa_range.start + (m.va_range.start
-                            - qm.va_range.start)) as Paddr);
-                        assert(m.property == qm.property);
                     }
                 }
             }
@@ -1185,8 +1148,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             let path = subtree.value().path;
             let qm = self@.query_mapping();
             self.query_mapping_from_subtree(qm);
-            let cont = self.continuations[self.level - 1];
-            cont.path().lemma_push_tail_len(cont.idx as int);
             PageTableOwner(subtree).view_rec_node_page_size_bound(path, qm);
         }
     }
@@ -1219,8 +1180,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             let path = subtree.value().path;
             let qm = self@.query_mapping();
             self.query_mapping_from_subtree(qm);
-            let cont = self.continuations[self.level - 1];
-            cont.path().lemma_push_tail_len(cont.idx as int);
             PageTableOwner(subtree).view_rec_page_size_bound(path, qm);
         }
     }
@@ -1358,9 +1317,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         ensures
             v1.split_while_huge(size).mappings == v2.split_while_huge(size).mappings,
     {
-        if v1.cur_va == v2.cur_va {
-            assert(v1 == v2);
-        }
     }
 }
 

--- a/ostd/specs/mm/page_table/cursor/split_while_huge_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/split_while_huge_lemmas.rs
@@ -1186,7 +1186,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             let qm = self@.query_mapping();
             self.query_mapping_from_subtree(qm);
             let cont = self.continuations[self.level - 1];
-            cont.path().lemma_push_tail_len(cont.idx as usize);
+            cont.path().lemma_push_tail_len(cont.idx as int);
             PageTableOwner(subtree).view_rec_node_page_size_bound(path, qm);
         }
     }
@@ -1220,7 +1220,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             let qm = self@.query_mapping();
             self.query_mapping_from_subtree(qm);
             let cont = self.continuations[self.level - 1];
-            cont.path().lemma_push_tail_len(cont.idx as usize);
+            cont.path().lemma_push_tail_len(cont.idx as int);
             PageTableOwner(subtree).view_rec_page_size_bound(path, qm);
         }
     }

--- a/ostd/specs/mm/page_table/cursor/split_while_huge_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/split_while_huge_lemmas.rs
@@ -1123,7 +1123,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self@.present(),
             qm == self@.query_mapping(),
         ensures
-            PageTableOwner(self.cur_subtree()).view_rec(self.cur_subtree().value().path).contains(qm),
+            PageTableOwner(self.cur_subtree()).view_rec(self.cur_subtree().value().path).contains(
+                qm,
+            ),
     {
         let f = self@.mappings.filter(
             |m2: Mapping| m2.va_range.start <= self@.cur_va < m2.va_range.end,

--- a/ostd/specs/mm/page_table/cursor/split_while_huge_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/split_while_huge_lemmas.rs
@@ -1160,7 +1160,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self@.present(),
             qm == self@.query_mapping(),
         ensures
-            PageTableOwner(self.cur_subtree()).view_rec(self.cur_subtree().value.path).contains(qm),
+            PageTableOwner(self.cur_subtree()).view_rec(self.cur_subtree().value().path).contains(qm),
     {
         let f = self@.mappings.filter(
             |m2: Mapping| m2.va_range.start <= self@.cur_va < m2.va_range.end,
@@ -1182,11 +1182,11 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         if self@.present() {
             self.cur_subtree_inv();
             let subtree = self.cur_subtree();
-            let path = subtree.value.path;
+            let path = subtree.value().path;
             let qm = self@.query_mapping();
             self.query_mapping_from_subtree(qm);
             let cont = self.continuations[self.level - 1];
-            cont.path().push_tail_property_len(cont.idx as usize);
+            cont.path().lemma_push_tail_len(cont.idx as usize);
             PageTableOwner(subtree).view_rec_node_page_size_bound(path, qm);
         }
     }
@@ -1216,11 +1216,11 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         if self@.present() {
             self.cur_subtree_inv();
             let subtree = self.cur_subtree();
-            let path = subtree.value.path;
+            let path = subtree.value().path;
             let qm = self@.query_mapping();
             self.query_mapping_from_subtree(qm);
             let cont = self.continuations[self.level - 1];
-            cont.path().push_tail_property_len(cont.idx as usize);
+            cont.path().lemma_push_tail_len(cont.idx as usize);
             PageTableOwner(subtree).view_rec_page_size_bound(path, qm);
         }
     }

--- a/ostd/specs/mm/page_table/cursor/tree_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/tree_lemmas.rs
@@ -41,7 +41,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         assert forall|j: int|
             #![auto]
             0 <= j < self.children.len()
-                && self.children[j] is Some implies self.children[j].unwrap().tree_predicate_map(
+                && self.children[j] is Some implies self.children[j].unwrap().subtree_satisfies(
             self.path().push_tail(j as usize),
             g,
         ) by {
@@ -75,7 +75,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             forall|j: int|
                 #![auto]
                 0 <= j < NR_ENTRIES && j != idx ==> self.children[j] == cont0.children[j],
-            self.children[idx] is Some ==> self.children[idx]->0.tree_predicate_map(
+            self.children[idx] is Some ==> self.children[idx]->0.subtree_satisfies(
                 self.path().push_tail(idx as usize),
                 g,
             ),
@@ -85,7 +85,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         assert forall|j: int|
             #![auto]
             0 <= j < self.children.len()
-                && self.children[j] is Some implies self.children[j].unwrap().tree_predicate_map(
+                && self.children[j] is Some implies self.children[j].unwrap().subtree_satisfies(
             self.path().push_tail(j as usize),
             g,
         ) by {
@@ -143,7 +143,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             assert forall|j: int|
                 #![trigger cont.children[j]]
                 0 <= j < cont.children.len()
-                    && cont.children[j] is Some implies cont.children[j].unwrap().tree_predicate_map(
+                    && cont.children[j] is Some implies cont.children[j].unwrap().subtree_satisfies(
             cont.path().push_tail(j as usize), g) by {
                 cont.inv_children_unroll(j);
                 OwnerSubtree::lemma_map_implies(
@@ -238,7 +238,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             reveal(CursorContinuation::inv_children);
             assert forall|j: int|
                 0 <= j < NR_ENTRIES
-                    && #[trigger] cont.children[j] is Some implies cont.children[j].unwrap().tree_predicate_map(
+                    && #[trigger] cont.children[j] is Some implies cont.children[j].unwrap().subtree_satisfies(
             cont.path().push_tail(j as usize), g) by {
                 cont.inv_children_unroll(j);
                 PageTableOwner::tree_not_in_scope(

--- a/ostd/specs/mm/page_table/cursor/tree_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/tree_lemmas.rs
@@ -42,13 +42,13 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             #![auto]
             0 <= j < self.children.len()
                 && self.children[j] is Some implies self.children[j].unwrap().subtree_satisfies(
-            self.path().push_tail(j as usize),
+            self.path().push_tail(j),
             g,
         ) by {
             self.inv_children_unroll(j);
             OwnerSubtree::lemma_map_implies(
                 self.children[j].unwrap(),
-                self.path().push_tail(j as usize),
+                self.path().push_tail(j),
                 f,
                 g,
             );
@@ -76,7 +76,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
                 #![auto]
                 0 <= j < NR_ENTRIES && j != idx ==> self.children[j] == cont0.children[j],
             self.children[idx] is Some ==> self.children[idx]->0.subtree_satisfies(
-                self.path().push_tail(idx as usize),
+                self.path().push_tail(idx as int),
                 g,
             ),
         ensures
@@ -86,14 +86,14 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             #![auto]
             0 <= j < self.children.len()
                 && self.children[j] is Some implies self.children[j].unwrap().subtree_satisfies(
-            self.path().push_tail(j as usize),
+            self.path().push_tail(j),
             g,
         ) by {
             if j != idx {
                 cont0.inv_children_unroll(j);
                 OwnerSubtree::lemma_map_implies(
                     cont0.children[j].unwrap(),
-                    cont0.path().push_tail(j as usize),
+                    cont0.path().push_tail(j),
                     f,
                     g,
                 );
@@ -144,11 +144,11 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 #![trigger cont.children[j]]
                 0 <= j < cont.children.len()
                     && cont.children[j] is Some implies cont.children[j].unwrap().subtree_satisfies(
-            cont.path().push_tail(j as usize), g) by {
+            cont.path().push_tail(j), g) by {
                 cont.inv_children_unroll(j);
                 OwnerSubtree::lemma_map_implies(
                     cont.children[j].unwrap(),
-                    cont.path().push_tail(j as usize),
+                    cont.path().push_tail(j),
                     f,
                     g,
                 );
@@ -239,13 +239,13 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             assert forall|j: int|
                 0 <= j < NR_ENTRIES
                     && #[trigger] cont.children[j] is Some implies cont.children[j].unwrap().subtree_satisfies(
-            cont.path().push_tail(j as usize), g) by {
+            cont.path().push_tail(j), g) by {
                 cont.inv_children_unroll(j);
                 PageTableOwner::tree_not_in_scope(
                     cont.children[j].unwrap(),
-                    cont.path().push_tail(j as usize),
+                    cont.path().push_tail(j),
                 );
-                cont.children[j].unwrap().lemma_map_implies(cont.path().push_tail(j as usize), nsp, g);
+                cont.children[j].unwrap().lemma_map_implies(cont.path().push_tail(j), nsp, g);
             };
         };
     }

--- a/ostd/specs/mm/page_table/cursor/tree_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/tree_lemmas.rs
@@ -46,7 +46,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             g,
         ) by {
             self.inv_children_unroll(j);
-            OwnerSubtree::lemma_map_implies(
+            OwnerSubtree::lemma_subtree_satisfies_implies(
                 self.children[j].unwrap(),
                 self.path().push_tail(j),
                 f,
@@ -91,7 +91,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         ) by {
             if j != idx {
                 cont0.inv_children_unroll(j);
-                OwnerSubtree::lemma_map_implies(
+                OwnerSubtree::lemma_subtree_satisfies_implies(
                     cont0.children[j].unwrap(),
                     cont0.path().push_tail(j),
                     f,
@@ -146,7 +146,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     && cont.children[j] is Some implies cont.children[j].unwrap().subtree_satisfies(
             cont.path().push_tail(j), g) by {
                 cont.inv_children_unroll(j);
-                OwnerSubtree::lemma_map_implies(
+                OwnerSubtree::lemma_subtree_satisfies_implies(
                     cont.children[j].unwrap(),
                     cont.path().push_tail(j),
                     f,
@@ -245,7 +245,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     cont.children[j].unwrap(),
                     cont.path().push_tail(j),
                 );
-                cont.children[j].unwrap().lemma_map_implies(cont.path().push_tail(j), nsp, g);
+                cont.children[j].unwrap().lemma_subtree_satisfies_implies(cont.path().push_tail(j), nsp, g);
             };
         };
     }

--- a/ostd/specs/mm/page_table/cursor/tree_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/tree_lemmas.rs
@@ -144,7 +144,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 #![trigger cont.children[j]]
                 0 <= j < cont.children.len()
                     && cont.children[j] is Some implies cont.children[j].unwrap().subtree_satisfies(
-            cont.path().push_tail(j), g) by {
+                cont.path().push_tail(j),
+                g,
+            ) by {
                 cont.inv_children_unroll(j);
                 OwnerSubtree::lemma_subtree_satisfies_implies(
                     cont.children[j].unwrap(),
@@ -245,7 +247,11 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     cont.children[j].unwrap(),
                     cont.path().push_tail(j),
                 );
-                cont.children[j].unwrap().lemma_subtree_satisfies_implies(cont.path().push_tail(j), nsp, g);
+                cont.children[j].unwrap().lemma_subtree_satisfies_implies(
+                    cont.path().push_tail(j),
+                    nsp,
+                    g,
+                );
             };
         };
     }

--- a/ostd/specs/mm/page_table/cursor/tree_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/tree_lemmas.rs
@@ -46,7 +46,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             g,
         ) by {
             self.inv_children_unroll(j);
-            OwnerSubtree::map_implies(
+            OwnerSubtree::lemma_map_implies(
                 self.children[j].unwrap(),
                 self.path().push_tail(j as usize),
                 f,
@@ -91,7 +91,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
         ) by {
             if j != idx {
                 cont0.inv_children_unroll(j);
-                OwnerSubtree::map_implies(
+                OwnerSubtree::lemma_map_implies(
                     cont0.children[j].unwrap(),
                     cont0.path().push_tail(j as usize),
                     f,
@@ -146,7 +146,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     && cont.children[j] is Some implies cont.children[j].unwrap().tree_predicate_map(
             cont.path().push_tail(j as usize), g) by {
                 cont.inv_children_unroll(j);
-                OwnerSubtree::map_implies(
+                OwnerSubtree::lemma_map_implies(
                     cont.children[j].unwrap(),
                     cont.path().push_tail(j as usize),
                     f,
@@ -245,7 +245,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                     cont.children[j].unwrap(),
                     cont.path().push_tail(j as usize),
                 );
-                cont.children[j].unwrap().map_implies(cont.path().push_tail(j as usize), nsp, g);
+                cont.children[j].unwrap().lemma_map_implies(cont.path().push_tail(j as usize), nsp, g);
             };
         };
     }

--- a/ostd/specs/mm/page_table/cursor/va_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/va_lemmas.rs
@@ -327,8 +327,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
         self.va.to_path_len(L - 1);
 
-        assert forall|i: int| 0 <= i < subtree_path.len() implies subtree_path[i]
-            == va_path[i] by {
+        assert forall|i: int| 0 <= i < subtree_path.len() implies subtree_path[i] == va_path[i] by {
             self.va.to_path_index(L - 1, i);
         };
 

--- a/ostd/specs/mm/page_table/cursor/va_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/va_lemmas.rs
@@ -234,11 +234,11 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         self.view_preserves_inv();
         self.cur_entry_frame_present();
         let subtree = self.cur_subtree();
-        let path = subtree.value.path;
+        let path = subtree.value().path;
         let frame = self.cur_entry_owner().frame();
         let cont = self.continuations[self.level - 1];
 
-        cont.path().push_tail_property_len(cont.idx as usize);
+        cont.path().lemma_push_tail_len(cont.idx as usize);
 
         let ps = page_size(self.level as PagingLevel);
         let m = Mapping {
@@ -317,9 +317,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.inv(),
             self.in_locked_range(),
         ensures
-            vaddr(self.cur_subtree().value.path) + self.va.leading_bits * 0x1_0000_0000_0000int
+            vaddr(self.cur_subtree().value().path) + self.va.leading_bits * 0x1_0000_0000_0000int
                 <= self.cur_va(),
-            self.cur_va() < vaddr(self.cur_subtree().value.path) + self.va.leading_bits
+            self.cur_va() < vaddr(self.cur_subtree().value().path) + self.va.leading_bits
                 * 0x1_0000_0000_0000int + page_size(self.level as PagingLevel),
     {
         let L = self.level as int;
@@ -328,35 +328,35 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         let va_path = self.va.to_path(L - 1);
 
         self.va.to_path_len(L - 1);
-        cont.path().push_tail_property_len(cont.idx as usize);
+        cont.path().lemma_push_tail_len(cont.idx as usize);
 
         assert forall|i: int| 0 <= i < subtree_path.len() implies subtree_path.index(i)
             == va_path.index(i) by {
             self.va.to_path_index(L - 1, i);
             if L == 4 {
-                cont.path().push_tail_property_index(cont.idx as usize);
+                cont.path().lemma_push_tail_index(cont.idx as usize);
             } else if L == 3 {
-                cont.path().push_tail_property_index(cont.idx as usize);
-                self.continuations[3].path().push_tail_property_index(
+                cont.path().lemma_push_tail_index(cont.idx as usize);
+                self.continuations[3].path().lemma_push_tail_index(
                     self.continuations[3].idx as usize,
                 );
             } else if L == 2 {
-                cont.path().push_tail_property_index(cont.idx as usize);
-                self.continuations[2].path().push_tail_property_index(
+                cont.path().lemma_push_tail_index(cont.idx as usize);
+                self.continuations[2].path().lemma_push_tail_index(
                     self.continuations[2].idx as usize,
                 );
-                self.continuations[3].path().push_tail_property_index(
+                self.continuations[3].path().lemma_push_tail_index(
                     self.continuations[3].idx as usize,
                 );
             } else {
-                cont.path().push_tail_property_index(cont.idx as usize);
-                self.continuations[1].path().push_tail_property_index(
+                cont.path().lemma_push_tail_index(cont.idx as usize);
+                self.continuations[1].path().lemma_push_tail_index(
                     self.continuations[1].idx as usize,
                 );
-                self.continuations[2].path().push_tail_property_index(
+                self.continuations[2].path().lemma_push_tail_index(
                     self.continuations[2].idx as usize,
                 );
-                self.continuations[3].path().push_tail_property_index(
+                self.continuations[3].path().lemma_push_tail_index(
                     self.continuations[3].idx as usize,
                 );
             }

--- a/ostd/specs/mm/page_table/cursor/va_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/va_lemmas.rs
@@ -238,7 +238,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         let frame = self.cur_entry_owner().frame();
         let cont = self.continuations[self.level - 1];
 
-        cont.path().lemma_push_tail_len(cont.idx as usize);
+        cont.path().lemma_push_tail_len(cont.idx as int);
 
         let ps = page_size(self.level as PagingLevel);
         let m = Mapping {
@@ -324,40 +324,40 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
     {
         let L = self.level as int;
         let cont = self.continuations[L - 1];
-        let subtree_path = cont.path().push_tail(cont.idx as usize);
+        let subtree_path = cont.path().push_tail(cont.idx as int);
         let va_path = self.va.to_path(L - 1);
 
         self.va.to_path_len(L - 1);
-        cont.path().lemma_push_tail_len(cont.idx as usize);
+        cont.path().lemma_push_tail_len(cont.idx as int);
 
         assert forall|i: int| 0 <= i < subtree_path.len() implies subtree_path.index(i)
             == va_path.index(i) by {
             self.va.to_path_index(L - 1, i);
             if L == 4 {
-                cont.path().lemma_push_tail_index(cont.idx as usize);
+                cont.path().lemma_push_tail_index(cont.idx as int);
             } else if L == 3 {
-                cont.path().lemma_push_tail_index(cont.idx as usize);
+                cont.path().lemma_push_tail_index(cont.idx as int);
                 self.continuations[3].path().lemma_push_tail_index(
-                    self.continuations[3].idx as usize,
+                    self.continuations[3].idx as int,
                 );
             } else if L == 2 {
-                cont.path().lemma_push_tail_index(cont.idx as usize);
+                cont.path().lemma_push_tail_index(cont.idx as int);
                 self.continuations[2].path().lemma_push_tail_index(
-                    self.continuations[2].idx as usize,
+                    self.continuations[2].idx as int,
                 );
                 self.continuations[3].path().lemma_push_tail_index(
-                    self.continuations[3].idx as usize,
+                    self.continuations[3].idx as int,
                 );
             } else {
-                cont.path().lemma_push_tail_index(cont.idx as usize);
+                cont.path().lemma_push_tail_index(cont.idx as int);
                 self.continuations[1].path().lemma_push_tail_index(
-                    self.continuations[1].idx as usize,
+                    self.continuations[1].idx as int,
                 );
                 self.continuations[2].path().lemma_push_tail_index(
-                    self.continuations[2].idx as usize,
+                    self.continuations[2].idx as int,
                 );
                 self.continuations[3].path().lemma_push_tail_index(
-                    self.continuations[3].idx as usize,
+                    self.continuations[3].idx as int,
                 );
             }
         };

--- a/ostd/specs/mm/page_table/cursor/va_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/va_lemmas.rs
@@ -29,6 +29,8 @@ use vstd_extra::arithmetic::nat_align_down;
 
 verus! {
 
+broadcast use group_ghost_tree_lemmas;
+
 impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
     // ─── Spec helpers ────────────────────────────────────────────────────
     pub open spec fn zero_below_level_rec(self, level: PagingLevel) -> Self
@@ -284,6 +286,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             );
             let q_cur = cur_va as int / ps as int;
             let q_path = vaddr_of::<C>(path) as int / ps as int;
+            assert(vaddr_of::<C>(path) as int % ps as int == 0);
             assert(q_path * ps == vaddr_of::<C>(path));
             vstd::arithmetic::mul::lemma_mul_inequality(q_path, q_cur, ps as int);
             if q_path < q_cur {

--- a/ostd/specs/mm/page_table/cursor/va_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/va_lemmas.rs
@@ -330,8 +330,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         self.va.to_path_len(L - 1);
         cont.path().lemma_push_tail_len(cont.idx as int);
 
-        assert forall|i: int| 0 <= i < subtree_path.len() implies subtree_path.index(i)
-            == va_path.index(i) by {
+        assert forall|i: int| 0 <= i < subtree_path.len() implies subtree_path[i]
+            == va_path[i] by {
             self.va.to_path_index(L - 1, i);
             if L == 4 {
                 cont.path().lemma_push_tail_index(cont.idx as int);

--- a/ostd/specs/mm/page_table/cursor/va_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/va_lemmas.rs
@@ -136,12 +136,10 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         old_self.va.align_down_to_vaddr_nat_align_down(old_self.level as int);
 
         let ghost old_va_val = old_self.va.to_vaddr() as nat;
-        let ghost new_va_val = self.va.to_vaddr() as nat;
         let ghost prefix_va_val = old_self.prefix.to_vaddr() as nat;
         let ghost ps = page_size(old_self.level as PagingLevel) as nat;
         let ghost guard_ps = page_size(old_self.guard_level as PagingLevel) as nat;
         let ghost start = old_self.locked_range().start as nat;
-        let ghost end = old_self.locked_range().end as nat;
 
         vstd_extra::arithmetic::lemma_nat_align_down_monotone(prefix_va_val, ps, guard_ps);
         assert(start % ps == 0);
@@ -238,9 +236,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         let subtree = self.cur_subtree();
         let path = subtree.value().path;
         let frame = self.cur_entry_owner().frame();
-        let cont = self.continuations[self.level - 1];
-
-        cont.path().lemma_push_tail_len(cont.idx as int);
 
         let ps = page_size(self.level as PagingLevel);
         let m = Mapping {
@@ -331,38 +326,10 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         let va_path = self.va.to_path(L - 1);
 
         self.va.to_path_len(L - 1);
-        cont.path().lemma_push_tail_len(cont.idx as int);
 
         assert forall|i: int| 0 <= i < subtree_path.len() implies subtree_path[i]
             == va_path[i] by {
             self.va.to_path_index(L - 1, i);
-            if L == 4 {
-                cont.path().lemma_push_tail_index(cont.idx as int);
-            } else if L == 3 {
-                cont.path().lemma_push_tail_index(cont.idx as int);
-                self.continuations[3].path().lemma_push_tail_index(
-                    self.continuations[3].idx as int,
-                );
-            } else if L == 2 {
-                cont.path().lemma_push_tail_index(cont.idx as int);
-                self.continuations[2].path().lemma_push_tail_index(
-                    self.continuations[2].idx as int,
-                );
-                self.continuations[3].path().lemma_push_tail_index(
-                    self.continuations[3].idx as int,
-                );
-            } else {
-                cont.path().lemma_push_tail_index(cont.idx as int);
-                self.continuations[1].path().lemma_push_tail_index(
-                    self.continuations[1].idx as int,
-                );
-                self.continuations[2].path().lemma_push_tail_index(
-                    self.continuations[2].idx as int,
-                );
-                self.continuations[3].path().lemma_push_tail_index(
-                    self.continuations[3].idx as int,
-                );
-            }
         };
 
         self.va.to_path_inv(L - 1);

--- a/ostd/specs/mm/page_table/mod.rs
+++ b/ostd/specs/mm/page_table/mod.rs
@@ -1530,9 +1530,9 @@ impl AbstractVaddr {
     /// - level=3: path of length 1 with just the root index
     ///
     /// Path index mapping:
-    /// - path.index(0) = self.index[NR_LEVELS - 1]  (root level)
-    /// - path.index(i) = self.index[NR_LEVELS - 1 - i]
-    /// - path.index(NR_LEVELS - level - 1) = self.index[level]  (last entry)
+    /// - path[0] = self.index[NR_LEVELS - 1]  (root level)
+    /// - path[i] = self.index[NR_LEVELS - 1 - i]
+    /// - path[NR_LEVELS - level - 1] = self.index[level]  (last entry)
     pub open spec fn to_path(self, level: int) -> TreePath<NR_ENTRIES>
         recommends
             0 <= level < NR_LEVELS,
@@ -1586,8 +1586,8 @@ impl AbstractVaddr {
             self.align_down_shape(4);
             self.to_path_index(3, 0);
             path.lemma_index_satisfies_elem_inv(0);
-            assert(vaddr(path) == path.index(0) * 0x80_0000_0000usize) by {
-                assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, path.index(0) as usize) + rec_vaddr(
+            assert(vaddr(path) == path[0] * 0x80_0000_0000usize) by {
+                assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, path[0] as usize) + rec_vaddr(
                     path,
                     1,
                 )) as usize);
@@ -1614,10 +1614,10 @@ impl AbstractVaddr {
             self.to_path_index(2, 1);
             path.lemma_index_satisfies_elem_inv(0);
             path.lemma_index_satisfies_elem_inv(1);
-            assert(vaddr(path) == path.index(0) * 0x80_0000_0000usize + path.index(1)
+            assert(vaddr(path) == path[0] * 0x80_0000_0000usize + path[1]
                 * 0x4000_0000usize) by {
                 assert(vaddr(path) == rec_vaddr(path, 0));
-                assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, path.index(1) as usize) + rec_vaddr(
+                assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, path[1] as usize) + rec_vaddr(
                     path,
                     2,
                 )) as usize);
@@ -1641,28 +1641,26 @@ impl AbstractVaddr {
             path.lemma_index_satisfies_elem_inv(0);
             path.lemma_index_satisfies_elem_inv(1);
             path.lemma_index_satisfies_elem_inv(2);
-            assert(vaddr(path) == path.index(0) * 0x80_0000_0000usize + path.index(1)
-                * 0x4000_0000usize + path.index(2) * 0x20_0000usize) by {
+            assert(vaddr(path) == path[0] * 0x80_0000_0000usize + path[1]
+                * 0x4000_0000usize + path[2] * 0x20_0000usize) by {
                 assert(vaddr(path) == rec_vaddr(path, 0));
                 assert(rec_vaddr(path, 3) == 0);
-                assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, path.index(2) as usize) + rec_vaddr(
+                assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, path[2] as usize) + rec_vaddr(
                     path,
                     3,
                 )) as usize);
-                assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, path.index(1) as usize) + rec_vaddr(
+                assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, path[1] as usize) + rec_vaddr(
                     path,
                     2,
                 )) as usize);
-                assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, path.index(0) as usize) + rec_vaddr(
+                assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, path[0] as usize) + rec_vaddr(
                     path,
                     1,
                 )) as usize);
-                assert(vaddr_make::<NR_LEVELS>(0, path.index(0) as usize) == 0x80_0000_0000usize
-                    * path.index(0)) by (compute);
-                assert(vaddr_make::<NR_LEVELS>(1, path.index(1) as usize) == 0x4000_0000usize * path.index(
-                    1,
-                )) by (compute);
-                assert(vaddr_make::<NR_LEVELS>(2, path.index(2) as usize) == 0x20_0000usize * path.index(2))
+                assert(vaddr_make::<NR_LEVELS>(0, path[0] as usize) == 0x80_0000_0000usize
+                    * path[0]) by (compute);
+                assert(vaddr_make::<NR_LEVELS>(1, path[1] as usize) == 0x4000_0000usize * path[1]) by (compute);
+                assert(vaddr_make::<NR_LEVELS>(2, path[2] as usize) == 0x20_0000usize * path[2])
                     by (compute);
             };
             assert(aligned.rec_compute_vaddr(3) == self.index[3] * 0x80_0000_0000usize) by {
@@ -1688,30 +1686,28 @@ impl AbstractVaddr {
             path.lemma_index_satisfies_elem_inv(1);
             path.lemma_index_satisfies_elem_inv(2);
             path.lemma_index_satisfies_elem_inv(3);
-            assert(vaddr(path) == path.index(0) * 0x80_0000_0000usize + path.index(1)
-                * 0x4000_0000usize + path.index(2) * 0x20_0000usize + path.index(3) * 0x1000usize)
+            assert(vaddr(path) == path[0] * 0x80_0000_0000usize + path[1]
+                * 0x4000_0000usize + path[2] * 0x20_0000usize + path[3] * 0x1000usize)
                 by {
                 assert(vaddr(path) == rec_vaddr(path, 0));
                 assert(rec_vaddr(path, 4) == 0);
-                assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, path.index(2) as usize) + rec_vaddr(
+                assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, path[2] as usize) + rec_vaddr(
                     path,
                     3,
                 )) as usize);
-                assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, path.index(1) as usize) + rec_vaddr(
+                assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, path[1] as usize) + rec_vaddr(
                     path,
                     2,
                 )) as usize);
-                assert(vaddr_make::<NR_LEVELS>(0, path.index(0) as usize) == 0x80_0000_0000usize
-                    * path.index(0)) by (compute);
-                assert(vaddr_make::<NR_LEVELS>(1, path.index(1) as usize) == 0x4000_0000usize * path.index(
-                    1,
-                )) by (compute);
-                assert(vaddr_make::<NR_LEVELS>(2, path.index(2) as usize) == 0x20_0000usize * path.index(2))
+                assert(vaddr_make::<NR_LEVELS>(0, path[0] as usize) == 0x80_0000_0000usize
+                    * path[0]) by (compute);
+                assert(vaddr_make::<NR_LEVELS>(1, path[1] as usize) == 0x4000_0000usize * path[1]) by (compute);
+                assert(vaddr_make::<NR_LEVELS>(2, path[2] as usize) == 0x20_0000usize * path[2])
                     by {
                     assert(vaddr_shift_bits::<NR_LEVELS>(2) == 21nat) by (compute);
                     assert(pow2(21nat) == 0x20_0000) by (compute);
                 }
-                assert(vaddr_make::<NR_LEVELS>(3, path.index(3) as usize) == 0x1000usize * path.index(3))
+                assert(vaddr_make::<NR_LEVELS>(3, path[3] as usize) == 0x1000usize * path[3])
                     by (compute);
             };
             assert(aligned.rec_compute_vaddr(4) == 0);
@@ -1945,7 +1941,7 @@ impl AbstractVaddr {
         self.to_path_len(level);
         assert forall|i: int| 0 <= i < self.to_path(level).len() implies TreePath::<
             NR_ENTRIES,
-        >::elem_inv(#[trigger] self.to_path(level).index(i)) by {
+        >::elem_inv(#[trigger] self.to_path(level)[i]) by {
             let j = NR_LEVELS - 1 - i;
             self.to_path_index(level, i);
             assert(self.index.contains_key(j));
@@ -1965,7 +1961,7 @@ impl AbstractVaddr {
             path2.inv(),
             path1.len() == path2.len(),
             0 <= idx <= path1.len(),
-            forall|i: int| idx <= i < path1.len() ==> path1.index(i) == path2.index(i),
+            forall|i: int| idx <= i < path1.len() ==> path1[i] == path2[i],
         ensures
             rec_vaddr(path1, idx) == rec_vaddr(path2, idx),
         decreases path1.len() - idx,
@@ -1984,7 +1980,7 @@ impl AbstractVaddr {
             self.inv(),
             path.inv(),
             path.len() <= NR_LEVELS,
-            forall|i: int| 0 <= i < path.len() ==> path.index(i) == self.index[NR_LEVELS - 1 - i],
+            forall|i: int| 0 <= i < path.len() ==> path[i] == self.index[NR_LEVELS - 1 - i],
         ensures
             vaddr(path) == self.align_down(NR_LEVELS - path.len() + 1).compute_vaddr()
                 - self.align_down(NR_LEVELS - path.len() + 1).offset,
@@ -2017,8 +2013,8 @@ impl AbstractVaddr {
             let level = NR_LEVELS - path.len();
             self.to_path_inv(level);
             self.to_path_len(level);
-            assert forall|i: int| 0 <= i < path.len() implies #[trigger] path.index(i)
-                == self.to_path(level).index(i) by {
+            assert forall|i: int| 0 <= i < path.len() implies #[trigger] path[i]
+                == self.to_path(level)[i] by {
                 self.to_path_index(level, i);
             };
             Self::rec_vaddr_eq_if_indices_eq(path, self.to_path(level), 0);
@@ -2035,7 +2031,7 @@ impl AbstractVaddr {
             0 <= level < NR_LEVELS,
             0 <= i < NR_LEVELS - level,
         ensures
-            self.to_path(level).index(i) == self.index[NR_LEVELS - 1 - i],
+            self.to_path(level)[i] == self.index[NR_LEVELS - 1 - i],
     {
         self.to_path_len(level);
         self.rec_to_path_index(NR_LEVELS - 1, level, i);
@@ -2047,7 +2043,7 @@ impl AbstractVaddr {
             0 <= bottom_level <= abstract_level < NR_LEVELS,
             0 <= i < abstract_level - bottom_level + 1,
         ensures
-            self.rec_to_path(abstract_level, bottom_level).index(i) == self.index[abstract_level
+            self.rec_to_path(abstract_level, bottom_level)[i] == self.index[abstract_level
                 - i],
         decreases abstract_level - bottom_level,
     {

--- a/ostd/specs/mm/page_table/mod.rs
+++ b/ostd/specs/mm/page_table/mod.rs
@@ -1543,7 +1543,7 @@ impl AbstractVaddr {
     /// Builds the path sequence from abstract_level down to bottom_level (both inclusive).
     /// abstract_level and bottom_level refer to the index keys in self.index (0 = lowest level, NR_LEVELS-1 = root).
     /// Returns indices in order from highest level (first in seq) to lowest level (last in seq).
-    pub open spec fn rec_to_path(self, abstract_level: int, bottom_level: int) -> Seq<usize>
+    pub open spec fn rec_to_path(self, abstract_level: int, bottom_level: int) -> Seq<int>
         decreases abstract_level - bottom_level,
         when bottom_level <= abstract_level
     {
@@ -1551,10 +1551,10 @@ impl AbstractVaddr {
             seq![]
         } else if abstract_level == bottom_level {
             // Base case: just this one level
-            seq![self.index[abstract_level] as usize]
+            seq![self.index[abstract_level]]
         } else {
             // Recursive case: place the current higher level first, then recurse downward.
-            seq![self.index[abstract_level] as usize].add(
+            seq![self.index[abstract_level]].add(
                 self.rec_to_path(abstract_level - 1, bottom_level),
             )
         }
@@ -1587,7 +1587,7 @@ impl AbstractVaddr {
             self.to_path_index(3, 0);
             path.lemma_index_satisfies_elem_inv(0);
             assert(vaddr(path) == path.index(0) * 0x80_0000_0000usize) by {
-                assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, path.index(0)) + rec_vaddr(
+                assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, path.index(0) as usize) + rec_vaddr(
                     path,
                     1,
                 )) as usize);
@@ -1617,7 +1617,7 @@ impl AbstractVaddr {
             assert(vaddr(path) == path.index(0) * 0x80_0000_0000usize + path.index(1)
                 * 0x4000_0000usize) by {
                 assert(vaddr(path) == rec_vaddr(path, 0));
-                assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, path.index(1)) + rec_vaddr(
+                assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, path.index(1) as usize) + rec_vaddr(
                     path,
                     2,
                 )) as usize);
@@ -1645,24 +1645,24 @@ impl AbstractVaddr {
                 * 0x4000_0000usize + path.index(2) * 0x20_0000usize) by {
                 assert(vaddr(path) == rec_vaddr(path, 0));
                 assert(rec_vaddr(path, 3) == 0);
-                assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, path.index(2)) + rec_vaddr(
+                assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, path.index(2) as usize) + rec_vaddr(
                     path,
                     3,
                 )) as usize);
-                assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, path.index(1)) + rec_vaddr(
+                assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, path.index(1) as usize) + rec_vaddr(
                     path,
                     2,
                 )) as usize);
-                assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, path.index(0)) + rec_vaddr(
+                assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, path.index(0) as usize) + rec_vaddr(
                     path,
                     1,
                 )) as usize);
-                assert(vaddr_make::<NR_LEVELS>(0, path.index(0)) == 0x80_0000_0000usize
+                assert(vaddr_make::<NR_LEVELS>(0, path.index(0) as usize) == 0x80_0000_0000usize
                     * path.index(0)) by (compute);
-                assert(vaddr_make::<NR_LEVELS>(1, path.index(1)) == 0x4000_0000usize * path.index(
+                assert(vaddr_make::<NR_LEVELS>(1, path.index(1) as usize) == 0x4000_0000usize * path.index(
                     1,
                 )) by (compute);
-                assert(vaddr_make::<NR_LEVELS>(2, path.index(2)) == 0x20_0000usize * path.index(2))
+                assert(vaddr_make::<NR_LEVELS>(2, path.index(2) as usize) == 0x20_0000usize * path.index(2))
                     by (compute);
             };
             assert(aligned.rec_compute_vaddr(3) == self.index[3] * 0x80_0000_0000usize) by {
@@ -1693,25 +1693,25 @@ impl AbstractVaddr {
                 by {
                 assert(vaddr(path) == rec_vaddr(path, 0));
                 assert(rec_vaddr(path, 4) == 0);
-                assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, path.index(2)) + rec_vaddr(
+                assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, path.index(2) as usize) + rec_vaddr(
                     path,
                     3,
                 )) as usize);
-                assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, path.index(1)) + rec_vaddr(
+                assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, path.index(1) as usize) + rec_vaddr(
                     path,
                     2,
                 )) as usize);
-                assert(vaddr_make::<NR_LEVELS>(0, path.index(0)) == 0x80_0000_0000usize
+                assert(vaddr_make::<NR_LEVELS>(0, path.index(0) as usize) == 0x80_0000_0000usize
                     * path.index(0)) by (compute);
-                assert(vaddr_make::<NR_LEVELS>(1, path.index(1)) == 0x4000_0000usize * path.index(
+                assert(vaddr_make::<NR_LEVELS>(1, path.index(1) as usize) == 0x4000_0000usize * path.index(
                     1,
                 )) by (compute);
-                assert(vaddr_make::<NR_LEVELS>(2, path.index(2)) == 0x20_0000usize * path.index(2))
+                assert(vaddr_make::<NR_LEVELS>(2, path.index(2) as usize) == 0x20_0000usize * path.index(2))
                     by {
                     assert(vaddr_shift_bits::<NR_LEVELS>(2) == 21nat) by (compute);
                     assert(pow2(21nat) == 0x20_0000) by (compute);
                 }
-                assert(vaddr_make::<NR_LEVELS>(3, path.index(3)) == 0x1000usize * path.index(3))
+                assert(vaddr_make::<NR_LEVELS>(3, path.index(3) as usize) == 0x1000usize * path.index(3))
                     by (compute);
             };
             assert(aligned.rec_compute_vaddr(4) == 0);
@@ -2054,7 +2054,7 @@ impl AbstractVaddr {
         assert(self.index.contains_key(abstract_level));
         if abstract_level == bottom_level {
         } else {
-            let head = seq![self.index[abstract_level] as usize];
+            let head = seq![self.index[abstract_level]];
             let tail = self.rec_to_path(abstract_level - 1, bottom_level);
             let full = head.add(tail);
             if i == 0 {

--- a/ostd/specs/mm/page_table/mod.rs
+++ b/ostd/specs/mm/page_table/mod.rs
@@ -1554,9 +1554,7 @@ impl AbstractVaddr {
             seq![self.index[abstract_level]]
         } else {
             // Recursive case: place the current higher level first, then recurse downward.
-            seq![self.index[abstract_level]].add(
-                self.rec_to_path(abstract_level - 1, bottom_level),
-            )
+            seq![self.index[abstract_level]].add(self.rec_to_path(abstract_level - 1, bottom_level))
         }
     }
 
@@ -1587,10 +1585,8 @@ impl AbstractVaddr {
             self.to_path_index(3, 0);
             path.lemma_index_satisfies_elem_inv(0);
             assert(vaddr(path) == path[0] * 0x80_0000_0000usize) by {
-                assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, path[0] as usize) + rec_vaddr(
-                    path,
-                    1,
-                )) as usize);
+                assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, path[0] as usize)
+                    + rec_vaddr(path, 1)) as usize);
             };
             assert(aligned.rec_compute_vaddr(3) == self.index[3] * 0x80_0000_0000usize) by {
                 assert(aligned.rec_compute_vaddr(3) == (aligned.index[3] * page_size(4)
@@ -1614,13 +1610,10 @@ impl AbstractVaddr {
             self.to_path_index(2, 1);
             path.lemma_index_satisfies_elem_inv(0);
             path.lemma_index_satisfies_elem_inv(1);
-            assert(vaddr(path) == path[0] * 0x80_0000_0000usize + path[1]
-                * 0x4000_0000usize) by {
+            assert(vaddr(path) == path[0] * 0x80_0000_0000usize + path[1] * 0x4000_0000usize) by {
                 assert(vaddr(path) == rec_vaddr(path, 0));
-                assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, path[1] as usize) + rec_vaddr(
-                    path,
-                    2,
-                )) as usize);
+                assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, path[1] as usize)
+                    + rec_vaddr(path, 2)) as usize);
             };
             assert(aligned.rec_compute_vaddr(3) == self.index[3] * 0x80_0000_0000usize) by {
                 assert(aligned.rec_compute_vaddr(3) == (aligned.index[3] * page_size(4)
@@ -1641,25 +1634,20 @@ impl AbstractVaddr {
             path.lemma_index_satisfies_elem_inv(0);
             path.lemma_index_satisfies_elem_inv(1);
             path.lemma_index_satisfies_elem_inv(2);
-            assert(vaddr(path) == path[0] * 0x80_0000_0000usize + path[1]
-                * 0x4000_0000usize + path[2] * 0x20_0000usize) by {
+            assert(vaddr(path) == path[0] * 0x80_0000_0000usize + path[1] * 0x4000_0000usize
+                + path[2] * 0x20_0000usize) by {
                 assert(vaddr(path) == rec_vaddr(path, 0));
                 assert(rec_vaddr(path, 3) == 0);
-                assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, path[2] as usize) + rec_vaddr(
-                    path,
-                    3,
-                )) as usize);
-                assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, path[1] as usize) + rec_vaddr(
-                    path,
-                    2,
-                )) as usize);
-                assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, path[0] as usize) + rec_vaddr(
-                    path,
-                    1,
-                )) as usize);
+                assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, path[2] as usize)
+                    + rec_vaddr(path, 3)) as usize);
+                assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, path[1] as usize)
+                    + rec_vaddr(path, 2)) as usize);
+                assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, path[0] as usize)
+                    + rec_vaddr(path, 1)) as usize);
                 assert(vaddr_make::<NR_LEVELS>(0, path[0] as usize) == 0x80_0000_0000usize
                     * path[0]) by (compute);
-                assert(vaddr_make::<NR_LEVELS>(1, path[1] as usize) == 0x4000_0000usize * path[1]) by (compute);
+                assert(vaddr_make::<NR_LEVELS>(1, path[1] as usize) == 0x4000_0000usize * path[1])
+                    by (compute);
                 assert(vaddr_make::<NR_LEVELS>(2, path[2] as usize) == 0x20_0000usize * path[2])
                     by (compute);
             };
@@ -1686,22 +1674,18 @@ impl AbstractVaddr {
             path.lemma_index_satisfies_elem_inv(1);
             path.lemma_index_satisfies_elem_inv(2);
             path.lemma_index_satisfies_elem_inv(3);
-            assert(vaddr(path) == path[0] * 0x80_0000_0000usize + path[1]
-                * 0x4000_0000usize + path[2] * 0x20_0000usize + path[3] * 0x1000usize)
-                by {
+            assert(vaddr(path) == path[0] * 0x80_0000_0000usize + path[1] * 0x4000_0000usize
+                + path[2] * 0x20_0000usize + path[3] * 0x1000usize) by {
                 assert(vaddr(path) == rec_vaddr(path, 0));
                 assert(rec_vaddr(path, 4) == 0);
-                assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, path[2] as usize) + rec_vaddr(
-                    path,
-                    3,
-                )) as usize);
-                assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, path[1] as usize) + rec_vaddr(
-                    path,
-                    2,
-                )) as usize);
+                assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, path[2] as usize)
+                    + rec_vaddr(path, 3)) as usize);
+                assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, path[1] as usize)
+                    + rec_vaddr(path, 2)) as usize);
                 assert(vaddr_make::<NR_LEVELS>(0, path[0] as usize) == 0x80_0000_0000usize
                     * path[0]) by (compute);
-                assert(vaddr_make::<NR_LEVELS>(1, path[1] as usize) == 0x4000_0000usize * path[1]) by (compute);
+                assert(vaddr_make::<NR_LEVELS>(1, path[1] as usize) == 0x4000_0000usize * path[1])
+                    by (compute);
                 assert(vaddr_make::<NR_LEVELS>(2, path[2] as usize) == 0x20_0000usize * path[2])
                     by {
                     assert(vaddr_shift_bits::<NR_LEVELS>(2) == 21nat) by (compute);
@@ -2013,8 +1997,9 @@ impl AbstractVaddr {
             let level = NR_LEVELS - path.len();
             self.to_path_inv(level);
             self.to_path_len(level);
-            assert forall|i: int| 0 <= i < path.len() implies #[trigger] path[i]
-                == self.to_path(level)[i] by {
+            assert forall|i: int| 0 <= i < path.len() implies #[trigger] path[i] == self.to_path(
+                level,
+            )[i] by {
                 self.to_path_index(level, i);
             };
             Self::rec_vaddr_eq_if_indices_eq(path, self.to_path(level), 0);
@@ -2043,8 +2028,7 @@ impl AbstractVaddr {
             0 <= bottom_level <= abstract_level < NR_LEVELS,
             0 <= i < abstract_level - bottom_level + 1,
         ensures
-            self.rec_to_path(abstract_level, bottom_level)[i] == self.index[abstract_level
-                - i],
+            self.rec_to_path(abstract_level, bottom_level)[i] == self.index[abstract_level - i],
         decreases abstract_level - bottom_level,
     {
         assert(self.index.contains_key(abstract_level));

--- a/ostd/specs/mm/page_table/mod.rs
+++ b/ostd/specs/mm/page_table/mod.rs
@@ -1585,7 +1585,7 @@ impl AbstractVaddr {
             let aligned = self.align_down(4);
             self.align_down_shape(4);
             self.to_path_index(3, 0);
-            path.index_satisfies_elem_inv(0);
+            path.lemma_index_satisfies_elem_inv(0);
             assert(vaddr(path) == path.index(0) * 0x80_0000_0000usize) by {
                 assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, path.index(0)) + rec_vaddr(
                     path,
@@ -1612,8 +1612,8 @@ impl AbstractVaddr {
             self.align_down_shape(3);
             self.to_path_index(2, 0);
             self.to_path_index(2, 1);
-            path.index_satisfies_elem_inv(0);
-            path.index_satisfies_elem_inv(1);
+            path.lemma_index_satisfies_elem_inv(0);
+            path.lemma_index_satisfies_elem_inv(1);
             assert(vaddr(path) == path.index(0) * 0x80_0000_0000usize + path.index(1)
                 * 0x4000_0000usize) by {
                 assert(vaddr(path) == rec_vaddr(path, 0));
@@ -1638,9 +1638,9 @@ impl AbstractVaddr {
             self.to_path_index(1, 0);
             self.to_path_index(1, 1);
             self.to_path_index(1, 2);
-            path.index_satisfies_elem_inv(0);
-            path.index_satisfies_elem_inv(1);
-            path.index_satisfies_elem_inv(2);
+            path.lemma_index_satisfies_elem_inv(0);
+            path.lemma_index_satisfies_elem_inv(1);
+            path.lemma_index_satisfies_elem_inv(2);
             assert(vaddr(path) == path.index(0) * 0x80_0000_0000usize + path.index(1)
                 * 0x4000_0000usize + path.index(2) * 0x20_0000usize) by {
                 assert(vaddr(path) == rec_vaddr(path, 0));
@@ -1684,10 +1684,10 @@ impl AbstractVaddr {
             self.to_path_index(0, 1);
             self.to_path_index(0, 2);
             self.to_path_index(0, 3);
-            path.index_satisfies_elem_inv(0);
-            path.index_satisfies_elem_inv(1);
-            path.index_satisfies_elem_inv(2);
-            path.index_satisfies_elem_inv(3);
+            path.lemma_index_satisfies_elem_inv(0);
+            path.lemma_index_satisfies_elem_inv(1);
+            path.lemma_index_satisfies_elem_inv(2);
+            path.lemma_index_satisfies_elem_inv(3);
             assert(vaddr(path) == path.index(0) * 0x80_0000_0000usize + path.index(1)
                 * 0x4000_0000usize + path.index(2) * 0x20_0000usize + path.index(3) * 0x1000usize)
                 by {
@@ -1971,8 +1971,8 @@ impl AbstractVaddr {
         decreases path1.len() - idx,
     {
         if idx < path1.len() {
-            path1.index_satisfies_elem_inv(idx);
-            path2.index_satisfies_elem_inv(idx);
+            path1.lemma_index_satisfies_elem_inv(idx);
+            path2.lemma_index_satisfies_elem_inv(idx);
             Self::rec_vaddr_eq_if_indices_eq(path1, path2, idx + 1);
         }
     }

--- a/ostd/specs/mm/page_table/node/owners.rs
+++ b/ostd/specs/mm/page_table/node/owners.rs
@@ -217,7 +217,7 @@ impl<C: PageTableConfig> OwnerOf for PageTablePageMeta<C> {
 /// - `slot_index` identifies the underlying frame's index in the metadata region
 /// - Each node is a page table with a level between 1 and 4 (on x86); `level` tracks
 ///   the level of this node.
-/// - `tree_level` is the level field of the `ghost_tree::Node` that carries this object.
+/// - `tree_level` is the level field of the `ghost_tree::TreeNode` that carries this object.
 ///   Carried here for convenience, though it can be computed from `level`.
 pub tracked struct NodeOwner<C: PageTableConfig> {
     pub meta_own: PageMetaOwner,

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -537,15 +537,15 @@ pub proof fn rebase_freshly_allocated_children<C: PageTableConfig>(
     rebase_freshly_allocated_children_at(owner, new_path, 0);
 }
 
-/// `tree_predicate_map` for a freshly-allocated node grafted into the cursor:
+/// `subtree_satisfies` for a freshly-allocated node grafted into the cursor:
 /// every child is a `new_val`-shaped node (all grandchildren `None`), so each
-/// child's `tree_predicate_map` reduces to `f` at that child
-/// (`lemma_new_val_tree_predicate_map`). Combined with `f` at the root node, this
+/// child's `subtree_satisfies` reduces to `f` at that child
+/// (`lemma_new_val_subtree_satisfies`). Combined with `f` at the root node, this
 /// discharges the whole one-level subtree. Used by `alloc_if_none` for the
 /// `node_unlocked_except` / `metaregion_sound_pred` / `path_tracked_pred`
 /// predicates over the fresh node (all of which hold trivially at the absent
 /// children).
-pub proof fn fresh_node_tree_predicate_map<C: PageTableConfig>(
+pub proof fn fresh_node_subtree_satisfies<C: PageTableConfig>(
     node: OwnerSubtree<C>,
     path: TreePath<NR_ENTRIES>,
     f: spec_fn(EntryOwner<C>, TreePath<NR_ENTRIES>) -> bool,
@@ -564,15 +564,15 @@ pub proof fn fresh_node_tree_predicate_map<C: PageTableConfig>(
                 path.push_tail(i as usize),
             ),
     ensures
-        node.tree_predicate_map(path, f),
+        node.subtree_satisfies(path, f),
 {
     assert forall|i: int|
         0 <= i < node.children().len()
-            && #[trigger] node.children()[i] is Some implies node.children()[i]->0.tree_predicate_map(
+            && #[trigger] node.children()[i] is Some implies node.children()[i]->0.subtree_satisfies(
         path.push_tail(i as usize),
         f,
     ) by {
-        // Each child has all-`None` grandchildren, so its `tree_predicate_map`
+        // Each child has all-`None` grandchildren, so its `subtree_satisfies`
         // unfolds to `f` at the child (the grandchild forall is vacuous).
         node.lemma_child_some_properties(i as usize);
     };
@@ -1141,7 +1141,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             PageTableOwner(subtree).pt_inv(),
             subtree.value().path == path,
         ensures
-            subtree.tree_predicate_map(path, Self::path_correct_pred()),
+            subtree.subtree_satisfies(path, Self::path_correct_pred()),
         decreases INC_LEVELS - subtree.level(),
     {
         assert(subtree.children().len() == NR_ENTRIES);
@@ -1150,7 +1150,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         if subtree.level() < INC_LEVELS - 1 {
             assert forall|i: int|
                 0 <= i < subtree.children().len() && (
-                #[trigger] subtree.children()[i]) is Some implies subtree.children()[i].unwrap().tree_predicate_map(
+                #[trigger] subtree.children()[i]) is Some implies subtree.children()[i].unwrap().subtree_satisfies(
             path.push_tail(i as usize), Self::path_correct_pred()) by {
                 if subtree.value().is_node() {
                     PageTableOwner(subtree).pt_inv_unroll(i);
@@ -1190,7 +1190,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             path.len() == self.0.level(),
             self.0.value().parent_level == (INC_LEVELS - self.0.level()) as PagingLevel,
             self.0.value().path == path,
-            self.0.tree_predicate_map(path, Self::path_correct_pred()),
+            self.0.subtree_satisfies(path, Self::path_correct_pred()),
             forall|mm: Mapping|
                 #![trigger self.view_rec(path).contains(mm)]
                 self.view_rec(path).contains(mm) ==> ambient.contains(mm),
@@ -1198,7 +1198,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 #![trigger ambient.contains(mm)]
                 ambient.contains(mm) ==> mm.va_range.start != vaddr_of::<C>(removed_path),
         ensures
-            self.0.tree_predicate_map(
+            self.0.subtree_satisfies(
                 path,
                 |e: EntryOwner<C>, _p: TreePath<NR_ENTRIES>|
                     e.is_frame() ==> e.path != removed_path,
@@ -1241,7 +1241,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         if self.0.level() < INC_LEVELS - 1 {
             assert forall|i: int|
                 0 <= i < self.0.children().len() && (
-                #[trigger] self.0.children()[i]) is Some implies self.0.children()[i].unwrap().tree_predicate_map(
+                #[trigger] self.0.children()[i]) is Some implies self.0.children()[i].unwrap().subtree_satisfies(
             path.push_tail(i as usize), g) by {
                 if self.0.value().is_node() {
                     self.pt_inv_unroll(i);
@@ -1257,7 +1257,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 }
             };
         }
-        assert(self.0.tree_predicate_map(path, g));
+        assert(self.0.subtree_satisfies(path, g));
     }
 
     pub proof fn view_rec_disjoint_vaddrs(
@@ -1705,7 +1705,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         decreases INC_LEVELS - self.0.level(),
         when self.0.inv()
     {
-        self.0.tree_predicate_map(self.0.value().path, Self::metaregion_sound_pred(regions))
+        self.0.subtree_satisfies(self.0.value().path, Self::metaregion_sound_pred(regions))
     }
 
     /// `PageTableOwner::metaregion_sound` is preserved across regions changes
@@ -1738,12 +1738,12 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     )
         requires
             subtree.inv(),
-            subtree.tree_predicate_map(path, Self::metaregion_sound_pred(r0)),
+            subtree.subtree_satisfies(path, Self::metaregion_sound_pred(r0)),
             r0.slot_owners == r1.slot_owners,
             forall|k: usize| r0.slots.contains_key(k) ==> #[trigger] r1.slots.contains_key(k),
             forall|k: usize| r0.slots.contains_key(k) ==> r0.slots[k] == #[trigger] r1.slots[k],
         ensures
-            subtree.tree_predicate_map(path, Self::metaregion_sound_pred(r1)),
+            subtree.subtree_satisfies(path, Self::metaregion_sound_pred(r1)),
         decreases INC_LEVELS - subtree.level(),
     {
         // The root entry: its metaregion_sound transfers via the per-entry lemma.
@@ -1753,7 +1753,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             assert forall|i: int|
                 #![trigger subtree.children()[i]]
                 0 <= i < NR_ENTRIES
-                    && subtree.children()[i] is Some implies subtree.children()[i].unwrap().tree_predicate_map(
+                    && subtree.children()[i] is Some implies subtree.children()[i].unwrap().subtree_satisfies(
             path.push_tail(i as usize), Self::metaregion_sound_pred(r1)) by {
                 Self::metaregion_sound_preserved_slot_owners_eq_subtree(
                     subtree.children()[i].unwrap(),
@@ -1786,7 +1786,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             forall|k: usize| r0.slots.contains_key(k) ==> #[trigger] r1.slots.contains_key(k),
             forall|k: usize| r0.slots.contains_key(k) ==> r0.slots[k] == #[trigger] r1.slots[k],
             // No tree entry's primary slot is at changed_idx.
-            self.0.tree_predicate_map(
+            self.0.subtree_satisfies(
                 self.0.value().path,
                 |e: EntryOwner<C>, p: TreePath<NR_ENTRIES>|
                     e.meta_slot_paddr() is Some ==> frame_to_index(e.meta_slot_paddr()->0)
@@ -1795,7 +1795,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             // For huge-frame entries, none of their sub-page slots is at changed_idx
             // either; provided as a separate condition because the per-entry lemma
             // requires it.
-            self.0.tree_predicate_map(
+            self.0.subtree_satisfies(
                 self.0.value().path,
                 |e: EntryOwner<C>, p: TreePath<NR_ENTRIES>|
                     e.is_frame() && e.parent_level > 1 ==> {
@@ -1836,20 +1836,20 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     )
         requires
             subtree.inv(),
-            subtree.tree_predicate_map(path, Self::metaregion_sound_pred(r0)),
+            subtree.subtree_satisfies(path, Self::metaregion_sound_pred(r0)),
             forall|i: usize|
                 #![trigger r1.slot_owners[i]]
                 i != changed_idx ==> r0.slot_owners[i] == r1.slot_owners[i],
             r0.slot_owners.dom() == r1.slot_owners.dom(),
             forall|k: usize| r0.slots.contains_key(k) ==> #[trigger] r1.slots.contains_key(k),
             forall|k: usize| r0.slots.contains_key(k) ==> r0.slots[k] == #[trigger] r1.slots[k],
-            subtree.tree_predicate_map(
+            subtree.subtree_satisfies(
                 path,
                 |e: EntryOwner<C>, p: TreePath<NR_ENTRIES>|
                     e.meta_slot_paddr() is Some ==> frame_to_index(e.meta_slot_paddr()->0)
                         != changed_idx,
             ),
-            subtree.tree_predicate_map(
+            subtree.subtree_satisfies(
                 path,
                 |e: EntryOwner<C>, p: TreePath<NR_ENTRIES>|
                     e.is_frame() && e.parent_level > 1 ==> {
@@ -1870,7 +1870,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                     },
             ),
         ensures
-            subtree.tree_predicate_map(path, Self::metaregion_sound_pred(r1)),
+            subtree.subtree_satisfies(path, Self::metaregion_sound_pred(r1)),
         decreases INC_LEVELS - subtree.level(),
     {
         subtree.value().metaregion_sound_one_slot_changed(r0, r1, changed_idx);
@@ -1878,7 +1878,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             assert forall|i: int|
                 #![trigger subtree.children()[i]]
                 0 <= i < NR_ENTRIES
-                    && subtree.children()[i] is Some implies subtree.children()[i].unwrap().tree_predicate_map(
+                    && subtree.children()[i] is Some implies subtree.children()[i].unwrap().subtree_satisfies(
             path.push_tail(i as usize), Self::metaregion_sound_pred(r1)) by {
                 Self::metaregion_sound_preserved_one_slot_changed_subtree(
                     subtree.children()[i].unwrap(),
@@ -1929,19 +1929,19 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         |entry: EntryOwner<C>, _path: TreePath<NR_ENTRIES>| true
     }
 
-    /// `tree_predicate_map` for the trivial `not_in_scope_pred`.
+    /// `subtree_satisfies` for the trivial `not_in_scope_pred`.
     pub proof fn tree_not_in_scope(subtree: OwnerSubtree<C>, path: TreePath<NR_ENTRIES>)
         requires
             subtree.inv(),
         ensures
-            subtree.tree_predicate_map(path, Self::not_in_scope_pred()),
+            subtree.subtree_satisfies(path, Self::not_in_scope_pred()),
         decreases INC_LEVELS - subtree.level(),
     {
         // `not_in_scope_pred` is trivially `true`; recurse to discharge it.
         if subtree.level() < INC_LEVELS - 1 {
             assert forall|i: int|
                 0 <= i < subtree.children().len() && (
-                #[trigger] subtree.children()[i]) is Some implies subtree.children()[i].unwrap().tree_predicate_map(
+                #[trigger] subtree.children()[i]) is Some implies subtree.children()[i].unwrap().subtree_satisfies(
             path.push_tail(i as usize), Self::not_in_scope_pred()) by {
                 Self::tree_not_in_scope(subtree.children()[i].unwrap(), path.push_tail(i as usize));
             };
@@ -2114,13 +2114,13 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             root_path.len() <= INC_LEVELS - 1,
             root_path.len() == subtree.level(),
         ensures
-            subtree.tree_predicate_map(root_path, Self::is_at_pred(entry, dest_path)),
+            subtree.subtree_satisfies(root_path, Self::is_at_pred(entry, dest_path)),
         decreases INC_LEVELS - root_path.len(),
     {
         if subtree.level() < INC_LEVELS - 1 {
             if subtree.value().is_node() {
                 assert forall|i: int| 0 <= i < NR_ENTRIES implies (
-                #[trigger] subtree.children()[i as int]).unwrap().tree_predicate_map(
+                #[trigger] subtree.children()[i as int]).unwrap().subtree_satisfies(
                     root_path.push_tail(i as usize),
                     Self::is_at_pred(entry, dest_path),
                 ) by {
@@ -2157,13 +2157,13 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             root_path.len() <= INC_LEVELS - 1,
             root_path.len() == subtree.level(),
         ensures
-            subtree.tree_predicate_map(root_path, Self::path_in_tree_pred(dest_path)),
+            subtree.subtree_satisfies(root_path, Self::path_in_tree_pred(dest_path)),
         decreases INC_LEVELS - root_path.len(),
     {
         if subtree.level() < INC_LEVELS - 1 {
             if subtree.value().is_node() {
                 assert forall|i: int| 0 <= i < NR_ENTRIES implies (
-                #[trigger] subtree.children()[i as int]).unwrap().tree_predicate_map(
+                #[trigger] subtree.children()[i as int]).unwrap().subtree_satisfies(
                     root_path.push_tail(i as usize),
                     Self::path_in_tree_pred(dest_path),
                 ) by {
@@ -2197,15 +2197,15 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             path_j.len() == subtree.level(),
             path_j.inv(),
             path_j.len() <= INC_LEVELS - 1,
-            subtree.tree_predicate_map(path_j, Self::metaregion_sound_pred(regions)),
-            subtree.tree_predicate_map(path_j, Self::path_correct_pred()),
+            subtree.subtree_satisfies(path_j, Self::metaregion_sound_pred(regions)),
+            subtree.subtree_satisfies(path_j, Self::path_correct_pred()),
             old_entry.is_node(),
             old_entry.meta_slot_paddr() is Some,
             regions.slot_owners[frame_to_index(old_entry.meta_slot_paddr()->0)].paths_in_pt
                 == set![old_entry.path],
             !Self::is_prefix_of(path_j, old_entry.path),
         ensures
-            subtree.tree_predicate_map(
+            subtree.subtree_satisfies(
                 path_j,
                 |e: EntryOwner<C>, p: TreePath<NR_ENTRIES>| e.meta_slot_paddr_neq(old_entry),
             ),
@@ -2242,7 +2242,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         if subtree.level() < INC_LEVELS - 1 {
             assert forall|i: int|
                 0 <= i < subtree.children().len() && (
-                #[trigger] subtree.children()[i]) is Some implies subtree.children()[i].unwrap().tree_predicate_map(
+                #[trigger] subtree.children()[i]) is Some implies subtree.children()[i].unwrap().subtree_satisfies(
             path_j.push_tail(i as usize), g) by {
                 let child = subtree.children()[i].unwrap();
                 let child_path = path_j.push_tail(i as usize);
@@ -2279,9 +2279,9 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             Self::is_prefix_of(root_path, dest_path),
             root_path.len() <= INC_LEVELS - 1,
             root_path.len() == subtree.level(),
-            subtree.tree_predicate_map(root_path, Self::path_in_tree_pred(dest_path)),
-            subtree.tree_predicate_map(root_path, Self::is_at_pred(entry1, dest_path)),
-            subtree.tree_predicate_map(root_path, Self::is_at_pred(entry2, dest_path)),
+            subtree.subtree_satisfies(root_path, Self::path_in_tree_pred(dest_path)),
+            subtree.subtree_satisfies(root_path, Self::is_at_pred(entry1, dest_path)),
+            subtree.subtree_satisfies(root_path, Self::is_at_pred(entry2, dest_path)),
         ensures
             entry1 == entry2,
         decreases INC_LEVELS - root_path.len(),
@@ -2326,8 +2326,8 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             self.pt_inv(),
             path.len() == self.0.level(),
             self.view_rec(path).contains(m),
-            self.0.tree_predicate_map(path, Self::path_correct_pred()),
-            self.0.tree_predicate_map(path, Self::relate_region_tracked_pred(regions)),
+            self.0.subtree_satisfies(path, Self::path_correct_pred()),
+            self.0.subtree_satisfies(path, Self::relate_region_tracked_pred(regions)),
         ensures
             Self::is_prefix_of(path, entry.path),
             regions.slot_owners[frame_to_index(m.pa_range.start)].paths_in_pt == set![entry.path],
@@ -2335,8 +2335,8 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             m.page_size == page_size((INC_LEVELS - entry.path.len()) as PagingLevel),
             entry.is_frame(),
             m.property == entry.frame().prop,
-            self.0.tree_predicate_map(path, Self::is_at_pred(entry, entry.path)),
-            self.0.tree_predicate_map(path, Self::path_in_tree_pred(entry.path)),
+            self.0.subtree_satisfies(path, Self::is_at_pred(entry, entry.path)),
+            self.0.subtree_satisfies(path, Self::path_in_tree_pred(entry.path)),
             entry.inv(),
         decreases INC_LEVELS - path.len(),
     {
@@ -2346,17 +2346,17 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             assert(Self::is_prefix_of(path, self.0.value().path));
             if self.0.level() < INC_LEVELS - 1 {
                 // Non-leaf frame: pt_inv gives children[i] is None,
-                // so tree_predicate_map has no children to recurse into.
+                // so subtree_satisfies has no children to recurse into.
                 assert forall|i: int| 0 <= i < NR_ENTRIES implies (
                 #[trigger] self.0.children()[i]) is None by {
                     self.pt_inv_non_node(i);
                 };
             }
-            assert(self.0.tree_predicate_map(
+            assert(self.0.subtree_satisfies(
                 path,
                 Self::is_at_pred(self.0.value(), self.0.value().path),
             ));
-            assert(self.0.tree_predicate_map(path, Self::path_in_tree_pred(self.0.value().path)));
+            assert(self.0.subtree_satisfies(path, Self::path_in_tree_pred(self.0.value().path)));
             self.0.value()
         } else if self.0.value().is_node() {
             let i = self.view_rec_contains_choose(path, m);
@@ -2369,7 +2369,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             Self::prefix_transitive(path, path.push_tail(i as usize), entry.path);
             assert forall|j: int|
                 0 <= j < NR_ENTRIES
-                    && #[trigger] self.0.children()[j] is Some implies self.0.children()[j].unwrap().tree_predicate_map(
+                    && #[trigger] self.0.children()[j] is Some implies self.0.children()[j].unwrap().subtree_satisfies(
             path.push_tail(j as usize), Self::is_at_pred(entry, entry.path)) by {
                 if j != i {
                     self.pt_inv_unroll(j);
@@ -2383,11 +2383,11 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                     );
                 }
             };
-            assert(self.0.tree_predicate_map(path, Self::is_at_pred(entry, entry.path)));
+            assert(self.0.subtree_satisfies(path, Self::is_at_pred(entry, entry.path)));
 
             assert forall|j: int|
                 0 <= j < NR_ENTRIES
-                    && #[trigger] self.0.children()[j] is Some implies self.0.children()[j].unwrap().tree_predicate_map(
+                    && #[trigger] self.0.children()[j] is Some implies self.0.children()[j].unwrap().subtree_satisfies(
             path.push_tail(j as usize), Self::path_in_tree_pred(entry.path)) by {
                 if j != i {
                     self.pt_inv_unroll(j);
@@ -2400,7 +2400,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                     );
                 }
             };
-            assert(self.0.tree_predicate_map(path, Self::path_in_tree_pred(entry.path)));
+            assert(self.0.subtree_satisfies(path, Self::path_in_tree_pred(entry.path)));
             entry
         } else {
             proof_from_false()
@@ -2423,17 +2423,17 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             m1.pa_range.start == m2.pa_range.start,
             m1.inv(),
             m2.inv(),
-            self.0.tree_predicate_map(path, Self::path_tracked_pred(regions)),
-            self.0.tree_predicate_map(path, Self::path_correct_pred()),
-            self.0.tree_predicate_map(path, Self::relate_region_tracked_pred(regions)),
+            self.0.subtree_satisfies(path, Self::path_tracked_pred(regions)),
+            self.0.subtree_satisfies(path, Self::path_correct_pred()),
+            self.0.subtree_satisfies(path, Self::relate_region_tracked_pred(regions)),
         ensures
             m1 == m2,
     {
         let entry1 = self.view_rec_inversion(path, regions, m1);
         let entry2 = self.view_rec_inversion(path, regions, m2);
 
-        assert(self.0.tree_predicate_map(path, Self::is_at_pred(entry1, entry1.path)));
-        assert(self.0.tree_predicate_map(path, Self::is_at_pred(entry2, entry2.path)));
+        assert(self.0.subtree_satisfies(path, Self::is_at_pred(entry1, entry1.path)));
+        assert(self.0.subtree_satisfies(path, Self::is_at_pred(entry2, entry2.path)));
 
         // Same paddr ⇒ same slot ⇒ same singleton paths_in_pt ⇒ same entry path.
         let idx = frame_to_index(m1.pa_range.start);
@@ -2461,7 +2461,7 @@ impl<C: PageTableConfig> Inv for PageTableOwner<C> {
         &&& self.0.value().path.len() == self.0.level()
         &&& self.0.value().parent_level == (INC_LEVELS - self.0.level()) as PagingLevel
         &&& self.0.value().node().tree_level == self.0.value().path.len()
-        &&& self.0.tree_predicate_map(self.0.value().path, Self::path_correct_pred())
+        &&& self.0.subtree_satisfies(self.0.value().path, Self::path_correct_pred())
     }
 }
 

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -574,7 +574,8 @@ pub proof fn fresh_node_subtree_satisfies<C: PageTableConfig>(
     ) by {
         // Each child has all-`None` grandchildren, so its `subtree_satisfies`
         // unfolds to `f` at the child (the grandchild forall is vacuous).
-        node.lemma_child_some_properties(i as usize);
+        assert(node.children()[i]->0.inv());
+        assert(node.children()[i]->0.level() == node.level() + 1);
     };
 }
 

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -144,10 +144,9 @@ pub proof fn lemma_vaddr_strict_bound(path: TreePath<NR_ENTRIES>)
         let i2 = path[2];
         assert(rec_vaddr(path, 3) == 0);
         assert(rec_vaddr(path, 2) == vaddr_make::<NR_LEVELS>(2, i2 as usize) as usize);
-        assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + vaddr_make::<NR_LEVELS>(
-            2,
-            i2 as usize,
-        )) as usize);
+        assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + vaddr_make::<
+            NR_LEVELS,
+        >(2, i2 as usize)) as usize);
     } else {
         path.lemma_index_satisfies_elem_inv(0);
         path.lemma_index_satisfies_elem_inv(1);
@@ -159,18 +158,18 @@ pub proof fn lemma_vaddr_strict_bound(path: TreePath<NR_ENTRIES>)
         let i3 = path[3];
         assert(rec_vaddr(path, 4) == 0);
         assert(rec_vaddr(path, 3) == vaddr_make::<NR_LEVELS>(3, i3 as usize) as usize);
-        assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, i2 as usize) + vaddr_make::<NR_LEVELS>(
+        assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, i2 as usize) + vaddr_make::<
+            NR_LEVELS,
+        >(3, i3 as usize)) as usize);
+        assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + vaddr_make::<
+            NR_LEVELS,
+        >(2, i2 as usize) + vaddr_make::<NR_LEVELS>(3, i3 as usize)) as usize);
+        assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, i0 as usize) + vaddr_make::<
+            NR_LEVELS,
+        >(1, i1 as usize) + vaddr_make::<NR_LEVELS>(2, i2 as usize) + vaddr_make::<NR_LEVELS>(
             3,
             i3 as usize,
         )) as usize);
-        assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + vaddr_make::<NR_LEVELS>(
-            2,
-            i2 as usize,
-        ) + vaddr_make::<NR_LEVELS>(3, i3 as usize)) as usize);
-        assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, i0 as usize) + vaddr_make::<NR_LEVELS>(
-            1,
-            i1 as usize,
-        ) + vaddr_make::<NR_LEVELS>(2, i2 as usize) + vaddr_make::<NR_LEVELS>(3, i3 as usize)) as usize);
         assert(vaddr_make::<NR_LEVELS>(2, i2 as usize) == 0x20_0000usize * i2) by (compute);
         assert(vaddr_make::<NR_LEVELS>(3, i3 as usize) == 0x1000usize * i3) by (compute);
         assert(0x80_0000_0000usize * i0 + 0x4000_0000usize * i1 + 0x20_0000usize * i2 + 0x1000usize
@@ -222,16 +221,15 @@ pub proof fn lemma_vaddr_top_index_cell(path: TreePath<NR_ENTRIES>)
         let i2 = path[2];
         assert(rec_vaddr(path, 3) == 0);
         assert(rec_vaddr(path, 2) == vaddr_make::<NR_LEVELS>(2, i2 as usize) as usize);
-        assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + vaddr_make::<NR_LEVELS>(
-            2,
-            i2 as usize,
-        )) as usize);
+        assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + vaddr_make::<
+            NR_LEVELS,
+        >(2, i2 as usize)) as usize);
         assert(vaddr_make::<NR_LEVELS>(1, i1 as usize) == 0x4000_0000usize * i1) by (compute);
         assert(vaddr_make::<NR_LEVELS>(2, i2 as usize) == 0x20_0000usize * i2) by (compute);
-        assert(vaddr(path) == 0x80_0000_0000usize * i0 + 0x4000_0000usize * i1
-            + 0x20_0000usize * i2);
-        assert(0x4000_0000int * i1 + 0x20_0000int * i2 + 0x20_0000int
-            <= 0x80_0000_0000int) by (nonlinear_arith)
+        assert(vaddr(path) == 0x80_0000_0000usize * i0 + 0x4000_0000usize * i1 + 0x20_0000usize
+            * i2);
+        assert(0x4000_0000int * i1 + 0x20_0000int * i2 + 0x20_0000int <= 0x80_0000_0000int)
+            by (nonlinear_arith)
             requires
                 i1 < 512,
                 i2 < 512,
@@ -242,16 +240,14 @@ pub proof fn lemma_vaddr_top_index_cell(path: TreePath<NR_ENTRIES>)
         let i3 = path[3];
         assert(rec_vaddr(path, 4) == 0);
         assert(rec_vaddr(path, 3) == vaddr_make::<NR_LEVELS>(3, i3 as usize) as usize);
-        assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, i2 as usize) + vaddr_make::<NR_LEVELS>(
-            3,
-            i3 as usize,
-        )) as usize);
-        assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + vaddr_make::<NR_LEVELS>(
-            2,
-            i2 as usize,
-        ) + vaddr_make::<NR_LEVELS>(3, i3 as usize)) as usize);
-        assert(vaddr(path) == 0x80_0000_0000usize * i0 + 0x4000_0000usize * i1
-            + 0x20_0000usize * i2 + 0x1000usize * i3);
+        assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, i2 as usize) + vaddr_make::<
+            NR_LEVELS,
+        >(3, i3 as usize)) as usize);
+        assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + vaddr_make::<
+            NR_LEVELS,
+        >(2, i2 as usize) + vaddr_make::<NR_LEVELS>(3, i3 as usize)) as usize);
+        assert(vaddr(path) == 0x80_0000_0000usize * i0 + 0x4000_0000usize * i1 + 0x20_0000usize * i2
+            + 0x1000usize * i3);
         assert(0x80_0000_0000int * i0 + 0x4000_0000int * i1 + 0x20_0000int * i2 + 0x1000int * i3
             + 0x1000int <= (i0 + 1) * 0x80_0000_0000int) by (nonlinear_arith)
             requires
@@ -457,8 +453,7 @@ pub open spec fn allocated_empty_node_grandchildren_none<C: PageTableConfig>(
     owner: OwnerSubtree<C>,
 ) -> bool {
     forall|i: int, j: int|
-        0 <= i < NR_ENTRIES && 0 <= j < NR_ENTRIES
-            ==> !#[trigger] owner.child(i).has_child(j)
+        0 <= i < NR_ENTRIES && 0 <= j < NR_ENTRIES ==> !#[trigger] owner.child(i).has_child(j)
 }
 
 /// Recursive worker for `rebase_freshly_allocated_children`. Rebases
@@ -486,10 +481,7 @@ pub proof fn rebase_freshly_allocated_children_at<C: PageTableConfig>(
                 let c_old = old(owner).child(j);
                 let c_new = (#[trigger] final(owner).children()[j])->0;
                 &&& final(owner).has_child(j)
-                &&& c_new.value() == EntryOwner {
-                    path: new_path.push_tail(j),
-                    ..c_old.value()
-                }
+                &&& c_new.value() == EntryOwner { path: new_path.push_tail(j), ..c_old.value() }
                 &&& c_new.level() == c_old.level()
                 &&& c_new.children() == c_old.children()
             },
@@ -531,10 +523,7 @@ pub proof fn rebase_freshly_allocated_children<C: PageTableConfig>(
                 let c_old = old(owner).child(i);
                 let c_new = (#[trigger] final(owner).children()[i])->0;
                 &&& final(owner).has_child(i)
-                &&& c_new.value() == EntryOwner {
-                    path: new_path.push_tail(i),
-                    ..c_old.value()
-                }
+                &&& c_new.value() == EntryOwner { path: new_path.push_tail(i), ..c_old.value() }
                 &&& c_new.level() == c_old.level()
                 &&& c_new.children() == c_old.children()
             },
@@ -561,22 +550,16 @@ pub proof fn fresh_node_subtree_satisfies<C: PageTableConfig>(
         f(node.value(), path),
         forall|i: int| 0 <= i < NR_ENTRIES ==> #[trigger] node.has_child(i),
         forall|i: int, j: int|
-            0 <= i < NR_ENTRIES && 0 <= j < NR_ENTRIES
-                ==> !#[trigger] node.child(i).has_child(j),
+            0 <= i < NR_ENTRIES && 0 <= j < NR_ENTRIES ==> !#[trigger] node.child(i).has_child(j),
         forall|i: int|
-            0 <= i < NR_ENTRIES ==> #[trigger] f(
-                node.child(i).value(),
-                path.push_tail(i),
-            ),
+            0 <= i < NR_ENTRIES ==> #[trigger] f(node.child(i).value(), path.push_tail(i)),
     ensures
         node.subtree_satisfies(path, f),
 {
     assert forall|i: int|
-        0 <= i < node.children().len()
-            && #[trigger] node.has_child(i) implies node.child(i).subtree_satisfies(
-        path.push_tail(i),
-        f,
-    ) by {
+        0 <= i < node.children().len() && #[trigger] node.has_child(i) implies node.child(
+        i,
+    ).subtree_satisfies(path.push_tail(i), f) by {
         // Each child has all-`None` grandchildren, so its `subtree_satisfies`
         // unfolds to `f` at the child (the grandchild forall is vacuous).
         assert(node.child(i).inv());
@@ -659,7 +642,10 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         // la_inv + is_node() gives tree_level < L-1, so depth > 0 and the
         // node branch of pt_inv_at_depth fires.
         let depth = (INC_LEVELS - self.0.level()) as nat;
-        assert(<EntryOwner<C> as TreeNodeValue<INC_LEVELS>>::la_inv(self.0.value(), self.0.level()));
+        assert(<EntryOwner<C> as TreeNodeValue<INC_LEVELS>>::la_inv(
+            self.0.value(),
+            self.0.level(),
+        ));
     }
 
     pub proof fn pt_inv_non_node(self, i: int)
@@ -721,8 +707,9 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         // Drive `pt_inv_at_depth(depth)` via the `is_node` branch: prove
         // `pt_edge_at` and the recursive `pt_inv_at_depth(depth-1)` for each child.
         assert forall|i: int| 0 <= i < NR_ENTRIES implies #[trigger] owner.has_child(i)
-            && Self::pt_edge_at(owner, i)
-            && PageTableOwner(owner.child(i)).pt_inv_at_depth((depth - 1) as nat) by {
+            && Self::pt_edge_at(owner, i) && PageTableOwner(owner.child(i)).pt_inv_at_depth(
+            (depth - 1) as nat,
+        ) by {
             let child = owner.child(i);
             // pt_edge_at follows from the per-edge facts in the precondition.
             // owner.inv() ⇒ child.inv() (`TreeNode::inv` recurses since
@@ -801,9 +788,9 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             self.0.value().is_node(),
             0 <= i < self.0.children().len(),
             self.0.has_child(i),
-            #[trigger] PageTableOwner(self.0.children()[i]->0).view_rec(
-                path.push_tail(i),
-            ).contains(m),
+            #[trigger] PageTableOwner(self.0.children()[i]->0).view_rec(path.push_tail(i)).contains(
+                m,
+            ),
         ensures
             self.view_rec(path).contains(m),
     {
@@ -828,9 +815,10 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 #![trigger self.view_rec(path).contains(m)]
                 self.view_rec(path).contains(m) ==> exists|i: int|
                     #![trigger self.0.children()[i]]
-                    0 <= i < self.0.children().len() && self.0.children()[i] is Some && PageTableOwner(
-                        self.0.children()[i]->0,
-                    ).view_rec(path.push_tail(i)).contains(m),
+                    0 <= i < self.0.children().len() && self.0.children()[i] is Some
+                        && PageTableOwner(self.0.children()[i]->0).view_rec(
+                        path.push_tail(i),
+                    ).contains(m),
     {
         broadcast use vstd::seq_lib::group_seq_properties;
 
@@ -848,9 +836,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             assert(mapped.contains(elem_s));
             let i = mapped.lemma_contains_to_index(elem_s);
             if self.0.has_child(i) {
-                assert(mapped[i] == PageTableOwner(self.0.child(i)).view_rec(
-                    path.push_tail(i),
-                ));
+                assert(mapped[i] == PageTableOwner(self.0.child(i)).view_rec(path.push_tail(i)));
             } else {
                 assert(false);
             }
@@ -943,19 +929,17 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             let i1 = path[1];
             assert(rec_vaddr(path, 2) == 0);
             assert(rec_vaddr(path, 1) == vaddr_make::<NR_LEVELS>(1, i1 as usize) as usize);
-            assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, i0 as usize) + vaddr_make::<NR_LEVELS>(
-                1,
-                i1 as usize,
-            )) as usize);
+            assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, i0 as usize) + vaddr_make::<
+                NR_LEVELS,
+            >(1, i1 as usize)) as usize);
             assert(vaddr_make::<NR_LEVELS>(1, i1 as usize) == 0x4000_0000usize * i1) by (compute);
             assert(pt.len() == 3);
             assert(pt[2] == i);
             assert(rec_vaddr(pt, 3) == 0);
             assert(rec_vaddr(pt, 2) == vaddr_make::<NR_LEVELS>(2, i as usize) as usize);
-            assert(rec_vaddr(pt, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + vaddr_make::<NR_LEVELS>(
-                2,
-                i as usize,
-            )) as usize);
+            assert(rec_vaddr(pt, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + vaddr_make::<
+                NR_LEVELS,
+            >(2, i as usize)) as usize);
             assert(vaddr_make::<NR_LEVELS>(2, i as usize) == 0x20_0000usize * i) by (compute);
             assert(page_size(2) == 0x20_0000usize);
             assert(0x80_0000_0000usize * i0 + 0x4000_0000usize * i1 + 0x20_0000usize * (i + 1)
@@ -972,14 +956,12 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             let i2 = path[2];
             assert(rec_vaddr(path, 3) == 0);
             assert(rec_vaddr(path, 2) == vaddr_make::<NR_LEVELS>(2, i2 as usize) as usize);
-            assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + vaddr_make::<NR_LEVELS>(
-                2,
-                i2 as usize,
-            )) as usize);
-            assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, i0 as usize) + vaddr_make::<NR_LEVELS>(
-                1,
-                i1 as usize,
-            ) + vaddr_make::<NR_LEVELS>(2, i2 as usize)) as usize);
+            assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + vaddr_make::<
+                NR_LEVELS,
+            >(2, i2 as usize)) as usize);
+            assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, i0 as usize) + vaddr_make::<
+                NR_LEVELS,
+            >(1, i1 as usize) + vaddr_make::<NR_LEVELS>(2, i2 as usize)) as usize);
             assert(vaddr_make::<NR_LEVELS>(1, i1 as usize) == 0x4000_0000usize * i1) by (compute);
             assert(vaddr_make::<NR_LEVELS>(2, i2 as usize) == 0x20_0000usize * i2) by (compute);
             assert(pt.len() == 4);
@@ -989,18 +971,18 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             assert(pt[3] == i);
             assert(rec_vaddr(pt, 4) == 0);
             assert(rec_vaddr(pt, 3) == vaddr_make::<NR_LEVELS>(3, i as usize) as usize);
-            assert(rec_vaddr(pt, 2) == (vaddr_make::<NR_LEVELS>(2, i2 as usize) + vaddr_make::<NR_LEVELS>(
+            assert(rec_vaddr(pt, 2) == (vaddr_make::<NR_LEVELS>(2, i2 as usize) + vaddr_make::<
+                NR_LEVELS,
+            >(3, i as usize)) as usize);
+            assert(rec_vaddr(pt, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + vaddr_make::<
+                NR_LEVELS,
+            >(2, i2 as usize) + vaddr_make::<NR_LEVELS>(3, i as usize)) as usize);
+            assert(rec_vaddr(pt, 0) == (vaddr_make::<NR_LEVELS>(0, i0 as usize) + vaddr_make::<
+                NR_LEVELS,
+            >(1, i1 as usize) + vaddr_make::<NR_LEVELS>(2, i2 as usize) + vaddr_make::<NR_LEVELS>(
                 3,
                 i as usize,
             )) as usize);
-            assert(rec_vaddr(pt, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + vaddr_make::<NR_LEVELS>(
-                2,
-                i2 as usize,
-            ) + vaddr_make::<NR_LEVELS>(3, i as usize)) as usize);
-            assert(rec_vaddr(pt, 0) == (vaddr_make::<NR_LEVELS>(0, i0 as usize) + vaddr_make::<NR_LEVELS>(
-                1,
-                i1 as usize,
-            ) + vaddr_make::<NR_LEVELS>(2, i2 as usize) + vaddr_make::<NR_LEVELS>(3, i as usize)) as usize);
             assert(vaddr_make::<NR_LEVELS>(3, i as usize) == 0x1000usize * i) by (compute);
             assert(page_size(1) == 0x1000usize);
             assert(0x80_0000_0000usize * i0 + 0x4000_0000usize * i1 + 0x20_0000usize * i2
@@ -1122,8 +1104,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         // `(index(0)+1) <= t`. Adding the `LEADING_BITS*2^48` base shifts both
         // ends — giving the user (LB=0) low half and the kernel (LB=0xffff)
         // high half.
-        assert((path[0] + 1) * 0x80_0000_0000int <= t * 0x80_0000_0000int)
-            by (nonlinear_arith)
+        assert((path[0] + 1) * 0x80_0000_0000int <= t * 0x80_0000_0000int) by (nonlinear_arith)
             requires
                 path[0] < t,
         ;
@@ -1348,9 +1329,10 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 ) implies set![4096usize, 2097152usize, 1073741824usize].contains(m.page_size) by {
                 let i = choose|i: int|
                     #![trigger self.0.children()[i]]
-                    0 <= i < self.0.children().len() && self.0.children()[i] is Some && PageTableOwner(
-                        self.0.children()[i].unwrap(),
-                    ).view_rec(path.push_tail(i)).contains(m);
+                    0 <= i < self.0.children().len() && self.0.children()[i] is Some
+                        && PageTableOwner(self.0.children()[i].unwrap()).view_rec(
+                        path.push_tail(i),
+                    ).contains(m);
                 self.pt_inv_unroll(i);
                 let child = self.0.children()[i].unwrap();
                 PageTableOwner(child).view_rec_mapping_page_size(path.push_tail(i));
@@ -1398,7 +1380,8 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 path,
                 1,
             )) as usize);
-            assert(vaddr_make::<NR_LEVELS>(0, i0 as usize) == 0x80_0000_0000usize * i0) by (compute);
+            assert(vaddr_make::<NR_LEVELS>(0, i0 as usize) == 0x80_0000_0000usize * i0)
+                by (compute);
             assert(rec_vaddr(path, 0) == 0x80_0000_0000usize * i0);
             assert(page_size(4) == 0x80_0000_0000usize);
             assert((0x80_0000_0000usize * i0) % 0x80_0000_0000 == 0) by (nonlinear_arith);
@@ -1418,7 +1401,8 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 path,
                 1,
             )) as usize);
-            assert(vaddr_make::<NR_LEVELS>(0, i0 as usize) == 0x80_0000_0000usize * i0) by (compute);
+            assert(vaddr_make::<NR_LEVELS>(0, i0 as usize) == 0x80_0000_0000usize * i0)
+                by (compute);
             assert(vaddr_make::<NR_LEVELS>(1, i1 as usize) == 0x4000_0000usize * i1) by (compute);
             let s = 0x80_0000_0000usize * i0 + 0x4000_0000usize * i1;
             assert(rec_vaddr(path, 0) == s);
@@ -1450,7 +1434,8 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 path,
                 1,
             )) as usize);
-            assert(vaddr_make::<NR_LEVELS>(0, i0 as usize) == 0x80_0000_0000usize * i0) by (compute);
+            assert(vaddr_make::<NR_LEVELS>(0, i0 as usize) == 0x80_0000_0000usize * i0)
+                by (compute);
             assert(vaddr_make::<NR_LEVELS>(1, i1 as usize) == 0x4000_0000usize * i1) by (compute);
             assert(vaddr_make::<NR_LEVELS>(2, i2 as usize) == 0x20_0000usize * i2) by (compute);
             let s = 0x80_0000_0000usize * i0 + 0x4000_0000usize * i1 + 0x20_0000usize * i2;
@@ -1490,7 +1475,8 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 path,
                 1,
             )) as usize);
-            assert(vaddr_make::<NR_LEVELS>(0, i0 as usize) == 0x80_0000_0000usize * i0) by (compute);
+            assert(vaddr_make::<NR_LEVELS>(0, i0 as usize) == 0x80_0000_0000usize * i0)
+                by (compute);
             assert(vaddr_make::<NR_LEVELS>(1, i1 as usize) == 0x4000_0000usize * i1) by (compute);
             assert(vaddr_make::<NR_LEVELS>(2, i2 as usize) == 0x20_0000usize * i2) by (compute);
             assert(vaddr_make::<NR_LEVELS>(3, i3 as usize) == 0x1000usize * i3) by (compute);
@@ -1611,9 +1597,10 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 self.view_rec(path).contains(m) implies m.inv() by {
                 let i = choose|i: int|
                     #![trigger self.0.children()[i]]
-                    0 <= i < self.0.children().len() && self.0.children()[i] is Some && PageTableOwner(
-                        self.0.children()[i].unwrap(),
-                    ).view_rec(path.push_tail(i)).contains(m);
+                    0 <= i < self.0.children().len() && self.0.children()[i] is Some
+                        && PageTableOwner(self.0.children()[i].unwrap()).view_rec(
+                        path.push_tail(i),
+                    ).contains(m);
                 self.pt_inv_unroll(i);
                 let child = self.0.children()[i].unwrap();
                 PageTableOwner(child).view_rec_mapping_inv(path.push_tail(i));
@@ -1661,9 +1648,10 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             assert forall|m: Mapping| self.view_rec(path).contains(m) implies false by {
                 let i = choose|i: int|
                     #![trigger self.0.children()[i]]
-                    0 <= i < self.0.children().len() && self.0.children()[i] is Some && PageTableOwner(
-                        self.0.children()[i]->0,
-                    ).view_rec(path.push_tail(i)).contains(m);
+                    0 <= i < self.0.children().len() && self.0.children()[i] is Some
+                        && PageTableOwner(self.0.children()[i]->0).view_rec(
+                        path.push_tail(i),
+                    ).contains(m);
                 self.pt_inv_unroll(i);
                 // PTE `i` is absent — else `count_present(cp) >= 1`.
                 if cp[i].is_present() {
@@ -1718,7 +1706,12 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         ensures
             self.metaregion_sound(r1),
     {
-        Self::metaregion_sound_preserved_slot_owners_eq_subtree(self.0, self.0.value().path, r0, r1);
+        Self::metaregion_sound_preserved_slot_owners_eq_subtree(
+            self.0,
+            self.0.value().path,
+            r0,
+            r1,
+        );
     }
 
     /// Recursive helper: same preservation property, applied to an arbitrary subtree.
@@ -1744,9 +1737,9 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         if subtree.level() < INC_LEVELS - 1 {
             assert forall|i: int|
                 #![trigger subtree.has_child(i)]
-                0 <= i < NR_ENTRIES
-                    && subtree.has_child(i) implies subtree.child(i).subtree_satisfies(
-            path.push_tail(i), Self::metaregion_sound_pred(r1)) by {
+                0 <= i < NR_ENTRIES && subtree.has_child(i) implies subtree.child(
+                i,
+            ).subtree_satisfies(path.push_tail(i), Self::metaregion_sound_pred(r1)) by {
                 Self::metaregion_sound_preserved_slot_owners_eq_subtree(
                     subtree.child(i),
                     path.push_tail(i),
@@ -1869,9 +1862,9 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         if subtree.level() < INC_LEVELS - 1 {
             assert forall|i: int|
                 #![trigger subtree.has_child(i)]
-                0 <= i < NR_ENTRIES
-                    && subtree.has_child(i) implies subtree.child(i).subtree_satisfies(
-            path.push_tail(i), Self::metaregion_sound_pred(r1)) by {
+                0 <= i < NR_ENTRIES && subtree.has_child(i) implies subtree.child(
+                i,
+            ).subtree_satisfies(path.push_tail(i), Self::metaregion_sound_pred(r1)) by {
                 Self::metaregion_sound_preserved_one_slot_changed_subtree(
                     subtree.child(i),
                     path.push_tail(i),
@@ -2370,9 +2363,9 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             assert(self.0.subtree_satisfies(path, Self::is_at_pred(entry, entry.path)));
 
             assert forall|j: int|
-                0 <= j < NR_ENTRIES
-                    && #[trigger] self.0.has_child(j) implies self.0.child(j).subtree_satisfies(
-            path.push_tail(j), Self::path_in_tree_pred(entry.path)) by {
+                0 <= j < NR_ENTRIES && #[trigger] self.0.has_child(j) implies self.0.child(
+                j,
+            ).subtree_satisfies(path.push_tail(j), Self::path_in_tree_pred(entry.path)) by {
                 if j != i {
                     self.pt_inv_unroll(j);
                     Self::prefix_push_different_indices(path, entry.path, i, j);

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -428,7 +428,7 @@ pub open spec fn allocated_empty_node_owner<C: PageTableConfig>(
     &&& !owner.value().node().children_perm.value().all(|child: C::E| child.is_present())
     &&& forall|i: int|
         0 <= i < NR_ENTRIES ==> {
-            &&& (#[trigger] owner.children()[i]) is Some
+            &&& #[trigger] owner.has_child(i)
             &&& owner.child(i).value().is_absent()
             &&& owner.child(i).value().inv()
             &&& owner.child(i).value().path == owner.value().path.push_tail(i)
@@ -464,7 +464,7 @@ pub open spec fn allocated_empty_node_grandchildren_none<C: PageTableConfig>(
 ) -> bool {
     forall|i: int, j: int|
         0 <= i < NR_ENTRIES && 0 <= j < NR_ENTRIES
-            ==> #[trigger] owner.children()[i]->0.children()[j] is None
+            ==> !#[trigger] owner.child(i).has_child(j)
 }
 
 /// Recursive worker for `rebase_freshly_allocated_children`. Rebases
@@ -565,13 +565,13 @@ pub proof fn fresh_node_subtree_satisfies<C: PageTableConfig>(
         node.inv(),
         node.level() < INC_LEVELS - 1,
         f(node.value(), path),
-        forall|i: int| 0 <= i < NR_ENTRIES ==> #[trigger] node.children()[i] is Some,
+        forall|i: int| 0 <= i < NR_ENTRIES ==> #[trigger] node.has_child(i),
         forall|i: int, j: int|
             0 <= i < NR_ENTRIES && 0 <= j < NR_ENTRIES
-                ==> #[trigger] node.children()[i].unwrap().children()[j] is None,
+                ==> !#[trigger] node.child(i).has_child(j),
         forall|i: int|
             0 <= i < NR_ENTRIES ==> #[trigger] f(
-                node.children()[i].unwrap().value(),
+                node.child(i).value(),
                 path.push_tail(i),
             ),
     ensures
@@ -579,7 +579,7 @@ pub proof fn fresh_node_subtree_satisfies<C: PageTableConfig>(
 {
     assert forall|i: int|
         0 <= i < node.children().len()
-            && #[trigger] node.children()[i] is Some implies node.child(i).subtree_satisfies(
+            && #[trigger] node.has_child(i) implies node.child(i).subtree_satisfies(
         path.push_tail(i),
         f,
     ) by {
@@ -633,14 +633,14 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             true
         } else if self.0.value().is_node() {
             forall|i: int|
-                #![trigger self.0.children()[i]]
+                #![trigger self.0.has_child(i)]
                 0 <= i < NR_ENTRIES ==> Self::pt_edge_at(self.0, i) && PageTableOwner(
-                    self.0.children()[i]->0,
+                    self.0.child(i),
                 ).pt_inv_at_depth((depth - 1) as nat)
         } else {
             forall|i: int|
-                #![trigger self.0.children()[i]]
-                0 <= i < NR_ENTRIES ==> self.0.children()[i] is None
+                #![trigger self.0.has_child(i)]
+                0 <= i < NR_ENTRIES ==> !self.0.has_child(i)
         }
     }
 
@@ -684,7 +684,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     pub proof fn non_node_pt_inv_at_depth(self, depth: nat)
         requires
             !self.0.value().is_node(),
-            forall|j: int| 0 <= j < NR_ENTRIES ==> #[trigger] self.0.children()[j] is None,
+            forall|j: int| 0 <= j < NR_ENTRIES ==> !#[trigger] self.0.has_child(j),
         ensures
             self.pt_inv_at_depth(depth),
         decreases depth,
@@ -707,16 +707,15 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             owner.children().len() == NR_ENTRIES,
             forall|i: int|
                 0 <= i < NR_ENTRIES ==> {
-                    let c = #[trigger] owner.children()[i];
-                    &&& c is Some
-                    &&& c->0.value().is_absent()
-                    &&& c->0.value().path.len() == owner.value().node().tree_level + 1
-                    &&& c->0.value().match_pte(
+                    &&& #[trigger] owner.has_child(i)
+                    &&& owner.child(i).value().is_absent()
+                    &&& owner.child(i).value().path.len() == owner.value().node().tree_level + 1
+                    &&& owner.child(i).value().match_pte(
                         owner.value().node().children_perm.value()[i],
                         owner.value().node().level,
                     )
-                    &&& c->0.value().path == owner.value().path.push_tail(i)
-                    &&& c->0.value().parent_level == owner.value().node().level
+                    &&& owner.child(i).value().path == owner.value().path.push_tail(i)
+                    &&& owner.child(i).value().parent_level == owner.value().node().level
                 },
             allocated_empty_node_grandchildren_none(owner),
         ensures
@@ -725,20 +724,29 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         let depth = (INC_LEVELS - owner.level()) as nat;
         // `is_node` + `la_inv` forces `owner.level < INC_LEVELS - 1`, so depth >= 2.
         assert(<EntryOwner<C> as TreeNodeValue<INC_LEVELS>>::la_inv(owner.value(), owner.level()));
+        assert(owner.level() < INC_LEVELS - 1);
+        assert(depth > 0);
         // Drive `pt_inv_at_depth(depth)` via the `is_node` branch: prove
         // `pt_edge_at` and the recursive `pt_inv_at_depth(depth-1)` for each child.
-        assert forall|i: int| 0 <= i < NR_ENTRIES implies #[trigger] Self::pt_edge_at(owner, i)
+        assert forall|i: int| 0 <= i < NR_ENTRIES implies #[trigger] owner.has_child(i)
+            && Self::pt_edge_at(owner, i)
             && PageTableOwner(owner.child(i)).pt_inv_at_depth((depth - 1) as nat) by {
             let child = owner.child(i);
             // pt_edge_at follows from the per-edge facts in the precondition.
             // owner.inv() ⇒ child.inv() (`TreeNode::inv` recurses since
             // INC_LEVELS - owner.level > 1) ⇒ child.value.inv() ⇒ inv_base
             // ⇒ (node is Some ⇒ !absent), so is_absent ⇒ !is_node.
+            assert(owner.has_child(i));
+            assert(owner.children()[i] is Some);
             assert(child.inv());
+            assert(child.value().is_absent());
+            assert(!child.value().is_node());
             // Each child is non-node with all grandchildren None — the
             // non-node branch of pt_inv_at_depth fires.
             PageTableOwner(child).non_node_pt_inv_at_depth((depth - 1) as nat);
         };
+        assert(PageTableOwner(owner).pt_inv_at_depth(depth));
+        assert(PageTableOwner(owner).pt_inv());
     }
 
     /// For a top-level (root) page table, entries at indices outside of
@@ -748,9 +756,9 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     pub open spec fn top_level_indices_absent(self) -> bool {
         let range = C::TOP_LEVEL_INDEX_RANGE();
         self.0.value().is_node() ==> forall|i: int|
-            #![trigger self.0.children()[i]]
-            0 <= i < NR_ENTRIES && !(range.start <= i < range.end) ==> self.0.children()[i] is Some
-                && self.0.children()[i]->0.value().is_absent()
+            #![trigger self.0.has_child(i)]
+            0 <= i < NR_ENTRIES && !(range.start <= i < range.end) ==> self.0.has_child(i)
+                && self.0.child(i).value().is_absent()
     }
 
     pub open spec fn view_rec_node_children(self, path: TreePath<NR_ENTRIES>) -> Seq<Set<Mapping>>
@@ -918,8 +926,15 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             ;
         } else if path.len() == 1 {
             let i0 = path[0];
+            assert(0 <= i0 < 512);
             assert(rec_vaddr(path, 1) == 0);
             assert(rec_vaddr(path, 0) == vaddr_make::<NR_LEVELS>(0, i0 as usize) as usize);
+            assert(i0 as usize == i0);
+            assert(0x80_0000_0000usize * i0 <= usize::MAX) by (nonlinear_arith)
+                requires
+                    0 <= i0 < 512,
+            ;
+            assert(vaddr_make::<NR_LEVELS>(0, i0 as usize) == 0x80_0000_0000usize * i0);
             assert(rec_vaddr(path, 0) == 0x80_0000_0000usize * i0);
             assert(pt.len() == 2);
             assert(pt[0] == i0);
@@ -1763,12 +1778,12 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         // Recursively for each Some child.
         if subtree.level() < INC_LEVELS - 1 {
             assert forall|i: int|
-                #![trigger subtree.children()[i]]
+                #![trigger subtree.has_child(i)]
                 0 <= i < NR_ENTRIES
-                    && subtree.children()[i] is Some implies subtree.children()[i].unwrap().subtree_satisfies(
+                    && subtree.has_child(i) implies subtree.child(i).subtree_satisfies(
             path.push_tail(i), Self::metaregion_sound_pred(r1)) by {
                 Self::metaregion_sound_preserved_slot_owners_eq_subtree(
-                    subtree.children()[i].unwrap(),
+                    subtree.child(i),
                     path.push_tail(i),
                     r0,
                     r1,
@@ -1888,12 +1903,12 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         subtree.value().metaregion_sound_one_slot_changed(r0, r1, changed_idx);
         if subtree.level() < INC_LEVELS - 1 {
             assert forall|i: int|
-                #![trigger subtree.children()[i]]
+                #![trigger subtree.has_child(i)]
                 0 <= i < NR_ENTRIES
-                    && subtree.children()[i] is Some implies subtree.children()[i].unwrap().subtree_satisfies(
+                    && subtree.has_child(i) implies subtree.child(i).subtree_satisfies(
             path.push_tail(i), Self::metaregion_sound_pred(r1)) by {
                 Self::metaregion_sound_preserved_one_slot_changed_subtree(
-                    subtree.children()[i].unwrap(),
+                    subtree.child(i),
                     path.push_tail(i),
                     r0,
                     r1,

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -378,7 +378,7 @@ impl<C: PageTableConfig, const L: usize> TreeNodeValue<L> for EntryOwner<C> {
 
 pub const INC_LEVELS: usize = NR_LEVELS + 1;
 
-/// `OwnerSubtree` is a tree `Node` (from `vstd_extra::ghost_tree`) containing `EntryOwner`s.
+/// `OwnerSubtree` is a [`TreeNode`] containing `EntryOwner`s.
 /// It lives in a tree of maximum depth 5. Page table nodes can be at levels 0-3, and their entries are their children at the next
 /// level down. This means that level 4, the lowest level, can only contain frame entries as it consists of the entries of level 1 page tables.
 ///
@@ -387,7 +387,7 @@ pub const INC_LEVELS: usize = NR_LEVELS + 1;
 ///                        tree level 2 ==> path length 2 ==> level 2 page table or frame mapped by level 3 table
 ///                        tree level 3 ==> path length 3 ==> level 1 page table or frame mapped by level 2 table
 ///                        tree level 4 ==> path length 4 ==> frame mapped by level 1 table
-pub type OwnerSubtree<C> = Node<EntryOwner<C>, NR_ENTRIES, INC_LEVELS>;
+pub type OwnerSubtree<C> = TreeNode<EntryOwner<C>, NR_ENTRIES, INC_LEVELS>;
 
 /// Specifies that `owner` is the ghost owner of a newly allocated empty page table node.
 /// Captures the structural post-conditions of `PageTableNode::alloc`.
@@ -579,7 +579,7 @@ pub proof fn fresh_node_subtree_satisfies<C: PageTableConfig>(
 }
 
 /// # Verification Design
-/// `PageTableOwner` is a wrapper around [`OwnerSubtree`], which is a [`vstd_extra::ghost_tree::Node`]
+/// `PageTableOwner` is a wrapper around [`OwnerSubtree`], which is a [`TreeNode`].
 /// in a tree of [`EntryOwner`]s. In turn, `EntryOwner` carries a enum that may be a
 /// [`FrameEntryOwner`] if the entry is a leaf node that maps a frame, or a [`NodeOwner`] if
 /// the entry is a sub-table. The root of the top-level page table owner should always be
@@ -719,7 +719,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             && PageTableOwner(owner.children()[i].unwrap()).pt_inv_at_depth((depth - 1) as nat) by {
             let child = owner.children()[i].unwrap();
             // pt_edge_at follows from the per-edge facts in the precondition.
-            // owner.inv() ⇒ child.inv() (Node::inv recurses since
+            // owner.inv() ⇒ child.inv() (`TreeNode::inv` recurses since
             // INC_LEVELS - owner.level > 1) ⇒ child.value.inv() ⇒ inv_base
             // ⇒ (node is Some ⇒ !absent), so is_absent ⇒ !is_node.
             assert(child.inv());

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -75,7 +75,7 @@ pub open spec fn rec_vaddr(
     if idx == path.len() {
         0
     } else {
-        let offset: usize = path.index(idx);
+        let offset = path.index(idx) as usize;
         (vaddr_make::<NR_LEVELS>(idx, offset) + rec_vaddr(path, idx + 1)) as usize
     }
 }
@@ -125,44 +125,54 @@ pub proof fn lemma_vaddr_strict_bound(path: TreePath<NR_ENTRIES>)
     vstd::arithmetic::power2::lemma2_to64_rest();
     if path.len() == 0 {
     } else if path.len() == 1 {
+        path.lemma_index_satisfies_elem_inv(0);
         let i0 = path.index(0);
         assert(rec_vaddr(path, 1) == 0);
     } else if path.len() == 2 {
+        path.lemma_index_satisfies_elem_inv(0);
+        path.lemma_index_satisfies_elem_inv(1);
         let i0 = path.index(0);
         let i1 = path.index(1);
         assert(rec_vaddr(path, 2) == 0);
-        assert(rec_vaddr(path, 1) == vaddr_make::<NR_LEVELS>(1, i1) as usize);
+        assert(rec_vaddr(path, 1) == vaddr_make::<NR_LEVELS>(1, i1 as usize) as usize);
     } else if path.len() == 3 {
+        path.lemma_index_satisfies_elem_inv(0);
+        path.lemma_index_satisfies_elem_inv(1);
+        path.lemma_index_satisfies_elem_inv(2);
         let i0 = path.index(0);
         let i1 = path.index(1);
         let i2 = path.index(2);
         assert(rec_vaddr(path, 3) == 0);
-        assert(rec_vaddr(path, 2) == vaddr_make::<NR_LEVELS>(2, i2) as usize);
-        assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1) + vaddr_make::<NR_LEVELS>(
+        assert(rec_vaddr(path, 2) == vaddr_make::<NR_LEVELS>(2, i2 as usize) as usize);
+        assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + vaddr_make::<NR_LEVELS>(
             2,
-            i2,
+            i2 as usize,
         )) as usize);
     } else {
+        path.lemma_index_satisfies_elem_inv(0);
+        path.lemma_index_satisfies_elem_inv(1);
+        path.lemma_index_satisfies_elem_inv(2);
+        path.lemma_index_satisfies_elem_inv(3);
         let i0 = path.index(0);
         let i1 = path.index(1);
         let i2 = path.index(2);
         let i3 = path.index(3);
         assert(rec_vaddr(path, 4) == 0);
-        assert(rec_vaddr(path, 3) == vaddr_make::<NR_LEVELS>(3, i3) as usize);
-        assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, i2) + vaddr_make::<NR_LEVELS>(
+        assert(rec_vaddr(path, 3) == vaddr_make::<NR_LEVELS>(3, i3 as usize) as usize);
+        assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, i2 as usize) + vaddr_make::<NR_LEVELS>(
             3,
-            i3,
+            i3 as usize,
         )) as usize);
-        assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1) + vaddr_make::<NR_LEVELS>(
+        assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + vaddr_make::<NR_LEVELS>(
             2,
-            i2,
-        ) + vaddr_make::<NR_LEVELS>(3, i3)) as usize);
-        assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, i0) + vaddr_make::<NR_LEVELS>(
+            i2 as usize,
+        ) + vaddr_make::<NR_LEVELS>(3, i3 as usize)) as usize);
+        assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, i0 as usize) + vaddr_make::<NR_LEVELS>(
             1,
-            i1,
-        ) + vaddr_make::<NR_LEVELS>(2, i2) + vaddr_make::<NR_LEVELS>(3, i3)) as usize);
-        assert(vaddr_make::<NR_LEVELS>(2, i2) == 0x20_0000usize * i2) by (compute);
-        assert(vaddr_make::<NR_LEVELS>(3, i3) == 0x1000usize * i3) by (compute);
+            i1 as usize,
+        ) + vaddr_make::<NR_LEVELS>(2, i2 as usize) + vaddr_make::<NR_LEVELS>(3, i3 as usize)) as usize);
+        assert(vaddr_make::<NR_LEVELS>(2, i2 as usize) == 0x20_0000usize * i2) by (compute);
+        assert(vaddr_make::<NR_LEVELS>(3, i3 as usize) == 0x1000usize * i3) by (compute);
         assert(0x80_0000_0000usize * i0 + 0x4000_0000usize * i1 + 0x20_0000usize * i2 + 0x1000usize
             * i3 < 0x1_0000_0000_0000int) by (nonlinear_arith)
             requires
@@ -193,7 +203,7 @@ pub proof fn lemma_vaddr_top_index_cell(path: TreePath<NR_ENTRIES>)
     vstd::arithmetic::power2::lemma2_to64_rest();
     let i0 = path.index(0);
     assert(i0 < NR_ENTRIES);
-    assert(vaddr_make::<NR_LEVELS>(0, i0) == 0x80_0000_0000usize * i0) by (compute);
+    assert(vaddr_make::<NR_LEVELS>(0, i0 as usize) == 0x80_0000_0000usize * i0) by (compute);
     if path.len() == 1 {
         assert(rec_vaddr(path, 1) == 0);
         assert(vaddr(path) == 0x80_0000_0000usize * i0);
@@ -201,8 +211,8 @@ pub proof fn lemma_vaddr_top_index_cell(path: TreePath<NR_ENTRIES>)
         let i1 = path.index(1);
         assert(i1 < NR_ENTRIES);
         assert(rec_vaddr(path, 2) == 0);
-        assert(rec_vaddr(path, 1) == vaddr_make::<NR_LEVELS>(1, i1) as usize);
-        assert(vaddr_make::<NR_LEVELS>(1, i1) == 0x4000_0000usize * i1) by (compute);
+        assert(rec_vaddr(path, 1) == vaddr_make::<NR_LEVELS>(1, i1 as usize) as usize);
+        assert(vaddr_make::<NR_LEVELS>(1, i1 as usize) == 0x4000_0000usize * i1) by (compute);
         assert(vaddr(path) == 0x80_0000_0000usize * i0 + 0x4000_0000usize * i1);
         assert(0x4000_0000int * i1 + 0x4000_0000int <= 0x80_0000_0000int) by (nonlinear_arith)
             requires
@@ -214,13 +224,13 @@ pub proof fn lemma_vaddr_top_index_cell(path: TreePath<NR_ENTRIES>)
         assert(i1 < NR_ENTRIES);
         assert(i2 < NR_ENTRIES);
         assert(rec_vaddr(path, 3) == 0);
-        assert(rec_vaddr(path, 2) == vaddr_make::<NR_LEVELS>(2, i2) as usize);
-        assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1) + vaddr_make::<NR_LEVELS>(
+        assert(rec_vaddr(path, 2) == vaddr_make::<NR_LEVELS>(2, i2 as usize) as usize);
+        assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + vaddr_make::<NR_LEVELS>(
             2,
-            i2,
+            i2 as usize,
         )) as usize);
-        assert(vaddr_make::<NR_LEVELS>(1, i1) == 0x4000_0000usize * i1) by (compute);
-        assert(vaddr_make::<NR_LEVELS>(2, i2) == 0x20_0000usize * i2) by (compute);
+        assert(vaddr_make::<NR_LEVELS>(1, i1 as usize) == 0x4000_0000usize * i1) by (compute);
+        assert(vaddr_make::<NR_LEVELS>(2, i2 as usize) == 0x20_0000usize * i2) by (compute);
         assert(vaddr(path) == 0x80_0000_0000usize * i0 + 0x4000_0000usize * i1
             + 0x20_0000usize * i2);
         assert(0x4000_0000int * i1 + 0x20_0000int * i2 + 0x20_0000int
@@ -237,15 +247,15 @@ pub proof fn lemma_vaddr_top_index_cell(path: TreePath<NR_ENTRIES>)
         assert(i2 < NR_ENTRIES);
         assert(i3 < NR_ENTRIES);
         assert(rec_vaddr(path, 4) == 0);
-        assert(rec_vaddr(path, 3) == vaddr_make::<NR_LEVELS>(3, i3) as usize);
-        assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, i2) + vaddr_make::<NR_LEVELS>(
+        assert(rec_vaddr(path, 3) == vaddr_make::<NR_LEVELS>(3, i3 as usize) as usize);
+        assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, i2 as usize) + vaddr_make::<NR_LEVELS>(
             3,
-            i3,
+            i3 as usize,
         )) as usize);
-        assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1) + vaddr_make::<NR_LEVELS>(
+        assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + vaddr_make::<NR_LEVELS>(
             2,
-            i2,
-        ) + vaddr_make::<NR_LEVELS>(3, i3)) as usize);
+            i2 as usize,
+        ) + vaddr_make::<NR_LEVELS>(3, i3 as usize)) as usize);
         assert(vaddr(path) == 0x80_0000_0000usize * i0 + 0x4000_0000usize * i1
             + 0x20_0000usize * i2 + 0x1000usize * i3);
         assert(0x80_0000_0000int * i0 + 0x4000_0000int * i1 + 0x20_0000int * i2 + 0x1000int * i3
@@ -306,13 +316,15 @@ pub proof fn page_size_monotonic(a: PagingLevel, b: PagingLevel)
 /// on `C`.
 pub proof fn sibling_paths_disjoint<C: PageTableConfig>(
     prefix: TreePath<NR_ENTRIES>,
-    j: usize,
-    k: usize,
+    j: int,
+    k: int,
     size: usize,
 )
     requires
         prefix.inv(),
         prefix.len() < INC_LEVELS - 1,
+        0 <= j,
+        0 <= k,
         j < NR_ENTRIES,
         k < NR_ENTRIES,
         j != k,
@@ -415,12 +427,11 @@ pub open spec fn allocated_empty_node_owner<C: PageTableConfig>(
     &&& owner.value().node().inv()
     &&& !owner.value().node().children_perm.value().all(|child: C::E| child.is_present())
     &&& forall|i: int|
-        #![auto]
         0 <= i < NR_ENTRIES ==> {
-            &&& owner.children()[i] is Some
+            &&& (#[trigger] owner.children()[i]) is Some
             &&& owner.children()[i]->0.value().is_absent()
             &&& owner.children()[i]->0.value().inv()
-            &&& owner.children()[i]->0.value().path == owner.value().path.push_tail(i as usize)
+            &&& owner.children()[i]->0.value().path == owner.value().path.push_tail(i)
         }
     &&& forall|i: int|
         #![auto]
@@ -482,7 +493,7 @@ pub proof fn rebase_freshly_allocated_children_at<C: PageTableConfig>(
                 let c_new = (#[trigger] final(owner).children()[j])->0;
                 &&& final(owner).children()[j] is Some
                 &&& c_new.value() == EntryOwner {
-                    path: new_path.push_tail(j as usize),
+                    path: new_path.push_tail(j),
                     ..c_old.value()
                 }
                 &&& c_new.level() == c_old.level()
@@ -494,7 +505,7 @@ pub proof fn rebase_freshly_allocated_children_at<C: PageTableConfig>(
         let tracked mut child_opt = owner.tracked_remove_child(i as int);
         let tracked mut child = child_opt.tracked_unwrap();
         let tracked child_value = child.tracked_borrow_mut_value();
-        child_value.path = new_path.push_tail(i);
+        child_value.path = new_path.push_tail(i as int);
         owner.tracked_insert_child(i as int, Some(child));
         rebase_freshly_allocated_children_at(owner, new_path, (i + 1) as usize);
     }
@@ -527,7 +538,7 @@ pub proof fn rebase_freshly_allocated_children<C: PageTableConfig>(
                 let c_new = (#[trigger] final(owner).children()[i])->0;
                 &&& final(owner).children()[i] is Some
                 &&& c_new.value() == EntryOwner {
-                    path: new_path.push_tail(i as usize),
+                    path: new_path.push_tail(i),
                     ..c_old.value()
                 }
                 &&& c_new.level() == c_old.level()
@@ -561,7 +572,7 @@ pub proof fn fresh_node_subtree_satisfies<C: PageTableConfig>(
         forall|i: int|
             0 <= i < NR_ENTRIES ==> #[trigger] f(
                 node.children()[i].unwrap().value(),
-                path.push_tail(i as usize),
+                path.push_tail(i),
             ),
     ensures
         node.subtree_satisfies(path, f),
@@ -569,7 +580,7 @@ pub proof fn fresh_node_subtree_satisfies<C: PageTableConfig>(
     assert forall|i: int|
         0 <= i < node.children().len()
             && #[trigger] node.children()[i] is Some implies node.children()[i]->0.subtree_satisfies(
-        path.push_tail(i as usize),
+        path.push_tail(i),
         f,
     ) by {
         // Each child has all-`None` grandchildren, so its `subtree_satisfies`
@@ -608,7 +619,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             parent.value().node().children_perm.value()[i],
             parent.value().node().level,
         )))
-        &&& parent.children()[i]->0.value().path == parent.value().path.push_tail(i as usize)
+        &&& parent.children()[i]->0.value().path == parent.value().path.push_tail(i)
         &&& parent.children()[i]->0.value().parent_level == parent.value().node().level
     }
 
@@ -704,7 +715,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                         owner.value().node().children_perm.value()[i],
                         owner.value().node().level,
                     )
-                    &&& c->0.value().path == owner.value().path.push_tail(i as usize)
+                    &&& c->0.value().path == owner.value().path.push_tail(i)
                     &&& c->0.value().parent_level == owner.value().node().level
                 },
             allocated_empty_node_grandchildren_none(owner),
@@ -749,7 +760,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         self.0.children().map(
             |i, child: Option<OwnerSubtree<C>>|
                 if child is Some {
-                    PageTableOwner(child->0).view_rec(path.push_tail(i as usize))
+                    PageTableOwner(child->0).view_rec(path.push_tail(i))
                 } else {
                     Set::empty()
                 },
@@ -794,7 +805,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             0 <= i < self.0.children().len(),
             self.0.children()[i] is Some,
             #[trigger] PageTableOwner(self.0.children()[i]->0).view_rec(
-                path.push_tail(i as usize),
+                path.push_tail(i),
             ).contains(m),
         ensures
             self.view_rec(path).contains(m),
@@ -822,7 +833,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                     #![trigger self.0.children()[i]]
                     0 <= i < self.0.children().len() && self.0.children()[i] is Some && PageTableOwner(
                         self.0.children()[i]->0,
-                    ).view_rec(path.push_tail(i as usize)).contains(m),
+                    ).view_rec(path.push_tail(i)).contains(m),
     {
         broadcast use vstd::seq_lib::group_seq_properties;
 
@@ -830,7 +841,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             #![trigger self.0.children()[i]]
             0 <= i < self.0.children().len() && self.0.children()[i] is Some && PageTableOwner(
                 self.0.children()[i]->0,
-            ).view_rec(path.push_tail(i as usize)).contains(m) by {
+            ).view_rec(path.push_tail(i)).contains(m) by {
             let mapped = self.view_rec_node_children(path);
             assert(!self.0.value().is_frame());
             mapped.to_set().lemma_flatten_contains(m);
@@ -841,7 +852,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             let i = mapped.lemma_contains_to_index(elem_s);
             if self.0.children()[i] is Some {
                 assert(mapped[i] == PageTableOwner(self.0.children()[i]->0).view_rec(
-                    path.push_tail(i as usize),
+                    path.push_tail(i),
                 ));
             } else {
                 assert(false);
@@ -858,7 +869,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         ensures
             0 <= i < self.0.children().len() && self.0.children()[i] is Some && PageTableOwner(
                 self.0.children()[i]->0,
-            ).view_rec(path.push_tail(i as usize)).contains(m),
+            ).view_rec(path.push_tail(i)).contains(m),
     {
         broadcast use PageTableOwner::group_lemmas;
 
@@ -866,16 +877,16 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             #![auto]
             0 <= i < self.0.children().len() && self.0.children()[i] is Some && PageTableOwner(
                 self.0.children()[i].unwrap(),
-            ).view_rec(path.push_tail(i as usize)).contains(m)
+            ).view_rec(path.push_tail(i)).contains(m)
     }
 
     /// Closed-form for `vaddr(path.push_tail(i))` by case-split on `path.len() ∈ {0,1,2,3}`.
     #[verifier::rlimit(400)]
-    pub proof fn lemma_vaddr_push_tail_eq(path: TreePath<NR_ENTRIES>, i: usize)
+    pub proof fn lemma_vaddr_push_tail_eq(path: TreePath<NR_ENTRIES>, i: int)
         requires
             path.inv(),
             path.len() < INC_LEVELS - 1,
-            i < NR_ENTRIES,
+            0 <= i < NR_ENTRIES,
         ensures
             vaddr(path.push_tail(i)) == vaddr(path) + i * page_size(
                 (INC_LEVELS - path.len() - 1) as PagingLevel,
@@ -899,7 +910,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         if path.len() == 0 {
             assert(pt.len() == 1);
             assert(rec_vaddr(pt, 1) == 0);
-            assert(vaddr_make::<NR_LEVELS>(0, i) == 0x80_0000_0000usize * i) by (compute);
+            assert(vaddr_make::<NR_LEVELS>(0, i as usize) == 0x80_0000_0000usize * i) by (compute);
             assert(page_size(4) == 0x80_0000_0000usize);
             assert(0x80_0000_0000usize * (i + 1) <= usize::MAX) by (nonlinear_arith)
                 requires
@@ -908,13 +919,13 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         } else if path.len() == 1 {
             let i0 = path.index(0);
             assert(rec_vaddr(path, 1) == 0);
-            assert(rec_vaddr(path, 0) == vaddr_make::<NR_LEVELS>(0, i0) as usize);
+            assert(rec_vaddr(path, 0) == vaddr_make::<NR_LEVELS>(0, i0 as usize) as usize);
             assert(rec_vaddr(path, 0) == 0x80_0000_0000usize * i0);
             assert(pt.len() == 2);
             assert(pt.index(0) == i0);
             assert(pt.index(1) == i);
             assert(rec_vaddr(pt, 2) == 0);
-            assert(rec_vaddr(pt, 1) == vaddr_make::<NR_LEVELS>(1, i) as usize);
+            assert(rec_vaddr(pt, 1) == vaddr_make::<NR_LEVELS>(1, i as usize) as usize);
             assert(rec_vaddr(pt, 0) == (0x80_0000_0000usize * i0) + 0x4000_0000usize * i);
             assert(page_size(3) == 0x4000_0000usize);
             assert(0x80_0000_0000usize * i0 + 0x4000_0000usize * (i + 1) <= usize::MAX)
@@ -927,21 +938,21 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             let i0 = path.index(0);
             let i1 = path.index(1);
             assert(rec_vaddr(path, 2) == 0);
-            assert(rec_vaddr(path, 1) == vaddr_make::<NR_LEVELS>(1, i1) as usize);
-            assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, i0) + vaddr_make::<NR_LEVELS>(
+            assert(rec_vaddr(path, 1) == vaddr_make::<NR_LEVELS>(1, i1 as usize) as usize);
+            assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, i0 as usize) + vaddr_make::<NR_LEVELS>(
                 1,
-                i1,
+                i1 as usize,
             )) as usize);
-            assert(vaddr_make::<NR_LEVELS>(1, i1) == 0x4000_0000usize * i1) by (compute);
+            assert(vaddr_make::<NR_LEVELS>(1, i1 as usize) == 0x4000_0000usize * i1) by (compute);
             assert(pt.len() == 3);
             assert(pt.index(2) == i);
             assert(rec_vaddr(pt, 3) == 0);
-            assert(rec_vaddr(pt, 2) == vaddr_make::<NR_LEVELS>(2, i) as usize);
-            assert(rec_vaddr(pt, 1) == (vaddr_make::<NR_LEVELS>(1, i1) + vaddr_make::<NR_LEVELS>(
+            assert(rec_vaddr(pt, 2) == vaddr_make::<NR_LEVELS>(2, i as usize) as usize);
+            assert(rec_vaddr(pt, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + vaddr_make::<NR_LEVELS>(
                 2,
-                i,
+                i as usize,
             )) as usize);
-            assert(vaddr_make::<NR_LEVELS>(2, i) == 0x20_0000usize * i) by (compute);
+            assert(vaddr_make::<NR_LEVELS>(2, i as usize) == 0x20_0000usize * i) by (compute);
             assert(page_size(2) == 0x20_0000usize);
             assert(0x80_0000_0000usize * i0 + 0x4000_0000usize * i1 + 0x20_0000usize * (i + 1)
                 <= usize::MAX) by (nonlinear_arith)
@@ -956,37 +967,37 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             let i1 = path.index(1);
             let i2 = path.index(2);
             assert(rec_vaddr(path, 3) == 0);
-            assert(rec_vaddr(path, 2) == vaddr_make::<NR_LEVELS>(2, i2) as usize);
-            assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1) + vaddr_make::<NR_LEVELS>(
+            assert(rec_vaddr(path, 2) == vaddr_make::<NR_LEVELS>(2, i2 as usize) as usize);
+            assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + vaddr_make::<NR_LEVELS>(
                 2,
-                i2,
+                i2 as usize,
             )) as usize);
-            assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, i0) + vaddr_make::<NR_LEVELS>(
+            assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, i0 as usize) + vaddr_make::<NR_LEVELS>(
                 1,
-                i1,
-            ) + vaddr_make::<NR_LEVELS>(2, i2)) as usize);
-            assert(vaddr_make::<NR_LEVELS>(1, i1) == 0x4000_0000usize * i1) by (compute);
-            assert(vaddr_make::<NR_LEVELS>(2, i2) == 0x20_0000usize * i2) by (compute);
+                i1 as usize,
+            ) + vaddr_make::<NR_LEVELS>(2, i2 as usize)) as usize);
+            assert(vaddr_make::<NR_LEVELS>(1, i1 as usize) == 0x4000_0000usize * i1) by (compute);
+            assert(vaddr_make::<NR_LEVELS>(2, i2 as usize) == 0x20_0000usize * i2) by (compute);
             assert(pt.len() == 4);
             assert(pt.index(0) == i0);
             assert(pt.index(1) == i1);
             assert(pt.index(2) == i2);
             assert(pt.index(3) == i);
             assert(rec_vaddr(pt, 4) == 0);
-            assert(rec_vaddr(pt, 3) == vaddr_make::<NR_LEVELS>(3, i) as usize);
-            assert(rec_vaddr(pt, 2) == (vaddr_make::<NR_LEVELS>(2, i2) + vaddr_make::<NR_LEVELS>(
+            assert(rec_vaddr(pt, 3) == vaddr_make::<NR_LEVELS>(3, i as usize) as usize);
+            assert(rec_vaddr(pt, 2) == (vaddr_make::<NR_LEVELS>(2, i2 as usize) + vaddr_make::<NR_LEVELS>(
                 3,
-                i,
+                i as usize,
             )) as usize);
-            assert(rec_vaddr(pt, 1) == (vaddr_make::<NR_LEVELS>(1, i1) + vaddr_make::<NR_LEVELS>(
+            assert(rec_vaddr(pt, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + vaddr_make::<NR_LEVELS>(
                 2,
-                i2,
-            ) + vaddr_make::<NR_LEVELS>(3, i)) as usize);
-            assert(rec_vaddr(pt, 0) == (vaddr_make::<NR_LEVELS>(0, i0) + vaddr_make::<NR_LEVELS>(
+                i2 as usize,
+            ) + vaddr_make::<NR_LEVELS>(3, i as usize)) as usize);
+            assert(rec_vaddr(pt, 0) == (vaddr_make::<NR_LEVELS>(0, i0 as usize) + vaddr_make::<NR_LEVELS>(
                 1,
-                i1,
-            ) + vaddr_make::<NR_LEVELS>(2, i2) + vaddr_make::<NR_LEVELS>(3, i)) as usize);
-            assert(vaddr_make::<NR_LEVELS>(3, i) == 0x1000usize * i) by (compute);
+                i1 as usize,
+            ) + vaddr_make::<NR_LEVELS>(2, i2 as usize) + vaddr_make::<NR_LEVELS>(3, i as usize)) as usize);
+            assert(vaddr_make::<NR_LEVELS>(3, i as usize) == 0x1000usize * i) by (compute);
             assert(page_size(1) == 0x1000usize);
             assert(0x80_0000_0000usize * i0 + 0x4000_0000usize * i1 + 0x20_0000usize * i2
                 + 0x1000usize * (i + 1) <= usize::MAX) by (nonlinear_arith)
@@ -1042,13 +1053,13 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 #![trigger self.0.children()[i]]
                 0 <= i < self.0.children().len() && self.0.children()[i] is Some && PageTableOwner(
                     self.0.children()[i].unwrap(),
-                ).view_rec(path.push_tail(i as usize)).contains(m);
+                ).view_rec(path.push_tail(i)).contains(m);
             self.pt_inv_unroll(i);
             let child = PageTableOwner(self.0.children()[i].unwrap());
-            path.lemma_push_tail_preserves_inv(i as usize);
-            path.lemma_push_tail_len(i as usize);
-            child.view_rec_vaddr_range(path.push_tail(i as usize), m);
-            Self::lemma_vaddr_push_tail_eq(path, i as usize);
+            path.lemma_push_tail_preserves_inv(i);
+            path.lemma_push_tail_len(i);
+            child.view_rec_vaddr_range(path.push_tail(i), m);
+            Self::lemma_vaddr_push_tail_eq(path, i);
 
             let parent_ps = page_size((INC_LEVELS - path.len()) as PagingLevel) as int;
             let child_ps = page_size((INC_LEVELS - path.len() - 1) as PagingLevel) as int;
@@ -1079,14 +1090,14 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                     0 <= i < 512,
                     child_ps >= 0,
             ;
-            assert(m.va_range.end <= vaddr_of::<C>(path.push_tail(i as usize)) + child_ps);
-            assert(vaddr(path.push_tail(i as usize)) == vaddr(path) + i * child_ps);
+            assert(m.va_range.end <= vaddr_of::<C>(path.push_tail(i)) + child_ps);
+            assert(vaddr(path.push_tail(i)) == vaddr(path) + i * child_ps);
             // Bridge `vaddr_of(push_tail(i)) == vaddr_of(path) + i * child_ps`
             // via the no-wrap helper: both `vaddr_of` terms equal their `int`
             // counterparts, and the `vaddr` identity above lifts directly.
             lemma_vaddr_of_eq_int::<C>(path);
-            lemma_vaddr_of_eq_int::<C>(path.push_tail(i as usize));
-            assert(vaddr_of::<C>(path.push_tail(i as usize)) == vaddr_of::<C>(path) + i * child_ps);
+            lemma_vaddr_of_eq_int::<C>(path.push_tail(i));
+            assert(vaddr_of::<C>(path.push_tail(i)) == vaddr_of::<C>(path) + i * child_ps);
             assert(i * child_ps + child_ps == (i + 1) * child_ps) by (nonlinear_arith);
             assert(m.va_range.end <= vaddr_of::<C>(path) + (i + 1) * child_ps);
             assert(m.va_range.end <= vaddr_of::<C>(path) + parent_ps);
@@ -1152,14 +1163,14 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             assert forall|i: int|
                 0 <= i < subtree.children().len() && (
                 #[trigger] subtree.children()[i]) is Some implies subtree.children()[i].unwrap().subtree_satisfies(
-            path.push_tail(i as usize), Self::path_correct_pred()) by {
+            path.push_tail(i), Self::path_correct_pred()) by {
                 if subtree.value().is_node() {
                     PageTableOwner(subtree).pt_inv_unroll(i);
                     // pt_edge_at: child.value.path == subtree.value.path.push_tail(i)
-                    assert(subtree.children()[i].unwrap().value().path == path.push_tail(i as usize));
+                    assert(subtree.children()[i].unwrap().value().path == path.push_tail(i));
                     Self::pt_inv_implies_path_correct(
                         subtree.children()[i].unwrap(),
-                        path.push_tail(i as usize),
+                        path.push_tail(i),
                     );
                 } else {
                     // Non-node ⟹ children all None, contradicts `is Some`.
@@ -1243,16 +1254,16 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             assert forall|i: int|
                 0 <= i < self.0.children().len() && (
                 #[trigger] self.0.children()[i]) is Some implies self.0.children()[i].unwrap().subtree_satisfies(
-            path.push_tail(i as usize), g) by {
+            path.push_tail(i), g) by {
                 if self.0.value().is_node() {
                     self.pt_inv_unroll(i);
                     let child = PageTableOwner(self.0.children()[i].unwrap());
-                    path.lemma_push_tail_preserves_inv(i as usize);
-                    path.lemma_push_tail_len(i as usize);
+                    path.lemma_push_tail_preserves_inv(i);
+                    path.lemma_push_tail_len(i);
                     // child.view_rec ⊆ self.view_rec(path) ⊆ ambient
                     // path-correctness passes to the child.
                     self.0.lemma_map_unroll_once(path, Self::path_correct_pred(), i);
-                    child.no_frame_with_path_rec(path.push_tail(i as usize), removed_path, ambient);
+                    child.no_frame_with_path_rec(path.push_tail(i), removed_path, ambient);
                 } else {
                     PageTableOwner(self.0).pt_inv_non_node(i);
                 }
@@ -1289,15 +1300,15 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             let i1 = self.view_rec_contains_choose(path, m1);
             let i2 = self.view_rec_contains_choose(path, m2);
 
-            path.lemma_push_tail_preserves_inv(i1 as usize);
-            path.lemma_push_tail_preserves_inv(i2 as usize);
-            path.lemma_push_tail_len(i1 as usize);
-            path.lemma_push_tail_len(i2 as usize);
+            path.lemma_push_tail_preserves_inv(i1);
+            path.lemma_push_tail_preserves_inv(i2);
+            path.lemma_push_tail_len(i1);
+            path.lemma_push_tail_len(i2);
 
             if i1 == i2 {
                 self.pt_inv_unroll(i1);
                 PageTableOwner(self.0.children()[i1].unwrap()).view_rec_disjoint_vaddrs(
-                    path.push_tail(i1 as usize),
+                    path.push_tail(i1),
                     m1,
                     m2,
                 );
@@ -1306,23 +1317,23 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 self.pt_inv_unroll(i2);
                 let child_ps = page_size((INC_LEVELS - path.len() - 1) as PagingLevel);
                 PageTableOwner(self.0.children()[i1].unwrap()).view_rec_vaddr_range(
-                    path.push_tail(i1 as usize),
+                    path.push_tail(i1),
                     m1,
                 );
                 PageTableOwner(self.0.children()[i2].unwrap()).view_rec_vaddr_range(
-                    path.push_tail(i2 as usize),
+                    path.push_tail(i2),
                     m2,
                 );
                 if i1 < i2 {
-                    sibling_paths_disjoint::<C>(path, i1 as usize, i2 as usize, child_ps);
+                    sibling_paths_disjoint::<C>(path, i1, i2, child_ps);
                 } else {
-                    sibling_paths_disjoint::<C>(path, i2 as usize, i1 as usize, child_ps);
+                    sibling_paths_disjoint::<C>(path, i2, i1, child_ps);
                 }
                 // Bridge `vaddr_of == vaddr + LEADING_BITS * 2^48` for both
                 // children, then the int-arithmetic shift cancels across
                 // the disjointness inequality.
-                lemma_vaddr_of_eq_int::<C>(path.push_tail(i1 as usize));
-                lemma_vaddr_of_eq_int::<C>(path.push_tail(i2 as usize));
+                lemma_vaddr_of_eq_int::<C>(path.push_tail(i1));
+                lemma_vaddr_of_eq_int::<C>(path.push_tail(i2));
             }
         }
     }
@@ -1358,10 +1369,10 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                     #![trigger self.0.children()[i]]
                     0 <= i < self.0.children().len() && self.0.children()[i] is Some && PageTableOwner(
                         self.0.children()[i].unwrap(),
-                    ).view_rec(path.push_tail(i as usize)).contains(m);
+                    ).view_rec(path.push_tail(i)).contains(m);
                 self.pt_inv_unroll(i);
                 let child = self.0.children()[i].unwrap();
-                PageTableOwner(child).view_rec_mapping_page_size(path.push_tail(i as usize));
+                PageTableOwner(child).view_rec_mapping_page_size(path.push_tail(i));
             };
         }
     }
@@ -1402,11 +1413,11 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         } else if path.len() == 1 {
             let i0 = path.index(0);
             assert(rec_vaddr(path, 1) == 0);
-            assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, i0) + rec_vaddr(
+            assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, i0 as usize) + rec_vaddr(
                 path,
                 1,
             )) as usize);
-            assert(vaddr_make::<NR_LEVELS>(0, i0) == 0x80_0000_0000usize * i0) by (compute);
+            assert(vaddr_make::<NR_LEVELS>(0, i0 as usize) == 0x80_0000_0000usize * i0) by (compute);
             assert(rec_vaddr(path, 0) == 0x80_0000_0000usize * i0);
             assert(page_size(4) == 0x80_0000_0000usize);
             assert((0x80_0000_0000usize * i0) % 0x80_0000_0000 == 0) by (nonlinear_arith);
@@ -1418,16 +1429,16 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             let i0 = path.index(0);
             let i1 = path.index(1);
             assert(rec_vaddr(path, 2) == 0);
-            assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1) + rec_vaddr(
+            assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + rec_vaddr(
                 path,
                 2,
             )) as usize);
-            assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, i0) + rec_vaddr(
+            assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, i0 as usize) + rec_vaddr(
                 path,
                 1,
             )) as usize);
-            assert(vaddr_make::<NR_LEVELS>(0, i0) == 0x80_0000_0000usize * i0) by (compute);
-            assert(vaddr_make::<NR_LEVELS>(1, i1) == 0x4000_0000usize * i1) by (compute);
+            assert(vaddr_make::<NR_LEVELS>(0, i0 as usize) == 0x80_0000_0000usize * i0) by (compute);
+            assert(vaddr_make::<NR_LEVELS>(1, i1 as usize) == 0x4000_0000usize * i1) by (compute);
             let s = 0x80_0000_0000usize * i0 + 0x4000_0000usize * i1;
             assert(rec_vaddr(path, 0) == s);
             assert(page_size(3) == 0x4000_0000usize);
@@ -1446,21 +1457,21 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             let i1 = path.index(1);
             let i2 = path.index(2);
             assert(rec_vaddr(path, 3) == 0);
-            assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, i2) + rec_vaddr(
+            assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, i2 as usize) + rec_vaddr(
                 path,
                 3,
             )) as usize);
-            assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1) + rec_vaddr(
+            assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + rec_vaddr(
                 path,
                 2,
             )) as usize);
-            assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, i0) + rec_vaddr(
+            assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, i0 as usize) + rec_vaddr(
                 path,
                 1,
             )) as usize);
-            assert(vaddr_make::<NR_LEVELS>(0, i0) == 0x80_0000_0000usize * i0) by (compute);
-            assert(vaddr_make::<NR_LEVELS>(1, i1) == 0x4000_0000usize * i1) by (compute);
-            assert(vaddr_make::<NR_LEVELS>(2, i2) == 0x20_0000usize * i2) by (compute);
+            assert(vaddr_make::<NR_LEVELS>(0, i0 as usize) == 0x80_0000_0000usize * i0) by (compute);
+            assert(vaddr_make::<NR_LEVELS>(1, i1 as usize) == 0x4000_0000usize * i1) by (compute);
+            assert(vaddr_make::<NR_LEVELS>(2, i2 as usize) == 0x20_0000usize * i2) by (compute);
             let s = 0x80_0000_0000usize * i0 + 0x4000_0000usize * i1 + 0x20_0000usize * i2;
             assert(rec_vaddr(path, 0) == s);
             assert(page_size(2) == 0x20_0000usize);
@@ -1482,26 +1493,26 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             let i2 = path.index(2);
             let i3 = path.index(3);
             assert(rec_vaddr(path, 4) == 0);
-            assert(rec_vaddr(path, 3) == (vaddr_make::<NR_LEVELS>(3, i3) + rec_vaddr(
+            assert(rec_vaddr(path, 3) == (vaddr_make::<NR_LEVELS>(3, i3 as usize) + rec_vaddr(
                 path,
                 4,
             )) as usize);
-            assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, i2) + rec_vaddr(
+            assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, i2 as usize) + rec_vaddr(
                 path,
                 3,
             )) as usize);
-            assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1) + rec_vaddr(
+            assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + rec_vaddr(
                 path,
                 2,
             )) as usize);
-            assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, i0) + rec_vaddr(
+            assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, i0 as usize) + rec_vaddr(
                 path,
                 1,
             )) as usize);
-            assert(vaddr_make::<NR_LEVELS>(0, i0) == 0x80_0000_0000usize * i0) by (compute);
-            assert(vaddr_make::<NR_LEVELS>(1, i1) == 0x4000_0000usize * i1) by (compute);
-            assert(vaddr_make::<NR_LEVELS>(2, i2) == 0x20_0000usize * i2) by (compute);
-            assert(vaddr_make::<NR_LEVELS>(3, i3) == 0x1000usize * i3) by (compute);
+            assert(vaddr_make::<NR_LEVELS>(0, i0 as usize) == 0x80_0000_0000usize * i0) by (compute);
+            assert(vaddr_make::<NR_LEVELS>(1, i1 as usize) == 0x4000_0000usize * i1) by (compute);
+            assert(vaddr_make::<NR_LEVELS>(2, i2 as usize) == 0x20_0000usize * i2) by (compute);
+            assert(vaddr_make::<NR_LEVELS>(3, i3 as usize) == 0x1000usize * i3) by (compute);
             let s = (0x80_0000_0000usize * i0 + 0x4000_0000usize * i1 + 0x20_0000usize * i2
                 + 0x1000usize * i3) as int;
             assert(rec_vaddr(path, 0) == s);
@@ -1621,11 +1632,11 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                     #![trigger self.0.children()[i]]
                     0 <= i < self.0.children().len() && self.0.children()[i] is Some && PageTableOwner(
                         self.0.children()[i].unwrap(),
-                    ).view_rec(path.push_tail(i as usize)).contains(m);
+                    ).view_rec(path.push_tail(i)).contains(m);
                 self.pt_inv_unroll(i);
                 let child = self.0.children()[i].unwrap();
-                path.lemma_push_tail_preserves_inv(i as usize);
-                PageTableOwner(child).view_rec_mapping_inv(path.push_tail(i as usize));
+                path.lemma_push_tail_preserves_inv(i);
+                PageTableOwner(child).view_rec_mapping_inv(path.push_tail(i));
             };
         }
     }
@@ -1672,7 +1683,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                     #![trigger self.0.children()[i]]
                     0 <= i < self.0.children().len() && self.0.children()[i] is Some && PageTableOwner(
                         self.0.children()[i]->0,
-                    ).view_rec(path.push_tail(i as usize)).contains(m);
+                    ).view_rec(path.push_tail(i)).contains(m);
                 self.pt_inv_unroll(i);
                 // PTE `i` is absent — else `count_present(cp) >= 1`.
                 if cp[i].is_present() {
@@ -1688,7 +1699,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 // with an absent PTE forces the child `is_absent`.
                 assert(self.0.children()[i]->0.value().is_absent());
                 // An absent entry is neither frame nor node ⟹ empty `view_rec`.
-                assert(PageTableOwner(self.0.children()[i]->0).view_rec(path.push_tail(i as usize))
+                assert(PageTableOwner(self.0.children()[i]->0).view_rec(path.push_tail(i))
                     =~= set![]);
             };
             assert(self.view_rec(path) =~= set![]);
@@ -1755,10 +1766,10 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 #![trigger subtree.children()[i]]
                 0 <= i < NR_ENTRIES
                     && subtree.children()[i] is Some implies subtree.children()[i].unwrap().subtree_satisfies(
-            path.push_tail(i as usize), Self::metaregion_sound_pred(r1)) by {
+            path.push_tail(i), Self::metaregion_sound_pred(r1)) by {
                 Self::metaregion_sound_preserved_slot_owners_eq_subtree(
                     subtree.children()[i].unwrap(),
-                    path.push_tail(i as usize),
+                    path.push_tail(i),
                     r0,
                     r1,
                 );
@@ -1880,10 +1891,10 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 #![trigger subtree.children()[i]]
                 0 <= i < NR_ENTRIES
                     && subtree.children()[i] is Some implies subtree.children()[i].unwrap().subtree_satisfies(
-            path.push_tail(i as usize), Self::metaregion_sound_pred(r1)) by {
+            path.push_tail(i), Self::metaregion_sound_pred(r1)) by {
                 Self::metaregion_sound_preserved_one_slot_changed_subtree(
                     subtree.children()[i].unwrap(),
-                    path.push_tail(i as usize),
+                    path.push_tail(i),
                     r0,
                     r1,
                     changed_idx,
@@ -1943,8 +1954,8 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             assert forall|i: int|
                 0 <= i < subtree.children().len() && (
                 #[trigger] subtree.children()[i]) is Some implies subtree.children()[i].unwrap().subtree_satisfies(
-            path.push_tail(i as usize), Self::not_in_scope_pred()) by {
-                Self::tree_not_in_scope(subtree.children()[i].unwrap(), path.push_tail(i as usize));
+            path.push_tail(i), Self::not_in_scope_pred()) by {
+                Self::tree_not_in_scope(subtree.children()[i].unwrap(), path.push_tail(i));
             };
         }
     }
@@ -1967,9 +1978,9 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 #![trigger self.0.children()[i]]
                 0 <= i < self.0.children().len() && self.0.children()[i] is Some && PageTableOwner(
                     self.0.children()[i].unwrap(),
-                ).view_rec(path.push_tail(i as usize)).contains(m);
+                ).view_rec(path.push_tail(i)).contains(m);
             PageTableOwner(self.0.children()[i].unwrap()).view_rec_page_size_bound(
-                path.push_tail(i as usize),
+                path.push_tail(i),
                 m,
             );
             page_size_monotonic(
@@ -1997,9 +2008,9 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             #![trigger self.0.children()[i]]
             0 <= i < self.0.children().len() && self.0.children()[i] is Some && PageTableOwner(
                 self.0.children()[i].unwrap(),
-            ).view_rec(path.push_tail(i as usize)).contains(m);
+            ).view_rec(path.push_tail(i)).contains(m);
         PageTableOwner(self.0.children()[i].unwrap()).view_rec_page_size_bound(
-            path.push_tail(i as usize),
+            path.push_tail(i),
             m,
         );
     }
@@ -2032,8 +2043,8 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     pub proof fn prefix_push_different_indices(
         prefix: TreePath<NR_ENTRIES>,
         path: TreePath<NR_ENTRIES>,
-        i: usize,
-        j: usize,
+        i: int,
+        j: int,
     )
         requires
             prefix.inv(),
@@ -2049,7 +2060,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     pub proof fn prefix_push_tail_implies_prefix<const N: usize>(
         prefix: TreePath<N>,
         path: TreePath<N>,
-        i: usize,
+        i: int,
     )
         requires
             prefix.inv(),
@@ -2122,13 +2133,13 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             if subtree.value().is_node() {
                 assert forall|i: int| 0 <= i < NR_ENTRIES implies (
                 #[trigger] subtree.children()[i as int]).unwrap().subtree_satisfies(
-                    root_path.push_tail(i as usize),
+                    root_path.push_tail(i),
                     Self::is_at_pred(entry, dest_path),
                 ) by {
                     PageTableOwner(subtree).pt_inv_unroll(i);
                     Self::is_at_holds_when_on_wrong_path(
                         subtree.children()[i as int].unwrap(),
-                        root_path.push_tail(i as usize),
+                        root_path.push_tail(i),
                         dest_path,
                         entry,
                     );
@@ -2165,13 +2176,13 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             if subtree.value().is_node() {
                 assert forall|i: int| 0 <= i < NR_ENTRIES implies (
                 #[trigger] subtree.children()[i as int]).unwrap().subtree_satisfies(
-                    root_path.push_tail(i as usize),
+                    root_path.push_tail(i),
                     Self::path_in_tree_pred(dest_path),
                 ) by {
                     PageTableOwner(subtree).pt_inv_unroll(i);
                     Self::path_in_tree_holds_when_on_wrong_path(
                         subtree.children()[i as int].unwrap(),
-                        root_path.push_tail(i as usize),
+                        root_path.push_tail(i),
                         dest_path,
                     );
                 };
@@ -2244,20 +2255,20 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             assert forall|i: int|
                 0 <= i < subtree.children().len() && (
                 #[trigger] subtree.children()[i]) is Some implies subtree.children()[i].unwrap().subtree_satisfies(
-            path_j.push_tail(i as usize), g) by {
+            path_j.push_tail(i), g) by {
                 let child = subtree.children()[i].unwrap();
-                let child_path = path_j.push_tail(i as usize);
+                let child_path = path_j.push_tail(i);
                 subtree.lemma_map_unroll_once(path_j, f_sound, i);
                 subtree.lemma_map_unroll_once(path_j, f_path, i);
-                path_j.lemma_push_tail_len(i as usize);
-                path_j.lemma_push_tail_index(i as usize);
-                path_j.lemma_push_tail_preserves_inv(i as usize);
+                path_j.lemma_push_tail_len(i);
+                path_j.lemma_push_tail_index(i);
+                path_j.lemma_push_tail_preserves_inv(i);
                 assert(child_path.inv());
                 assert(child_path.len() == child.level());
                 assert(child.value().path == child_path);
                 assert(!Self::is_prefix_of(child_path, old_entry.path)) by {
                     if Self::is_prefix_of(child_path, old_entry.path) {
-                        Self::prefix_push_tail_implies_prefix(path_j, old_entry.path, i as usize);
+                        Self::prefix_push_tail_implies_prefix(path_j, old_entry.path, i);
                     }
                 };
                 Self::neq_old_from_path_disjoint(child, child_path, old_entry, regions);
@@ -2309,7 +2320,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             assert(Self::is_prefix_of(root_path.push_tail(i), dest_path));
             Self::is_at_eq_rec(
                 subtree.children()[i as int].unwrap(),
-                root_path.push_tail(i as usize),
+                root_path.push_tail(i),
                 dest_path,
                 entry1,
                 entry2,
@@ -2363,22 +2374,22 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             let i = self.view_rec_contains_choose(path, m);
             self.pt_inv_unroll(i);
             let entry = PageTableOwner(self.0.children()[i].unwrap()).view_rec_inversion(
-                path.push_tail(i as usize),
+                path.push_tail(i),
                 regions,
                 m,
             );
-            Self::prefix_transitive(path, path.push_tail(i as usize), entry.path);
+            Self::prefix_transitive(path, path.push_tail(i), entry.path);
             assert forall|j: int|
                 0 <= j < NR_ENTRIES
                     && #[trigger] self.0.children()[j] is Some implies self.0.children()[j].unwrap().subtree_satisfies(
-            path.push_tail(j as usize), Self::is_at_pred(entry, entry.path)) by {
+            path.push_tail(j), Self::is_at_pred(entry, entry.path)) by {
                 if j != i {
                     self.pt_inv_unroll(j);
-                    Self::prefix_push_different_indices(path, entry.path, i as usize, j as usize);
-                    assert(!Self::is_prefix_of(path.push_tail(j as usize), entry.path));
+                    Self::prefix_push_different_indices(path, entry.path, i, j);
+                    assert(!Self::is_prefix_of(path.push_tail(j), entry.path));
                     Self::is_at_holds_when_on_wrong_path(
                         self.0.children()[j].unwrap(),
-                        path.push_tail(j as usize),
+                        path.push_tail(j),
                         entry.path,
                         entry,
                     );
@@ -2389,14 +2400,14 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             assert forall|j: int|
                 0 <= j < NR_ENTRIES
                     && #[trigger] self.0.children()[j] is Some implies self.0.children()[j].unwrap().subtree_satisfies(
-            path.push_tail(j as usize), Self::path_in_tree_pred(entry.path)) by {
+            path.push_tail(j), Self::path_in_tree_pred(entry.path)) by {
                 if j != i {
                     self.pt_inv_unroll(j);
-                    Self::prefix_push_different_indices(path, entry.path, i as usize, j as usize);
-                    assert(!Self::is_prefix_of(path.push_tail(j as usize), entry.path));
+                    Self::prefix_push_different_indices(path, entry.path, i, j);
+                    assert(!Self::is_prefix_of(path.push_tail(j), entry.path));
                     Self::path_in_tree_holds_when_on_wrong_path(
                         self.0.children()[j].unwrap(),
-                        path.push_tail(j as usize),
+                        path.push_tail(j),
                         entry.path,
                     );
                 }

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -429,19 +429,19 @@ pub open spec fn allocated_empty_node_owner<C: PageTableConfig>(
     &&& forall|i: int|
         0 <= i < NR_ENTRIES ==> {
             &&& (#[trigger] owner.children()[i]) is Some
-            &&& owner.children()[i]->0.value().is_absent()
-            &&& owner.children()[i]->0.value().inv()
-            &&& owner.children()[i]->0.value().path == owner.value().path.push_tail(i)
+            &&& owner.child(i).value().is_absent()
+            &&& owner.child(i).value().inv()
+            &&& owner.child(i).value().path == owner.value().path.push_tail(i)
         }
     &&& forall|i: int|
         #![auto]
-        0 <= i < NR_ENTRIES ==> owner.children()[i]->0.value().match_pte(
+        0 <= i < NR_ENTRIES ==> owner.child(i).value().match_pte(
             owner.value().node().children_perm.value()[i],
-            owner.children()[i]->0.value().parent_level,
+            owner.child(i).value().parent_level,
         )
     &&& forall|i: int|
         #![auto]
-        0 <= i < NR_ENTRIES ==> owner.children()[i]->0.value().parent_level
+        0 <= i < NR_ENTRIES ==> owner.child(i).value().parent_level
             == owner.value().node().level
     // The freshly-allocated PT node is zero-filled, so every PTE in
     // `children_perm` is the absent PTE. (Stronger than the existing
@@ -489,9 +489,9 @@ pub proof fn rebase_freshly_allocated_children_at<C: PageTableConfig>(
             0 <= j < i ==> (#[trigger] final(owner).children()[j]) == old(owner).children()[j],
         forall|j: int|
             i <= j < NR_ENTRIES ==> {
-                let c_old = old(owner).children()[j]->0;
+                let c_old = old(owner).child(j);
                 let c_new = (#[trigger] final(owner).children()[j])->0;
-                &&& final(owner).children()[j] is Some
+                &&& final(owner).has_child(j)
                 &&& c_new.value() == EntryOwner {
                     path: new_path.push_tail(j),
                     ..c_old.value()
@@ -534,9 +534,9 @@ pub proof fn rebase_freshly_allocated_children<C: PageTableConfig>(
         final(owner).children().len() == NR_ENTRIES,
         forall|i: int|
             0 <= i < NR_ENTRIES ==> {
-                let c_old = old(owner).children()[i]->0;
+                let c_old = old(owner).child(i);
                 let c_new = (#[trigger] final(owner).children()[i])->0;
-                &&& final(owner).children()[i] is Some
+                &&& final(owner).has_child(i)
                 &&& c_new.value() == EntryOwner {
                     path: new_path.push_tail(i),
                     ..c_old.value()
@@ -579,14 +579,14 @@ pub proof fn fresh_node_subtree_satisfies<C: PageTableConfig>(
 {
     assert forall|i: int|
         0 <= i < node.children().len()
-            && #[trigger] node.children()[i] is Some implies node.children()[i]->0.subtree_satisfies(
+            && #[trigger] node.children()[i] is Some implies node.child(i).subtree_satisfies(
         path.push_tail(i),
         f,
     ) by {
         // Each child has all-`None` grandchildren, so its `subtree_satisfies`
         // unfolds to `f` at the child (the grandchild forall is vacuous).
-        assert(node.children()[i]->0.inv());
-        assert(node.children()[i]->0.level() == node.level() + 1);
+        assert(node.child(i).inv());
+        assert(node.child(i).level() == node.level() + 1);
     };
 }
 
@@ -728,8 +728,8 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         // Drive `pt_inv_at_depth(depth)` via the `is_node` branch: prove
         // `pt_edge_at` and the recursive `pt_inv_at_depth(depth-1)` for each child.
         assert forall|i: int| 0 <= i < NR_ENTRIES implies #[trigger] Self::pt_edge_at(owner, i)
-            && PageTableOwner(owner.children()[i].unwrap()).pt_inv_at_depth((depth - 1) as nat) by {
-            let child = owner.children()[i].unwrap();
+            && PageTableOwner(owner.child(i)).pt_inv_at_depth((depth - 1) as nat) by {
+            let child = owner.child(i);
             // pt_edge_at follows from the per-edge facts in the precondition.
             // owner.inv() ⇒ child.inv() (`TreeNode::inv` recurses since
             // INC_LEVELS - owner.level > 1) ⇒ child.value.inv() ⇒ inv_base

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -31,7 +31,7 @@ use core::ops::Deref;
 
 verus! {
 
-broadcast use group_ghost_tree;
+broadcast use group_ghost_tree_lemmas;
 
 #[verifier::inline]
 pub open spec fn vaddr_shift_bits<const L: usize>(idx: int) -> nat

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -114,8 +114,8 @@ pub proof fn lemma_vaddr_strict_bound(path: TreePath<NR_ENTRIES>)
     ensures
         vaddr(path) < 0x1_0000_0000_0000int,
 {
-    broadcast use TreePath::lemma_index_satisfies_elem_inv;
     broadcast use {
+        TreePath::lemma_index_satisfies_elem_inv,
         TreePath::lemma_push_tail_len,
         TreePath::lemma_push_tail_preserves_inv,
     };
@@ -724,8 +724,6 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         let depth = (INC_LEVELS - owner.level()) as nat;
         // `is_node` + `la_inv` forces `owner.level < INC_LEVELS - 1`, so depth >= 2.
         assert(<EntryOwner<C> as TreeNodeValue<INC_LEVELS>>::la_inv(owner.value(), owner.level()));
-        assert(owner.level() < INC_LEVELS - 1);
-        assert(depth > 0);
         // Drive `pt_inv_at_depth(depth)` via the `is_node` branch: prove
         // `pt_edge_at` and the recursive `pt_inv_at_depth(depth-1)` for each child.
         assert forall|i: int| 0 <= i < NR_ENTRIES implies #[trigger] owner.has_child(i)
@@ -738,9 +736,6 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             // ⇒ (node is Some ⇒ !absent), so is_absent ⇒ !is_node.
             assert(owner.has_child(i));
             assert(owner.children()[i] is Some);
-            assert(child.inv());
-            assert(child.value().is_absent());
-            assert(!child.value().is_node());
             // Each child is non-node with all grandchildren None — the
             // non-node branch of pt_inv_at_depth fires.
             PageTableOwner(child).non_node_pt_inv_at_depth((depth - 1) as nat);
@@ -1071,8 +1066,6 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 ).view_rec(path.push_tail(i)).contains(m);
             self.pt_inv_unroll(i);
             let child = PageTableOwner(self.0.children()[i].unwrap());
-            path.lemma_push_tail_preserves_inv(i);
-            path.lemma_push_tail_len(i);
             child.view_rec_vaddr_range(path.push_tail(i), m);
             Self::lemma_vaddr_push_tail_eq(path, i);
 
@@ -1080,20 +1073,6 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             let child_ps = page_size((INC_LEVELS - path.len() - 1) as PagingLevel) as int;
             vstd::arithmetic::power2::lemma2_to64();
             vstd::arithmetic::power2::lemma2_to64_rest();
-            if path.len() == 0 {
-                assert(parent_ps == 0x1_0000_0000_0000);
-                assert(child_ps == 0x80_0000_0000);
-            } else if path.len() == 1 {
-                assert(parent_ps == 0x80_0000_0000);
-                assert(child_ps == 0x4000_0000);
-            } else if path.len() == 2 {
-                assert(parent_ps == 0x4000_0000);
-                assert(child_ps == 0x20_0000);
-            } else {
-                assert(path.len() == 3);
-                assert(parent_ps == 0x20_0000);
-                assert(child_ps == 0x1000);
-            }
             assert(parent_ps == 512 * child_ps) by (nonlinear_arith)
                 requires
                     (parent_ps == 0x1_0000_0000_0000 && child_ps == 0x80_0000_0000) || (parent_ps
@@ -1273,8 +1252,6 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 if self.0.value().is_node() {
                     self.pt_inv_unroll(i);
                     let child = PageTableOwner(self.0.children()[i].unwrap());
-                    path.lemma_push_tail_preserves_inv(i);
-                    path.lemma_push_tail_len(i);
                     // child.view_rec ⊆ self.view_rec(path) ⊆ ambient
                     // path-correctness passes to the child.
                     self.0.lemma_subtree_satisfies_unroll_once(path, Self::path_correct_pred(), i);

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -209,7 +209,6 @@ pub proof fn lemma_vaddr_top_index_cell(path: TreePath<NR_ENTRIES>)
         assert(vaddr(path) == 0x80_0000_0000usize * i0);
     } else if path.len() == 2 {
         let i1 = path[1];
-        assert(i1 < NR_ENTRIES);
         assert(rec_vaddr(path, 2) == 0);
         assert(rec_vaddr(path, 1) == vaddr_make::<NR_LEVELS>(1, i1 as usize) as usize);
         assert(vaddr_make::<NR_LEVELS>(1, i1 as usize) == 0x4000_0000usize * i1) by (compute);
@@ -221,8 +220,6 @@ pub proof fn lemma_vaddr_top_index_cell(path: TreePath<NR_ENTRIES>)
     } else if path.len() == 3 {
         let i1 = path[1];
         let i2 = path[2];
-        assert(i1 < NR_ENTRIES);
-        assert(i2 < NR_ENTRIES);
         assert(rec_vaddr(path, 3) == 0);
         assert(rec_vaddr(path, 2) == vaddr_make::<NR_LEVELS>(2, i2 as usize) as usize);
         assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + vaddr_make::<NR_LEVELS>(
@@ -243,9 +240,6 @@ pub proof fn lemma_vaddr_top_index_cell(path: TreePath<NR_ENTRIES>)
         let i1 = path[1];
         let i2 = path[2];
         let i3 = path[3];
-        assert(i1 < NR_ENTRIES);
-        assert(i2 < NR_ENTRIES);
-        assert(i3 < NR_ENTRIES);
         assert(rec_vaddr(path, 4) == 0);
         assert(rec_vaddr(path, 3) == vaddr_make::<NR_LEVELS>(3, i3 as usize) as usize);
         assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, i2 as usize) + vaddr_make::<NR_LEVELS>(
@@ -900,8 +894,8 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         broadcast use {
             TreePath::lemma_push_tail_len,
             TreePath::lemma_push_tail_preserves_inv,
+            TreePath::lemma_index_satisfies_elem_inv,
         };
-        broadcast use TreePath::lemma_index_satisfies_elem_inv;
 
         lemma_page_size_spec_values();
         vstd::arithmetic::power2::lemma2_to64();
@@ -1292,11 +1286,6 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             let i1 = self.view_rec_contains_choose(path, m1);
             let i2 = self.view_rec_contains_choose(path, m2);
 
-            path.lemma_push_tail_preserves_inv(i1);
-            path.lemma_push_tail_preserves_inv(i2);
-            path.lemma_push_tail_len(i1);
-            path.lemma_push_tail_len(i2);
-
             if i1 == i2 {
                 self.pt_inv_unroll(i1);
                 PageTableOwner(self.0.children()[i1].unwrap()).view_rec_disjoint_vaddrs(
@@ -1627,7 +1616,6 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                     ).view_rec(path.push_tail(i)).contains(m);
                 self.pt_inv_unroll(i);
                 let child = self.0.children()[i].unwrap();
-                path.lemma_push_tail_preserves_inv(i);
                 PageTableOwner(child).view_rec_mapping_inv(path.push_tail(i));
             };
         }
@@ -2062,10 +2050,6 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         ensures
             Self::is_prefix_of(prefix, path),
     {
-        prefix.lemma_push_tail_len(i);
-        prefix.lemma_push_tail_index(i);
-        prefix.lemma_push_tail_preserves_inv(i);
-        assert(prefix.len() <= path.len());
         assert forall|j: int| 0 <= j < prefix.len() implies prefix[j] == path[j] by {
             assert(prefix.push_tail(i)[j] == prefix[j]);
             assert(prefix.push_tail(i)[j] == path[j]);
@@ -2252,11 +2236,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 let child_path = path_j.push_tail(i);
                 subtree.lemma_subtree_satisfies_unroll_once(path_j, f_sound, i);
                 subtree.lemma_subtree_satisfies_unroll_once(path_j, f_path, i);
-                path_j.lemma_push_tail_len(i);
-                path_j.lemma_push_tail_index(i);
-                path_j.lemma_push_tail_preserves_inv(i);
                 assert(child_path.inv());
-                assert(child_path.len() == child.level());
                 assert(child.value().path == child_path);
                 assert(!Self::is_prefix_of(child_path, old_entry.path)) by {
                     if Self::is_prefix_of(child_path, old_entry.path) {

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -2256,7 +2256,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 0 <= i < subtree.children().len() && (
                 #[trigger] subtree.children()[i]) is Some implies subtree.children()[i].unwrap().subtree_satisfies(
             path_j.push_tail(i), g) by {
-                let child = subtree.children()[i].unwrap();
+                let child = subtree.child(i);
                 let child_path = path_j.push_tail(i);
                 subtree.lemma_map_unroll_once(path_j, f_sound, i);
                 subtree.lemma_map_unroll_once(path_j, f_path, i);

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -106,7 +106,7 @@ pub open spec fn vaddr_of<C: PageTableConfig>(path: TreePath<NR_ENTRIES>) -> usi
 /// `vaddr(path) < 2^48` for every valid path: each term in the positional
 /// sum is `i_k * 2^(12 + 9·k)` with `i_k < 512 = 2^9`, so the sum is
 /// strictly less than `2^48`.
-#[verifier::rlimit(400)]
+#[verifier::spinoff_prover]
 pub proof fn lemma_vaddr_strict_bound(path: TreePath<NR_ENTRIES>)
     requires
         path.inv(),
@@ -127,12 +127,15 @@ pub proof fn lemma_vaddr_strict_bound(path: TreePath<NR_ENTRIES>)
     } else if path.len() == 1 {
         path.lemma_index_satisfies_elem_inv(0);
         let i0 = path[0];
+        assert(0 <= i0 < NR_ENTRIES);
         assert(rec_vaddr(path, 1) == 0);
     } else if path.len() == 2 {
         path.lemma_index_satisfies_elem_inv(0);
         path.lemma_index_satisfies_elem_inv(1);
         let i0 = path[0];
         let i1 = path[1];
+        assert(0 <= i0 < NR_ENTRIES);
+        assert(0 <= i1 < NR_ENTRIES);
         assert(rec_vaddr(path, 2) == 0);
         assert(rec_vaddr(path, 1) == vaddr_make::<NR_LEVELS>(1, i1 as usize) as usize);
     } else if path.len() == 3 {
@@ -142,6 +145,9 @@ pub proof fn lemma_vaddr_strict_bound(path: TreePath<NR_ENTRIES>)
         let i0 = path[0];
         let i1 = path[1];
         let i2 = path[2];
+        assert(0 <= i0 < NR_ENTRIES);
+        assert(0 <= i1 < NR_ENTRIES);
+        assert(0 <= i2 < NR_ENTRIES);
         assert(rec_vaddr(path, 3) == 0);
         assert(rec_vaddr(path, 2) == vaddr_make::<NR_LEVELS>(2, i2 as usize) as usize);
         assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + vaddr_make::<
@@ -156,6 +162,10 @@ pub proof fn lemma_vaddr_strict_bound(path: TreePath<NR_ENTRIES>)
         let i1 = path[1];
         let i2 = path[2];
         let i3 = path[3];
+        assert(0 <= i0 < NR_ENTRIES);
+        assert(0 <= i1 < NR_ENTRIES);
+        assert(0 <= i2 < NR_ENTRIES);
+        assert(0 <= i3 < NR_ENTRIES);
         assert(rec_vaddr(path, 4) == 0);
         assert(rec_vaddr(path, 3) == vaddr_make::<NR_LEVELS>(3, i3 as usize) as usize);
         assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, i2 as usize) + vaddr_make::<

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -1262,7 +1262,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                     path.lemma_push_tail_len(i);
                     // child.view_rec ⊆ self.view_rec(path) ⊆ ambient
                     // path-correctness passes to the child.
-                    self.0.lemma_map_unroll_once(path, Self::path_correct_pred(), i);
+                    self.0.lemma_subtree_satisfies_unroll_once(path, Self::path_correct_pred(), i);
                     child.no_frame_with_path_rec(path.push_tail(i), removed_path, ambient);
                 } else {
                     PageTableOwner(self.0).pt_inv_non_node(i);
@@ -2258,8 +2258,8 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             path_j.push_tail(i), g) by {
                 let child = subtree.child(i);
                 let child_path = path_j.push_tail(i);
-                subtree.lemma_map_unroll_once(path_j, f_sound, i);
-                subtree.lemma_map_unroll_once(path_j, f_path, i);
+                subtree.lemma_subtree_satisfies_unroll_once(path_j, f_sound, i);
+                subtree.lemma_subtree_satisfies_unroll_once(path_j, f_path, i);
                 path_j.lemma_push_tail_len(i);
                 path_j.lemma_push_tail_index(i);
                 path_j.lemma_push_tail_preserves_inv(i);

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -2399,14 +2399,14 @@ impl<C: PageTableConfig> PageTableOwner<C> {
 
             assert forall|j: int|
                 0 <= j < NR_ENTRIES
-                    && #[trigger] self.0.children()[j] is Some implies self.0.children()[j].unwrap().subtree_satisfies(
+                    && #[trigger] self.0.has_child(j) implies self.0.child(j).subtree_satisfies(
             path.push_tail(j), Self::path_in_tree_pred(entry.path)) by {
                 if j != i {
                     self.pt_inv_unroll(j);
                     Self::prefix_push_different_indices(path, entry.path, i, j);
                     assert(!Self::is_prefix_of(path.push_tail(j), entry.path));
                     Self::path_in_tree_holds_when_on_wrong_path(
-                        self.0.children()[j].unwrap(),
+                        self.0.child(j),
                         path.push_tail(j),
                         entry.path,
                     );

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -601,8 +601,8 @@ pub tracked struct PageTableOwner<C: PageTableConfig>(pub OwnerSubtree<C>);
 impl<C: PageTableConfig> PageTableOwner<C> {
     /// Per-edge constraint between a node-parent and its child at index `i`.
     pub open spec fn pt_edge_at(parent: OwnerSubtree<C>, i: int) -> bool {
-        &&& parent.children()[i] is Some
-        &&& parent.children()[i]->0.value().path.len() == parent.value().node().tree_level
+        &&& parent.has_child(i)
+        &&& parent.child(i).value().path.len() == parent.value().node().tree_level
             + 1
         // The child either matches its PTE as an owned node/frame/absent
         // entry, OR — only at the top level (`level == NR_LEVELS`, e.g. a user
@@ -611,16 +611,16 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         // owned by another config. Borrowed children contribute nothing to
         // `view_rec`. The top-level guard keeps deeper consumers on pure
         // `match_pte`, so borrowing never appears below the root.
-        &&& (parent.children()[i]->0.value().match_pte(
+        &&& (parent.child(i).value().match_pte(
             parent.value().node().children_perm.value()[i],
             parent.value().node().level,
         ) || (parent.value().node().level == NR_LEVELS && C::LEADING_BITS_spec() == 0
-            && parent.children()[i]->0.value().borrowed_match_pte(
+            && parent.child(i).value().borrowed_match_pte(
             parent.value().node().children_perm.value()[i],
             parent.value().node().level,
         )))
-        &&& parent.children()[i]->0.value().path == parent.value().path.push_tail(i)
-        &&& parent.children()[i]->0.value().parent_level == parent.value().node().level
+        &&& parent.child(i).value().path == parent.value().path.push_tail(i)
+        &&& parent.child(i).value().parent_level == parent.value().node().level
     }
 
     /// Depth-indexed PT-specific per-edge invariant. `depth` is a manifest
@@ -660,7 +660,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             0 <= i < NR_ENTRIES,
         ensures
             Self::pt_edge_at(self.0, i),
-            PageTableOwner(self.0.children()[i]->0).pt_inv(),
+            PageTableOwner(self.0.child(i)).pt_inv(),
     {
         // la_inv + is_node() gives tree_level < L-1, so depth > 0 and the
         // node branch of pt_inv_at_depth fires.
@@ -674,7 +674,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             !self.0.value().is_node(),
             0 <= i < NR_ENTRIES,
         ensures
-            self.0.children()[i] is None,
+            !self.0.has_child(i),
     {
     }
 
@@ -803,7 +803,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             path.len() < INC_LEVELS - 1,
             self.0.value().is_node(),
             0 <= i < self.0.children().len(),
-            self.0.children()[i] is Some,
+            self.0.has_child(i),
             #[trigger] PageTableOwner(self.0.children()[i]->0).view_rec(
                 path.push_tail(i),
             ).contains(m),
@@ -850,8 +850,8 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             mapped.to_set_ensures();
             assert(mapped.contains(elem_s));
             let i = mapped.lemma_contains_to_index(elem_s);
-            if self.0.children()[i] is Some {
-                assert(mapped[i] == PageTableOwner(self.0.children()[i]->0).view_rec(
+            if self.0.has_child(i) {
+                assert(mapped[i] == PageTableOwner(self.0.child(i)).view_rec(
                     path.push_tail(i),
                 ));
             } else {

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -75,7 +75,7 @@ pub open spec fn rec_vaddr(
     if idx == path.len() {
         0
     } else {
-        let offset = path.index(idx) as usize;
+        let offset = path[idx] as usize;
         (vaddr_make::<NR_LEVELS>(idx, offset) + rec_vaddr(path, idx + 1)) as usize
     }
 }
@@ -126,22 +126,22 @@ pub proof fn lemma_vaddr_strict_bound(path: TreePath<NR_ENTRIES>)
     if path.len() == 0 {
     } else if path.len() == 1 {
         path.lemma_index_satisfies_elem_inv(0);
-        let i0 = path.index(0);
+        let i0 = path[0];
         assert(rec_vaddr(path, 1) == 0);
     } else if path.len() == 2 {
         path.lemma_index_satisfies_elem_inv(0);
         path.lemma_index_satisfies_elem_inv(1);
-        let i0 = path.index(0);
-        let i1 = path.index(1);
+        let i0 = path[0];
+        let i1 = path[1];
         assert(rec_vaddr(path, 2) == 0);
         assert(rec_vaddr(path, 1) == vaddr_make::<NR_LEVELS>(1, i1 as usize) as usize);
     } else if path.len() == 3 {
         path.lemma_index_satisfies_elem_inv(0);
         path.lemma_index_satisfies_elem_inv(1);
         path.lemma_index_satisfies_elem_inv(2);
-        let i0 = path.index(0);
-        let i1 = path.index(1);
-        let i2 = path.index(2);
+        let i0 = path[0];
+        let i1 = path[1];
+        let i2 = path[2];
         assert(rec_vaddr(path, 3) == 0);
         assert(rec_vaddr(path, 2) == vaddr_make::<NR_LEVELS>(2, i2 as usize) as usize);
         assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + vaddr_make::<NR_LEVELS>(
@@ -153,10 +153,10 @@ pub proof fn lemma_vaddr_strict_bound(path: TreePath<NR_ENTRIES>)
         path.lemma_index_satisfies_elem_inv(1);
         path.lemma_index_satisfies_elem_inv(2);
         path.lemma_index_satisfies_elem_inv(3);
-        let i0 = path.index(0);
-        let i1 = path.index(1);
-        let i2 = path.index(2);
-        let i3 = path.index(3);
+        let i0 = path[0];
+        let i1 = path[1];
+        let i2 = path[2];
+        let i3 = path[3];
         assert(rec_vaddr(path, 4) == 0);
         assert(rec_vaddr(path, 3) == vaddr_make::<NR_LEVELS>(3, i3 as usize) as usize);
         assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, i2 as usize) + vaddr_make::<NR_LEVELS>(
@@ -192,8 +192,8 @@ pub proof fn lemma_vaddr_top_index_cell(path: TreePath<NR_ENTRIES>)
         path.inv(),
         1 <= path.len() <= INC_LEVELS - 1,
     ensures
-        (path.index(0)) * 0x80_0000_0000int <= vaddr(path),
-        vaddr(path) + page_size((INC_LEVELS - path.len()) as PagingLevel) <= (path.index(0) + 1)
+        (path[0]) * 0x80_0000_0000int <= vaddr(path),
+        vaddr(path) + page_size((INC_LEVELS - path.len()) as PagingLevel) <= (path[0] + 1)
             * 0x80_0000_0000int,
 {
     broadcast use TreePath::lemma_index_satisfies_elem_inv;
@@ -201,14 +201,14 @@ pub proof fn lemma_vaddr_top_index_cell(path: TreePath<NR_ENTRIES>)
     lemma_page_size_spec_values();
     vstd::arithmetic::power2::lemma2_to64();
     vstd::arithmetic::power2::lemma2_to64_rest();
-    let i0 = path.index(0);
+    let i0 = path[0];
     assert(i0 < NR_ENTRIES);
     assert(vaddr_make::<NR_LEVELS>(0, i0 as usize) == 0x80_0000_0000usize * i0) by (compute);
     if path.len() == 1 {
         assert(rec_vaddr(path, 1) == 0);
         assert(vaddr(path) == 0x80_0000_0000usize * i0);
     } else if path.len() == 2 {
-        let i1 = path.index(1);
+        let i1 = path[1];
         assert(i1 < NR_ENTRIES);
         assert(rec_vaddr(path, 2) == 0);
         assert(rec_vaddr(path, 1) == vaddr_make::<NR_LEVELS>(1, i1 as usize) as usize);
@@ -219,8 +219,8 @@ pub proof fn lemma_vaddr_top_index_cell(path: TreePath<NR_ENTRIES>)
                 i1 < 512,
         ;
     } else if path.len() == 3 {
-        let i1 = path.index(1);
-        let i2 = path.index(2);
+        let i1 = path[1];
+        let i2 = path[2];
         assert(i1 < NR_ENTRIES);
         assert(i2 < NR_ENTRIES);
         assert(rec_vaddr(path, 3) == 0);
@@ -240,9 +240,9 @@ pub proof fn lemma_vaddr_top_index_cell(path: TreePath<NR_ENTRIES>)
                 i2 < 512,
         ;
     } else {
-        let i1 = path.index(1);
-        let i2 = path.index(2);
-        let i3 = path.index(3);
+        let i1 = path[1];
+        let i2 = path[2];
+        let i3 = path[3];
         assert(i1 < NR_ENTRIES);
         assert(i2 < NR_ENTRIES);
         assert(i3 < NR_ENTRIES);
@@ -917,13 +917,13 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                     i < 512,
             ;
         } else if path.len() == 1 {
-            let i0 = path.index(0);
+            let i0 = path[0];
             assert(rec_vaddr(path, 1) == 0);
             assert(rec_vaddr(path, 0) == vaddr_make::<NR_LEVELS>(0, i0 as usize) as usize);
             assert(rec_vaddr(path, 0) == 0x80_0000_0000usize * i0);
             assert(pt.len() == 2);
-            assert(pt.index(0) == i0);
-            assert(pt.index(1) == i);
+            assert(pt[0] == i0);
+            assert(pt[1] == i);
             assert(rec_vaddr(pt, 2) == 0);
             assert(rec_vaddr(pt, 1) == vaddr_make::<NR_LEVELS>(1, i as usize) as usize);
             assert(rec_vaddr(pt, 0) == (0x80_0000_0000usize * i0) + 0x4000_0000usize * i);
@@ -935,8 +935,8 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                     i < 512,
             ;
         } else if path.len() == 2 {
-            let i0 = path.index(0);
-            let i1 = path.index(1);
+            let i0 = path[0];
+            let i1 = path[1];
             assert(rec_vaddr(path, 2) == 0);
             assert(rec_vaddr(path, 1) == vaddr_make::<NR_LEVELS>(1, i1 as usize) as usize);
             assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, i0 as usize) + vaddr_make::<NR_LEVELS>(
@@ -945,7 +945,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             )) as usize);
             assert(vaddr_make::<NR_LEVELS>(1, i1 as usize) == 0x4000_0000usize * i1) by (compute);
             assert(pt.len() == 3);
-            assert(pt.index(2) == i);
+            assert(pt[2] == i);
             assert(rec_vaddr(pt, 3) == 0);
             assert(rec_vaddr(pt, 2) == vaddr_make::<NR_LEVELS>(2, i as usize) as usize);
             assert(rec_vaddr(pt, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + vaddr_make::<NR_LEVELS>(
@@ -963,9 +963,9 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             ;
         } else {
             assert(path.len() == 3);
-            let i0 = path.index(0);
-            let i1 = path.index(1);
-            let i2 = path.index(2);
+            let i0 = path[0];
+            let i1 = path[1];
+            let i2 = path[2];
             assert(rec_vaddr(path, 3) == 0);
             assert(rec_vaddr(path, 2) == vaddr_make::<NR_LEVELS>(2, i2 as usize) as usize);
             assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + vaddr_make::<NR_LEVELS>(
@@ -979,10 +979,10 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             assert(vaddr_make::<NR_LEVELS>(1, i1 as usize) == 0x4000_0000usize * i1) by (compute);
             assert(vaddr_make::<NR_LEVELS>(2, i2 as usize) == 0x20_0000usize * i2) by (compute);
             assert(pt.len() == 4);
-            assert(pt.index(0) == i0);
-            assert(pt.index(1) == i1);
-            assert(pt.index(2) == i2);
-            assert(pt.index(3) == i);
+            assert(pt[0] == i0);
+            assert(pt[1] == i1);
+            assert(pt[2] == i2);
+            assert(pt[3] == i);
             assert(rec_vaddr(pt, 4) == 0);
             assert(rec_vaddr(pt, 3) == vaddr_make::<NR_LEVELS>(3, i as usize) as usize);
             assert(rec_vaddr(pt, 2) == (vaddr_make::<NR_LEVELS>(2, i2 as usize) + vaddr_make::<NR_LEVELS>(
@@ -1116,10 +1116,10 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             1 <= path.len() <= INC_LEVELS - 1,
             path.len() == self.0.level(),
             self.0.value().parent_level == (INC_LEVELS - self.0.level()) as PagingLevel,
-            path.index(0) < t,
+            path[0] < t,
             self.view_rec(path).contains(m),
         ensures
-            (path.index(0)) * 0x80_0000_0000int + C::LEADING_BITS_spec() * 0x1_0000_0000_0000int
+            (path[0]) * 0x80_0000_0000int + C::LEADING_BITS_spec() * 0x1_0000_0000_0000int
                 <= m.va_range.start,
             m.va_range.start < m.va_range.end,
             m.va_range.end <= t * 0x80_0000_0000int + C::LEADING_BITS_spec()
@@ -1134,10 +1134,10 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         // `(index(0)+1) <= t`. Adding the `LEADING_BITS*2^48` base shifts both
         // ends — giving the user (LB=0) low half and the kernel (LB=0xffff)
         // high half.
-        assert((path.index(0) + 1) * 0x80_0000_0000int <= t * 0x80_0000_0000int)
+        assert((path[0] + 1) * 0x80_0000_0000int <= t * 0x80_0000_0000int)
             by (nonlinear_arith)
             requires
-                path.index(0) < t,
+                path[0] < t,
         ;
     }
 
@@ -1411,7 +1411,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         if path.len() == 0 {
             assert(rec_vaddr(path, 0) == 0);
         } else if path.len() == 1 {
-            let i0 = path.index(0);
+            let i0 = path[0];
             assert(rec_vaddr(path, 1) == 0);
             assert(rec_vaddr(path, 0) == (vaddr_make::<NR_LEVELS>(0, i0 as usize) + rec_vaddr(
                 path,
@@ -1426,8 +1426,8 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                     i0 < 512,
             ;
         } else if path.len() == 2 {
-            let i0 = path.index(0);
-            let i1 = path.index(1);
+            let i0 = path[0];
+            let i1 = path[1];
             assert(rec_vaddr(path, 2) == 0);
             assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1 as usize) + rec_vaddr(
                 path,
@@ -1453,9 +1453,9 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                     i1 < 512,
             ;
         } else if path.len() == 3 {
-            let i0 = path.index(0);
-            let i1 = path.index(1);
-            let i2 = path.index(2);
+            let i0 = path[0];
+            let i1 = path[1];
+            let i2 = path[2];
             assert(rec_vaddr(path, 3) == 0);
             assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, i2 as usize) + rec_vaddr(
                 path,
@@ -1488,10 +1488,10 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             ;
         } else {
             assert(path.len() == 4);
-            let i0 = path.index(0);
-            let i1 = path.index(1);
-            let i2 = path.index(2);
-            let i3 = path.index(3);
+            let i0 = path[0];
+            let i1 = path[1];
+            let i2 = path[2];
+            let i3 = path[3];
             assert(rec_vaddr(path, 4) == 0);
             assert(rec_vaddr(path, 3) == (vaddr_make::<NR_LEVELS>(3, i3 as usize) + rec_vaddr(
                 path,
@@ -2018,7 +2018,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     /// Spec function: path1 is a prefix of path2
     pub open spec fn is_prefix_of<const N: usize>(prefix: TreePath<N>, path: TreePath<N>) -> bool {
         &&& prefix.len() <= path.len()
-        &&& forall|i: int| 0 <= i < prefix.len() ==> prefix.index(i) == path.index(i)
+        &&& forall|i: int| 0 <= i < prefix.len() ==> prefix[i] == path[i]
     }
 
     /// Transitivity of is_prefix_of
@@ -2034,9 +2034,9 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             Self::is_prefix_of(p1, p3),
     {
         assert(p1.len() <= p3.len());
-        assert forall|i: int| 0 <= i < p1.len() implies p1.index(i) == p3.index(i) by {
-            assert(p1.index(i) == p2.index(i));
-            assert(p2.index(i) == p3.index(i));
+        assert forall|i: int| 0 <= i < p1.len() implies p1[i] == p3[i] by {
+            assert(p1[i] == p2[i]);
+            assert(p2[i] == p3[i]);
         };
     }
 
@@ -2054,7 +2054,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         ensures
             !Self::is_prefix_of(prefix.push_tail(j), path),
     {
-        assert(path.index(prefix.len() as int) == i);
+        assert(path[prefix.len() as int] == i);
     }
 
     pub proof fn prefix_push_tail_implies_prefix<const N: usize>(
@@ -2074,9 +2074,9 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         prefix.lemma_push_tail_index(i);
         prefix.lemma_push_tail_preserves_inv(i);
         assert(prefix.len() <= path.len());
-        assert forall|j: int| 0 <= j < prefix.len() implies prefix.index(j) == path.index(j) by {
-            assert(prefix.push_tail(i).index(j) == prefix.index(j));
-            assert(prefix.push_tail(i).index(j) == path.index(j));
+        assert forall|j: int| 0 <= j < prefix.len() implies prefix[j] == path[j] by {
+            assert(prefix.push_tail(i)[j] == prefix[j]);
+            assert(prefix.push_tail(i)[j] == path[j]);
         };
     }
 
@@ -2309,13 +2309,13 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 assert(root_path.0.len() == dest_path.0.len());
                 assert forall|i: int| 0 <= i < root_path.0.len() implies #[trigger] root_path.0[i]
                     == dest_path.0[i] by {
-                    assert(root_path.index(i) == dest_path.index(i));
+                    assert(root_path[i] == dest_path[i]);
                 };
                 assert(root_path == dest_path);
                 assert(false);
             }
             assert(root_path.len() < dest_path.len());
-            let i = dest_path.index(root_path.len() as int);
+            let i = dest_path[root_path.len() as int];
             PageTableOwner(subtree).pt_inv_unroll(i as int);
             assert(Self::is_prefix_of(root_path.push_tail(i), dest_path));
             Self::is_at_eq_rec(

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -488,11 +488,10 @@ pub proof fn rebase_freshly_allocated_children_at<C: PageTableConfig>(
     decreases NR_ENTRIES - i,
 {
     if i < NR_ENTRIES {
-        let tracked mut child_opt = owner.tracked_remove_child(i as int);
-        let tracked mut child = child_opt.tracked_unwrap();
-        let tracked child_value = child.tracked_borrow_mut_value();
+        let tracked mut child_value = owner.tracked_borrow_mut_child(
+            i as int,
+        ).tracked_borrow_mut_value();
         child_value.path = new_path.push_tail(i as int);
-        owner.tracked_insert_child(i as int, Some(child));
         rebase_freshly_allocated_children_at(owner, new_path, (i + 1) as usize);
     }
 }

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -31,6 +31,8 @@ use core::ops::Deref;
 
 verus! {
 
+broadcast use group_ghost_tree;
+
 #[verifier::inline]
 pub open spec fn vaddr_shift_bits<const L: usize>(idx: int) -> nat
     recommends
@@ -112,8 +114,11 @@ pub proof fn lemma_vaddr_strict_bound(path: TreePath<NR_ENTRIES>)
     ensures
         vaddr(path) < 0x1_0000_0000_0000int,
 {
-    broadcast use TreePath::index_satisfies_elem_inv;
-    broadcast use TreePath::push_tail_property;
+    broadcast use TreePath::lemma_index_satisfies_elem_inv;
+    broadcast use {
+        TreePath::lemma_push_tail_len,
+        TreePath::lemma_push_tail_preserves_inv,
+    };
 
     lemma_page_size_spec_values();
     vstd::arithmetic::power2::lemma2_to64();
@@ -181,31 +186,56 @@ pub proof fn lemma_vaddr_top_index_cell(path: TreePath<NR_ENTRIES>)
         vaddr(path) + page_size((INC_LEVELS - path.len()) as PagingLevel) <= (path.index(0) + 1)
             * 0x80_0000_0000int,
 {
-    broadcast use TreePath::index_satisfies_elem_inv;
+    broadcast use TreePath::lemma_index_satisfies_elem_inv;
 
     lemma_page_size_spec_values();
     vstd::arithmetic::power2::lemma2_to64();
     vstd::arithmetic::power2::lemma2_to64_rest();
     let i0 = path.index(0);
+    assert(i0 < NR_ENTRIES);
+    assert(vaddr_make::<NR_LEVELS>(0, i0) == 0x80_0000_0000usize * i0) by (compute);
     if path.len() == 1 {
         assert(rec_vaddr(path, 1) == 0);
+        assert(vaddr(path) == 0x80_0000_0000usize * i0);
     } else if path.len() == 2 {
         let i1 = path.index(1);
+        assert(i1 < NR_ENTRIES);
         assert(rec_vaddr(path, 2) == 0);
         assert(rec_vaddr(path, 1) == vaddr_make::<NR_LEVELS>(1, i1) as usize);
+        assert(vaddr_make::<NR_LEVELS>(1, i1) == 0x4000_0000usize * i1) by (compute);
+        assert(vaddr(path) == 0x80_0000_0000usize * i0 + 0x4000_0000usize * i1);
+        assert(0x4000_0000int * i1 + 0x4000_0000int <= 0x80_0000_0000int) by (nonlinear_arith)
+            requires
+                i1 < 512,
+        ;
     } else if path.len() == 3 {
         let i1 = path.index(1);
         let i2 = path.index(2);
+        assert(i1 < NR_ENTRIES);
+        assert(i2 < NR_ENTRIES);
         assert(rec_vaddr(path, 3) == 0);
         assert(rec_vaddr(path, 2) == vaddr_make::<NR_LEVELS>(2, i2) as usize);
         assert(rec_vaddr(path, 1) == (vaddr_make::<NR_LEVELS>(1, i1) + vaddr_make::<NR_LEVELS>(
             2,
             i2,
         )) as usize);
+        assert(vaddr_make::<NR_LEVELS>(1, i1) == 0x4000_0000usize * i1) by (compute);
+        assert(vaddr_make::<NR_LEVELS>(2, i2) == 0x20_0000usize * i2) by (compute);
+        assert(vaddr(path) == 0x80_0000_0000usize * i0 + 0x4000_0000usize * i1
+            + 0x20_0000usize * i2);
+        assert(0x4000_0000int * i1 + 0x20_0000int * i2 + 0x20_0000int
+            <= 0x80_0000_0000int) by (nonlinear_arith)
+            requires
+                i1 < 512,
+                i2 < 512,
+        ;
     } else {
         let i1 = path.index(1);
         let i2 = path.index(2);
         let i3 = path.index(3);
+        assert(i1 < NR_ENTRIES);
+        assert(i2 < NR_ENTRIES);
+        assert(i3 < NR_ENTRIES);
         assert(rec_vaddr(path, 4) == 0);
         assert(rec_vaddr(path, 3) == vaddr_make::<NR_LEVELS>(3, i3) as usize);
         assert(rec_vaddr(path, 2) == (vaddr_make::<NR_LEVELS>(2, i2) + vaddr_make::<NR_LEVELS>(
@@ -216,6 +246,8 @@ pub proof fn lemma_vaddr_top_index_cell(path: TreePath<NR_ENTRIES>)
             2,
             i2,
         ) + vaddr_make::<NR_LEVELS>(3, i3)) as usize);
+        assert(vaddr(path) == 0x80_0000_0000usize * i0 + 0x4000_0000usize * i1
+            + 0x20_0000usize * i2 + 0x1000usize * i3);
         assert(0x80_0000_0000int * i0 + 0x4000_0000int * i1 + 0x20_0000int * i2 + 0x1000int * i3
             + 0x1000int <= (i0 + 1) * 0x80_0000_0000int) by (nonlinear_arith)
             requires
@@ -324,14 +356,14 @@ impl<C: PageTableConfig, const L: usize> TreeNodeValue<L> for EntryOwner<C> {
         }
     }
 
-    proof fn default_preserves_inv() {
+    proof fn lemma_default_preserves_inv() {
     }
 
     open spec fn la_inv(self, lv: nat) -> bool {
         self.is_node() ==> lv < L - 1
     }
 
-    proof fn default_preserves_la_inv() {
+    proof fn lemma_default_preserves_la_inv() {
     }
 
     // PT-specific per-edge facts now live in `PageTableOwner::pt_inv` /
@@ -340,7 +372,7 @@ impl<C: PageTableConfig, const L: usize> TreeNodeValue<L> for EntryOwner<C> {
         true
     }
 
-    proof fn default_preserves_rel_children(self, lv: nat) {
+    proof fn lemma_default_preserves_rel_children(self, lv: nat) {
     }
 }
 
@@ -370,47 +402,47 @@ pub open spec fn allocated_empty_node_owner<C: PageTableConfig>(
     level: PagingLevel,
 ) -> bool {
     &&& owner.inv()
-    &&& owner.value.is_node()
-    &&& owner.value.path == TreePath::<NR_ENTRIES>::new(Seq::empty())
-    &&& owner.value.parent_level == (level + 1) as PagingLevel
-    &&& owner.value.node().level
+    &&& owner.value().is_node()
+    &&& owner.value().path == TreePath::<NR_ENTRIES>::new(Seq::empty())
+    &&& owner.value().parent_level == (level + 1) as PagingLevel
+    &&& owner.value().node().level
         == level
     // The fresh subtree's ghost-tree depth. Lets `alloc_if_none` discharge
     // `final(owner).inv()`'s `child.level == self.level + 1`: the grafted
     // children sit at `new_node.level + 1`, which must match the cursor entry's
     // depth + 1.
-    &&& owner.level == (INC_LEVELS - level - 1) as nat
-    &&& owner.value.node().inv()
-    &&& !owner.value.node().children_perm.value().all(|child: C::E| child.is_present())
+    &&& owner.level() == (INC_LEVELS - level - 1) as nat
+    &&& owner.value().node().inv()
+    &&& !owner.value().node().children_perm.value().all(|child: C::E| child.is_present())
     &&& forall|i: int|
         #![auto]
         0 <= i < NR_ENTRIES ==> {
-            &&& owner.children[i] is Some
-            &&& owner.children[i]->0.value.is_absent()
-            &&& owner.children[i]->0.value.inv()
-            &&& owner.children[i]->0.value.path == owner.value.path.push_tail(i as usize)
+            &&& owner.children()[i] is Some
+            &&& owner.children()[i]->0.value().is_absent()
+            &&& owner.children()[i]->0.value().inv()
+            &&& owner.children()[i]->0.value().path == owner.value().path.push_tail(i as usize)
         }
     &&& forall|i: int|
         #![auto]
-        0 <= i < NR_ENTRIES ==> owner.children[i]->0.value.match_pte(
-            owner.value.node().children_perm.value()[i],
-            owner.children[i]->0.value.parent_level,
+        0 <= i < NR_ENTRIES ==> owner.children()[i]->0.value().match_pte(
+            owner.value().node().children_perm.value()[i],
+            owner.children()[i]->0.value().parent_level,
         )
     &&& forall|i: int|
         #![auto]
-        0 <= i < NR_ENTRIES ==> owner.children[i]->0.value.parent_level
-            == owner.value.node().level
+        0 <= i < NR_ENTRIES ==> owner.children()[i]->0.value().parent_level
+            == owner.value().node().level
     // The freshly-allocated PT node is zero-filled, so every PTE in
     // `children_perm` is the absent PTE. (Stronger than the existing
     // "not all are present" clause; needed by `split_if_mapped_huge`'s
     // loop invariant which inspects each slot's PTE.)
     &&& forall|j: int|
-        0 <= j < NR_ENTRIES ==> #[trigger] owner.value.node().children_perm.value()[j]
+        0 <= j < NR_ENTRIES ==> #[trigger] owner.value().node().children_perm.value()[j]
             == C::E::new_absent_spec()
 }
 
 /// Grandchildren of a freshly-allocated PT node are all `None`. The absent
-/// children come from `OwnerSubtree::new_val_tracked` (see
+/// children come from `OwnerSubtree::tracked_new_val` (see
 /// `vstd_extra::ghost_tree`), which initializes `children = Seq::new(N, |_| None)`.
 /// Kept as a separate predicate (rather than folded into
 /// `allocated_empty_node_owner`) to avoid SMT trigger pressure at every
@@ -421,7 +453,7 @@ pub open spec fn allocated_empty_node_grandchildren_none<C: PageTableConfig>(
 ) -> bool {
     forall|i: int, j: int|
         0 <= i < NR_ENTRIES && 0 <= j < NR_ENTRIES
-            ==> #[trigger] owner.children[i]->0.children[j] is None
+            ==> #[trigger] owner.children()[i]->0.children()[j] is None
 }
 
 /// Recursive worker for `rebase_freshly_allocated_children`. Rebases
@@ -435,34 +467,35 @@ pub proof fn rebase_freshly_allocated_children_at<C: PageTableConfig>(
 )
     requires
         i <= NR_ENTRIES,
-        old(owner).children.len() == NR_ENTRIES,
+        old(owner).children().len() == NR_ENTRIES,
         new_path.inv(),
-        forall|j: int| i <= j < NR_ENTRIES ==> (#[trigger] old(owner).children[j]) is Some,
+        forall|j: int| i <= j < NR_ENTRIES ==> (#[trigger] old(owner).children()[j]) is Some,
     ensures
-        final(owner).value == old(owner).value,
-        final(owner).level == old(owner).level,
-        final(owner).children.len() == NR_ENTRIES,
+        final(owner).value() == old(owner).value(),
+        final(owner).level() == old(owner).level(),
+        final(owner).children().len() == NR_ENTRIES,
         forall|j: int|
-            0 <= j < i ==> (#[trigger] final(owner).children[j]) == old(owner).children[j],
+            0 <= j < i ==> (#[trigger] final(owner).children()[j]) == old(owner).children()[j],
         forall|j: int|
             i <= j < NR_ENTRIES ==> {
-                let c_old = old(owner).children[j]->0;
-                let c_new = (#[trigger] final(owner).children[j])->0;
-                &&& final(owner).children[j] is Some
-                &&& c_new.value == EntryOwner {
+                let c_old = old(owner).children()[j]->0;
+                let c_new = (#[trigger] final(owner).children()[j])->0;
+                &&& final(owner).children()[j] is Some
+                &&& c_new.value() == EntryOwner {
                     path: new_path.push_tail(j as usize),
-                    ..c_old.value
+                    ..c_old.value()
                 }
-                &&& c_new.level == c_old.level
-                &&& c_new.children == c_old.children
+                &&& c_new.level() == c_old.level()
+                &&& c_new.children() == c_old.children()
             },
     decreases NR_ENTRIES - i,
 {
     if i < NR_ENTRIES {
-        let tracked mut child_opt = owner.children.tracked_remove(i as int);
+        let tracked mut child_opt = owner.tracked_remove_child(i as int);
         let tracked mut child = child_opt.tracked_unwrap();
-        child.value.path = new_path.push_tail(i);
-        owner.children.tracked_insert(i as int, Some(child));
+        let tracked child_value = child.tracked_borrow_mut_value();
+        child_value.path = new_path.push_tail(i);
+        owner.tracked_insert_child(i as int, Some(child));
         rebase_freshly_allocated_children_at(owner, new_path, (i + 1) as usize);
     }
 }
@@ -481,24 +514,24 @@ pub proof fn rebase_freshly_allocated_children<C: PageTableConfig>(
     new_path: TreePath<NR_ENTRIES>,
 )
     requires
-        old(owner).children.len() == NR_ENTRIES,
+        old(owner).children().len() == NR_ENTRIES,
         new_path.inv(),
-        forall|i: int| 0 <= i < NR_ENTRIES ==> (#[trigger] old(owner).children[i]) is Some,
+        forall|i: int| 0 <= i < NR_ENTRIES ==> (#[trigger] old(owner).children()[i]) is Some,
     ensures
-        final(owner).value == old(owner).value,
-        final(owner).level == old(owner).level,
-        final(owner).children.len() == NR_ENTRIES,
+        final(owner).value() == old(owner).value(),
+        final(owner).level() == old(owner).level(),
+        final(owner).children().len() == NR_ENTRIES,
         forall|i: int|
             0 <= i < NR_ENTRIES ==> {
-                let c_old = old(owner).children[i]->0;
-                let c_new = (#[trigger] final(owner).children[i])->0;
-                &&& final(owner).children[i] is Some
-                &&& c_new.value == EntryOwner {
+                let c_old = old(owner).children()[i]->0;
+                let c_new = (#[trigger] final(owner).children()[i])->0;
+                &&& final(owner).children()[i] is Some
+                &&& c_new.value() == EntryOwner {
                     path: new_path.push_tail(i as usize),
-                    ..c_old.value
+                    ..c_old.value()
                 }
-                &&& c_new.level == c_old.level
-                &&& c_new.children == c_old.children
+                &&& c_new.level() == c_old.level()
+                &&& c_new.children() == c_old.children()
             },
 {
     rebase_freshly_allocated_children_at(owner, new_path, 0);
@@ -507,7 +540,7 @@ pub proof fn rebase_freshly_allocated_children<C: PageTableConfig>(
 /// `tree_predicate_map` for a freshly-allocated node grafted into the cursor:
 /// every child is a `new_val`-shaped node (all grandchildren `None`), so each
 /// child's `tree_predicate_map` reduces to `f` at that child
-/// (`new_val_tree_predicate_map`). Combined with `f` at the root node, this
+/// (`lemma_new_val_tree_predicate_map`). Combined with `f` at the root node, this
 /// discharges the whole one-level subtree. Used by `alloc_if_none` for the
 /// `node_unlocked_except` / `metaregion_sound_pred` / `path_tracked_pred`
 /// predicates over the fresh node (all of which hold trivially at the absent
@@ -519,29 +552,29 @@ pub proof fn fresh_node_tree_predicate_map<C: PageTableConfig>(
 )
     requires
         node.inv(),
-        node.level < INC_LEVELS - 1,
-        f(node.value, path),
-        forall|i: int| 0 <= i < NR_ENTRIES ==> #[trigger] node.children[i] is Some,
+        node.level() < INC_LEVELS - 1,
+        f(node.value(), path),
+        forall|i: int| 0 <= i < NR_ENTRIES ==> #[trigger] node.children()[i] is Some,
         forall|i: int, j: int|
             0 <= i < NR_ENTRIES && 0 <= j < NR_ENTRIES
-                ==> #[trigger] node.children[i].unwrap().children[j] is None,
+                ==> #[trigger] node.children()[i].unwrap().children()[j] is None,
         forall|i: int|
             0 <= i < NR_ENTRIES ==> #[trigger] f(
-                node.children[i].unwrap().value,
+                node.children()[i].unwrap().value(),
                 path.push_tail(i as usize),
             ),
     ensures
         node.tree_predicate_map(path, f),
 {
     assert forall|i: int|
-        0 <= i < node.children.len()
-            && #[trigger] node.children[i] is Some implies node.children[i]->0.tree_predicate_map(
+        0 <= i < node.children().len()
+            && #[trigger] node.children()[i] is Some implies node.children()[i]->0.tree_predicate_map(
         path.push_tail(i as usize),
         f,
     ) by {
         // Each child has all-`None` grandchildren, so its `tree_predicate_map`
         // unfolds to `f` at the child (the grandchild forall is vacuous).
-        node.child_some_properties(i as usize);
+        node.lemma_child_some_properties(i as usize);
     };
 }
 
@@ -556,8 +589,8 @@ pub tracked struct PageTableOwner<C: PageTableConfig>(pub OwnerSubtree<C>);
 impl<C: PageTableConfig> PageTableOwner<C> {
     /// Per-edge constraint between a node-parent and its child at index `i`.
     pub open spec fn pt_edge_at(parent: OwnerSubtree<C>, i: int) -> bool {
-        &&& parent.children[i] is Some
-        &&& parent.children[i]->0.value.path.len() == parent.value.node().tree_level
+        &&& parent.children()[i] is Some
+        &&& parent.children()[i]->0.value().path.len() == parent.value().node().tree_level
             + 1
         // The child either matches its PTE as an owned node/frame/absent
         // entry, OR — only at the top level (`level == NR_LEVELS`, e.g. a user
@@ -566,16 +599,16 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         // owned by another config. Borrowed children contribute nothing to
         // `view_rec`. The top-level guard keeps deeper consumers on pure
         // `match_pte`, so borrowing never appears below the root.
-        &&& (parent.children[i]->0.value.match_pte(
-            parent.value.node().children_perm.value()[i],
-            parent.value.node().level,
-        ) || (parent.value.node().level == NR_LEVELS && C::LEADING_BITS_spec() == 0
-            && parent.children[i]->0.value.borrowed_match_pte(
-            parent.value.node().children_perm.value()[i],
-            parent.value.node().level,
+        &&& (parent.children()[i]->0.value().match_pte(
+            parent.value().node().children_perm.value()[i],
+            parent.value().node().level,
+        ) || (parent.value().node().level == NR_LEVELS && C::LEADING_BITS_spec() == 0
+            && parent.children()[i]->0.value().borrowed_match_pte(
+            parent.value().node().children_perm.value()[i],
+            parent.value().node().level,
         )))
-        &&& parent.children[i]->0.value.path == parent.value.path.push_tail(i as usize)
-        &&& parent.children[i]->0.value.parent_level == parent.value.node().level
+        &&& parent.children()[i]->0.value().path == parent.value().path.push_tail(i as usize)
+        &&& parent.children()[i]->0.value().parent_level == parent.value().node().level
     }
 
     /// Depth-indexed PT-specific per-edge invariant. `depth` is a manifest
@@ -586,16 +619,16 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     {
         if depth == 0 {
             true
-        } else if self.0.value.is_node() {
+        } else if self.0.value().is_node() {
             forall|i: int|
-                #![trigger self.0.children[i]]
+                #![trigger self.0.children()[i]]
                 0 <= i < NR_ENTRIES ==> Self::pt_edge_at(self.0, i) && PageTableOwner(
-                    self.0.children[i]->0,
+                    self.0.children()[i]->0,
                 ).pt_inv_at_depth((depth - 1) as nat)
         } else {
             forall|i: int|
-                #![trigger self.0.children[i]]
-                0 <= i < NR_ENTRIES ==> self.0.children[i] is None
+                #![trigger self.0.children()[i]]
+                0 <= i < NR_ENTRIES ==> self.0.children()[i] is None
         }
     }
 
@@ -605,31 +638,31 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     /// have all children None" recursively via `pt_inv_at_depth`.
     pub open spec fn pt_inv(self) -> bool {
         &&& self.0.inv()
-        &&& self.pt_inv_at_depth((INC_LEVELS - self.0.level) as nat)
+        &&& self.pt_inv_at_depth((INC_LEVELS - self.0.level()) as nat)
     }
 
     pub proof fn pt_inv_unroll(self, i: int)
         requires
             self.pt_inv(),
-            self.0.value.is_node(),
+            self.0.value().is_node(),
             0 <= i < NR_ENTRIES,
         ensures
             Self::pt_edge_at(self.0, i),
-            PageTableOwner(self.0.children[i]->0).pt_inv(),
+            PageTableOwner(self.0.children()[i]->0).pt_inv(),
     {
         // la_inv + is_node() gives tree_level < L-1, so depth > 0 and the
         // node branch of pt_inv_at_depth fires.
-        let depth = (INC_LEVELS - self.0.level) as nat;
-        assert(<EntryOwner<C> as TreeNodeValue<INC_LEVELS>>::la_inv(self.0.value, self.0.level));
+        let depth = (INC_LEVELS - self.0.level()) as nat;
+        assert(<EntryOwner<C> as TreeNodeValue<INC_LEVELS>>::la_inv(self.0.value(), self.0.level()));
     }
 
     pub proof fn pt_inv_non_node(self, i: int)
         requires
             self.pt_inv(),
-            !self.0.value.is_node(),
+            !self.0.value().is_node(),
             0 <= i < NR_ENTRIES,
         ensures
-            self.0.children[i] is None,
+            self.0.children()[i] is None,
     {
     }
 
@@ -638,8 +671,8 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     /// children of a freshly-allocated PT node.
     pub proof fn non_node_pt_inv_at_depth(self, depth: nat)
         requires
-            !self.0.value.is_node(),
-            forall|j: int| 0 <= j < NR_ENTRIES ==> #[trigger] self.0.children[j] is None,
+            !self.0.value().is_node(),
+            forall|j: int| 0 <= j < NR_ENTRIES ==> #[trigger] self.0.children()[j] is None,
         ensures
             self.pt_inv_at_depth(depth),
         decreases depth,
@@ -658,33 +691,33 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     pub proof fn allocated_empty_node_pt_inv(owner: OwnerSubtree<C>)
         requires
             owner.inv(),
-            owner.value.is_node(),
-            owner.children.len() == NR_ENTRIES,
+            owner.value().is_node(),
+            owner.children().len() == NR_ENTRIES,
             forall|i: int|
                 0 <= i < NR_ENTRIES ==> {
-                    let c = #[trigger] owner.children[i];
+                    let c = #[trigger] owner.children()[i];
                     &&& c is Some
-                    &&& c->0.value.is_absent()
-                    &&& c->0.value.path.len() == owner.value.node().tree_level + 1
-                    &&& c->0.value.match_pte(
-                        owner.value.node().children_perm.value()[i],
-                        owner.value.node().level,
+                    &&& c->0.value().is_absent()
+                    &&& c->0.value().path.len() == owner.value().node().tree_level + 1
+                    &&& c->0.value().match_pte(
+                        owner.value().node().children_perm.value()[i],
+                        owner.value().node().level,
                     )
-                    &&& c->0.value.path == owner.value.path.push_tail(i as usize)
-                    &&& c->0.value.parent_level == owner.value.node().level
+                    &&& c->0.value().path == owner.value().path.push_tail(i as usize)
+                    &&& c->0.value().parent_level == owner.value().node().level
                 },
             allocated_empty_node_grandchildren_none(owner),
         ensures
             PageTableOwner(owner).pt_inv(),
     {
-        let depth = (INC_LEVELS - owner.level) as nat;
+        let depth = (INC_LEVELS - owner.level()) as nat;
         // `is_node` + `la_inv` forces `owner.level < INC_LEVELS - 1`, so depth >= 2.
-        assert(<EntryOwner<C> as TreeNodeValue<INC_LEVELS>>::la_inv(owner.value, owner.level));
+        assert(<EntryOwner<C> as TreeNodeValue<INC_LEVELS>>::la_inv(owner.value(), owner.level()));
         // Drive `pt_inv_at_depth(depth)` via the `is_node` branch: prove
         // `pt_edge_at` and the recursive `pt_inv_at_depth(depth-1)` for each child.
         assert forall|i: int| 0 <= i < NR_ENTRIES implies #[trigger] Self::pt_edge_at(owner, i)
-            && PageTableOwner(owner.children[i].unwrap()).pt_inv_at_depth((depth - 1) as nat) by {
-            let child = owner.children[i].unwrap();
+            && PageTableOwner(owner.children()[i].unwrap()).pt_inv_at_depth((depth - 1) as nat) by {
+            let child = owner.children()[i].unwrap();
             // pt_edge_at follows from the per-edge facts in the precondition.
             // owner.inv() ⇒ child.inv() (Node::inv recurses since
             // INC_LEVELS - owner.level > 1) ⇒ child.value.inv() ⇒ inv_base
@@ -702,17 +735,17 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     /// of the virtual address space.
     pub open spec fn top_level_indices_absent(self) -> bool {
         let range = C::TOP_LEVEL_INDEX_RANGE();
-        self.0.value.is_node() ==> forall|i: int|
-            #![trigger self.0.children[i]]
-            0 <= i < NR_ENTRIES && !(range.start <= i < range.end) ==> self.0.children[i] is Some
-                && self.0.children[i]->0.value.is_absent()
+        self.0.value().is_node() ==> forall|i: int|
+            #![trigger self.0.children()[i]]
+            0 <= i < NR_ENTRIES && !(range.start <= i < range.end) ==> self.0.children()[i] is Some
+                && self.0.children()[i]->0.value().is_absent()
     }
 
     pub open spec fn view_rec_node_children(self, path: TreePath<NR_ENTRIES>) -> Seq<Set<Mapping>>
         decreases INC_LEVELS - path.len(), 0nat,
         when self.0.inv() && path.len() < INC_LEVELS - 1
     {
-        self.0.children.map(
+        self.0.children().map(
             |i, child: Option<OwnerSubtree<C>>|
                 if child is Some {
                     PageTableOwner(child->0).view_rec(path.push_tail(i as usize))
@@ -726,7 +759,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         decreases INC_LEVELS - path.len(), 1nat,
         when self.0.inv() && path.len() <= INC_LEVELS - 1
     {
-        if self.0.value.is_frame() {
+        if self.0.value().is_frame() {
             let va = vaddr_of::<C>(path);
             let pt_level = INC_LEVELS - path.len();
             let page_size = page_size(pt_level as PagingLevel);
@@ -734,13 +767,13 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             set![Mapping {
                 va_range: Range { start: va as int, end: va + page_size },
                 pa_range: Range {
-                    start: self.0.value.frame().mapped_pa,
-                    end: (self.0.value.frame().mapped_pa + page_size) as Paddr,
+                    start: self.0.value().frame().mapped_pa,
+                    end: (self.0.value().frame().mapped_pa + page_size) as Paddr,
                 },
                 page_size: page_size,
-                property: self.0.value.frame().prop,
+                property: self.0.value().frame().prop,
             }]
-        } else if self.0.value.is_node() && path.len() < INC_LEVELS - 1 {
+        } else if self.0.value().is_node() && path.len() < INC_LEVELS - 1 {
             self.view_rec_node_children(path).to_set().flatten()
         } else {
             set![]
@@ -756,10 +789,10 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         requires
             self.0.inv(),
             path.len() < INC_LEVELS - 1,
-            self.0.value.is_node(),
-            0 <= i < self.0.children.len(),
-            self.0.children[i] is Some,
-            #[trigger] PageTableOwner(self.0.children[i]->0).view_rec(
+            self.0.value().is_node(),
+            0 <= i < self.0.children().len(),
+            self.0.children()[i] is Some,
+            #[trigger] PageTableOwner(self.0.children()[i]->0).view_rec(
                 path.push_tail(i as usize),
             ).contains(m),
         ensures
@@ -768,8 +801,8 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         broadcast use vstd::seq_lib::group_seq_properties;
 
         let mapped = self.view_rec_node_children(path);
-        assert(self.0.value.kind is Node);
-        assert(!self.0.value.is_frame());
+        assert(self.0.value().kind is Node);
+        assert(!self.0.value().is_frame());
         mapped.to_set_ensures();
         assert(mapped.to_set().contains(mapped[i]));
         mapped.to_set().lemma_flatten_contains(m);
@@ -779,34 +812,34 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         requires
             self.0.inv(),
             path.len() < INC_LEVELS - 1,
-            self.0.value.is_node(),
+            self.0.value().is_node(),
         ensures
             #![trigger self.view_rec(path)]
             forall|m: Mapping|
                 #![trigger self.view_rec(path).contains(m)]
                 self.view_rec(path).contains(m) ==> exists|i: int|
-                    #![trigger self.0.children[i]]
-                    0 <= i < self.0.children.len() && self.0.children[i] is Some && PageTableOwner(
-                        self.0.children[i]->0,
+                    #![trigger self.0.children()[i]]
+                    0 <= i < self.0.children().len() && self.0.children()[i] is Some && PageTableOwner(
+                        self.0.children()[i]->0,
                     ).view_rec(path.push_tail(i as usize)).contains(m),
     {
         broadcast use vstd::seq_lib::group_seq_properties;
 
         assert forall|m: Mapping| #[trigger] self.view_rec(path).contains(m) implies exists|i: int|
-            #![trigger self.0.children[i]]
-            0 <= i < self.0.children.len() && self.0.children[i] is Some && PageTableOwner(
-                self.0.children[i]->0,
+            #![trigger self.0.children()[i]]
+            0 <= i < self.0.children().len() && self.0.children()[i] is Some && PageTableOwner(
+                self.0.children()[i]->0,
             ).view_rec(path.push_tail(i as usize)).contains(m) by {
             let mapped = self.view_rec_node_children(path);
-            assert(!self.0.value.is_frame());
+            assert(!self.0.value().is_frame());
             mapped.to_set().lemma_flatten_contains(m);
             let elem_s = choose|elem_s: Set<Mapping>| #[trigger]
                 mapped.to_set().contains(elem_s) && elem_s.contains(m);
             mapped.to_set_ensures();
             assert(mapped.contains(elem_s));
             let i = mapped.lemma_contains_to_index(elem_s);
-            if self.0.children[i] is Some {
-                assert(mapped[i] == PageTableOwner(self.0.children[i]->0).view_rec(
+            if self.0.children()[i] is Some {
+                assert(mapped[i] == PageTableOwner(self.0.children()[i]->0).view_rec(
                     path.push_tail(i as usize),
                 ));
             } else {
@@ -820,18 +853,18 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             self.0.inv(),
             path.len() < INC_LEVELS - 1,
             self.view_rec(path).contains(m),
-            self.0.value.is_node(),
+            self.0.value().is_node(),
         ensures
-            0 <= i < self.0.children.len() && self.0.children[i] is Some && PageTableOwner(
-                self.0.children[i]->0,
+            0 <= i < self.0.children().len() && self.0.children()[i] is Some && PageTableOwner(
+                self.0.children()[i]->0,
             ).view_rec(path.push_tail(i as usize)).contains(m),
     {
         broadcast use PageTableOwner::group_lemmas;
 
         choose|i: int|
             #![auto]
-            0 <= i < self.0.children.len() && self.0.children[i] is Some && PageTableOwner(
-                self.0.children[i].unwrap(),
+            0 <= i < self.0.children().len() && self.0.children()[i] is Some && PageTableOwner(
+                self.0.children()[i].unwrap(),
             ).view_rec(path.push_tail(i as usize)).contains(m)
     }
 
@@ -849,8 +882,11 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             vaddr(path) + (i + 1) * page_size((INC_LEVELS - path.len() - 1) as PagingLevel)
                 <= usize::MAX,
     {
-        broadcast use TreePath::push_tail_property;
-        broadcast use TreePath::index_satisfies_elem_inv;
+        broadcast use {
+            TreePath::lemma_push_tail_len,
+            TreePath::lemma_push_tail_preserves_inv,
+        };
+        broadcast use TreePath::lemma_index_satisfies_elem_inv;
 
         lemma_page_size_spec_values();
         vstd::arithmetic::power2::lemma2_to64();
@@ -967,8 +1003,8 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             self.pt_inv(),
             path.inv(),
             path.len() <= INC_LEVELS - 1,
-            path.len() == self.0.level,
-            self.0.value.parent_level == (INC_LEVELS - self.0.level) as PagingLevel,
+            path.len() == self.0.level(),
+            self.0.value().parent_level == (INC_LEVELS - self.0.level()) as PagingLevel,
             self.view_rec(path).contains(m),
         ensures
             vaddr_of::<C>(path) <= m.va_range.start,
@@ -981,9 +1017,9 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         broadcast use PageTableOwner::group_lemmas;
 
         lemma_page_size_spec_values();
-        if self.0.value.is_frame() {
+        if self.0.value().is_frame() {
             Self::lemma_vaddr_path_alignment_and_bound(path);
-            let frame = self.0.value.frame();
+            let frame = self.0.value().frame();
             let pt_level = (INC_LEVELS - path.len()) as PagingLevel;
             let expected = Mapping {
                 va_range: Range {
@@ -1000,16 +1036,16 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             assert(self.view_rec(path) == set![expected]);
             assert(m == expected);
             assert(page_size(pt_level) > 0);
-        } else if self.0.value.is_node() && path.len() < INC_LEVELS - 1 {
+        } else if self.0.value().is_node() && path.len() < INC_LEVELS - 1 {
             let i = choose|i: int|
-                #![trigger self.0.children[i]]
-                0 <= i < self.0.children.len() && self.0.children[i] is Some && PageTableOwner(
-                    self.0.children[i].unwrap(),
+                #![trigger self.0.children()[i]]
+                0 <= i < self.0.children().len() && self.0.children()[i] is Some && PageTableOwner(
+                    self.0.children()[i].unwrap(),
                 ).view_rec(path.push_tail(i as usize)).contains(m);
             self.pt_inv_unroll(i);
-            let child = PageTableOwner(self.0.children[i].unwrap());
-            path.push_tail_preserves_inv(i as usize);
-            path.push_tail_property_len(i as usize);
+            let child = PageTableOwner(self.0.children()[i].unwrap());
+            path.lemma_push_tail_preserves_inv(i as usize);
+            path.lemma_push_tail_len(i as usize);
             child.view_rec_vaddr_range(path.push_tail(i as usize), m);
             Self::lemma_vaddr_push_tail_eq(path, i as usize);
 
@@ -1066,8 +1102,8 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             self.pt_inv(),
             path.inv(),
             1 <= path.len() <= INC_LEVELS - 1,
-            path.len() == self.0.level,
-            self.0.value.parent_level == (INC_LEVELS - self.0.level) as PagingLevel,
+            path.len() == self.0.level(),
+            self.0.value().parent_level == (INC_LEVELS - self.0.level()) as PagingLevel,
             path.index(0) < t,
             self.view_rec(path).contains(m),
         ensures
@@ -1103,25 +1139,25 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     pub proof fn pt_inv_implies_path_correct(subtree: OwnerSubtree<C>, path: TreePath<NR_ENTRIES>)
         requires
             PageTableOwner(subtree).pt_inv(),
-            subtree.value.path == path,
+            subtree.value().path == path,
         ensures
             subtree.tree_predicate_map(path, Self::path_correct_pred()),
-        decreases INC_LEVELS - subtree.level,
+        decreases INC_LEVELS - subtree.level(),
     {
-        assert(subtree.children.len() == NR_ENTRIES);
+        assert(subtree.children().len() == NR_ENTRIES);
         // Root: path_correct_pred(value, path) == (value.path == path).
-        assert(Self::path_correct_pred()(subtree.value, path));
-        if subtree.level < INC_LEVELS - 1 {
+        assert(Self::path_correct_pred()(subtree.value(), path));
+        if subtree.level() < INC_LEVELS - 1 {
             assert forall|i: int|
-                0 <= i < subtree.children.len() && (
-                #[trigger] subtree.children[i]) is Some implies subtree.children[i].unwrap().tree_predicate_map(
+                0 <= i < subtree.children().len() && (
+                #[trigger] subtree.children()[i]) is Some implies subtree.children()[i].unwrap().tree_predicate_map(
             path.push_tail(i as usize), Self::path_correct_pred()) by {
-                if subtree.value.is_node() {
+                if subtree.value().is_node() {
                     PageTableOwner(subtree).pt_inv_unroll(i);
                     // pt_edge_at: child.value.path == subtree.value.path.push_tail(i)
-                    assert(subtree.children[i].unwrap().value.path == path.push_tail(i as usize));
+                    assert(subtree.children()[i].unwrap().value().path == path.push_tail(i as usize));
                     Self::pt_inv_implies_path_correct(
-                        subtree.children[i].unwrap(),
+                        subtree.children()[i].unwrap(),
                         path.push_tail(i as usize),
                     );
                 } else {
@@ -1151,9 +1187,9 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             self.pt_inv(),
             path.inv(),
             path.len() <= INC_LEVELS - 1,
-            path.len() == self.0.level,
-            self.0.value.parent_level == (INC_LEVELS - self.0.level) as PagingLevel,
-            self.0.value.path == path,
+            path.len() == self.0.level(),
+            self.0.value().parent_level == (INC_LEVELS - self.0.level()) as PagingLevel,
+            self.0.value().path == path,
             self.0.tree_predicate_map(path, Self::path_correct_pred()),
             forall|mm: Mapping|
                 #![trigger self.view_rec(path).contains(mm)]
@@ -1175,12 +1211,12 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             e.is_frame() ==> e.path != removed_path;
 
         // Path-correctness at the root: value.path == path.
-        assert(Self::path_correct_pred()(self.0.value, path));
-        assert(self.0.value.path == path);
+        assert(Self::path_correct_pred()(self.0.value(), path));
+        assert(self.0.value().path == path);
 
         // Root entry satisfies `g`.
-        if self.0.value.is_frame() {
-            let frame = self.0.value.frame();
+        if self.0.value().is_frame() {
+            let frame = self.0.value().frame();
             let pt_level = (INC_LEVELS - path.len()) as PagingLevel;
             let expected = Mapping {
                 va_range: Range {
@@ -1198,23 +1234,23 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             assert(self.view_rec(path).contains(expected));
             assert(ambient.contains(expected));
             assert(vaddr_of::<C>(path) != vaddr_of::<C>(removed_path));
-            assert(self.0.value.path != removed_path);
+            assert(self.0.value().path != removed_path);
         }
-        assert(g(self.0.value, path));
+        assert(g(self.0.value(), path));
 
-        if self.0.level < INC_LEVELS - 1 {
+        if self.0.level() < INC_LEVELS - 1 {
             assert forall|i: int|
-                0 <= i < self.0.children.len() && (
-                #[trigger] self.0.children[i]) is Some implies self.0.children[i].unwrap().tree_predicate_map(
+                0 <= i < self.0.children().len() && (
+                #[trigger] self.0.children()[i]) is Some implies self.0.children()[i].unwrap().tree_predicate_map(
             path.push_tail(i as usize), g) by {
-                if self.0.value.is_node() {
+                if self.0.value().is_node() {
                     self.pt_inv_unroll(i);
-                    let child = PageTableOwner(self.0.children[i].unwrap());
-                    path.push_tail_preserves_inv(i as usize);
-                    path.push_tail_property_len(i as usize);
+                    let child = PageTableOwner(self.0.children()[i].unwrap());
+                    path.lemma_push_tail_preserves_inv(i as usize);
+                    path.lemma_push_tail_len(i as usize);
                     // child.view_rec ⊆ self.view_rec(path) ⊆ ambient
                     // path-correctness passes to the child.
-                    self.0.map_unroll_once(path, Self::path_correct_pred(), i);
+                    self.0.lemma_map_unroll_once(path, Self::path_correct_pred(), i);
                     child.no_frame_with_path_rec(path.push_tail(i as usize), removed_path, ambient);
                 } else {
                     PageTableOwner(self.0).pt_inv_non_node(i);
@@ -1234,8 +1270,8 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             self.pt_inv(),
             path.inv(),
             path.len() <= INC_LEVELS - 1,
-            path.len() == self.0.level,
-            self.0.value.parent_level == (INC_LEVELS - self.0.level) as PagingLevel,
+            path.len() == self.0.level(),
+            self.0.value().parent_level == (INC_LEVELS - self.0.level()) as PagingLevel,
             self.view_rec(path).contains(m1),
             self.view_rec(path).contains(m2),
             m1 != m2,
@@ -1246,20 +1282,20 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         broadcast use PageTableOwner::group_lemmas;
         broadcast use group_set_properties;
 
-        if self.0.value.is_frame() {
+        if self.0.value().is_frame() {
             assert(self.view_rec(path).is_singleton());
-        } else if self.0.value.is_node() {
+        } else if self.0.value().is_node() {
             let i1 = self.view_rec_contains_choose(path, m1);
             let i2 = self.view_rec_contains_choose(path, m2);
 
-            path.push_tail_preserves_inv(i1 as usize);
-            path.push_tail_preserves_inv(i2 as usize);
-            path.push_tail_property_len(i1 as usize);
-            path.push_tail_property_len(i2 as usize);
+            path.lemma_push_tail_preserves_inv(i1 as usize);
+            path.lemma_push_tail_preserves_inv(i2 as usize);
+            path.lemma_push_tail_len(i1 as usize);
+            path.lemma_push_tail_len(i2 as usize);
 
             if i1 == i2 {
                 self.pt_inv_unroll(i1);
-                PageTableOwner(self.0.children[i1].unwrap()).view_rec_disjoint_vaddrs(
+                PageTableOwner(self.0.children()[i1].unwrap()).view_rec_disjoint_vaddrs(
                     path.push_tail(i1 as usize),
                     m1,
                     m2,
@@ -1268,11 +1304,11 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 self.pt_inv_unroll(i1);
                 self.pt_inv_unroll(i2);
                 let child_ps = page_size((INC_LEVELS - path.len() - 1) as PagingLevel);
-                PageTableOwner(self.0.children[i1].unwrap()).view_rec_vaddr_range(
+                PageTableOwner(self.0.children()[i1].unwrap()).view_rec_vaddr_range(
                     path.push_tail(i1 as usize),
                     m1,
                 );
-                PageTableOwner(self.0.children[i2].unwrap()).view_rec_vaddr_range(
+                PageTableOwner(self.0.children()[i2].unwrap()).view_rec_vaddr_range(
                     path.push_tail(i2 as usize),
                     m2,
                 );
@@ -1300,8 +1336,8 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         requires
             self.pt_inv(),
             path.len() <= INC_LEVELS - 1,
-            path.len() == self.0.level,
-            self.0.value.parent_level == (INC_LEVELS - self.0.level) as PagingLevel,
+            path.len() == self.0.level(),
+            self.0.value().parent_level == (INC_LEVELS - self.0.level()) as PagingLevel,
         ensures
             forall|m: Mapping| #[trigger]
                 self.view_rec(path).contains(m)
@@ -1310,20 +1346,20 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     {
         broadcast use PageTableOwner::group_lemmas;
 
-        if self.0.value.is_frame() {
+        if self.0.value().is_frame() {
             lemma_page_size_spec_values();
-        } else if self.0.value.is_node() && path.len() < INC_LEVELS - 1 {
+        } else if self.0.value().is_node() && path.len() < INC_LEVELS - 1 {
             assert forall|m: Mapping| #[trigger]
                 self.view_rec(path).contains(
                     m,
                 ) implies set![4096usize, 2097152usize, 1073741824usize].contains(m.page_size) by {
                 let i = choose|i: int|
-                    #![trigger self.0.children[i]]
-                    0 <= i < self.0.children.len() && self.0.children[i] is Some && PageTableOwner(
-                        self.0.children[i].unwrap(),
+                    #![trigger self.0.children()[i]]
+                    0 <= i < self.0.children().len() && self.0.children()[i] is Some && PageTableOwner(
+                        self.0.children()[i].unwrap(),
                     ).view_rec(path.push_tail(i as usize)).contains(m);
                 self.pt_inv_unroll(i);
-                let child = self.0.children[i].unwrap();
+                let child = self.0.children()[i].unwrap();
                 PageTableOwner(child).view_rec_mapping_page_size(path.push_tail(i as usize));
             };
         }
@@ -1348,7 +1384,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         lemma_page_size_spec_values();
         vstd::arithmetic::power2::lemma2_to64();
         vstd::arithmetic::power2::lemma2_to64_rest();
-        broadcast use TreePath::index_satisfies_elem_inv;
+        broadcast use TreePath::lemma_index_satisfies_elem_inv;
         // NR_LEVELS = 4; each index is < 512.
         // rec_vaddr values per path.len():
         //   0: 0
@@ -1497,17 +1533,17 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             self.pt_inv(),
             path.inv(),
             path.len() <= INC_LEVELS - 1,
-            path.len() == self.0.level,
-            self.0.value.parent_level == (INC_LEVELS - self.0.level) as PagingLevel,
+            path.len() == self.0.level(),
+            self.0.value().parent_level == (INC_LEVELS - self.0.level()) as PagingLevel,
         ensures
             forall|m: Mapping| #[trigger] self.view_rec(path).contains(m) ==> m.inv(),
         decreases INC_LEVELS - path.len(),
     {
         broadcast use PageTableOwner::group_lemmas;
 
-        if self.0.value.is_frame() {
+        if self.0.value().is_frame() {
             lemma_page_size_spec_values();
-            let frame = self.0.value.frame();
+            let frame = self.0.value().frame();
             let pt_level = (INC_LEVELS - path.len()) as PagingLevel;
             Self::lemma_vaddr_path_alignment_and_bound(path);
             let m = Mapping {
@@ -1577,17 +1613,17 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                     pow2(64) == 0x1_0000_0000_0000_0000int,
             ;
             assert(m.inv());
-        } else if self.0.value.is_node() && path.len() < INC_LEVELS - 1 {
+        } else if self.0.value().is_node() && path.len() < INC_LEVELS - 1 {
             assert forall|m: Mapping| #[trigger]
                 self.view_rec(path).contains(m) implies m.inv() by {
                 let i = choose|i: int|
-                    #![trigger self.0.children[i]]
-                    0 <= i < self.0.children.len() && self.0.children[i] is Some && PageTableOwner(
-                        self.0.children[i].unwrap(),
+                    #![trigger self.0.children()[i]]
+                    0 <= i < self.0.children().len() && self.0.children()[i] is Some && PageTableOwner(
+                        self.0.children()[i].unwrap(),
                     ).view_rec(path.push_tail(i as usize)).contains(m);
                 self.pt_inv_unroll(i);
-                let child = self.0.children[i].unwrap();
-                path.push_tail_preserves_inv(i as usize);
+                let child = self.0.children()[i].unwrap();
+                path.lemma_push_tail_preserves_inv(i as usize);
                 PageTableOwner(child).view_rec_mapping_inv(path.push_tail(i as usize));
             };
         }
@@ -1597,7 +1633,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     pub proof fn view_rec_absent_empty(self, path: TreePath<NR_ENTRIES>)
         requires
             self.0.inv(),
-            self.0.value.is_absent(),
+            self.0.value().is_absent(),
             path.len() <= INC_LEVELS - 1,
         ensures
             self.view_rec(path) == set![],
@@ -1617,24 +1653,24 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     pub proof fn view_rec_nr_children_zero_empty(self, path: TreePath<NR_ENTRIES>)
         requires
             self.pt_inv(),
-            self.0.value.is_node(),
-            self.0.value.node().meta_own.nr_children.value() == 0,
-            self.0.value.node().count_consistent(),
+            self.0.value().is_node(),
+            self.0.value().node().meta_own.nr_children.value() == 0,
+            self.0.value().node().count_consistent(),
             path.len() <= INC_LEVELS - 1,
-            path.len() == self.0.level,
+            path.len() == self.0.level(),
         ensures
             self.view_rec(path) == set![],
     {
         if path.len() < INC_LEVELS - 1 {
-            let cp = self.0.value.node().children_perm.value();
+            let cp = self.0.value().node().children_perm.value();
             // `count_consistent` + `nr_children == 0` ⟹ no present PTEs.
             assert(crate::specs::mm::page_table::node::owners::count_present(cp) == 0);
             self.lemma_view_rec_contains(path);
             assert forall|m: Mapping| self.view_rec(path).contains(m) implies false by {
                 let i = choose|i: int|
-                    #![trigger self.0.children[i]]
-                    0 <= i < self.0.children.len() && self.0.children[i] is Some && PageTableOwner(
-                        self.0.children[i]->0,
+                    #![trigger self.0.children()[i]]
+                    0 <= i < self.0.children().len() && self.0.children()[i] is Some && PageTableOwner(
+                        self.0.children()[i]->0,
                     ).view_rec(path.push_tail(i as usize)).contains(m);
                 self.pt_inv_unroll(i);
                 // PTE `i` is absent — else `count_present(cp) >= 1`.
@@ -1649,9 +1685,9 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 // `pt_edge_at`'s borrowed disjunct needs a present PTE, so it is
                 // false here; the `match_pte` disjunct holds, and `match_pte`
                 // with an absent PTE forces the child `is_absent`.
-                assert(self.0.children[i]->0.value.is_absent());
+                assert(self.0.children()[i]->0.value().is_absent());
                 // An absent entry is neither frame nor node ⟹ empty `view_rec`.
-                assert(PageTableOwner(self.0.children[i]->0).view_rec(path.push_tail(i as usize))
+                assert(PageTableOwner(self.0.children()[i]->0).view_rec(path.push_tail(i as usize))
                     =~= set![]);
             };
             assert(self.view_rec(path) =~= set![]);
@@ -1666,10 +1702,10 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     }
 
     pub open spec fn metaregion_sound(self, regions: MetaRegionOwners) -> bool
-        decreases INC_LEVELS - self.0.level,
+        decreases INC_LEVELS - self.0.level(),
         when self.0.inv()
     {
-        self.0.tree_predicate_map(self.0.value.path, Self::metaregion_sound_pred(regions))
+        self.0.tree_predicate_map(self.0.value().path, Self::metaregion_sound_pred(regions))
     }
 
     /// `PageTableOwner::metaregion_sound` is preserved across regions changes
@@ -1690,7 +1726,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         ensures
             self.metaregion_sound(r1),
     {
-        Self::metaregion_sound_preserved_slot_owners_eq_subtree(self.0, self.0.value.path, r0, r1);
+        Self::metaregion_sound_preserved_slot_owners_eq_subtree(self.0, self.0.value().path, r0, r1);
     }
 
     /// Recursive helper: same preservation property, applied to an arbitrary subtree.
@@ -1708,19 +1744,19 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             forall|k: usize| r0.slots.contains_key(k) ==> r0.slots[k] == #[trigger] r1.slots[k],
         ensures
             subtree.tree_predicate_map(path, Self::metaregion_sound_pred(r1)),
-        decreases INC_LEVELS - subtree.level,
+        decreases INC_LEVELS - subtree.level(),
     {
         // The root entry: its metaregion_sound transfers via the per-entry lemma.
-        subtree.value.metaregion_sound_slot_owners_only(r0, r1);
+        subtree.value().metaregion_sound_slot_owners_only(r0, r1);
         // Recursively for each Some child.
-        if subtree.level < INC_LEVELS - 1 {
+        if subtree.level() < INC_LEVELS - 1 {
             assert forall|i: int|
-                #![trigger subtree.children[i]]
+                #![trigger subtree.children()[i]]
                 0 <= i < NR_ENTRIES
-                    && subtree.children[i] is Some implies subtree.children[i].unwrap().tree_predicate_map(
+                    && subtree.children()[i] is Some implies subtree.children()[i].unwrap().tree_predicate_map(
             path.push_tail(i as usize), Self::metaregion_sound_pred(r1)) by {
                 Self::metaregion_sound_preserved_slot_owners_eq_subtree(
-                    subtree.children[i].unwrap(),
+                    subtree.children()[i].unwrap(),
                     path.push_tail(i as usize),
                     r0,
                     r1,
@@ -1751,7 +1787,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             forall|k: usize| r0.slots.contains_key(k) ==> r0.slots[k] == #[trigger] r1.slots[k],
             // No tree entry's primary slot is at changed_idx.
             self.0.tree_predicate_map(
-                self.0.value.path,
+                self.0.value().path,
                 |e: EntryOwner<C>, p: TreePath<NR_ENTRIES>|
                     e.meta_slot_paddr() is Some ==> frame_to_index(e.meta_slot_paddr()->0)
                         != changed_idx,
@@ -1760,7 +1796,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             // either; provided as a separate condition because the per-entry lemma
             // requires it.
             self.0.tree_predicate_map(
-                self.0.value.path,
+                self.0.value().path,
                 |e: EntryOwner<C>, p: TreePath<NR_ENTRIES>|
                     e.is_frame() && e.parent_level > 1 ==> {
                         let pa = e.frame().mapped_pa;
@@ -1784,7 +1820,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     {
         Self::metaregion_sound_preserved_one_slot_changed_subtree(
             self.0,
-            self.0.value.path,
+            self.0.value().path,
             r0,
             r1,
             changed_idx,
@@ -1835,17 +1871,17 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             ),
         ensures
             subtree.tree_predicate_map(path, Self::metaregion_sound_pred(r1)),
-        decreases INC_LEVELS - subtree.level,
+        decreases INC_LEVELS - subtree.level(),
     {
-        subtree.value.metaregion_sound_one_slot_changed(r0, r1, changed_idx);
-        if subtree.level < INC_LEVELS - 1 {
+        subtree.value().metaregion_sound_one_slot_changed(r0, r1, changed_idx);
+        if subtree.level() < INC_LEVELS - 1 {
             assert forall|i: int|
-                #![trigger subtree.children[i]]
+                #![trigger subtree.children()[i]]
                 0 <= i < NR_ENTRIES
-                    && subtree.children[i] is Some implies subtree.children[i].unwrap().tree_predicate_map(
+                    && subtree.children()[i] is Some implies subtree.children()[i].unwrap().tree_predicate_map(
             path.push_tail(i as usize), Self::metaregion_sound_pred(r1)) by {
                 Self::metaregion_sound_preserved_one_slot_changed_subtree(
-                    subtree.children[i].unwrap(),
+                    subtree.children()[i].unwrap(),
                     path.push_tail(i as usize),
                     r0,
                     r1,
@@ -1899,15 +1935,15 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             subtree.inv(),
         ensures
             subtree.tree_predicate_map(path, Self::not_in_scope_pred()),
-        decreases INC_LEVELS - subtree.level,
+        decreases INC_LEVELS - subtree.level(),
     {
         // `not_in_scope_pred` is trivially `true`; recurse to discharge it.
-        if subtree.level < INC_LEVELS - 1 {
+        if subtree.level() < INC_LEVELS - 1 {
             assert forall|i: int|
-                0 <= i < subtree.children.len() && (
-                #[trigger] subtree.children[i]) is Some implies subtree.children[i].unwrap().tree_predicate_map(
+                0 <= i < subtree.children().len() && (
+                #[trigger] subtree.children()[i]) is Some implies subtree.children()[i].unwrap().tree_predicate_map(
             path.push_tail(i as usize), Self::not_in_scope_pred()) by {
-                Self::tree_not_in_scope(subtree.children[i].unwrap(), path.push_tail(i as usize));
+                Self::tree_not_in_scope(subtree.children()[i].unwrap(), path.push_tail(i as usize));
             };
         }
     }
@@ -1925,13 +1961,13 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     {
         broadcast use PageTableOwner::group_lemmas;
 
-        if self.0.value.is_node() && path.len() < INC_LEVELS - 1 {
+        if self.0.value().is_node() && path.len() < INC_LEVELS - 1 {
             let i = choose|i: int|
-                #![trigger self.0.children[i]]
-                0 <= i < self.0.children.len() && self.0.children[i] is Some && PageTableOwner(
-                    self.0.children[i].unwrap(),
+                #![trigger self.0.children()[i]]
+                0 <= i < self.0.children().len() && self.0.children()[i] is Some && PageTableOwner(
+                    self.0.children()[i].unwrap(),
                 ).view_rec(path.push_tail(i as usize)).contains(m);
-            PageTableOwner(self.0.children[i].unwrap()).view_rec_page_size_bound(
+            PageTableOwner(self.0.children()[i].unwrap()).view_rec_page_size_bound(
                 path.push_tail(i as usize),
                 m,
             );
@@ -1947,7 +1983,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     pub proof fn view_rec_node_page_size_bound(self, path: TreePath<NR_ENTRIES>, m: Mapping)
         requires
             self.0.inv(),
-            self.0.value.is_node(),
+            self.0.value().is_node(),
             path.len() < INC_LEVELS - 1,
             self.view_rec(path).contains(m),
         ensures
@@ -1957,11 +1993,11 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         broadcast use PageTableOwner::group_lemmas;
 
         let i = choose|i: int|
-            #![trigger self.0.children[i]]
-            0 <= i < self.0.children.len() && self.0.children[i] is Some && PageTableOwner(
-                self.0.children[i].unwrap(),
+            #![trigger self.0.children()[i]]
+            0 <= i < self.0.children().len() && self.0.children()[i] is Some && PageTableOwner(
+                self.0.children()[i].unwrap(),
             ).view_rec(path.push_tail(i as usize)).contains(m);
-        PageTableOwner(self.0.children[i].unwrap()).view_rec_page_size_bound(
+        PageTableOwner(self.0.children()[i].unwrap()).view_rec_page_size_bound(
             path.push_tail(i as usize),
             m,
         );
@@ -2022,7 +2058,9 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         ensures
             Self::is_prefix_of(prefix, path),
     {
-        prefix.push_tail_property(i);
+        prefix.lemma_push_tail_len(i);
+        prefix.lemma_push_tail_index(i);
+        prefix.lemma_push_tail_preserves_inv(i);
         assert(prefix.len() <= path.len());
         assert forall|j: int| 0 <= j < prefix.len() implies prefix.index(j) == path.index(j) by {
             assert(prefix.push_tail(i).index(j) == prefix.index(j));
@@ -2074,21 +2112,21 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             dest_path.inv(),
             !Self::is_prefix_of(root_path, dest_path),
             root_path.len() <= INC_LEVELS - 1,
-            root_path.len() == subtree.level,
+            root_path.len() == subtree.level(),
         ensures
             subtree.tree_predicate_map(root_path, Self::is_at_pred(entry, dest_path)),
         decreases INC_LEVELS - root_path.len(),
     {
-        if subtree.level < INC_LEVELS - 1 {
-            if subtree.value.is_node() {
+        if subtree.level() < INC_LEVELS - 1 {
+            if subtree.value().is_node() {
                 assert forall|i: int| 0 <= i < NR_ENTRIES implies (
-                #[trigger] subtree.children[i as int]).unwrap().tree_predicate_map(
+                #[trigger] subtree.children()[i as int]).unwrap().tree_predicate_map(
                     root_path.push_tail(i as usize),
                     Self::is_at_pred(entry, dest_path),
                 ) by {
                     PageTableOwner(subtree).pt_inv_unroll(i);
                     Self::is_at_holds_when_on_wrong_path(
-                        subtree.children[i as int].unwrap(),
+                        subtree.children()[i as int].unwrap(),
                         root_path.push_tail(i as usize),
                         dest_path,
                         entry,
@@ -2096,7 +2134,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 };
             } else {
                 assert forall|i: int| 0 <= i < NR_ENTRIES implies (
-                #[trigger] subtree.children[i as int]) is None by {
+                #[trigger] subtree.children()[i as int]) is None by {
                     PageTableOwner(subtree).pt_inv_non_node(i);
                 };
             }
@@ -2117,28 +2155,28 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             dest_path.inv(),
             !Self::is_prefix_of(root_path, dest_path),
             root_path.len() <= INC_LEVELS - 1,
-            root_path.len() == subtree.level,
+            root_path.len() == subtree.level(),
         ensures
             subtree.tree_predicate_map(root_path, Self::path_in_tree_pred(dest_path)),
         decreases INC_LEVELS - root_path.len(),
     {
-        if subtree.level < INC_LEVELS - 1 {
-            if subtree.value.is_node() {
+        if subtree.level() < INC_LEVELS - 1 {
+            if subtree.value().is_node() {
                 assert forall|i: int| 0 <= i < NR_ENTRIES implies (
-                #[trigger] subtree.children[i as int]).unwrap().tree_predicate_map(
+                #[trigger] subtree.children()[i as int]).unwrap().tree_predicate_map(
                     root_path.push_tail(i as usize),
                     Self::path_in_tree_pred(dest_path),
                 ) by {
                     PageTableOwner(subtree).pt_inv_unroll(i);
                     Self::path_in_tree_holds_when_on_wrong_path(
-                        subtree.children[i as int].unwrap(),
+                        subtree.children()[i as int].unwrap(),
                         root_path.push_tail(i as usize),
                         dest_path,
                     );
                 };
             } else {
                 assert forall|i: int| 0 <= i < NR_ENTRIES implies (
-                #[trigger] subtree.children[i as int]) is None by {
+                #[trigger] subtree.children()[i as int]) is None by {
                     PageTableOwner(subtree).pt_inv_non_node(i);
                 };
             }
@@ -2155,8 +2193,8 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     )
         requires
             subtree.inv(),
-            subtree.value.path == path_j,
-            path_j.len() == subtree.level,
+            subtree.value().path == path_j,
+            path_j.len() == subtree.level(),
             path_j.inv(),
             path_j.len() <= INC_LEVELS - 1,
             subtree.tree_predicate_map(path_j, Self::metaregion_sound_pred(regions)),
@@ -2171,49 +2209,51 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                 path_j,
                 |e: EntryOwner<C>, p: TreePath<NR_ENTRIES>| e.meta_slot_paddr_neq(old_entry),
             ),
-        decreases INC_LEVELS - subtree.level,
+        decreases INC_LEVELS - subtree.level(),
     {
         let f_sound = Self::metaregion_sound_pred(regions);
         let f_path = Self::path_correct_pred();
         let g = |e: EntryOwner<C>, p: TreePath<NR_ENTRIES>| e.meta_slot_paddr_neq(old_entry);
 
-        assert(g(subtree.value, path_j)) by {
-            assert(f_sound(subtree.value, path_j));
-            assert(f_path(subtree.value, path_j));
-            assert(subtree.value.path == path_j);
-            if subtree.value.meta_slot_paddr() is Some {
+        assert(g(subtree.value(), path_j)) by {
+            assert(f_sound(subtree.value(), path_j));
+            assert(f_path(subtree.value(), path_j));
+            assert(subtree.value().path == path_j);
+            if subtree.value().meta_slot_paddr() is Some {
                 let old_paddr = old_entry.meta_slot_paddr()->0;
-                let entry_paddr = subtree.value.meta_slot_paddr()->0;
+                let entry_paddr = subtree.value().meta_slot_paddr()->0;
                 if entry_paddr == old_paddr {
                     let idx = frame_to_index(entry_paddr);
                     let old_idx = frame_to_index(old_paddr);
                     assert(idx == old_idx);
-                    if subtree.value.is_node() {
-                        assert(regions.slot_owners[idx].paths_in_pt == set![subtree.value.path]);
-                    } else if subtree.value.is_frame() {
-                        assert(regions.slot_owners[idx].paths_in_pt.contains(subtree.value.path));
+                    if subtree.value().is_node() {
+                        assert(regions.slot_owners[idx].paths_in_pt == set![subtree.value().path]);
+                    } else if subtree.value().is_frame() {
+                        assert(regions.slot_owners[idx].paths_in_pt.contains(subtree.value().path));
                     }
                     assert(regions.slot_owners[idx].paths_in_pt == set![old_entry.path]);
-                    assert(set![old_entry.path].contains(subtree.value.path));
-                    assert(subtree.value.path == old_entry.path);
+                    assert(set![old_entry.path].contains(subtree.value().path));
+                    assert(subtree.value().path == old_entry.path);
                     assert(Self::is_prefix_of(path_j, old_entry.path));
                 }
             }
         };
 
-        if subtree.level < INC_LEVELS - 1 {
+        if subtree.level() < INC_LEVELS - 1 {
             assert forall|i: int|
-                0 <= i < subtree.children.len() && (
-                #[trigger] subtree.children[i]) is Some implies subtree.children[i].unwrap().tree_predicate_map(
+                0 <= i < subtree.children().len() && (
+                #[trigger] subtree.children()[i]) is Some implies subtree.children()[i].unwrap().tree_predicate_map(
             path_j.push_tail(i as usize), g) by {
-                let child = subtree.children[i].unwrap();
+                let child = subtree.children()[i].unwrap();
                 let child_path = path_j.push_tail(i as usize);
-                subtree.map_unroll_once(path_j, f_sound, i);
-                subtree.map_unroll_once(path_j, f_path, i);
-                path_j.push_tail_property(i as usize);
+                subtree.lemma_map_unroll_once(path_j, f_sound, i);
+                subtree.lemma_map_unroll_once(path_j, f_path, i);
+                path_j.lemma_push_tail_len(i as usize);
+                path_j.lemma_push_tail_index(i as usize);
+                path_j.lemma_push_tail_preserves_inv(i as usize);
                 assert(child_path.inv());
-                assert(child_path.len() == child.level);
-                assert(child.value.path == child_path);
+                assert(child_path.len() == child.level());
+                assert(child.value().path == child_path);
                 assert(!Self::is_prefix_of(child_path, old_entry.path)) by {
                     if Self::is_prefix_of(child_path, old_entry.path) {
                         Self::prefix_push_tail_implies_prefix(path_j, old_entry.path, i as usize);
@@ -2238,7 +2278,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             root_path.inv(),
             Self::is_prefix_of(root_path, dest_path),
             root_path.len() <= INC_LEVELS - 1,
-            root_path.len() == subtree.level,
+            root_path.len() == subtree.level(),
             subtree.tree_predicate_map(root_path, Self::path_in_tree_pred(dest_path)),
             subtree.tree_predicate_map(root_path, Self::is_at_pred(entry1, dest_path)),
             subtree.tree_predicate_map(root_path, Self::is_at_pred(entry2, dest_path)),
@@ -2247,9 +2287,9 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         decreases INC_LEVELS - root_path.len(),
     {
         if root_path == dest_path {
-            assert(subtree.value == entry1);
-            assert(subtree.value == entry2);
-        } else if subtree.level == INC_LEVELS - 1 || !subtree.value.is_node() {
+            assert(subtree.value() == entry1);
+            assert(subtree.value() == entry2);
+        } else if subtree.level() == INC_LEVELS - 1 || !subtree.value().is_node() {
             proof_from_false()
         } else {
             assert(root_path.len() <= dest_path.len());
@@ -2267,7 +2307,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             PageTableOwner(subtree).pt_inv_unroll(i as int);
             assert(Self::is_prefix_of(root_path.push_tail(i), dest_path));
             Self::is_at_eq_rec(
-                subtree.children[i as int].unwrap(),
+                subtree.children()[i as int].unwrap(),
                 root_path.push_tail(i as usize),
                 dest_path,
                 entry1,
@@ -2284,7 +2324,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     ) -> (entry: EntryOwner<C>)
         requires
             self.pt_inv(),
-            path.len() == self.0.level,
+            path.len() == self.0.level(),
             self.view_rec(path).contains(m),
             self.0.tree_predicate_map(path, Self::path_correct_pred()),
             self.0.tree_predicate_map(path, Self::relate_region_tracked_pred(regions)),
@@ -2302,26 +2342,26 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     {
         broadcast use PageTableOwner::group_lemmas;
 
-        if self.0.value.is_frame() {
-            assert(Self::is_prefix_of(path, self.0.value.path));
-            if self.0.level < INC_LEVELS - 1 {
+        if self.0.value().is_frame() {
+            assert(Self::is_prefix_of(path, self.0.value().path));
+            if self.0.level() < INC_LEVELS - 1 {
                 // Non-leaf frame: pt_inv gives children[i] is None,
                 // so tree_predicate_map has no children to recurse into.
                 assert forall|i: int| 0 <= i < NR_ENTRIES implies (
-                #[trigger] self.0.children[i]) is None by {
+                #[trigger] self.0.children()[i]) is None by {
                     self.pt_inv_non_node(i);
                 };
             }
             assert(self.0.tree_predicate_map(
                 path,
-                Self::is_at_pred(self.0.value, self.0.value.path),
+                Self::is_at_pred(self.0.value(), self.0.value().path),
             ));
-            assert(self.0.tree_predicate_map(path, Self::path_in_tree_pred(self.0.value.path)));
-            self.0.value
-        } else if self.0.value.is_node() {
+            assert(self.0.tree_predicate_map(path, Self::path_in_tree_pred(self.0.value().path)));
+            self.0.value()
+        } else if self.0.value().is_node() {
             let i = self.view_rec_contains_choose(path, m);
             self.pt_inv_unroll(i);
-            let entry = PageTableOwner(self.0.children[i].unwrap()).view_rec_inversion(
+            let entry = PageTableOwner(self.0.children()[i].unwrap()).view_rec_inversion(
                 path.push_tail(i as usize),
                 regions,
                 m,
@@ -2329,14 +2369,14 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             Self::prefix_transitive(path, path.push_tail(i as usize), entry.path);
             assert forall|j: int|
                 0 <= j < NR_ENTRIES
-                    && #[trigger] self.0.children[j] is Some implies self.0.children[j].unwrap().tree_predicate_map(
+                    && #[trigger] self.0.children()[j] is Some implies self.0.children()[j].unwrap().tree_predicate_map(
             path.push_tail(j as usize), Self::is_at_pred(entry, entry.path)) by {
                 if j != i {
                     self.pt_inv_unroll(j);
                     Self::prefix_push_different_indices(path, entry.path, i as usize, j as usize);
                     assert(!Self::is_prefix_of(path.push_tail(j as usize), entry.path));
                     Self::is_at_holds_when_on_wrong_path(
-                        self.0.children[j].unwrap(),
+                        self.0.children()[j].unwrap(),
                         path.push_tail(j as usize),
                         entry.path,
                         entry,
@@ -2347,14 +2387,14 @@ impl<C: PageTableConfig> PageTableOwner<C> {
 
             assert forall|j: int|
                 0 <= j < NR_ENTRIES
-                    && #[trigger] self.0.children[j] is Some implies self.0.children[j].unwrap().tree_predicate_map(
+                    && #[trigger] self.0.children()[j] is Some implies self.0.children()[j].unwrap().tree_predicate_map(
             path.push_tail(j as usize), Self::path_in_tree_pred(entry.path)) by {
                 if j != i {
                     self.pt_inv_unroll(j);
                     Self::prefix_push_different_indices(path, entry.path, i as usize, j as usize);
                     assert(!Self::is_prefix_of(path.push_tail(j as usize), entry.path));
                     Self::path_in_tree_holds_when_on_wrong_path(
-                        self.0.children[j].unwrap(),
+                        self.0.children()[j].unwrap(),
                         path.push_tail(j as usize),
                         entry.path,
                     );
@@ -2377,7 +2417,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         requires
             self.pt_inv(),
             path.len() <= INC_LEVELS - 1,
-            path.len() == self.0.level,
+            path.len() == self.0.level(),
             self.view_rec(path).contains(m1),
             self.view_rec(path).contains(m2),
             m1.pa_range.start == m2.pa_range.start,
@@ -2414,14 +2454,14 @@ impl<C: PageTableConfig> PageTableOwner<C> {
 impl<C: PageTableConfig> Inv for PageTableOwner<C> {
     open spec fn inv(self) -> bool {
         &&& self.0.inv()
-        &&& self.pt_inv_at_depth((INC_LEVELS - self.0.level) as nat)
-        &&& self.0.value.is_node()
-        &&& self.0.value.path.len() <= INC_LEVELS - 1
-        &&& self.0.value.path.inv()
-        &&& self.0.value.path.len() == self.0.level
-        &&& self.0.value.parent_level == (INC_LEVELS - self.0.level) as PagingLevel
-        &&& self.0.value.node().tree_level == self.0.value.path.len()
-        &&& self.0.tree_predicate_map(self.0.value.path, Self::path_correct_pred())
+        &&& self.pt_inv_at_depth((INC_LEVELS - self.0.level()) as nat)
+        &&& self.0.value().is_node()
+        &&& self.0.value().path.len() <= INC_LEVELS - 1
+        &&& self.0.value().path.inv()
+        &&& self.0.value().path.len() == self.0.level()
+        &&& self.0.value().parent_level == (INC_LEVELS - self.0.level()) as PagingLevel
+        &&& self.0.value().node().tree_level == self.0.value().path.len()
+        &&& self.0.tree_predicate_map(self.0.value().path, Self::path_correct_pred())
     }
 }
 
@@ -2429,7 +2469,7 @@ impl<C: PageTableConfig> View for PageTableOwner<C> {
     type V = PageTableView;
 
     open spec fn view(&self) -> <Self as View>::V {
-        let mappings = self.view_rec(self.0.value.path);
+        let mappings = self.view_rec(self.0.value().path);
         PageTableView { mappings }
     }
 }

--- a/ostd/src/mm/kspace/kvirt_area.rs
+++ b/ostd/src/mm/kspace/kvirt_area.rs
@@ -421,7 +421,7 @@ impl KVirtArea {
             old(regions).inv(),
             owner.inv(),
             owner.pt_owner.metaregion_sound(*old(regions)),
-            owner.pt_owner.0.value.node().relate_guard(root_guard),
+            owner.pt_owner.0.value().node().relate_guard(root_guard),
             // Precise: out-of-range diverges at the top `assert!`, and the
             // inner `Cursor::query` clones the resolved leaf frame — that
             // clone aborts only when *that specific slot* is saturated.
@@ -566,7 +566,7 @@ impl KVirtArea {
             old(regions).inv(),
             owner.inv(),
             owner.pt_owner.metaregion_sound(*old(regions)),
-            owner.pt_owner.0.value.node().relate_guard(root_guard),
+            owner.pt_owner.0.value().node().relate_guard(root_guard),
             // For each frame, the map contains an appropriate owner keyed by
             // that frame's paddr. Duplicates in `frames` share the same owner.
             forall|i: int|
@@ -932,7 +932,7 @@ impl KVirtArea {
             old(regions).inv(),
             owner.inv(),
             owner.pt_owner.metaregion_sound(*old(regions)),
-            owner.pt_owner.0.value.node().relate_guard(root_guard),
+            owner.pt_owner.0.value().node().relate_guard(root_guard),
             Self::untracked_range_slots_in_regions(&pa_range, *old(regions)),
             map_offset + vstd_extra::external::range::range_usize_len(&pa_range) <= usize::MAX,
         ensures

--- a/ostd/src/mm/kspace/kvirt_area.rs
+++ b/ostd/src/mm/kspace/kvirt_area.rs
@@ -202,14 +202,14 @@ fn collect_largest_pages(va: Vaddr, pa: Paddr, len: usize) -> alloc::vec::Vec<(P
     ensures
         final(kernel_owner)@ is Some,
         final(kernel_owner)@->0.inv(),
-        (final(kernel_owner)@->0).0.value.is_node(),
-        res.root.ptr.addr() == (final(kernel_owner)@->0).0.value.node().meta_addr_self(),
+        (final(kernel_owner)@->0).0.value().is_node(),
+        res.root.ptr.addr() == (final(kernel_owner)@->0).0.value().node().meta_addr_self(),
         !PageTable::<KernelPtConfig>::create_user_pt_panic_condition(
-            (final(kernel_owner)@->0).0.value.node(),
+            (final(kernel_owner)@->0).0.value().node(),
         ),
-        (final(kernel_owner)@->0).0.value.metaregion_sound(*regions),
+        (final(kernel_owner)@->0).0.value().metaregion_sound(*regions),
         final(kernel_owner)@->0.metaregion_sound(*regions),
-        guards.unlocked((final(kernel_owner)@->0).0.value.node().meta_addr_self()),
+        guards.unlocked((final(kernel_owner)@->0).0.value().node().meta_addr_self()),
 )]
 pub(crate) fn get_kernel_page_table<'rcu>() -> &'static PageTable<KernelPtConfig> {
     KERNEL_PAGE_TABLE.get().unwrap()
@@ -294,7 +294,7 @@ impl KVirtAreaOwner {
     pub closed spec fn cursor_view_at(self, addr: Vaddr) -> CursorView<KernelPtConfig> {
         CursorView {
             cur_va: nat_align_down(addr as nat, PAGE_SIZE as nat) as Vaddr,
-            mappings: self.pt_owner.view_rec(self.pt_owner.0.value.path),
+            mappings: self.pt_owner.view_rec(self.pt_owner.0.value().path),
             phantom: PhantomData,
         }
     }

--- a/ostd/src/mm/page_table/cursor/locking.rs
+++ b/ostd/src/mm/page_table/cursor/locking.rs
@@ -40,7 +40,7 @@ pub assume_specification<Idx: Clone>[ Range::<Idx>::clone ](range: &Range<Idx>) 
         Tracked(guards): Tracked<&mut Guards<'rcu>>
     requires
         pt.relates_owner(pt_own, *old(regions)),
-        pt_own.0.value.node().relate_guard(root_guard),
+        pt_own.0.value().node().relate_guard(root_guard),
         forall|i: int| 0 <= i < NR_ENTRIES ==> pt_own.0.children()[i] is Some,
         va.start < va.end,
         // Per-config tightening; see `Cursor::new`. Pulled through to the

--- a/ostd/src/mm/page_table/cursor/locking.rs
+++ b/ostd/src/mm/page_table/cursor/locking.rs
@@ -41,7 +41,7 @@ pub assume_specification<Idx: Clone>[ Range::<Idx>::clone ](range: &Range<Idx>) 
     requires
         pt.relates_owner(pt_own, *old(regions)),
         pt_own.0.value().node().relate_guard(root_guard),
-        forall|i: int| 0 <= i < NR_ENTRIES ==> pt_own.0.children()[i] is Some,
+        forall|i: int| 0 <= i < NR_ENTRIES ==> pt_own.0.has_child(i),
         va.start < va.end,
         // Per-config tightening; see `Cursor::new`. Pulled through to the
         // cursor's `LOCKED_END_BOUND_spec` invariant.

--- a/ostd/src/mm/page_table/cursor/locking.rs
+++ b/ostd/src/mm/page_table/cursor/locking.rs
@@ -4,6 +4,7 @@ use core::{marker::PhantomData, mem::ManuallyDrop, ops::Range, sync::atomic::Ord
 
 use vstd::prelude::*;
 
+use vstd_extra::ghost_tree::*;
 use vstd_extra::ownership::*;
 
 use crate::mm::frame::{
@@ -27,6 +28,8 @@ use align_ext::AlignExt;
 use core::ops::IndexMut;
 
 verus! {
+
+broadcast use group_ghost_tree_lemmas;
 
 pub assume_specification<Idx: Clone>[ Range::<Idx>::clone ](range: &Range<Idx>) -> (res: Range<Idx>)
     ensures
@@ -123,6 +126,13 @@ pub fn lock_range<'rcu, C: PageTableConfig, A: InAtomicMode>(
     va: &Range<Vaddr>,
 ) -> (Cursor<'rcu, C, A>, Tracked<CursorOwner<'rcu, C>>) {
     let ghost start_idx = AbstractVaddr::from_vaddr(va.start).index[NR_LEVELS - 1];
+
+    proof {
+        assert forall|i: int| 0 <= i < NR_ENTRIES implies
+            (#[trigger] pt_own.0.children()[i]) is Some by {
+            assert(pt_own.0.has_child(i));
+        };
+    }
 
     let tracked mut cursor_own: CursorOwner<'rcu, C> = CursorOwner::tracked_new(
         pt_own.0,

--- a/ostd/src/mm/page_table/cursor/locking.rs
+++ b/ostd/src/mm/page_table/cursor/locking.rs
@@ -128,8 +128,8 @@ pub fn lock_range<'rcu, C: PageTableConfig, A: InAtomicMode>(
     let ghost start_idx = AbstractVaddr::from_vaddr(va.start).index[NR_LEVELS - 1];
 
     proof {
-        assert forall|i: int| 0 <= i < NR_ENTRIES implies
-            (#[trigger] pt_own.0.children()[i]) is Some by {
+        assert forall|i: int| 0 <= i < NR_ENTRIES implies (
+        #[trigger] pt_own.0.children()[i]) is Some by {
             assert(pt_own.0.has_child(i));
         };
     }

--- a/ostd/src/mm/page_table/cursor/locking.rs
+++ b/ostd/src/mm/page_table/cursor/locking.rs
@@ -186,10 +186,6 @@ pub fn lock_range<'rcu, C: PageTableConfig, A: InAtomicMode>(
         assert(cont.entry_own.metaregion_sound(*regions));
         assert(regions.slots.contains_key(cont_slot_idx));
         assert(regions.slot_owners.contains_key(cont_slot_idx));
-        assert(vstd_extra::cast_ptr::PointsTo::<MetaSlot, Metadata<PageTablePageMeta<C>>>::new_spec(
-            regions.slots[cont_slot_idx],
-            regions.slot_owners[cont_slot_idx].inner_perms,
-        ).wf(&regions.slot_owners[cont_slot_idx].inner_perms));
     }
     let tracked cont_meta_perm = regions.borrow_typed_perm::<PageTablePageMeta<C>>(cont_slot_idx);
     #[verus_spec(with Tracked(cont_meta_perm))]

--- a/ostd/src/mm/page_table/cursor/locking.rs
+++ b/ostd/src/mm/page_table/cursor/locking.rs
@@ -40,7 +40,7 @@ pub assume_specification<Idx: Clone>[ Range::<Idx>::clone ](range: &Range<Idx>) 
         Tracked(regions): Tracked<&mut MetaRegionOwners>,
         Tracked(guards): Tracked<&mut Guards<'rcu>>
     requires
-        forall|i: int| 0 <= i < NR_ENTRIES ==> pt_own.0.children[i] is Some,
+        forall|i: int| 0 <= i < NR_ENTRIES ==> pt_own.0.children()[i] is Some,
         va.start < va.end,
         // Per-config tightening; see `Cursor::new`. Pulled through to the
         // cursor's `LOCKED_END_BOUND_spec` invariant.
@@ -57,7 +57,7 @@ pub assume_specification<Idx: Clone>[ Range::<Idx>::clone ](range: &Range<Idx>) 
         // The root continuation's path matches the input's root path — this
         // lets `view_rec(pt_own.0.value.path)` unify with the lemma's
         // `view_rec(continuations[3].path())`.
-        (*ret.1).continuations[3].path() == pt_own.0.value.path,
+        (*ret.1).continuations[3].path() == pt_own.0.value().path,
         // Non-saturation preservation: if the caller established that no
         // non-UNUSED slot was one increment away from REF_COUNT_MAX before
         // locking, the same bound holds after. Locking may allocate new PT
@@ -221,7 +221,7 @@ pub fn lock_range<'rcu, C: PageTableConfig, A: InAtomicMode>(
         assume(res.0.invariants(*res.1, *regions, *guards) && (*res.1).in_locked_range()
             && res.0.level == res.0.guard_level && res.0.va < res.0.barrier_va.end && (
         *res.1).as_page_table_owner() == pt_own && (*res.1).continuations[3].path()
-            == pt_own.0.value.path);
+            == pt_own.0.value().path);
         assume((forall|i: usize|
             #![trigger old(regions).slot_owners[i]]
             old(regions).slot_owners.contains_key(i) && old(
@@ -658,7 +658,7 @@ unsafe fn dfs_release_lock<'rcu, C: PageTableConfig, A: InAtomicMode>(
         final(owner).level <= 3 ==> final(owner).continuations[2].guard == old(owner).continuations[2].guard,
         final(owner).level <= 2 ==> final(owner).continuations[1].guard == old(owner).continuations[1].guard,
         final(owner).level == 1 ==> final(owner).continuations[0].guard == old(owner).continuations[0].guard,
-        final(owner).continuations[final(owner).level - 1].children[final(owner).continuations[final(owner).level - 1].idx as int]->0.value.is_absent(),
+        final(owner).continuations[final(owner).level - 1].children[final(owner).continuations[final(owner).level - 1].idx as int]->0.value().is_absent(),
         // entry_own at current level is preserved
         final(owner).continuations[final(owner).level - 1].entry_own == old(owner).continuations[old(owner).level - 1].entry_own,
         // Children at current level are preserved

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -273,7 +273,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
              Tracked(guards): Tracked<&mut Guards<'rcu>>,
         requires
             pt.relates_owner(pt_own, *old(regions)),
-            pt_own.0.value.node().relate_guard(root_guard),
+            pt_own.0.value().node().relate_guard(root_guard),
             // Per-config tightening: e.g. `KernelPtConfig` overrides
             // `LOCKED_END_BOUND_spec` to `FRAME_METADATA_BASE_VADDR`. Callers
             // for `KernelPtConfig` (KVirtArea, etc.) discharge this from the
@@ -2232,7 +2232,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
              Tracked(guards): Tracked<&mut Guards<'rcu>>,
         requires
             pt.relates_owner(pt_own, *old(regions)),
-            pt_own.0.value.node().relate_guard(root_guard),
+            pt_own.0.value().node().relate_guard(root_guard),
             // Per-config tightening; see `Cursor::new`.
             0 < va.end <= C::LOCKED_END_BOUND_spec(),
         ensures

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -2747,7 +2747,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         assert(child_owner.value().parent_level == parent_owner.level);
                         assert(reconstructed_entry_own.path == cont_pre_alloc.entry_own.path);
                         assert(child_owner.value().path == reconstructed_entry_own.path.push_tail(
-                            cont_pre_alloc.idx,
+                            cont_pre_alloc.idx as int,
                         ));
                         assert(child_owner.value().path.len() == parent_owner.tree_level + 1);
 
@@ -3177,7 +3177,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             let cont = owner1.continuations[owner1.level - 1];
             assert(new_owner.value() == EntryOwner::<C>::new_frame(
                 pa,
-                cont.path().push_tail(cont.idx as usize),
+                cont.path().push_tail(cont.idx as int),
                 cont.level(),
                 prop,
                 is_tracked,
@@ -3934,7 +3934,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             new_owner.value().parent_level == old(owner).continuations[old(owner).level
                 - 1].child().value().parent_level,
             new_owner.value().path == old(owner).continuations[old(owner).level - 1].path().push_tail(
-                old(owner).continuations[old(owner).level - 1].idx as usize,
+                old(owner).continuations[old(owner).level - 1].idx as int,
             ),
             new_child.wf(new_owner.value()),
             new_owner == OwnerSubtree::new_val(new_owner.value(), new_owner.level() as nat),
@@ -4144,15 +4144,15 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
 
             // Bridge view_mappings to view().mappings via open-spec unfolding,
             // and connect cont0/final_cont to PageTableOwner views by path equality.
-            assert(owner0.cur_subtree().value().path == cont0.path().push_tail(cont0.idx as usize));
-            assert(new_owner.value().path == cont1.path().push_tail(cont1.idx as usize));
+            assert(owner0.cur_subtree().value().path == cont0.path().push_tail(cont0.idx as int));
+            assert(new_owner.value().path == cont1.path().push_tail(cont1.idx as int));
             cont0.view_mappings_take_child();
             assert(cont0.view_mappings_take_child_spec() == PageTableOwner(
                 owner0.cur_subtree(),
             )@.mappings);
             let old_sub = cont0.view_mappings_take_child_spec();
             let new_sub = PageTableOwner(new_owner).view_rec(
-                cont1.path().push_tail(cont1.idx as usize),
+                cont1.path().push_tail(cont1.idx as int),
             );
             assert(cont1.view_mappings() == cont0.view_mappings() - old_sub);
             assert(owner.view_mappings() == (owner0.view_mappings() - cont0.view_mappings()).union(
@@ -4168,7 +4168,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                     #![auto]
                     0 <= j < final_cont.children.len() && final_cont.children[j] is Some
                         && PageTableOwner(final_cont.children[j].unwrap()).view_rec(
-                        final_cont.path().push_tail(j as usize),
+                        final_cont.path().push_tail(j),
                     ).contains(m);
             };
             assert forall|m: Mapping|
@@ -4181,7 +4181,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         new_owner,
                     ).children[j] is Some && PageTableOwner(
                         cont1.put_child(new_owner).children[j].unwrap(),
-                    ).view_rec(cont1.put_child(new_owner).path().push_tail(j as usize)).contains(m);
+                    ).view_rec(cont1.put_child(new_owner).path().push_tail(j)).contains(m);
             };
             assert(final_cont.view_mappings() == cont1.view_mappings() + new_sub);
             // Set arithmetic: (A - B) + C == A - D + E
@@ -4249,13 +4249,13 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         #![auto]
                         0 <= j < NR_ENTRIES
                             && cont.children[j] is Some implies cont.children[j].unwrap().subtree_satisfies(
-                    cont.path().push_tail(j as usize), g_sound) by {
+                    cont.path().push_tail(j), g_sound) by {
                         cont.inv_children_unroll(j);
                         let subtree = cont.children[j].unwrap();
-                        let path_j = cont.path().push_tail(j as usize);
+                        let path_j = cont.path().push_tail(j);
                         owner0.cursor_path_nesting(i, owner0.level - 1);
-                        cont0.path().lemma_push_tail_index(idx as usize);
-                        cont.path().lemma_push_tail_index(j as usize);
+                        cont0.path().lemma_push_tail_index(idx as int);
+                        cont.path().lemma_push_tail_index(j);
                         cont.pt_inv_children_unroll(j);
                         PageTableOwner::<C>::pt_inv_implies_path_correct(subtree, path_j);
                         PageTableOwner::<C>::neq_old_from_path_disjoint(
@@ -4279,7 +4279,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             };
 
             assert(new_owner.value().metaregion_sound(*regions));
-            let child_path = final_cont.path().push_tail(idx as usize);
+            let child_path = final_cont.path().push_tail(idx as int);
             assert(new_owner.subtree_satisfies(child_path, g_sound)) by {
                 OwnerSubtree::lemma_new_val_subtree_satisfies(new_owner, child_path, g_sound);
             };
@@ -4291,14 +4291,14 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         #![auto]
                         0 <= j < NR_ENTRIES
                             && final_cont.children[j] is Some implies final_cont.children[j].unwrap().subtree_satisfies(
-                    final_cont.path().push_tail(j as usize), g_sound) by {
+                    final_cont.path().push_tail(j), g_sound) by {
                         if j != idx {
                             cont0.inv_children_unroll(j);
                             let subtree = cont0.children[j].unwrap();
-                            let path_j = final_cont.path().push_tail(j as usize);
-                            cont0.path().lemma_push_tail_index(j as usize);
-                            cont0.path().lemma_push_tail_index(idx as usize);
-                            cont0.path().lemma_push_tail_len(j as usize);
+                            let path_j = final_cont.path().push_tail(j);
+                            cont0.path().lemma_push_tail_index(j);
+                            cont0.path().lemma_push_tail_index(idx as int);
+                            cont0.path().lemma_push_tail_len(j);
                             cont0.pt_inv_children_unroll(j);
                             PageTableOwner::<C>::pt_inv_implies_path_correct(subtree, path_j);
                             PageTableOwner::<C>::neq_old_from_path_disjoint(
@@ -4330,11 +4330,11 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         |e: EntryOwner<C>, p: TreePath<NR_ENTRIES>| e.metaregion_sound(regions0),
                     ));
                     assert(cont0.children[cont0.idx as int].unwrap().subtree_satisfies(
-                        cont0.path().push_tail(cont0.idx as usize),
+                        cont0.path().push_tail(cont0.idx as int),
                         |e: EntryOwner<C>, p: TreePath<NR_ENTRIES>| e.metaregion_sound(regions0),
                     ));
                     cont0.inv_children_rel_unroll(cont0.idx as int);
-                    cont0.path().lemma_push_tail_len(cont0.idx as usize);
+                    cont0.path().lemma_push_tail_len(cont0.idx as int);
                 }
                 assert forall|i: int|
                     #![trigger owner.continuations[i]]
@@ -4371,7 +4371,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 #![trigger final_cont.children[j]]
                 0 <= j < NR_ENTRIES && final_cont.children[j] is Some implies {
                 &&& final_cont.children[j].unwrap().value().path == final_cont.path().push_tail(
-                    j as usize,
+                    j,
                 )
                 &&& final_cont.children[j].unwrap().value().parent_level == final_cont.level()
                 &&& final_cont.children[j].unwrap().inv()
@@ -4557,7 +4557,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                                         && PageTableOwner(
                                         owner.continuations[i].children[j].unwrap(),
                                     ).view_rec(
-                                        owner.continuations[i].path().push_tail(j as usize),
+                                        owner.continuations[i].path().push_tail(j),
                                     ).contains(m);
                                 assert(owner_before_dfs.continuations[i].children[j]
                                     == owner.continuations[i].children[j]);
@@ -4574,7 +4574,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                                         owner_before_dfs.continuations[i].children[j].unwrap(),
                                     ).view_rec(
                                         owner_before_dfs.continuations[i].path().push_tail(
-                                            j as usize,
+                                            j,
                                         ),
                                     ).contains(m);
                                 assert(owner.continuations[i].children[j]

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -3555,9 +3555,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             absent_entry_owner,
             subtree_level,
         );
-        proof {
-            lemma_new_val_properties(absent_entry_owner_spec, subtree_level);
-        }
 
         assert(subtree.value().meta_slot_paddr() is None);
         proof {
@@ -4081,7 +4078,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 pre_new_owner.set_value(new_owner.value()),
             );
             assert(new_owner == OwnerSubtree::new_val(new_owner.value(), new_owner.level()));
-            lemma_new_val_properties(new_owner.value(), new_owner.level());
             old_child_owner_pre_replace.lemma_set_value_observable_fields(
                 old_child_owner.value(),
             );

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -3195,7 +3195,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 assert(new_owner.inv());
             };
 
-            OwnerSubtree::lemma_new_val_tree_predicate_map(
+            OwnerSubtree::lemma_new_val_subtree_satisfies(
                 new_owner,
                 new_owner.value().path,
                 CursorOwner::<'rcu, C>::node_unlocked(*guards),
@@ -3577,7 +3577,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         proof {
             // subtree.value is absent, so not_in_tree is vacuously true.
             owner.absent_not_in_tree(subtree.value());
-            OwnerSubtree::lemma_new_val_tree_predicate_map(
+            OwnerSubtree::lemma_new_val_subtree_satisfies(
                 subtree,
                 subtree.value().path,
                 CursorOwner::<'rcu, C>::node_unlocked(*guards),
@@ -3939,7 +3939,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             new_child.wf(new_owner.value()),
             new_owner == OwnerSubtree::new_val(new_owner.value(), new_owner.level() as nat),
             new_owner.value().metaregion_sound(*old(regions)),
-            new_owner.tree_predicate_map(
+            new_owner.subtree_satisfies(
                 new_owner.value().path,
                 CursorOwner::<'rcu, C>::node_unlocked(*old(guards)),
             ),
@@ -4248,7 +4248,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                     assert forall|j: int|
                         #![auto]
                         0 <= j < NR_ENTRIES
-                            && cont.children[j] is Some implies cont.children[j].unwrap().tree_predicate_map(
+                            && cont.children[j] is Some implies cont.children[j].unwrap().subtree_satisfies(
                     cont.path().push_tail(j as usize), g_sound) by {
                         cont.inv_children_unroll(j);
                         let subtree = cont.children[j].unwrap();
@@ -4280,8 +4280,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
 
             assert(new_owner.value().metaregion_sound(*regions));
             let child_path = final_cont.path().push_tail(idx as usize);
-            assert(new_owner.tree_predicate_map(child_path, g_sound)) by {
-                OwnerSubtree::lemma_new_val_tree_predicate_map(new_owner, child_path, g_sound);
+            assert(new_owner.subtree_satisfies(child_path, g_sound)) by {
+                OwnerSubtree::lemma_new_val_subtree_satisfies(new_owner, child_path, g_sound);
             };
 
             // Bottom continuation siblings: metaregion_sound
@@ -4290,7 +4290,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                     assert forall|j: int|
                         #![auto]
                         0 <= j < NR_ENTRIES
-                            && final_cont.children[j] is Some implies final_cont.children[j].unwrap().tree_predicate_map(
+                            && final_cont.children[j] is Some implies final_cont.children[j].unwrap().subtree_satisfies(
                     final_cont.path().push_tail(j as usize), g_sound) by {
                         if j != idx {
                             cont0.inv_children_unroll(j);
@@ -4329,7 +4329,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                     assert(cont0.map_children(
                         |e: EntryOwner<C>, p: TreePath<NR_ENTRIES>| e.metaregion_sound(regions0),
                     ));
-                    assert(cont0.children[cont0.idx as int].unwrap().tree_predicate_map(
+                    assert(cont0.children[cont0.idx as int].unwrap().subtree_satisfies(
                         cont0.path().push_tail(cont0.idx as usize),
                         |e: EntryOwner<C>, p: TreePath<NR_ENTRIES>| e.metaregion_sound(regions0),
                     ));

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -366,7 +366,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
 
         proof {
             assert(pt_own.0.value().is_node());
-            assert forall|i: int| 0 <= i < NR_ENTRIES implies pt_own.0.children()[i] is Some by {
+            assert forall|i: int| 0 <= i < NR_ENTRIES implies pt_own.0.has_child(i) by {
                 pt_own.pt_inv_unroll(i);
             };
         }

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -4225,8 +4225,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         let subtree = cont.children[j].unwrap();
                         let path_j = cont.path().push_tail(j);
                         owner0.cursor_path_nesting(i, owner0.level - 1);
-                        cont0.path().lemma_push_tail_index(idx as int);
-                        cont.path().lemma_push_tail_index(j);
                         cont.pt_inv_children_unroll(j);
                         PageTableOwner::<C>::pt_inv_implies_path_correct(subtree, path_j);
                         PageTableOwner::<C>::neq_old_from_path_disjoint(

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -2182,8 +2182,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             assert(child_owner0.value().is_frame());
             assert(child_owner.value().is_frame());
             assert(child_owner.children() == child_owner0.children());
-            assert forall|i: int| 0 <= i < NR_ENTRIES implies
-                !#[trigger] child_owner.has_child(i) by {
+            assert forall|i: int| 0 <= i < NR_ENTRIES implies !#[trigger] child_owner.has_child(
+                i,
+            ) by {
                 PageTableOwner(child_owner0).pt_inv_non_node(i);
             };
             PageTableOwner(child_owner).non_node_pt_inv_at_depth(
@@ -3186,7 +3187,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 assert(new_owner.inv());
             };
 
-
             let ghost pa_idx_install = frame_to_index(pa);
             let ghost new_frame_path = new_owner.value().path;
             let tracked mut pa_slot_install = regions.slot_owners.tracked_remove(pa_idx_install);
@@ -3542,10 +3542,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         );
         let ghost absent_entry_owner_spec = absent_entry_owner;
         let ghost subtree_level = (owner.continuations[owner.level - 1].tree_level + 1) as nat;
-        let tracked subtree = OwnerSubtree::tracked_new_val(
-            absent_entry_owner,
-            subtree_level,
-        );
+        let tracked subtree = OwnerSubtree::tracked_new_val(absent_entry_owner, subtree_level);
 
         assert(subtree.value().meta_slot_paddr() is None);
         proof {
@@ -4069,9 +4066,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 pre_new_owner.set_value(new_owner.value()),
             );
             assert(new_owner == OwnerSubtree::new_val(new_owner.value(), new_owner.level()));
-            old_child_owner_pre_replace.lemma_set_value_observable_fields(
-                old_child_owner.value(),
-            );
+            old_child_owner_pre_replace.lemma_set_value_observable_fields(old_child_owner.value());
             OwnerSubtree::<C>::lemma_ext_equal(
                 old_child_owner,
                 old_child_owner_pre_replace.set_value(old_child_owner.value()),
@@ -4106,10 +4101,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 (INC_LEVELS - new_owner.level()) as nat,
             );
             assert(PageTableOwner(new_owner).pt_inv());
-            final_cont.continuation_inv_holds_after_child_restore(
-                cont0,
-                cont0.entry_own.node(),
-            );
+            final_cont.continuation_inv_holds_after_child_restore(cont0, cont0.entry_own.node());
             assert(owner.inv());
             CursorOwner::view_mappings_replace_lowest(owner0, *owner, cont0, final_cont);
 
@@ -4330,9 +4322,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             assert forall|j: int|
                 #![trigger final_cont.children[j]]
                 0 <= j < NR_ENTRIES && final_cont.children[j] is Some implies {
-                &&& final_cont.children[j].unwrap().value().path == final_cont.path().push_tail(
-                    j,
-                )
+                &&& final_cont.children[j].unwrap().value().path == final_cont.path().push_tail(j)
                 &&& final_cont.children[j].unwrap().value().parent_level == final_cont.level()
                 &&& final_cont.children[j].unwrap().inv()
                 &&& final_cont.children[j].unwrap().level() == final_cont.tree_level + 1
@@ -4507,9 +4497,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                                         && owner.continuations[i].children[j] is Some
                                         && PageTableOwner(
                                         owner.continuations[i].children[j].unwrap(),
-                                    ).view_rec(
-                                        owner.continuations[i].path().push_tail(j),
-                                    ).contains(m);
+                                    ).view_rec(owner.continuations[i].path().push_tail(j)).contains(
+                                        m,
+                                    );
                                 assert(owner_before_dfs.continuations[i].children[j]
                                     == owner.continuations[i].children[j]);
                             };
@@ -4524,9 +4514,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                                         && PageTableOwner(
                                         owner_before_dfs.continuations[i].children[j].unwrap(),
                                     ).view_rec(
-                                        owner_before_dfs.continuations[i].path().push_tail(
-                                            j,
-                                        ),
+                                        owner_before_dfs.continuations[i].path().push_tail(j),
                                     ).contains(m);
                                 assert(owner.continuations[i].children[j]
                                     == owner_before_dfs.continuations[i].children[j]);

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -3195,11 +3195,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 assert(new_owner.inv());
             };
 
-            OwnerSubtree::lemma_new_val_subtree_satisfies(
-                new_owner,
-                new_owner.value().path,
-                CursorOwner::<'rcu, C>::node_unlocked(*guards),
-            );
 
             let ghost pa_idx_install = frame_to_index(pa);
             let ghost new_frame_path = new_owner.value().path;
@@ -3561,7 +3556,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             subtree_level,
         );
         proof {
-            subtree.lemma_new_val_properties(absent_entry_owner_spec, subtree_level);
+            lemma_new_val_properties(absent_entry_owner_spec, subtree_level);
         }
 
         assert(subtree.value().meta_slot_paddr() is None);
@@ -3574,15 +3569,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         let ghost va_after_find = self.0.va;
         let ghost level_after_find = self.0.level;
 
-        proof {
-            // subtree.value is absent, so not_in_tree is vacuously true.
-            owner.absent_not_in_tree(subtree.value());
-            OwnerSubtree::lemma_new_val_subtree_satisfies(
-                subtree,
-                subtree.value().path,
-                CursorOwner::<'rcu, C>::node_unlocked(*guards),
-            );
-        }
         #[verus_spec(with Tracked(owner), Tracked(subtree), Tracked(regions), Tracked(guards))]
         let frag = self.replace_cur_entry(Child::None);
         let ghost regions_after_replace = *regions;
@@ -4090,17 +4076,15 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         proof {
             pre_new_owner.lemma_set_value_observable_fields(new_owner.value());
             pre_new_owner.lemma_set_value_preserves_new_val_shape(new_owner.value());
-            pre_new_owner.lemma_set_value_property(new_owner.value());
             OwnerSubtree::<C>::lemma_ext_equal(
                 new_owner,
                 pre_new_owner.set_value(new_owner.value()),
             );
             assert(new_owner == OwnerSubtree::new_val(new_owner.value(), new_owner.level()));
-            new_owner.lemma_new_val_properties(new_owner.value(), new_owner.level());
+            lemma_new_val_properties(new_owner.value(), new_owner.level());
             old_child_owner_pre_replace.lemma_set_value_observable_fields(
                 old_child_owner.value(),
             );
-            old_child_owner_pre_replace.lemma_set_value_property(old_child_owner.value());
             OwnerSubtree::<C>::lemma_ext_equal(
                 old_child_owner,
                 old_child_owner_pre_replace.set_value(old_child_owner.value()),
@@ -4264,7 +4248,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                             old_child_pre_replace,
                             regions0,
                         );
-                        OwnerSubtree::lemma_map_implies_and(
+                        OwnerSubtree::lemma_subtree_satisfies_implies_and(
                             subtree,
                             path_j,
                             f_sound,
@@ -4280,9 +4264,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
 
             assert(new_owner.value().metaregion_sound(*regions));
             let child_path = final_cont.path().push_tail(idx as int);
-            assert(new_owner.subtree_satisfies(child_path, g_sound)) by {
-                OwnerSubtree::lemma_new_val_subtree_satisfies(new_owner, child_path, g_sound);
-            };
 
             // Bottom continuation siblings: metaregion_sound
             if old_child_pre_replace.is_node() {
@@ -4307,7 +4288,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                                 old_child_pre_replace,
                                 regions0,
                             );
-                            OwnerSubtree::lemma_map_implies_and(
+                            OwnerSubtree::lemma_subtree_satisfies_implies_and(
                                 subtree,
                                 path_j,
                                 f_sound,

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -68,6 +68,8 @@ use super::{
 
 verus! {
 
+broadcast use group_ghost_tree_lemmas;
+
 /// The state of virtual pages represented by a page table.
 ///
 /// This is the return type of the [`Cursor::query`] method.
@@ -2176,6 +2178,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         let tracked mut continuation = owner.continuations.tracked_remove(owner.level - 1);
         let ghost cont0 = continuation;
         let tracked mut child_owner = continuation.tracked_take_child();
+        let ghost child_owner0 = child_owner;
         let tracked mut parent_owner = continuation.entry_own.tracked_take_node();
 
         {
@@ -2199,6 +2202,19 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         let ghost child_owner_parent_level = child_owner.value().parent_level;
 
         proof {
+            cont0.pt_inv_children_unroll(cont0.idx as int);
+            assert(PageTableOwner(child_owner0).pt_inv());
+            assert(child_owner0.value().is_frame());
+            assert(child_owner.value().is_frame());
+            assert(child_owner.children() == child_owner0.children());
+            assert forall|i: int| 0 <= i < NR_ENTRIES implies
+                !#[trigger] child_owner.has_child(i) by {
+                PageTableOwner(child_owner0).pt_inv_non_node(i);
+            };
+            PageTableOwner(child_owner).non_node_pt_inv_at_depth(
+                (INC_LEVELS - child_owner.level()) as nat,
+            );
+            assert(PageTableOwner(child_owner).pt_inv());
             continuation.tracked_put_child(child_owner);
             continuation.entry_own.tracked_put_node(parent_owner);
             cont0.take_put_child();

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -367,7 +367,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
         //        const { assert!(C::NR_LEVELS() as usize <= MAX_NR_LEVELS) };
 
         proof {
-            assert(pt_own.0.value().is_node());
             assert forall|i: int| 0 <= i < NR_ENTRIES implies pt_own.0.has_child(i) by {
                 pt_own.pt_inv_unroll(i);
             };
@@ -558,12 +557,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                 cont0.take_put_child();
                 owner.continuations.tracked_insert(owner.level - 1, continuation);
                 owner.metaregion_slot_owners_preserved(regions_before_ref, *regions);
-                // `cur_entry` ensures `*final(owner) == *old(owner)` and the
-                // remove/put_child/insert dance restores the same
-                // continuation, so the owner — hence its model — is exactly
-                // the loop-head value here (before any `push_level`). This
-                // carries the loop invariant's `owner@.{mappings,cur_va}`
-                // equalities into the non-descending (`None`/`Frame`) arms.
                 assert(owner.continuations == owner_snap.continuations);
                 assert(*owner == owner_snap);
                 assert(owner@ == old(owner)@);
@@ -652,16 +645,11 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                         C::item_from_raw_roundtrip(item, pa, level, prop);
                     }
 
-                    assert(pa == owner.cur_entry_owner().frame().mapped_pa);
-
                     let ghost old_regions = *regions;
 
                     proof {
                         let idx = frame_to_index(pa);
-                        assert(owner.path_metaregion_sound(*regions));
-                        assert(owner.cur_entry_owner().metaregion_sound(*regions));
                         assert(regions.slot_owners.contains_key(idx));
-                        assert(owner.cur_entry_owner().inv_base());
                         EntryOwner::<C>::axiom_frame_is_tracked_matches_item(
                             owner.cur_entry_owner(),
                         );
@@ -671,12 +659,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                             EntryOwner::<C>::axiom_frame_is_tracked_iff_not_mmio(
                                 owner.cur_entry_owner(),
                             );
-                            assert(owner@ == old(owner)@);
-                            assert(owner@.query_mapping().pa_range.start == pa);
-                            assert(old(owner)@.present());
                             assert(!is_mmio_paddr(pa));
-                            assert(old(regions).slot_owners[idx].inner_perms.ref_count.value()
-                                == regions.slot_owners[idx].inner_perms.ref_count.value());
                             assert(old(self).query_panic_condition(*old(owner), *old(regions)));
                             assert(may_panic());
                         }
@@ -700,15 +683,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                             EntryOwner::<C>::axiom_frame_is_tracked_iff_not_mmio(
                                 owner.cur_entry_owner(),
                             );
-                            assert(old_regions.slot_owners[idx].slot_vaddr == meta_addr(idx));
-                            assert(old_regions.slot_owners[idx].inner_perms.ref_count.value()
-                                != REF_COUNT_UNUSED);
-                            assert(0 < old_regions.slot_owners[idx].inner_perms.ref_count.value());
                             assert(regions.slot_owners[idx].inv());
-                            assert(regions.slot_owners[idx].inner_perms.ref_count.value()
-                                == old_regions.slot_owners[idx].inner_perms.ref_count.value() + 1);
-                            assert(regions.slot_owners[idx].inner_perms.ref_count.value()
-                                <= REF_COUNT_MAX);
                             owner.clone_item_preserves_invariants(old_regions, *regions, idx);
                         } else {
                             assert(regions.slots == old_regions.slots);

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -4264,9 +4264,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                             cont0.inv_children_unroll(j);
                             let subtree = cont0.children[j].unwrap();
                             let path_j = final_cont.path().push_tail(j);
-                            cont0.path().lemma_push_tail_index(j);
-                            cont0.path().lemma_push_tail_index(idx as int);
-                            cont0.path().lemma_push_tail_len(j);
                             cont0.pt_inv_children_unroll(j);
                             PageTableOwner::<C>::pt_inv_implies_path_correct(subtree, path_j);
                             PageTableOwner::<C>::neq_old_from_path_disjoint(
@@ -4302,7 +4299,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         |e: EntryOwner<C>, p: TreePath<NR_ENTRIES>| e.metaregion_sound(regions0),
                     ));
                     cont0.inv_children_rel_unroll(cont0.idx as int);
-                    cont0.path().lemma_push_tail_len(cont0.idx as int);
                 }
                 assert forall|i: int|
                     #![trigger owner.continuations[i]]
@@ -4315,8 +4311,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                     }
                     owner0.inv_continuation(i);
                     let eo = owner0.continuations[i].entry_own;
-                    assert(eo.inv() && eo.is_node());
-                    assert(eo.metaregion_sound(regions0));
 
                     if old_child_pre_replace.is_node() {
                         // Path lengths differ: eo at tree_level, child at tree_level + 1.
@@ -4358,15 +4352,6 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         let result = match old {
             Child::None => None,
             Child::Frame(pa, ch_level, prop) => {
-                proof {
-                    let ghost entry_owner_snap = old_child_owner.value();
-                    assert(old_child_snap.invariants(entry_owner_snap, regions_after_replace));
-                    assert(entry_owner_snap.is_frame());
-                    assert(entry_owner_snap.metaregion_sound(regions_after_replace));
-
-                    // No slot_perm extraction/insertion — regions unchanged in Frame path.
-                    assert(*regions == regions_after_replace);
-                }
                 // SAFETY:
                 // This is part of (if `split_huge` happens) a page table item mapped
                 // with a previous call to `C::item_into_raw`, where:

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -291,7 +291,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                 &&& r.unwrap().0.va == va.start
                 &&& r.unwrap().0.barrier_va == *va
                 &&& r.unwrap().1@.as_page_table_owner() == pt_own
-                &&& r.unwrap().1@.continuations[3].path() == pt_own.0.value.path
+                &&& r.unwrap().1@.continuations[3].path() == pt_own.0.value().path
             },
             !Self::cursor_new_success_conditions(*va) ==> r is Err,
             // Cursor::new inherits lock_range's weakened preservation: only
@@ -364,8 +364,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
         //        const { assert!(C::NR_LEVELS() as usize <= MAX_NR_LEVELS) };
 
         proof {
-            assert(pt_own.0.value.is_node());
-            assert forall|i: int| 0 <= i < NR_ENTRIES implies pt_own.0.children[i] is Some by {
+            assert(pt_own.0.value().is_node());
+            assert forall|i: int| 0 <= i < NR_ENTRIES implies pt_own.0.children()[i] is Some by {
                 pt_own.pt_inv_unroll(i);
             };
         }
@@ -544,8 +544,11 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
             let tracked parent_owner = continuation.entry_own.tracked_borrow_node();
             let ghost regions_before_ref = *regions;
 
-            #[verus_spec(with Tracked(&child_owner.value), Tracked(&parent_owner), Tracked(regions))]
-            let cur_child = entry.to_ref();
+            let cur_child = {
+                let tracked child_value = child_owner.tracked_borrow_value();
+                #[verus_spec(with Tracked(child_value), Tracked(&parent_owner), Tracked(regions))]
+                entry.to_ref()
+            };
 
             proof {
                 continuation.tracked_put_child(child_owner);
@@ -565,11 +568,16 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
 
             let item = match cur_child {
                 ChildRef::PageTable(pt) => {
+                    let ghost owner_before_push = *owner;
                     let tracked mut continuation = owner.continuations.tracked_remove(
                         owner.level - 1,
                     );
+                    let ghost continuation_before_push = continuation;
                     let tracked mut child_owner = continuation.tracked_take_child();
-                    let tracked mut child_node = child_owner.value.tracked_take_node();
+                    let tracked mut child_node = {
+                        let tracked child_value = child_owner.tracked_borrow_mut_value();
+                        child_value.tracked_take_node()
+                    };
 
                     let ghost guards0 = *guards;
 
@@ -581,9 +589,19 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                     };
 
                     proof {
-                        child_owner.value.tracked_put_node(child_node);
+                        {
+                            let tracked child_value = child_owner.tracked_borrow_mut_value();
+                            child_value.tracked_put_node(child_node);
+                        }
+                        OwnerSubtree::<C>::lemma_ext_equal(
+                            child_owner,
+                            continuation_before_push.take_child().0,
+                        );
                         continuation.tracked_put_child(child_owner);
+                        continuation_before_push.take_put_child();
+                        assert(continuation == continuation_before_push);
                         owner.continuations.tracked_insert(owner.level - 1, continuation);
+                        assert(*owner == owner_before_push);
 
                         owner.map_children_implies(
                             CursorOwner::node_unlocked(guards0),
@@ -593,6 +611,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                     }
                     #[verus_spec(with Tracked(owner), Tracked(regions), Tracked(guards))]
                     self.push_level(guard);
+                    proof {
+                        assert(owner@.mappings == old(owner)@.mappings);
+                    }
 
                     continue;
                 },
@@ -1036,8 +1057,11 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
 
             let ghost regions_before_ref = *regions;
 
-            #[verus_spec(with Tracked(&child_owner.value), Tracked(&node_owner), Tracked(regions))]
-            let cur_child = cur_entry.to_ref();
+            let cur_child = {
+                let tracked child_value = child_owner.tracked_borrow_value();
+                #[verus_spec(with Tracked(child_value), Tracked(&node_owner), Tracked(regions))]
+                cur_entry.to_ref()
+            };
 
             proof {
                 continuation.tracked_put_child(child_owner);
@@ -1093,7 +1117,10 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                     let tracked mut child_owner = continuation.tracked_take_child();
 
                     let tracked mut parent_node_owner = continuation.entry_own.tracked_take_node();
-                    let tracked mut child_node_owner = child_owner.value.tracked_take_node();
+                    let tracked mut child_node_owner = {
+                        let tracked child_value = child_owner.tracked_borrow_mut_value();
+                        child_value.tracked_take_node()
+                    };
 
                     let ghost guards0 = *guards;
 
@@ -1115,9 +1142,15 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                     }
 
                     proof {
-                        child_owner.value.tracked_put_node(child_node_owner);
+                        {
+                            let tracked child_value = child_owner.tracked_borrow_mut_value();
+                            child_value.tracked_put_node(child_node_owner);
+                        }
+                        OwnerSubtree::<C>::lemma_ext_equal(child_owner, cont0.take_child().0);
                         continuation.tracked_put_child(child_owner);
+                        cont0.take_put_child();
                         continuation.entry_own.tracked_put_node(parent_node_owner);
+                        assert(continuation == cont0);
                         assert(cont0.children == continuation.children);
                         owner.continuations.tracked_insert(self.level - 1, continuation);
                         assert(owner.continuations == owner0.continuations);
@@ -1162,9 +1195,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                             );
                             // The subtree's node is the one just read by `nr_children`,
                             // carrying `count_consistent`.
-                            assert(subtree.value.node() == cur_node_owner);
+                            assert(subtree.value().node() == cur_node_owner);
                             PageTableOwner(subtree).view_rec_nr_children_zero_empty(
-                                subtree.value.path,
+                                subtree.value().path,
                             );
                             owner.cur_subtree_eq_filtered_mappings();
                         }
@@ -1250,7 +1283,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                         owner.move_forward_increases_va();
                         owner.move_forward_not_popped_too_high();
                         let ghost subtree = owner.cur_subtree();
-                        PageTableOwner(subtree).view_rec_absent_empty(subtree.value.path);
+                        PageTableOwner(subtree).view_rec_absent_empty(subtree.value().path);
                         owner.cur_subtree_eq_filtered_mappings();
                     }
 
@@ -1379,9 +1412,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                     }
 
                     proof {
-                        assert(child_owner.value.metaregion_sound(*regions));
-                        if child_owner.value.is_frame() {
-                            assert(child_owner.value.frame_sub_pages_valid(*regions));
+                        assert(child_owner.value().metaregion_sound(*regions));
+                        if child_owner.value().is_frame() {
+                            assert(child_owner.value().frame_sub_pages_valid(*regions));
                         }
                     }
                     let split_child = (
@@ -1390,11 +1423,11 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                     cur_entry.split_if_mapped_huge(rcu_guard)).expect(
                         "The entry must be a huge page",
                     );
-                    let ghost child_owner_children = child_owner.children;
+                    let ghost child_owner_children = child_owner.children();
                     proof {
                         assert(forall|j: int|
                             0 <= j < NR_ENTRIES ==> (
-                            #[trigger] child_owner_children[j]).unwrap().value.is_frame());
+                            #[trigger] child_owner_children[j]).unwrap().value().is_frame());
                     }
 
                     proof {
@@ -1405,7 +1438,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                         };
                         CursorContinuation::<'rcu, C>::rel_children_from_node_matching(
                             &cur_entry,
-                            child_owner.value,
+                            child_owner.value(),
                             continuation.entry_own.node(),
                             continuation.guard,
                             reconstructed_entry_own,
@@ -2015,9 +2048,12 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
             assert(cont0.entry_own.metaregion_sound(*regions));
             assert(regions.slots.contains_key(parent_own.slot_index));
         }
-        #[verus_spec(with Tracked(&parent_own),
-            Tracked(&child.value), Tracked(&*regions))]
-        let res = node.entry(pte_index::<C>(self.va, self.level));
+        let res = {
+            let tracked child_value = child.tracked_borrow_value();
+            #[verus_spec(with Tracked(&parent_own),
+                Tracked(child_value), Tracked(&*regions))]
+            node.entry(pte_index::<C>(self.va, self.level))
+        };
 
         proof {
             parent_continuation.entry_own.tracked_put_node(parent_own);
@@ -2148,16 +2184,18 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 assert(parent_owner.relate_guard(*node));
             }
 
-            let _pte =
-                #[verus_spec(with Tracked(&mut child_owner.value), Tracked(&mut parent_owner), Tracked(&*regions))]
-            node.protect_child(entry_idx, op);
+            let _pte = {
+                let tracked child_value = child_owner.tracked_borrow_mut_value();
+                #[verus_spec(with Tracked(child_value), Tracked(&mut parent_owner), Tracked(&*regions))]
+                node.protect_child(entry_idx, op)
+            };
         }
 
-        let ghost new_prop = child_owner.value.frame().prop;
+        let ghost new_prop = child_owner.value().frame().prop;
 
-        let ghost child_owner_path = child_owner.value.path;
-        let ghost child_owner_mapped_pa = child_owner.value.frame().mapped_pa;
-        let ghost child_owner_parent_level = child_owner.value.parent_level;
+        let ghost child_owner_path = child_owner.value().path;
+        let ghost child_owner_mapped_pa = child_owner.value().frame().mapped_pa;
+        let ghost child_owner_parent_level = child_owner.value().parent_level;
 
         proof {
             continuation.tracked_put_child(child_owner);
@@ -2440,7 +2478,10 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         let tracked mut continuation = owner.continuations.tracked_remove(owner.level - 1);
         let tracked mut child_owner = continuation.tracked_take_child();
         let ghost orig_child_owner = child_owner;
-        let tracked mut child_node = child_owner.value.tracked_take_node();
+        let tracked mut child_node = {
+            let tracked child_value = child_owner.tracked_borrow_mut_value();
+            child_value.tracked_take_node()
+        };
 
         // SAFETY: The `pt` must be locked and no other guards exist.
         let pt_guard = unsafe {
@@ -2449,7 +2490,11 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         };
 
         proof {
-            child_owner.value.tracked_put_node(child_node);
+            {
+                let tracked child_value = child_owner.tracked_borrow_mut_value();
+                child_value.tracked_put_node(child_node);
+            }
+            OwnerSubtree::<C>::lemma_ext_equal(child_owner, orig_child_owner);
             assert(child_owner == orig_child_owner);
             continuation.tracked_put_child(child_owner);
             cont_orig.take_put_child();
@@ -2589,9 +2634,12 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
 
                 let ghost regions_before_ref = *regions;
 
-                #[verus_spec(with Tracked(&child_owner.value), Tracked(&parent_owner),
-                    Tracked(regions))]
-                let cur_child = cur_entry.to_ref();
+                let cur_child = {
+                    let tracked child_value = child_owner.tracked_borrow_value();
+                    #[verus_spec(with Tracked(child_value), Tracked(&parent_owner),
+                        Tracked(regions))]
+                    cur_entry.to_ref()
+                };
 
                 proof {
                     cont0.take_put_child();
@@ -2649,7 +2697,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                     );
                     let ghost cont_pre_alloc = continuation;
                     let tracked mut child_owner = continuation.tracked_take_child();
-                    let ghost old_child_value = child_owner.value;
+                    let ghost old_child_value = child_owner.value();
                     let tracked mut parent_owner = continuation.entry_own.tracked_take_node();
 
                     proof {
@@ -2673,33 +2721,33 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         node.alloc_absent_child(entry_idx, rcu_guard)
                     };
 
-                    let ghost new_node_addr = child_owner.value.node().meta_addr_self();
-                    let ghost new_child_value = child_owner.value;
+                    let ghost new_node_addr = child_owner.value().node().meta_addr_self();
+                    let ghost new_child_value = child_owner.value();
 
                     let ghost new_pt_idx = frame_to_index(
                         new_child_value.meta_slot_paddr().unwrap(),
                     );
-                    let ghost child_owner_children = child_owner.children;
+                    let ghost child_owner_children = child_owner.children();
 
                     proof {
                         assert(forall|i: int|
                             0 <= i < NR_ENTRIES ==> (#[trigger] child_owner_children[i]) is Some
-                                && child_owner_children[i].unwrap().value.is_absent());
+                                && child_owner_children[i].unwrap().value().is_absent());
 
                         let ghost reconstructed_entry_own = EntryOwner {
                             kind: EntryOwnerKind::Node(parent_owner),
                             ..cont_pre_alloc.entry_own
                         };
-                        assert(child_owner.value.match_pte(
+                        assert(child_owner.value().match_pte(
                             parent_owner.children_perm.value()[cont_pre_alloc.idx as int],
                             parent_owner.level,
                         ));
-                        assert(child_owner.value.parent_level == parent_owner.level);
+                        assert(child_owner.value().parent_level == parent_owner.level);
                         assert(reconstructed_entry_own.path == cont_pre_alloc.entry_own.path);
-                        assert(child_owner.value.path == reconstructed_entry_own.path.push_tail(
+                        assert(child_owner.value().path == reconstructed_entry_own.path.push_tail(
                             cont_pre_alloc.idx,
                         ));
-                        assert(child_owner.value.path.len() == parent_owner.tree_level + 1);
+                        assert(child_owner.value().path.len() == parent_owner.tree_level + 1);
 
                         cont_pre_alloc.take_put_child();
                         continuation.entry_own.tracked_put_node(parent_owner);
@@ -2880,9 +2928,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                     let tracked mut parent_owner = continuation.entry_own.tracked_take_node();
 
                     proof {
-                        assert(child_owner.value.metaregion_sound(*regions));
-                        if child_owner.value.is_frame() {
-                            assert(child_owner.value.frame_sub_pages_valid(*regions));
+                        assert(child_owner.value().metaregion_sound(*regions));
+                        if child_owner.value().is_frame() {
+                            assert(child_owner.value().frame_sub_pages_valid(*regions));
                         }
                     }
                     let split_child = (
@@ -3125,15 +3173,15 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         proof {
             // Hoist common facts about new_owner from new_child postcondition.
             let cont = owner1.continuations[owner1.level - 1];
-            assert(new_owner.value == EntryOwner::<C>::new_frame(
+            assert(new_owner.value() == EntryOwner::<C>::new_frame(
                 pa,
                 cont.path().push_tail(cont.idx as usize),
                 cont.level(),
                 prop,
                 is_tracked,
             ));
-            assert(new_owner.value.is_frame());
-            assert(new_owner.value.frame().mapped_pa == pa);
+            assert(new_owner.value().is_frame());
+            assert(new_owner.value().frame().mapped_pa == pa);
 
             assert(PageTableOwner(new_owner)@.mappings == set![target]) by {
                 assert(owner1.level == level);
@@ -3145,14 +3193,14 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 assert(new_owner.inv());
             };
 
-            OwnerSubtree::new_val_tree_predicate_map(
+            OwnerSubtree::lemma_new_val_tree_predicate_map(
                 new_owner,
-                new_owner.value.path,
+                new_owner.value().path,
                 CursorOwner::<'rcu, C>::node_unlocked(*guards),
             );
 
             let ghost pa_idx_install = frame_to_index(pa);
-            let ghost new_frame_path = new_owner.value.path;
+            let ghost new_frame_path = new_owner.value().path;
             let tracked mut pa_slot_install = regions.slot_owners.tracked_remove(pa_idx_install);
             pa_slot_install.paths_in_pt = pa_slot_install.paths_in_pt.insert(new_frame_path);
             regions.slot_owners.tracked_insert(pa_idx_install, pa_slot_install);
@@ -3172,7 +3220,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 new_frame_path,
             );
 
-            assert(new_owner.value.metaregion_sound(*regions)) by {
+            assert(new_owner.value().metaregion_sound(*regions)) by {
                 broadcast use crate::specs::mm::frame::meta_owners::axiom_mmio_usage_iff_mmio_paddr;
 
                 assert(Self::item_slot_in_regions(item, regions_before_new_child));
@@ -3181,7 +3229,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 //   axiom_frame_is_tracked_iff_not_mmio (is_tracked <=> !is_mmio_paddr(pa))
                 //   axiom_mmio_paddr_huge_page_closed (sub_paddr inherits MMIO-ness)
                 //   axiom_mmio_usage_iff_mmio_paddr (usage == MMIO <=> is_mmio_paddr)
-                EntryOwner::<C>::axiom_frame_is_tracked_iff_not_mmio(new_owner.value);
+                EntryOwner::<C>::axiom_frame_is_tracked_iff_not_mmio(new_owner.value());
                 if level > 1 {
                     assert forall|j: usize|
                         #![trigger frame_to_index((pa + j * PAGE_SIZE) as usize)]
@@ -3197,7 +3245,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         );
                     }
                 }
-                assert(new_owner.value.frame_sub_pages_valid(*regions));
+                assert(new_owner.value().frame_sub_pages_valid(*regions));
             };
 
             assert(regions.inv()) by {
@@ -3504,14 +3552,19 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             owner.cur_entry_owner().path,
             owner.level,
         );
-        let tracked subtree = OwnerSubtree::new_val_tracked(
+        let ghost absent_entry_owner_spec = absent_entry_owner;
+        let ghost subtree_level = (owner.continuations[owner.level - 1].tree_level + 1) as nat;
+        let tracked subtree = OwnerSubtree::tracked_new_val(
             absent_entry_owner,
-            (owner.continuations[owner.level - 1].tree_level + 1) as nat,
+            subtree_level,
         );
-
-        assert(subtree.value.meta_slot_paddr() is None);
         proof {
-            owner.absent_not_in_tree(subtree.value);
+            subtree.lemma_new_val_properties(absent_entry_owner_spec, subtree_level);
+        }
+
+        assert(subtree.value().meta_slot_paddr() is None);
+        proof {
+            owner.absent_not_in_tree(subtree.value());
         }
 
         let ghost owner_before_replace = *owner;
@@ -3521,10 +3574,10 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
 
         proof {
             // subtree.value is absent, so not_in_tree is vacuously true.
-            owner.absent_not_in_tree(subtree.value);
-            OwnerSubtree::new_val_tree_predicate_map(
+            owner.absent_not_in_tree(subtree.value());
+            OwnerSubtree::lemma_new_val_tree_predicate_map(
                 subtree,
-                subtree.value.path,
+                subtree.value().path,
                 CursorOwner::<'rcu, C>::node_unlocked(*guards),
             );
         }
@@ -3554,7 +3607,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             let ghost old_cur_subtree_mappings = PageTableOwner(
                 owner_before_replace.cur_subtree(),
             )@.mappings;
-            PageTableOwner(subtree).view_rec_absent_empty(subtree.value.path);
+            PageTableOwner(subtree).view_rec_absent_empty(subtree.value().path);
             let ghost new_subtree_mappings = PageTableOwner(subtree)@.mappings;
             assert(new_subtree_mappings == Set::<Mapping>::empty());
 
@@ -3569,9 +3622,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 owner_before_replace.cur_subtree_inv();
                 owner_before_replace.new_child_mappings_eq_target(
                     cur_st,
-                    cur_st.value.frame().mapped_pa,
+                    cur_st.value().frame().mapped_pa,
                     level_after_find,
-                    cur_st.value.frame().prop,
+                    cur_st.value().frame().prop,
                 );
                 owner_before_replace.va.reflect_prop(va_after_find);
 
@@ -3598,10 +3651,10 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 owner_before_replace.cur_subtree_eq_filtered_mappings();
                 let ghost target = Mapping {
                     va_range: owner_before_replace@.cur_slot_range(m.page_size),
-                    pa_range: cur_st.value.frame().mapped_pa..(cur_st.value.frame().mapped_pa
+                    pa_range: cur_st.value().frame().mapped_pa..(cur_st.value().frame().mapped_pa
                         + m.page_size) as usize,
                     page_size: m.page_size,
-                    property: cur_st.value.frame().prop,
+                    property: cur_st.value().frame().prop,
                 };
                 assert(PageTableOwner(cur_st)@.mappings == set![target]);
                 assert(owner_before_replace@.mappings.filter(
@@ -3621,12 +3674,12 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 // here makes the eventual exact ref-count accounting
                 // (`ref_count == #handles + paths_in_pt.len()`) a true
                 // system invariant rather than monotonically inflated.
-                let ghost removed_idx = frame_to_index(cur_st.value.frame().mapped_pa);
-                let ghost removed_path = cur_st.value.path;
+                let ghost removed_idx = frame_to_index(cur_st.value().frame().mapped_pa);
+                let ghost removed_path = cur_st.value().path;
                 let ghost regions_pre_remove = *regions;
                 assert(owner_before_replace.cur_entry_owner().is_frame());
                 assert(owner_before_replace.cur_entry_owner().frame().mapped_pa
-                    == cur_st.value.frame().mapped_pa);
+                    == cur_st.value().frame().mapped_pa);
                 assert(owner_before_replace.metaregion_sound(regions_before_replace));
                 assert(owner_before_replace.path_metaregion_sound(regions_before_replace));
                 assert(owner_before_replace.cur_entry_owner().metaregion_sound(
@@ -3874,18 +3927,18 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             old(owner).in_locked_range(),
             !old(owner).popped_too_high,
             new_owner.inv(),
-            !new_owner.value.is_node(),
-            new_owner.level == old(owner).continuations[old(owner).level - 1].tree_level + 1,
-            new_owner.value.parent_level == old(owner).continuations[old(owner).level
-                - 1].child().value.parent_level,
-            new_owner.value.path == old(owner).continuations[old(owner).level - 1].path().push_tail(
+            !new_owner.value().is_node(),
+            new_owner.level() == old(owner).continuations[old(owner).level - 1].tree_level + 1,
+            new_owner.value().parent_level == old(owner).continuations[old(owner).level
+                - 1].child().value().parent_level,
+            new_owner.value().path == old(owner).continuations[old(owner).level - 1].path().push_tail(
                 old(owner).continuations[old(owner).level - 1].idx as usize,
             ),
-            new_child.wf(new_owner.value),
-            new_owner == OwnerSubtree::new_val(new_owner.value, new_owner.level as nat),
-            new_owner.value.metaregion_sound(*old(regions)),
+            new_child.wf(new_owner.value()),
+            new_owner == OwnerSubtree::new_val(new_owner.value(), new_owner.level() as nat),
+            new_owner.value().metaregion_sound(*old(regions)),
             new_owner.tree_predicate_map(
-                new_owner.value.path,
+                new_owner.value().path,
                 CursorOwner::<'rcu, C>::node_unlocked(*old(guards)),
             ),
         ensures
@@ -3933,8 +3986,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             // (new_owner.value here is the post-into_pte state; meta_slot_paddr() is unchanged.)
             forall|idx: usize|
                 #![trigger final(regions).slot_owners[idx].paths_in_pt]
-                (new_owner.value.is_absent() || idx != frame_to_index(
-                    new_owner.value.meta_slot_paddr()->0,
+                (new_owner.value().is_absent() || idx != frame_to_index(
+                    new_owner.value().meta_slot_paddr()->0,
                 )) ==> final(regions).slot_owners[idx].paths_in_pt == old(
                     regions,
                 ).slot_owners[idx].paths_in_pt,
@@ -3954,7 +4007,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             // When `res is None` (⇔ pre-replace cur_entry was absent), `Entry::replace`
             // fully preserves `regions.slots`.
             res is None ==> final(regions).slots == old(regions).slots,
-            res is Some && res->0 is Mapped && new_owner.value.is_absent() ==> forall|idx: usize|
+            res is Some && res->0 is Mapped && new_owner.value().is_absent() ==> forall|idx: usize|
                 #![trigger final(regions).slot_owners[idx]]
                 final(regions).slot_owners[idx] == old(regions).slot_owners[idx],
     )]
@@ -3994,10 +4047,12 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         }
         assert(owner.continuations == owner0.continuations.remove(owner.level - 1));
 
-        let ghost pre_new_owner_value = new_owner.value;
+        let ghost pre_new_owner_value = new_owner.value();
+        let ghost pre_new_owner = new_owner;
         // Capture the old child value before Entry::replace mutates it (we need the pre-replace
         // value to match Entry::metaregion_sound_neq_preserved's old(owner) parameter).
-        let ghost old_child_pre_replace = old_child_owner.value;
+        let ghost old_child_pre_replace = old_child_owner.value();
+        let ghost old_child_owner_pre_replace = old_child_owner;
 
         proof {
             assert(cont0 == owner0.continuations[owner0.level - 1]);
@@ -4005,7 +4060,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             assert(entry_idx == cont0.idx);
             assert(cur_path_guard == cont0.guard);
             cont0.inv_children_rel_unroll(cont0.idx as int);
-            assert(old_child_owner.value.match_pte(
+            assert(old_child_owner.value().match_pte(
                 cont0.entry_own.node().children_perm.value()[cont0.idx as int],
                 cont0.entry_own.node().level,
             ));
@@ -4019,14 +4074,36 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 assert(continuation.entry_own.node().relate_guard(*node));
             }
 
+            let tracked old_child_value = old_child_owner.tracked_borrow_mut_value();
+            let tracked new_value = new_owner.tracked_borrow_mut_value();
             #[verus_spec(with Tracked(regions),
-                Tracked(&mut old_child_owner.value),
-                Tracked(&mut new_owner.value),
+                Tracked(old_child_value),
+                Tracked(new_value),
                 Tracked(continuation.entry_own.tracked_borrow_mut_node()),
             )]
             node.replace_child(entry_idx, new_child)
         };
         let ghost old_child_snap = old;  // ghost alias to avoid `old(...)` keyword ambiguity in proofs
+
+        proof {
+            pre_new_owner.lemma_set_value_observable_fields(new_owner.value());
+            pre_new_owner.lemma_set_value_preserves_new_val_shape(new_owner.value());
+            pre_new_owner.lemma_set_value_property(new_owner.value());
+            OwnerSubtree::<C>::lemma_ext_equal(
+                new_owner,
+                pre_new_owner.set_value(new_owner.value()),
+            );
+            assert(new_owner == OwnerSubtree::new_val(new_owner.value(), new_owner.level()));
+            new_owner.lemma_new_val_properties(new_owner.value(), new_owner.level());
+            old_child_owner_pre_replace.lemma_set_value_observable_fields(
+                old_child_owner.value(),
+            );
+            old_child_owner_pre_replace.lemma_set_value_property(old_child_owner.value());
+            OwnerSubtree::<C>::lemma_ext_equal(
+                old_child_owner,
+                old_child_owner_pre_replace.set_value(old_child_owner.value()),
+            );
+        }
 
         assert(Entry::<C>::metaregion_sound_neq_preserved(
             old_child_pre_replace,
@@ -4052,12 +4129,21 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             let ghost final_cont = continuation;
             owner.continuations.tracked_insert(owner.level - 1, continuation);
 
+            PageTableOwner(new_owner).non_node_pt_inv_at_depth(
+                (INC_LEVELS - new_owner.level()) as nat,
+            );
+            assert(PageTableOwner(new_owner).pt_inv());
+            final_cont.continuation_inv_holds_after_child_restore(
+                cont0,
+                cont0.entry_own.node(),
+            );
+            assert(owner.inv());
             CursorOwner::view_mappings_replace_lowest(owner0, *owner, cont0, final_cont);
 
             // Bridge view_mappings to view().mappings via open-spec unfolding,
             // and connect cont0/final_cont to PageTableOwner views by path equality.
-            assert(owner0.cur_subtree().value.path == cont0.path().push_tail(cont0.idx as usize));
-            assert(new_owner.value.path == cont1.path().push_tail(cont1.idx as usize));
+            assert(owner0.cur_subtree().value().path == cont0.path().push_tail(cont0.idx as usize));
+            assert(new_owner.value().path == cont1.path().push_tail(cont1.idx as usize));
             cont0.view_mappings_take_child();
             assert(cont0.view_mappings_take_child_spec() == PageTableOwner(
                 owner0.cur_subtree(),
@@ -4136,7 +4222,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 assert(cont1.children[j] == cont0.children[j]);
             };
 
-            assert(new_owner.value.meta_slot_paddr() == pre_new_owner_value.meta_slot_paddr());
+            assert(new_owner.value().meta_slot_paddr() == pre_new_owner_value.meta_slot_paddr());
 
             let f_neq_old = |entry: EntryOwner<C>, path: TreePath<NR_ENTRIES>|
                 entry.meta_slot_paddr_neq(old_child_pre_replace);
@@ -4166,8 +4252,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         let subtree = cont.children[j].unwrap();
                         let path_j = cont.path().push_tail(j as usize);
                         owner0.cursor_path_nesting(i, owner0.level - 1);
-                        cont0.path().push_tail_property_index(idx as usize);
-                        cont.path().push_tail_property_index(j as usize);
+                        cont0.path().lemma_push_tail_index(idx as usize);
+                        cont.path().lemma_push_tail_index(j as usize);
                         cont.pt_inv_children_unroll(j);
                         PageTableOwner::<C>::pt_inv_implies_path_correct(subtree, path_j);
                         PageTableOwner::<C>::neq_old_from_path_disjoint(
@@ -4176,7 +4262,13 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                             old_child_pre_replace,
                             regions0,
                         );
-                        OwnerSubtree::map_implies_and(subtree, path_j, f_sound, f_neq_old, g_sound);
+                        OwnerSubtree::lemma_map_implies_and(
+                            subtree,
+                            path_j,
+                            f_sound,
+                            f_neq_old,
+                            g_sound,
+                        );
                     };
                 } else {
                     // Old child is absent or frame: metaregion_sound_preserved.
@@ -4184,10 +4276,10 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 }
             };
 
-            assert(new_owner.value.metaregion_sound(*regions));
+            assert(new_owner.value().metaregion_sound(*regions));
             let child_path = final_cont.path().push_tail(idx as usize);
             assert(new_owner.tree_predicate_map(child_path, g_sound)) by {
-                OwnerSubtree::new_val_tree_predicate_map(new_owner, child_path, g_sound);
+                OwnerSubtree::lemma_new_val_tree_predicate_map(new_owner, child_path, g_sound);
             };
 
             // Bottom continuation siblings: metaregion_sound
@@ -4202,9 +4294,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                             cont0.inv_children_unroll(j);
                             let subtree = cont0.children[j].unwrap();
                             let path_j = final_cont.path().push_tail(j as usize);
-                            cont0.path().push_tail_property_index(j as usize);
-                            cont0.path().push_tail_property_index(idx as usize);
-                            cont0.path().push_tail_property_len(j as usize);
+                            cont0.path().lemma_push_tail_index(j as usize);
+                            cont0.path().lemma_push_tail_index(idx as usize);
+                            cont0.path().lemma_push_tail_len(j as usize);
                             cont0.pt_inv_children_unroll(j);
                             PageTableOwner::<C>::pt_inv_implies_path_correct(subtree, path_j);
                             PageTableOwner::<C>::neq_old_from_path_disjoint(
@@ -4213,7 +4305,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                                 old_child_pre_replace,
                                 regions0,
                             );
-                            OwnerSubtree::map_implies_and(
+                            OwnerSubtree::lemma_map_implies_and(
                                 subtree,
                                 path_j,
                                 f_sound,
@@ -4240,7 +4332,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         |e: EntryOwner<C>, p: TreePath<NR_ENTRIES>| e.metaregion_sound(regions0),
                     ));
                     cont0.inv_children_rel_unroll(cont0.idx as int);
-                    cont0.path().push_tail_property_len(cont0.idx as usize);
+                    cont0.path().lemma_push_tail_len(cont0.idx as usize);
                 }
                 assert forall|i: int|
                     #![trigger owner.continuations[i]]
@@ -4276,12 +4368,12 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             assert forall|j: int|
                 #![trigger final_cont.children[j]]
                 0 <= j < NR_ENTRIES && final_cont.children[j] is Some implies {
-                &&& final_cont.children[j].unwrap().value.path == final_cont.path().push_tail(
+                &&& final_cont.children[j].unwrap().value().path == final_cont.path().push_tail(
                     j as usize,
                 )
-                &&& final_cont.children[j].unwrap().value.parent_level == final_cont.level()
+                &&& final_cont.children[j].unwrap().value().parent_level == final_cont.level()
                 &&& final_cont.children[j].unwrap().inv()
-                &&& final_cont.children[j].unwrap().level == final_cont.tree_level + 1
+                &&& final_cont.children[j].unwrap().level() == final_cont.tree_level + 1
             } by {
                 if j != idx {
                     final_cont.inv_children_unroll(j);
@@ -4297,7 +4389,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             Child::None => None,
             Child::Frame(pa, ch_level, prop) => {
                 proof {
-                    let ghost entry_owner_snap = old_child_owner.value;
+                    let ghost entry_owner_snap = old_child_owner.value();
                     assert(old_child_snap.invariants(entry_owner_snap, regions_after_replace));
                     assert(entry_owner_snap.is_frame());
                     assert(entry_owner_snap.metaregion_sound(regions_after_replace));
@@ -4341,9 +4433,12 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 // SAFETY: We must have locked this node.
 
                 let ghost owner2 = *owner;
-                let ghost child_entry = old_child_owner.value;
+                let ghost child_entry = old_child_owner.value();
 
-                let tracked mut old_node_owner = old_child_owner.value.tracked_take_node();
+                let tracked mut old_node_owner = {
+                    let tracked old_child_value = old_child_owner.tracked_borrow_mut_value();
+                    old_child_value.tracked_take_node()
+                };
 
                 let ghost regions_before_borrow = *regions;
 
@@ -4529,8 +4624,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
 
         assert(forall|idx: usize|
             #![trigger regions.slot_owners[idx].paths_in_pt]
-            (new_owner.value.is_absent() || idx != frame_to_index(
-                new_owner.value.meta_slot_paddr().unwrap(),
+            (new_owner.value().is_absent() || idx != frame_to_index(
+                new_owner.value().meta_slot_paddr().unwrap(),
             )) ==> regions.slot_owners[idx].paths_in_pt == regions0.slot_owners[idx].paths_in_pt)
             by {
             assert(forall|i: usize|

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -1120,7 +1120,7 @@ impl PageTable<KernelPtConfig> {
                     PageTableOwner::<KernelPtConfig>::metaregion_sound_pred(*regions),
                     i as int,
                 );
-                assert(child_subtree.tree_predicate_map(
+                assert(child_subtree.subtree_satisfies(
                     kernel_owner.0.value().path.push_tail(i as usize),
                     PageTableOwner::<KernelPtConfig>::metaregion_sound_pred(*regions),
                 ));
@@ -1291,7 +1291,7 @@ impl<C: PageTableConfig> PageTable<C> {
             forall |kt: PageTableOwner<KernelPtConfig>|
                 #![trigger kt.metaregion_sound(*old(regions))]
                 kt.inv() && kt.metaregion_sound(*old(regions)) ==>
-                kt.0.tree_predicate_map(
+                kt.0.subtree_satisfies(
                     kt.0.value().path,
                     |e: crate::specs::mm::page_table::node::entry_owners::EntryOwner<KernelPtConfig>,
                      p: vstd_extra::ghost_tree::TreePath<NR_ENTRIES>|
@@ -1307,7 +1307,7 @@ impl<C: PageTableConfig> PageTable<C> {
             forall |kt: PageTableOwner<KernelPtConfig>|
                 #![trigger kt.metaregion_sound(*old(regions))]
                 kt.inv() && kt.metaregion_sound(*old(regions)) ==>
-                kt.0.tree_predicate_map(
+                kt.0.subtree_satisfies(
                     kt.0.value().path,
                     |e: crate::specs::mm::page_table::node::entry_owners::EntryOwner<KernelPtConfig>,
                      p: vstd_extra::ghost_tree::TreePath<NR_ENTRIES>|

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -886,18 +886,18 @@ impl PageTable<KernelPtConfig> {
         requires
             kernel_owner.inv(),
             old(regions).inv(),
-            kernel_owner.0.value.is_node(),
-            !Self::create_user_pt_panic_condition(kernel_owner.0.value.node()),
+            kernel_owner.0.value().is_node(),
+            !Self::create_user_pt_panic_condition(kernel_owner.0.value().node()),
             // The kernel page table's root frame matches the tracked owner.
-            self.root.ptr.addr() == kernel_owner.0.value.node().meta_addr_self(),
+            self.root.ptr.addr() == kernel_owner.0.value().node().meta_addr_self(),
             // The kernel root entry is sound with respect to the meta regions.
-            kernel_owner.0.value.metaregion_sound(*old(regions)),
+            kernel_owner.0.value().metaregion_sound(*old(regions)),
             // The whole kernel page-table tree is sound: every entry's metaregion
             // bookkeeping matches `old(regions)`. Needed to derive each child's
             // soundness inside the loop body.
             kernel_owner.metaregion_sound(*old(regions)),
             // The kernel root is not currently locked.
-            old(guards).unlocked(kernel_owner.0.value.node().meta_addr_self()),
+            old(guards).unlocked(kernel_owner.0.value().node().meta_addr_self()),
         ensures
             final(regions).inv(),
     )]
@@ -916,18 +916,18 @@ impl PageTable<KernelPtConfig> {
         let new_root = new_pt.root;
         // Capture new_idx as a ghost BEFORE the tracked_take below empties new_pt_owner.
         let ghost new_idx_g: usize = crate::specs::mm::frame::mapping::frame_to_index(
-            new_pt_owner@.unwrap().0.value.meta_slot_paddr().unwrap(),
+            new_pt_owner@.unwrap().0.value().meta_slot_paddr().unwrap(),
         );
         let ghost new_pt_owner_snap = new_pt_owner@.unwrap();
         proof {
             let kern_idx = crate::specs::mm::frame::mapping::frame_to_index(
-                kernel_owner.0.value.meta_slot_paddr().unwrap(),
+                kernel_owner.0.value().meta_slot_paddr().unwrap(),
             );
             let new_idx = new_idx_g;
             crate::specs::mm::page_table::node::entry_owners::EntryOwner::<
                 KernelPtConfig,
             >::lemma_active_entry_not_in_free_pool(
-                kernel_owner.0.value,
+                kernel_owner.0.value(),
                 regions_before_alloc,
                 new_idx,
             );
@@ -939,19 +939,21 @@ impl PageTable<KernelPtConfig> {
 
         proof_decl! {
             let tracked root_owner: &NodeOwner<KernelPtConfig>
-                = kernel_owner.0.borrow_value().tracked_borrow_node();
+                = kernel_owner.0.tracked_borrow_value().tracked_borrow_node();
             let tracked mut new_pt_owner_val: PageTableOwner<UserPtConfig>
                 = new_pt_owner.tracked_take();
-            let tracked mut new_node_owner: NodeOwner<UserPtConfig>
-                = new_pt_owner_val.0.value.tracked_take_node();
+            let tracked mut new_node_owner: NodeOwner<UserPtConfig> = {
+                let tracked new_pt_value = new_pt_owner_val.0.tracked_borrow_mut_value();
+                new_pt_value.tracked_take_node()
+            };
             let tracked mut entry_owner: &EntryOwner<KernelPtConfig>;
         }
 
         // Discharge borrow/lock preconditions for the kernel root from
         // kernel_owner.inv() + metaregion_sound + guards unlocked.
         proof {
-            assert(kernel_owner.0.value.is_node());
-            assert(kernel_owner.0.value.metaregion_sound(*regions));
+            assert(kernel_owner.0.value().is_node());
+            assert(kernel_owner.0.value().metaregion_sound(*regions));
         }
         let ghost regions_before_self_borrow: MetaRegionOwners = *regions;
         let mut root_node = {
@@ -969,7 +971,7 @@ impl PageTable<KernelPtConfig> {
         };
         proof {
             let kern_idx = crate::specs::mm::frame::mapping::frame_to_index(
-                kernel_owner.0.value.meta_slot_paddr().unwrap(),
+                kernel_owner.0.value().meta_slot_paddr().unwrap(),
             );
             assert(regions_before_self_borrow.slot_owners
                 == regions_after_kroot_borrow.slot_owners);
@@ -982,7 +984,7 @@ impl PageTable<KernelPtConfig> {
                     crate::specs::mm::page_table::node::entry_owners::EntryOwner::<
                         KernelPtConfig,
                     >::lemma_active_entry_not_in_free_pool(
-                        kernel_owner.0.value,
+                        kernel_owner.0.value(),
                         regions_before_self_borrow,
                         k,
                     );
@@ -999,7 +1001,7 @@ impl PageTable<KernelPtConfig> {
                 crate::specs::mm::page_table::node::entry_owners::EntryOwner::<
                     KernelPtConfig,
                 >::lemma_active_entry_not_in_free_pool(
-                    kernel_owner.0.value,
+                    kernel_owner.0.value(),
                     regions_before_alloc,
                     new_idx,
                 );
@@ -1017,8 +1019,8 @@ impl PageTable<KernelPtConfig> {
             };
             assert(kernel_owner.metaregion_sound(regions_before_alloc));
 
-            kernel_owner.0.map_implies(
-                kernel_owner.0.value.path,
+            kernel_owner.0.lemma_map_implies(
+                kernel_owner.0.value().path,
                 |
                     e: crate::specs::mm::page_table::node::entry_owners::EntryOwner<KernelPtConfig>,
                     p: vstd_extra::ghost_tree::TreePath<NR_ENTRIES>,
@@ -1068,13 +1070,13 @@ impl PageTable<KernelPtConfig> {
         while i < KernelPtConfig::TOP_LEVEL_INDEX_RANGE().end
             invariant
                 kernel_owner.inv(),
-                kernel_owner.0.value.is_node(),
+                kernel_owner.0.value().is_node(),
                 regions.inv(),
-                !Self::create_user_pt_panic_condition(kernel_owner.0.value.node()),
+                !Self::create_user_pt_panic_condition(kernel_owner.0.value().node()),
                 i <= KernelPtConfig::TOP_LEVEL_INDEX_RANGE().end,
                 KernelPtConfig::TOP_LEVEL_INDEX_RANGE().start <= i,
                 // Lock postcondition for the kernel root.
-                *root_owner == kernel_owner.0.value.node(),
+                *root_owner == kernel_owner.0.value().node(),
                 root_owner.relate_guard(root_node),
                 // Tree-wide soundness of the kernel page table.
                 kernel_owner.metaregion_sound(*regions),
@@ -1085,7 +1087,7 @@ impl PageTable<KernelPtConfig> {
             decreases KernelPtConfig::TOP_LEVEL_INDEX_RANGE().end - i,
         {
             proof {
-                let kern_node = kernel_owner.0.value.node();
+                let kern_node = kernel_owner.0.value().node();
                 assert forall|j: usize|
                     #![trigger kern_node.children_perm.value()[j as int]]
                     KernelPtConfig::TOP_LEVEL_INDEX_RANGE().start <= j
@@ -1100,12 +1102,10 @@ impl PageTable<KernelPtConfig> {
                 }
 
                 kernel_owner.pt_inv_unroll(i as int);
-                let tracked child_opt: &Option<OwnerSubtree<KernelPtConfig>> =
-                    kernel_owner.0.children.tracked_borrow(i as int);
                 let tracked child_subtree: &OwnerSubtree<KernelPtConfig> =
-                    child_opt.tracked_borrow();
-                entry_owner = child_subtree.borrow_value();
-                let kern_node = kernel_owner.0.value.node();
+                    kernel_owner.0.tracked_borrow_child(i as int);
+                entry_owner = child_subtree.tracked_borrow_value();
+                let kern_node = kernel_owner.0.value().node();
                 assert(entry_owner.match_pte(
                     kern_node.children_perm.value()[i as int],
                     entry_owner.parent_level,
@@ -1115,13 +1115,13 @@ impl PageTable<KernelPtConfig> {
                 assert(entry_owner.inv());
                 assert(root_owner.relate_guard(root_node));
 
-                kernel_owner.0.map_unroll_once(
-                    kernel_owner.0.value.path,
+                kernel_owner.0.lemma_map_unroll_once(
+                    kernel_owner.0.value().path,
                     PageTableOwner::<KernelPtConfig>::metaregion_sound_pred(*regions),
                     i as int,
                 );
                 assert(child_subtree.tree_predicate_map(
-                    kernel_owner.0.value.path.push_tail(i as usize),
+                    kernel_owner.0.value().path.push_tail(i as usize),
                     PageTableOwner::<KernelPtConfig>::metaregion_sound_pred(*regions),
                 ));
                 assert(entry_owner.metaregion_sound(*regions));
@@ -1134,7 +1134,7 @@ impl PageTable<KernelPtConfig> {
             let child = root_entry.to_ref();
 
             proof {
-                let kern_node = kernel_owner.0.value.node();
+                let kern_node = kernel_owner.0.value().node();
                 let pte = kern_node.children_perm.value()[i as int];
 
                 assert(pte.is_present() && !pte.is_last(kern_node.level)) by {
@@ -1237,28 +1237,28 @@ impl<C: PageTableConfig> PageTable<C> {
         ensures
             final(owner)@ is Some,
             final(owner)@->0.inv(),
-            (final(owner)@->0).0.value.is_node(),
-            (final(owner)@->0).0.value.is_node(),
-            r.root.ptr.addr() == (final(owner)@->0).0.value.node().meta_addr_self(),
-            (final(owner)@->0).0.value.metaregion_sound(*final(regions)),
+            (final(owner)@->0).0.value().is_node(),
+            (final(owner)@->0).0.value().is_node(),
+            r.root.ptr.addr() == (final(owner)@->0).0.value().node().meta_addr_self(),
+            (final(owner)@->0).0.value().metaregion_sound(*final(regions)),
             final(regions).inv(),
-            final(guards).unlocked((final(owner)@->0).0.value.node().meta_addr_self()),
+            final(guards).unlocked((final(owner)@->0).0.value().node().meta_addr_self()),
             // Allocating a fresh node does not change the lock set, so any node
             // that was (un)locked before remains so.
             final(guards).guards == old(guards).guards,
             // The newly allocated slot was in the free pool before the call.
             old(regions).slots.contains_key(
                 crate::specs::mm::frame::mapping::frame_to_index(
-                    (final(owner)@->0).0.value.meta_slot_paddr()->0)),
+                    (final(owner)@->0).0.value().meta_slot_paddr()->0)),
             // After the alloc, the slot is removed from the free pool (now owned
             // by the new pt's NodeOwner).
             !final(regions).slots.contains_key(
                 crate::specs::mm::frame::mapping::frame_to_index(
-                    (final(owner)@->0).0.value.meta_slot_paddr()->0)),
+                    (final(owner)@->0).0.value().meta_slot_paddr()->0)),
             // Other slots and lock state are preserved.
             forall |i: usize| #![trigger final(regions).slot_owners[i]]
                 i != crate::specs::mm::frame::mapping::frame_to_index(
-                    (final(owner)@->0).0.value.meta_slot_paddr()->0)
+                    (final(owner)@->0).0.value().meta_slot_paddr()->0)
                 ==> final(regions).slot_owners[i] == old(regions).slot_owners[i],
             forall |a: usize| old(guards).lock_held(a) ==> final(guards).lock_held(a),
             forall |idx: usize| #![trigger final(regions).slot_owners[idx].paths_in_pt]
@@ -1281,14 +1281,14 @@ impl<C: PageTableConfig> PageTable<C> {
                 #![trigger kt.metaregion_sound(*old(regions))]
                 kt.inv() && kt.metaregion_sound(*old(regions)) ==>
                 kt.0.tree_predicate_map(
-                    kt.0.value.path,
+                    kt.0.value().path,
                     |e: crate::specs::mm::page_table::node::entry_owners::EntryOwner<KernelPtConfig>,
                      p: vstd_extra::ghost_tree::TreePath<NR_ENTRIES>|
                         e.meta_slot_paddr() is Some
                             ==> crate::specs::mm::frame::mapping::frame_to_index(
                                 e.meta_slot_paddr()->0) !=
                                 crate::specs::mm::frame::mapping::frame_to_index(
-                                    (final(owner)@->0).0.value.meta_slot_paddr()->0),
+                                    (final(owner)@->0).0.value().meta_slot_paddr()->0),
                 ),
             // Sub-page freshness: for any huge frame entry in any pre-existing
             // sound KernelPtConfig tree, the new PT's slot index isn't a sub-page
@@ -1297,7 +1297,7 @@ impl<C: PageTableConfig> PageTable<C> {
                 #![trigger kt.metaregion_sound(*old(regions))]
                 kt.inv() && kt.metaregion_sound(*old(regions)) ==>
                 kt.0.tree_predicate_map(
-                    kt.0.value.path,
+                    kt.0.value().path,
                     |e: crate::specs::mm::page_table::node::entry_owners::EntryOwner<KernelPtConfig>,
                      p: vstd_extra::ghost_tree::TreePath<NR_ENTRIES>|
                         e.is_frame() && e.parent_level > 1 ==> {
@@ -1309,7 +1309,7 @@ impl<C: PageTableConfig> PageTable<C> {
                                     #[trigger] crate::specs::mm::frame::mapping::frame_to_index(
                                         (pa + j * PAGE_SIZE) as usize);
                                 sub_idx != crate::specs::mm::frame::mapping::frame_to_index(
-                                    (final(owner)@->0).0.value.meta_slot_paddr()->0)
+                                    (final(owner)@->0).0.value().meta_slot_paddr()->0)
                             }
                         },
                 ),
@@ -1433,7 +1433,7 @@ impl<C: PageTableConfig> PageTable<C> {
                 &&& r.unwrap().0.va == va.start
                 &&& r.unwrap().0.barrier_va == *va
                 &&& r.unwrap().1@.as_page_table_owner() == owner
-                &&& r.unwrap().1@.continuations[3].path() == owner.0.value.path
+                &&& r.unwrap().1@.continuations[3].path() == owner.0.value().path
             },
             !Cursor::<C, G>::cursor_new_success_conditions(*va) ==> r is Err,
             forall|idx: usize| #![trigger final(regions).slot_owners[idx].paths_in_pt]

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -1121,7 +1121,7 @@ impl PageTable<KernelPtConfig> {
                     i as int,
                 );
                 assert(child_subtree.subtree_satisfies(
-                    kernel_owner.0.value().path.push_tail(i as usize),
+                    kernel_owner.0.value().path.push_tail(i as int),
                     PageTableOwner::<KernelPtConfig>::metaregion_sound_pred(*regions),
                 ));
                 assert(entry_owner.metaregion_sound(*regions));

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -1019,7 +1019,7 @@ impl PageTable<KernelPtConfig> {
             };
             assert(kernel_owner.metaregion_sound(regions_before_alloc));
 
-            kernel_owner.0.lemma_map_implies(
+            kernel_owner.0.lemma_subtree_satisfies_implies(
                 kernel_owner.0.value().path,
                 |
                     e: crate::specs::mm::page_table::node::entry_owners::EntryOwner<KernelPtConfig>,
@@ -1115,7 +1115,7 @@ impl PageTable<KernelPtConfig> {
                 assert(entry_owner.inv());
                 assert(root_owner.relate_guard(root_node));
 
-                kernel_owner.0.lemma_map_unroll_once(
+                kernel_owner.0.lemma_subtree_satisfies_unroll_once(
                     kernel_owner.0.value().path,
                     PageTableOwner::<KernelPtConfig>::metaregion_sound_pred(*regions),
                     i as int,

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -1225,7 +1225,7 @@ impl<C: PageTableConfig> PageTable<C> {
         regions: MetaRegionOwners,
     ) -> bool {
         &&& owner.inv()
-        &&& self.root.ptr.addr() == owner.0.value.node().meta_addr_self()
+        &&& self.root.ptr.addr() == owner.0.value().node().meta_addr_self()
         &&& owner.metaregion_sound(regions)
     }
 
@@ -1377,7 +1377,7 @@ impl<C: PageTableConfig> PageTable<C> {
             Tracked(guards): Tracked<&mut Guards<'rcu>>
         requires
             self.relates_owner(owner, *old(regions)),
-            owner.0.value.node().relate_guard(root_guard),
+            owner.0.value().node().relate_guard(root_guard),
             // Per-config tightening; see `Cursor::new`.
             0 < va.end <= C::LOCKED_END_BOUND_spec(),
         ensures
@@ -1433,7 +1433,7 @@ impl<C: PageTableConfig> PageTable<C> {
             Tracked(guards): Tracked<&mut Guards<'rcu>>
         requires
             self.relates_owner(owner, *old(regions)),
-            owner.0.value.node().relate_guard(root_guard),
+            owner.0.value().node().relate_guard(root_guard),
             // Per-config tightening; see `Cursor::new`.
             0 < va.end <= C::LOCKED_END_BOUND_spec(),
         ensures

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -468,32 +468,16 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         }
 
         proof {
-            // When both old and new are not nodes:
-            // from_pte/into_pte are identity, no slot_owners change. Regions unchanged.
-            if !old(owner).is_node() && !new_owner.is_node() {
-                // slot_owners and slots are identical → metaregion_sound trivially preserved.
-            }
-        }
-
-        proof {
             if new_owner.is_node() || new_owner.is_frame() {
                 let paddr = new_owner.meta_slot_paddr().unwrap();
                 regions.inv_implies_correct_addr(paddr);
             }
-        }
-
-        proof {
-            // Restore `count_consistent` (`nr_children == count_present(children_perm)`):
-            // `write_pte` changed only slot `self.idx`, and `nr_children` was
-            // inc/dec'd by exactly that slot's present-status change.
             crate::specs::mm::page_table::node::owners::lemma_count_present_upto_update(
                 cp0,
                 NR_ENTRIES as int,
                 self.idx as int,
                 new_pte,
             );
-            // Present-status of the old/new PTEs is pinned to the owner kind by
-            // `match_pte`, and the counter branches keyed off `is_none()`.
         }
 
         old_child
@@ -633,12 +617,6 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             let ghost old_owner_val = owner.value();
 
             proof {
-                // `nr_children < NR_ENTRIES` (needed below so the `+ 1`
-                // increment yields a valid count). Established PRE-`alloc` while
-                // the parent slot at `self.idx` is still absent and
-                // `count_consistent` holds (from `metaregion_sound_node`).
-                // `alloc`/`write_pte` preserve `parent_owner.meta_own.nr_children`,
-                // so the bound persists to the increment.
                 parent_owner.nr_children_absent_slot_bound(self.idx);
             }
 
@@ -688,11 +666,6 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             };
             self.pte = new_pte;
 
-            proof {
-                broadcast use group_page_meta;
-
-            }
-
             let pt_ref = unsafe {
                 #[verus_spec(with Tracked(regions))]
                 PageTableNodeRef::borrow_paddr(paddr)
@@ -729,11 +702,9 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 // `owner.level` (from `allocated_empty_node_owner` + the
                 // `owner.level + parent_owner.level == INC_LEVELS` precond), so
                 // the grafted children's levels line up with `owner.level + 1`.
-                {
-                    let tracked new_node_value = new_node_owner.tracked_borrow_mut_value();
-                    new_node_value.parent_level = level as PagingLevel;
-                    new_node_value.path = old_path;
-                }
+                let tracked new_node_value = new_node_owner.tracked_borrow_mut_value();
+                new_node_value.parent_level = level as PagingLevel;
+                new_node_value.path = old_path;
                 *owner = new_node_owner;
                 // Rebase children's paths from `[i]` (rooted at empty) onto
                 // the cursor path `old_path` so `pt_edge_at`'s
@@ -1343,18 +1314,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 }
                 new_owner.tracked_insert_child(i as int, Some(new_owner_child));
 
-                TreePath::lemma_push_tail_len(new_owner_path, i as int);
                 let owner_with_updated_value = new_owner_before_update.set_value(new_owner.value());
-                OwnerSubtree::lemma_insert_preserves_inv(
-                    owner_with_updated_value,
-                    i as int,
-                    new_owner_child,
-                );
-                OwnerSubtree::lemma_insert_property(
-                    owner_with_updated_value,
-                    i as int,
-                    new_owner_child,
-                );
                 vstd::seq_lib::lemma_update_is_remove_insert(
                     new_owner_before_update.children(),
                     i as int,

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -25,7 +25,7 @@ use core::marker::PhantomData;
 use core::ops::Deref;
 
 use crate::{
-    mm::{nr_subpage_per_huge, page_prop::PageProperty},
+    mm::{nr_subpage_per_huge, nr_subpage_per_huge_spec, page_prop::PageProperty},
     //    sync::RcuDrop,
     //    task::atomic_mode::InAtomicMode,
 };
@@ -570,7 +570,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 // would be `[i]` rather than `cursor_path.push_tail(i)`.
                 &&& forall|i: int| 0 <= i < NR_ENTRIES ==>
                     (#[trigger] final(owner).children()[i])->0.value().path
-                        == final(owner).value().path.push_tail(i as usize)
+                        == final(owner).value().path.push_tail(i)
                 // Grandchildren are all None (from `PageTableNode::alloc`'s
                 // `allocated_empty_node_grandchildren_none` ensures; the path
                 // rebasing leaves grandchildren untouched).
@@ -655,6 +655,16 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
 
             #[verus_spec(with Tracked(parent_owner), Tracked(regions), Tracked(guards), Ghost(self.idx) => Tracked(new_node_owner))]
             let new_page = PageTableNode::<C>::alloc(level - 1);
+            let ghost fresh_children = new_node_owner.children();
+            proof {
+                assert forall|i: int| 0 <= i < NR_ENTRIES implies
+                    (#[trigger] fresh_children[i]) is Some by {
+                    assert(crate::specs::mm::page_table::allocated_empty_node_owner(
+                        new_node_owner,
+                        (level - 1) as PagingLevel,
+                    ));
+                };
+            }
 
             proof {
                 let pte = C::E::new_pt_spec(
@@ -740,6 +750,9 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 // Rebase children's paths from `[i]` (rooted at empty) onto
                 // the cursor path `old_path` so `pt_edge_at`'s
                 // `child.path == parent.path.push_tail(i)` holds.
+                assert(owner.children() == fresh_children);
+                assert forall|i: int| 0 <= i < NR_ENTRIES implies
+                    (#[trigger] owner.children()[i]) is Some by {};
                 crate::specs::mm::page_table::rebase_freshly_allocated_children(owner, old_path);
 
                 let new_paddr = owner.value().meta_slot_paddr().unwrap();
@@ -785,15 +798,15 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 assert forall|i: int| 0 <= i < NR_ENTRIES implies {
                     &&& #[trigger] f_nu(
                         owner.children()[i].unwrap().value(),
-                        owner.value().path.push_tail(i as usize),
+                        owner.value().path.push_tail(i),
                     )
                     &&& f_ms(
                         owner.children()[i].unwrap().value(),
-                        owner.value().path.push_tail(i as usize),
+                        owner.value().path.push_tail(i),
                     )
                     &&& f_pt(
                         owner.children()[i].unwrap().value(),
-                        owner.value().path.push_tail(i as usize),
+                        owner.value().path.push_tail(i),
                     )
                 } by {};
 
@@ -965,6 +978,15 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         // level which is `level`). Convention: alloc(M) produces node.level=M.
         #[verus_spec(with Tracked(parent_owner), Tracked(regions), Tracked(guards), Ghost(self.idx) => Tracked(new_owner))]
         let new_page = PageTableNode::<C>::alloc(level - 1);
+        proof {
+            assert forall|i: int| 0 <= i < NR_ENTRIES implies
+                (#[trigger] new_owner.children()[i]) is Some by {
+                assert(crate::specs::mm::page_table::allocated_empty_node_owner(
+                    new_owner,
+                    (level - 1) as PagingLevel,
+                ));
+            };
+        }
 
         let ghost new_owner_slot_idx = new_owner.value().node().slot_index;
         let tracked new_owner_slot_perm = regions.slots.tracked_borrow(new_owner_slot_idx);
@@ -1053,8 +1075,14 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             };
         }
 
+        proof {
+            C::lemma_paging_consts_properties();
+            assert(nr_subpage_per_huge_spec::<C>() == NR_ENTRIES);
+        }
+
         for i in 0..nr_subpage_per_huge::<C>()
             invariant
+                nr_subpage_per_huge_spec::<C>() == NR_ENTRIES,
                 1 < level < NR_LEVELS,
                 owner.inv(),
                 owner.value().is_frame(),
@@ -1080,10 +1108,11 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 new_owner.value().node().relate_guard(pt_lock_guard),
                 guards.lock_held(new_owner_meta_addr),
                 new_owner.value().node().level == (level - 1) as PagingLevel,
+                forall|j: int| 0 <= j < NR_ENTRIES ==>
+                    (#[trigger] new_owner.children()[j]) is Some,
                 forall|j: int|
-                    #![auto]
                     0 <= j < NR_ENTRIES ==> {
-                        &&& new_owner.children()[j] is Some
+                        &&& (#[trigger] new_owner.children()[j]) is Some
                         &&& new_owner.children()[j].unwrap().value().match_pte(
                             new_owner.value().node().children_perm.value()[j],
                             new_owner.value().node().level,
@@ -1092,20 +1121,22 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                             == new_owner.value().node().level
                         &&& new_owner.children()[j].unwrap().value().inv()
                         &&& new_owner.children()[j].unwrap().value().path == new_owner_path.push_tail(
-                            j as usize,
+                            j,
                         )
                     },
                 forall|j: int|
-                    #![auto]
                     i <= j < NR_ENTRIES ==> {
+                        &&& (#[trigger] new_owner.children()[j]) is Some
                         &&& new_owner.children()[j].unwrap().value().is_absent()
                         &&& new_owner.value().node().children_perm.value()[j]
                             == C::E::new_absent_spec()
                     },
                 // Children [0, i) have been replaced with frames.
                 forall|j: int|
-                    #![auto]
-                    0 <= j < i ==> { new_owner.children()[j].unwrap().value().is_frame() },
+                    0 <= j < i ==> {
+                        &&& (#[trigger] new_owner.children()[j]) is Some
+                        &&& new_owner.children()[j].unwrap().value().is_frame()
+                    },
                 // Sub-page slots (4KB-grained, j > 0): slots.contains_key is unconditional;
                 // rc constraints apply only to non-MMIO sub-pages (MMIO sub-pages keep
                 // `usage == MMIO` and `rc == UNUSED`).
@@ -1155,6 +1186,9 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 // Prove required facts while we still have new_owner.value.node available.
                 let ghost the_node = new_owner.value().node();
 
+                assert(0 <= i < NR_ENTRIES);
+                assert(new_owner.children()[i as int] is Some);
+                assert(new_owner.inv_children());
                 assert(new_owner.children()[i as int]->0.inv());
                 assert(new_owner.children()[i as int]->0.level() == new_owner.level() + 1);
                 EntryOwner::huge_frame_split_child_at(owner.value(), *regions, i as usize);
@@ -1164,7 +1198,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
 
             let tracked mut child_owner = EntryOwner::tracked_new_frame(
                 small_pa,
-                new_owner.value().path.push_tail(i as usize),
+                new_owner.value().path.push_tail(i as int),
                 (level - 1) as PagingLevel,
                 prop,
                 /* is_tracked */
@@ -1346,17 +1380,17 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 }
                 new_owner.tracked_insert_child(i as int, Some(new_owner_child));
 
-                TreePath::lemma_push_tail_len(new_owner_path, i as usize);
+                TreePath::lemma_push_tail_len(new_owner_path, i as int);
                 new_owner_before_update.lemma_set_value_property(new_owner.value());
                 let owner_with_updated_value = new_owner_before_update.set_value(new_owner.value());
                 OwnerSubtree::lemma_insert_preserves_inv(
                     owner_with_updated_value,
-                    i as usize,
+                    i as int,
                     new_owner_child,
                 );
                 OwnerSubtree::lemma_insert_property(
                     owner_with_updated_value,
-                    i as usize,
+                    i as int,
                     new_owner_child,
                 );
                 vstd::seq_lib::lemma_update_is_remove_insert(
@@ -1368,24 +1402,33 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                     i as int,
                 ).insert(i as int, Some(new_owner_child)));
                 assert(owner_with_updated_value.insert(
-                    i as usize,
+                    i as int,
                     new_owner_child,
                 ).children() == new_owner_before_update.children().update(
                     i as int,
                     Some(new_owner_child),
                 ));
                 assert(new_owner.children() =~= owner_with_updated_value.insert(
-                    i as usize,
+                    i as int,
                     new_owner_child,
                 ).children());
                 assert(new_owner.children() == owner_with_updated_value.insert(
-                    i as usize,
+                    i as int,
                     new_owner_child,
                 ).children());
                 OwnerSubtree::lemma_ext_equal(
                     new_owner,
-                    owner_with_updated_value.insert(i as usize, new_owner_child),
+                    owner_with_updated_value.insert(i as int, new_owner_child),
                 );
+                assert forall|j: int| 0 <= j < NR_ENTRIES implies
+                    (#[trigger] new_owner.children()[j]) is Some by {
+                    if j != i {
+                        assert(owner_with_updated_value.insert(
+                            i as int,
+                            new_owner_child,
+                        ).children()[j] == owner_with_updated_value.children()[j]);
+                    }
+                };
                 assert(new_owner.inv());
 
                 // `replace` of a frame child preserves every slot's `inner_perms`
@@ -1828,7 +1871,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
                 #[trigger] final(owner).children()[i] is Some && final(owner).children()[i]->0.value().is_absent(),
             forall|i: int| 0 <= i < NR_ENTRIES ==>
                 (#[trigger] final(owner).children()[i])->0.value().path
-                    == final(owner).value().path.push_tail(i as usize),
+                    == final(owner).value().path.push_tail(i),
             crate::specs::mm::page_table::allocated_empty_node_grandchildren_none(*final(owner)),
             forall|i: int| 0 <= i < NR_ENTRIES ==>
                 (#[trigger] final(owner).children()[i])->0.value().parent_level
@@ -1898,6 +1941,16 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
 
         #[verus_spec(with Tracked(parent_owner), Tracked(regions), Tracked(guards), Ghost(idx) => Tracked(new_node_owner))]
         let new_page = PageTableNode::<C>::alloc(level - 1);
+        let ghost fresh_children = new_node_owner.children();
+        proof {
+            assert forall|i: int| 0 <= i < NR_ENTRIES implies
+                (#[trigger] fresh_children[i]) is Some by {
+                assert(crate::specs::mm::page_table::allocated_empty_node_owner(
+                    new_node_owner,
+                    (level - 1) as PagingLevel,
+                ));
+            };
+        }
 
         proof {
             let pte = C::E::new_pt_spec(
@@ -1973,6 +2026,9 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
                 new_node_value.path = old_path;
             }
             *owner = new_node_owner;
+            assert(owner.children() == fresh_children);
+            assert forall|i: int| 0 <= i < NR_ENTRIES implies
+                (#[trigger] owner.children()[i]) is Some by {};
             crate::specs::mm::page_table::rebase_freshly_allocated_children(owner, old_path);
 
             let new_paddr = owner.value().meta_slot_paddr().unwrap();
@@ -2006,10 +2062,10 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
             assert forall|i: int| 0 <= i < NR_ENTRIES implies {
                 &&& #[trigger] f_nu(
                     owner.children()[i].unwrap().value(),
-                    owner.value().path.push_tail(i as usize),
+                    owner.value().path.push_tail(i),
                 )
-                &&& f_ms(owner.children()[i].unwrap().value(), owner.value().path.push_tail(i as usize))
-                &&& f_pt(owner.children()[i].unwrap().value(), owner.value().path.push_tail(i as usize))
+                &&& f_ms(owner.children()[i].unwrap().value(), owner.value().path.push_tail(i))
+                &&& f_pt(owner.children()[i].unwrap().value(), owner.value().path.push_tail(i))
             } by {};
 
             crate::specs::mm::page_table::fresh_node_subtree_satisfies(

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -1383,12 +1383,12 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 TreePath::lemma_push_tail_len(new_owner_path, i as int);
                 new_owner_before_update.lemma_set_value_property(new_owner.value());
                 let owner_with_updated_value = new_owner_before_update.set_value(new_owner.value());
-                OwnerSubtree::lemma_insert_preserves_inv(
+                OwnerSubtree::lemma_update_preserves_inv(
                     owner_with_updated_value,
                     i as int,
                     new_owner_child,
                 );
-                OwnerSubtree::lemma_insert_property(
+                OwnerSubtree::lemma_update_property(
                     owner_with_updated_value,
                     i as int,
                     new_owner_child,
@@ -1401,29 +1401,29 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 assert(new_owner.children() == new_owner_before_update.children().remove(
                     i as int,
                 ).insert(i as int, Some(new_owner_child)));
-                assert(owner_with_updated_value.insert(
+                assert(owner_with_updated_value.update(
                     i as int,
                     new_owner_child,
                 ).children() == new_owner_before_update.children().update(
                     i as int,
                     Some(new_owner_child),
                 ));
-                assert(new_owner.children() =~= owner_with_updated_value.insert(
+                assert(new_owner.children() =~= owner_with_updated_value.update(
                     i as int,
                     new_owner_child,
                 ).children());
-                assert(new_owner.children() == owner_with_updated_value.insert(
+                assert(new_owner.children() == owner_with_updated_value.update(
                     i as int,
                     new_owner_child,
                 ).children());
                 OwnerSubtree::lemma_ext_equal(
                     new_owner,
-                    owner_with_updated_value.insert(i as int, new_owner_child),
+                    owner_with_updated_value.update(i as int, new_owner_child),
                 );
                 assert forall|j: int| 0 <= j < NR_ENTRIES implies
                     (#[trigger] new_owner.children()[j]) is Some by {
                     if j != i {
-                        assert(owner_with_updated_value.insert(
+                        assert(owner_with_updated_value.update(
                             i as int,
                             new_owner_child,
                         ).children()[j] == owner_with_updated_value.children()[j]);

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -34,6 +34,8 @@ use super::*;
 
 verus! {
 
+broadcast use group_ghost_tree_lemmas;
+
 /// A reference to a page table node.
 pub type PageTableNodeRef<'a, C> = FrameRef<'a, PageTablePageMeta<C>>;
 
@@ -663,6 +665,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                         new_node_owner,
                         (level - 1) as PagingLevel,
                     ));
+                    assert(new_node_owner.has_child(i));
                 };
             }
 
@@ -948,6 +951,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                     new_owner,
                     (level - 1) as PagingLevel,
                 ));
+                assert(new_owner.has_child(i));
             };
         }
 
@@ -1907,6 +1911,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
                     new_node_owner,
                     (level - 1) as PagingLevel,
                 ));
+                assert(new_node_owner.has_child(i));
             };
         }
 

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -577,12 +577,12 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 &&& crate::specs::mm::page_table::allocated_empty_node_grandchildren_none(*final(owner))
                 // Other child fields preserved from `allocated_empty_node_owner`.
                 &&& forall|i: int| 0 <= i < NR_ENTRIES ==>
-                    (#[trigger] final(owner).children()[i])->0.value().parent_level
+                    (#[trigger] final(owner).child(i)).value().parent_level
                         == final(owner).value().node().level
                 &&& forall|i: int| 0 <= i < NR_ENTRIES ==>
-                    (#[trigger] final(owner).children()[i])->0.value().match_pte(
+                    (#[trigger] final(owner).child(i)).value().match_pte(
                         final(owner).value().node().children_perm.value()[i],
-                        final(owner).children()[i]->0.value().parent_level)
+                        final(owner).child(i).value().parent_level)
                 // slot_owners unchanged for all indices except the new PT node's index.
                 &&& forall|i: usize| i != frame_to_index(final(owner).value().meta_slot_paddr()->0) ==>
                     (#[trigger] final(regions).slot_owners[i]) == old(regions).slot_owners[i]
@@ -711,21 +711,6 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 self.node.write_pte(self.idx, self.pte)
             };
 
-            proof {
-                // `count_consistent` is momentarily broken between `alloc` (which
-                // set the parent's PTE present via `set_children_perm`) and the
-                // `+ 1` below, so the full `metaregion_sound_node` doesn't hold
-                // here. But its id clause — all `nr_children_mut`/`read` need — is
-                // frame-stable, so we transfer it from the pre-`alloc` snapshot:
-                //  - `meta_own` is preserved by `set_children_perm`/`write_pte`.
-                //  - the parent slot (`!= child slot`, since the parent is a live
-                //    node with `rc != UNUSED` while the child slot was `UNUSED`)
-                //    is preserved by `alloc` (`get_from_unused`/`reparked` only
-                //    touch the child slot) and by `write_pte` (regions immutable),
-                //    so `meta_perm_of` — a deterministic `new_spec(slots[idx],
-                //    inner_perms)` — is structurally unchanged.
-            }
-
             let tracked parent_meta_perm2 = regions.borrow_typed_perm::<PageTablePageMeta<C>>(
                 parent_owner.slot_index,
             );
@@ -761,9 +746,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 let tracked mut new_meta_slot = regions.slot_owners.tracked_remove(new_idx);
                 new_meta_slot.paths_in_pt = set![owner.value().path];
                 regions.slot_owners.tracked_insert(new_idx, new_meta_slot);
-            }
-
-            proof {
+  
                 // Restore the parent's `count_consistent`: the slot at `self.idx`
                 // went absent → present (the new PT node) and `nr_children` was
                 // incremented by 1.
@@ -773,9 +756,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                     self.idx as int,
                     self.pte,
                 );
-            }
-
-            proof {
+  
                 // Discharge the region-preservation + fresh-node
                 // `subtree_satisfies` conjuncts of the big `is_absent` ensures
                 // block.

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -554,10 +554,10 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 &&& Self::metaregion_sound_neq_preserved(old(owner).value(), final(owner).value(), *old(regions), *final(regions))
                 &&& Self::path_tracked_pred_preserved(*old(regions), *final(regions))
                 &&& old(regions).slots.contains_key(frame_to_index(final(owner).value().meta_slot_paddr()->0))
-                &&& final(owner).tree_predicate_map(final(owner).value().path,
+                &&& final(owner).subtree_satisfies(final(owner).value().path,
                     CursorOwner::<'rcu, C>::node_unlocked_except(*final(guards), final(owner).value().node().meta_addr_self()))
-                &&& final(owner).tree_predicate_map(final(owner).value().path, PageTableOwner::<C>::metaregion_sound_pred(*final(regions)))
-                &&& final(owner).tree_predicate_map(final(owner).value().path, PageTableOwner::<C>::path_tracked_pred(*final(regions)))
+                &&& final(owner).subtree_satisfies(final(owner).value().path, PageTableOwner::<C>::metaregion_sound_pred(*final(regions)))
+                &&& final(owner).subtree_satisfies(final(owner).value().path, PageTableOwner::<C>::path_tracked_pred(*final(regions)))
                 &&& PageTableOwner(*final(owner)).view_rec(final(owner).value().path) == set![]
                 // All children of the newly allocated node are absent (empty PT node).
                 &&& forall|i: int| 0 <= i < NR_ENTRIES ==>
@@ -764,15 +764,15 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
 
             proof {
                 // Discharge the region-preservation + fresh-node
-                // `tree_predicate_map` conjuncts of the big `is_absent` ensures
+                // `subtree_satisfies` conjuncts of the big `is_absent` ensures
                 // block.
                 broadcast use crate::specs::mm::frame::meta_owners::axiom_mmio_usage_iff_mmio_paddr;
                 // (a) Region predicates preserved off the new node's slot: the
                 // install only touches `new_idx`. (Mirrors `replace`.)
-                // (b) `tree_predicate_map` over the fresh node: each predicate
+                // (b) `subtree_satisfies` over the fresh node: each predicate
                 // holds at the node root and trivially at the absent children
                 // (which have `None` grandchildren), via
-                // `fresh_node_tree_predicate_map`.
+                // `fresh_node_subtree_satisfies`.
 
                 let ghost new_node_addr = owner.value().node().meta_addr_self();
                 let f_nu = CursorOwner::<'rcu, C>::node_unlocked_except(*guards, new_node_addr);
@@ -797,17 +797,17 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                     )
                 } by {};
 
-                crate::specs::mm::page_table::fresh_node_tree_predicate_map(
+                crate::specs::mm::page_table::fresh_node_subtree_satisfies(
                     *owner,
                     owner.value().path,
                     f_nu,
                 );
-                crate::specs::mm::page_table::fresh_node_tree_predicate_map(
+                crate::specs::mm::page_table::fresh_node_subtree_satisfies(
                     *owner,
                     owner.value().path,
                     f_ms,
                 );
-                crate::specs::mm::page_table::fresh_node_tree_predicate_map(
+                crate::specs::mm::page_table::fresh_node_subtree_satisfies(
                     *owner,
                     owner.value().path,
                     f_pt,
@@ -895,9 +895,9 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 &&& OwnerSubtree::implies(
                     PageTableOwner::<C>::metaregion_sound_pred(*old(regions)),
                     PageTableOwner::<C>::metaregion_sound_pred(*final(regions)))
-                &&& final(owner).tree_predicate_map(final(owner).value().path,
+                &&& final(owner).subtree_satisfies(final(owner).value().path,
                     CursorOwner::<'rcu, C>::node_unlocked(*final(guards)))
-                &&& final(owner).tree_predicate_map(final(owner).value().path,
+                &&& final(owner).subtree_satisfies(final(owner).value().path,
                     PageTableOwner::<C>::metaregion_sound_pred(*final(regions)))
             },
             !old(owner).value().is_frame() || old(parent_owner).level <= 1 ==> {
@@ -1818,10 +1818,10 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
             ),
             Entry::<C>::path_tracked_pred_preserved(*old(regions), *final(regions)),
             old(regions).slots.contains_key(frame_to_index(final(owner).value().meta_slot_paddr()->0)),
-            final(owner).tree_predicate_map(final(owner).value().path,
+            final(owner).subtree_satisfies(final(owner).value().path,
                 CursorOwner::<'rcu, C>::node_unlocked_except(*final(guards), final(owner).value().node().meta_addr_self())),
-            final(owner).tree_predicate_map(final(owner).value().path, PageTableOwner::<C>::metaregion_sound_pred(*final(regions))),
-            final(owner).tree_predicate_map(final(owner).value().path, PageTableOwner::<C>::path_tracked_pred(*final(regions))),
+            final(owner).subtree_satisfies(final(owner).value().path, PageTableOwner::<C>::metaregion_sound_pred(*final(regions))),
+            final(owner).subtree_satisfies(final(owner).value().path, PageTableOwner::<C>::path_tracked_pred(*final(regions))),
             PageTableOwner(*final(owner)).view_rec(final(owner).value().path) == set![],
             forall|i: int| 0 <= i < NR_ENTRIES ==>
                 #[trigger] final(owner).children()[i] is Some && final(owner).children()[i]->0.value().is_absent(),
@@ -1984,15 +1984,15 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
 
         proof {
             // Discharge the region-preservation + fresh-node
-            // `tree_predicate_map` conjuncts of the big `is_absent` ensures
+            // `subtree_satisfies` conjuncts of the big `is_absent` ensures
             // block.
             broadcast use crate::specs::mm::frame::meta_owners::axiom_mmio_usage_iff_mmio_paddr;
             // (a) Region predicates preserved off the new node's slot: the
             // install only touches `new_idx`.
-            // (b) `tree_predicate_map` over the fresh node: each predicate
+            // (b) `subtree_satisfies` over the fresh node: each predicate
             // holds at the node root and trivially at the absent children
             // (which have `None` grandchildren), via
-            // `fresh_node_tree_predicate_map`.
+            // `fresh_node_subtree_satisfies`.
 
             let ghost new_node_addr = owner.value().node().meta_addr_self();
             let f_nu = CursorOwner::<'rcu, C>::node_unlocked_except(*guards, new_node_addr);
@@ -2011,17 +2011,17 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
                 &&& f_pt(owner.children()[i].unwrap().value(), owner.value().path.push_tail(i as usize))
             } by {};
 
-            crate::specs::mm::page_table::fresh_node_tree_predicate_map(
+            crate::specs::mm::page_table::fresh_node_subtree_satisfies(
                 *owner,
                 owner.value().path,
                 f_nu,
             );
-            crate::specs::mm::page_table::fresh_node_tree_predicate_map(
+            crate::specs::mm::page_table::fresh_node_subtree_satisfies(
                 *owner,
                 owner.value().path,
                 f_ms,
             );
-            crate::specs::mm::page_table::fresh_node_tree_predicate_map(
+            crate::specs::mm::page_table::fresh_node_subtree_satisfies(
                 *owner,
                 owner.value().path,
                 f_pt,

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -637,8 +637,8 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             let new_page = PageTableNode::<C>::alloc(level - 1);
             let ghost fresh_children = new_node_owner.children();
             proof {
-                assert forall|i: int| 0 <= i < NR_ENTRIES implies
-                    (#[trigger] fresh_children[i]) is Some by {
+                assert forall|i: int| 0 <= i < NR_ENTRIES implies (
+                #[trigger] fresh_children[i]) is Some by {
                     assert(crate::specs::mm::page_table::allocated_empty_node_owner(
                         new_node_owner,
                         (level - 1) as PagingLevel,
@@ -710,8 +710,8 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 // the cursor path `old_path` so `pt_edge_at`'s
                 // `child.path == parent.path.push_tail(i)` holds.
                 assert(owner.children() == fresh_children);
-                assert forall|i: int| 0 <= i < NR_ENTRIES implies
-                    (#[trigger] owner.children()[i]) is Some by {};
+                assert forall|i: int| 0 <= i < NR_ENTRIES implies (
+                #[trigger] owner.children()[i]) is Some by {};
                 crate::specs::mm::page_table::rebase_freshly_allocated_children(owner, old_path);
 
                 let new_paddr = owner.value().meta_slot_paddr().unwrap();
@@ -720,7 +720,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 let tracked mut new_meta_slot = regions.slot_owners.tracked_remove(new_idx);
                 new_meta_slot.paths_in_pt = set![owner.value().path];
                 regions.slot_owners.tracked_insert(new_idx, new_meta_slot);
-  
+
                 // Restore the parent's `count_consistent`: the slot at `self.idx`
                 // went absent → present (the new PT node) and `nr_children` was
                 // incremented by 1.
@@ -730,7 +730,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                     self.idx as int,
                     self.pte,
                 );
-  
+
                 // Discharge the region-preservation + fresh-node
                 // `subtree_satisfies` conjuncts of the big `is_absent` ensures
                 // block.
@@ -916,8 +916,8 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         #[verus_spec(with Tracked(parent_owner), Tracked(regions), Tracked(guards), Ghost(self.idx) => Tracked(new_owner))]
         let new_page = PageTableNode::<C>::alloc(level - 1);
         proof {
-            assert forall|i: int| 0 <= i < NR_ENTRIES implies
-                (#[trigger] new_owner.children()[i]) is Some by {
+            assert forall|i: int| 0 <= i < NR_ENTRIES implies (
+            #[trigger] new_owner.children()[i]) is Some by {
                 assert(crate::specs::mm::page_table::allocated_empty_node_owner(
                     new_owner,
                     (level - 1) as PagingLevel,
@@ -1046,8 +1046,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 new_owner.value().node().relate_guard(pt_lock_guard),
                 guards.lock_held(new_owner_meta_addr),
                 new_owner.value().node().level == (level - 1) as PagingLevel,
-                forall|j: int| 0 <= j < NR_ENTRIES ==>
-                    (#[trigger] new_owner.children()[j]) is Some,
+                forall|j: int| 0 <= j < NR_ENTRIES ==> (#[trigger] new_owner.children()[j]) is Some,
                 forall|j: int|
                     0 <= j < NR_ENTRIES ==> {
                         &&& (#[trigger] new_owner.children()[j]) is Some
@@ -1058,9 +1057,8 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                         &&& new_owner.children()[j].unwrap().value().parent_level
                             == new_owner.value().node().level
                         &&& new_owner.children()[j].unwrap().value().inv()
-                        &&& new_owner.children()[j].unwrap().value().path == new_owner_path.push_tail(
-                            j,
-                        )
+                        &&& new_owner.children()[j].unwrap().value().path
+                            == new_owner_path.push_tail(j)
                     },
                 forall|j: int|
                     i <= j < NR_ENTRIES ==> {
@@ -1323,13 +1321,8 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 assert(new_owner.children() == new_owner_before_update.children().remove(
                     i as int,
                 ).insert(i as int, Some(new_owner_child)));
-                assert(owner_with_updated_value.insert(
-                    i as int,
-                    new_owner_child,
-                ).children() == new_owner_before_update.children().update(
-                    i as int,
-                    Some(new_owner_child),
-                ));
+                assert(owner_with_updated_value.insert(i as int, new_owner_child).children()
+                    == new_owner_before_update.children().update(i as int, Some(new_owner_child)));
                 assert(new_owner.children() =~= owner_with_updated_value.insert(
                     i as int,
                     new_owner_child,
@@ -1342,8 +1335,8 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                     new_owner,
                     owner_with_updated_value.insert(i as int, new_owner_child),
                 );
-                assert forall|j: int| 0 <= j < NR_ENTRIES implies
-                    (#[trigger] new_owner.children()[j]) is Some by {
+                assert forall|j: int| 0 <= j < NR_ENTRIES implies (
+                #[trigger] new_owner.children()[j]) is Some by {
                     if j != i {
                         assert(owner_with_updated_value.insert(
                             i as int,
@@ -1865,8 +1858,8 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
         let new_page = PageTableNode::<C>::alloc(level - 1);
         let ghost fresh_children = new_node_owner.children();
         proof {
-            assert forall|i: int| 0 <= i < NR_ENTRIES implies
-                (#[trigger] fresh_children[i]) is Some by {
+            assert forall|i: int| 0 <= i < NR_ENTRIES implies (
+            #[trigger] fresh_children[i]) is Some by {
                 assert(crate::specs::mm::page_table::allocated_empty_node_owner(
                     new_node_owner,
                     (level - 1) as PagingLevel,

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -2027,8 +2027,6 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
             }
             *owner = new_node_owner;
             assert(owner.children() == fresh_children);
-            assert forall|i: int| 0 <= i < NR_ENTRIES implies
-                (#[trigger] owner.children()[i]) is Some by {};
             crate::specs::mm::page_table::rebase_freshly_allocated_children(owner, old_path);
 
             let new_paddr = owner.value().meta_slot_paddr().unwrap();
@@ -2057,16 +2055,6 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
             let f_pt = PageTableOwner::<C>::path_tracked_pred(*regions);
 
             // Root predicates.
-
-            // Child predicates (absent children ⟹ trivial).
-            assert forall|i: int| 0 <= i < NR_ENTRIES implies {
-                &&& #[trigger] f_nu(
-                    owner.children()[i].unwrap().value(),
-                    owner.value().path.push_tail(i),
-                )
-                &&& f_ms(owner.children()[i].unwrap().value(), owner.value().path.push_tail(i))
-                &&& f_pt(owner.children()[i].unwrap().value(), owner.value().path.push_tail(i))
-            } by {};
 
             crate::specs::mm::page_table::fresh_node_subtree_satisfies(
                 *owner,

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -1321,10 +1321,6 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 pt_lock_guard.replace_absent_with_frame(i, small_pa, level - 1, prop);
 
                 proof {
-                    OwnerSubtree::lemma_set_value_property(
-                        new_owner_child_before_update,
-                        child_owner,
-                    );
                     *new_owner_child_value = child_owner;
                 }
             }
@@ -1344,14 +1340,13 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 new_owner.tracked_insert_child(i as int, Some(new_owner_child));
 
                 TreePath::lemma_push_tail_len(new_owner_path, i as int);
-                new_owner_before_update.lemma_set_value_property(new_owner.value());
                 let owner_with_updated_value = new_owner_before_update.set_value(new_owner.value());
-                OwnerSubtree::lemma_update_preserves_inv(
+                OwnerSubtree::lemma_insert_preserves_inv(
                     owner_with_updated_value,
                     i as int,
                     new_owner_child,
                 );
-                OwnerSubtree::lemma_update_property(
+                OwnerSubtree::lemma_insert_property(
                     owner_with_updated_value,
                     i as int,
                     new_owner_child,

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -519,49 +519,49 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             Tracked(regions): Tracked<&mut MetaRegionOwners>,
             Tracked(guards): Tracked<&mut Guards<'rcu>>,
         requires
-            old(self).invariants(old(owner).value, *old(regions)),
+            old(self).invariants(old(owner).value(), *old(regions)),
             old(owner).inv(),
-            old(self).node_matching(old(owner).value, *old(parent_owner), *old(self).node),
-            old(owner).level < INC_LEVELS - 1,
+            old(self).node_matching(old(owner).value(), *old(parent_owner), *old(self).node),
+            old(owner).level() < INC_LEVELS - 1,
             // The cursor entry's ghost-tree level is its DEPTH
             // (`INC_LEVELS - parent_PT_level`), tying it to the freshly-
             // allocated node's depth (`new_node_owner.level`) so we can prove
             // `final(owner).inv()`'s `child.level == self.level + 1`.
-            old(owner).level + old(parent_owner).level == INC_LEVELS,
+            old(owner).level() + old(parent_owner).level == INC_LEVELS,
             old(parent_owner).metaregion_sound_node(*old(regions)),
         ensures
-            final(self).invariants(final(owner).value, *final(regions)),
+            final(self).invariants(final(owner).value(), *final(regions)),
             final(self).parent_perms_preserved(*old(parent_owner), *final(parent_owner)),
             final(self).idx == old(self).idx,
             final(parent_owner).count_consistent(),
             *final(self).node == *old(self).node,
-            old(owner).value.is_absent() && old(parent_owner).level > 1 ==> {
-                &&& final(self).node_matching(final(owner).value, *final(parent_owner), *final(self).node)
+            old(owner).value().is_absent() && old(parent_owner).level > 1 ==> {
+                &&& final(self).node_matching(final(owner).value(), *final(parent_owner), *final(self).node)
                 &&& final(owner).inv()
             },
-            old(owner).value.is_absent() && old(parent_owner).level > 1 ==> {
+            old(owner).value().is_absent() && old(parent_owner).level > 1 ==> {
                 &&& res is Some
-                &&& final(owner).value.is_node()
-                &&& final(owner).level == old(owner).level
-                &&& final(owner).value.parent_level == old(owner).value.parent_level
-                &&& final(guards).lock_held(final(owner).value.node().meta_addr_self())
-                &&& final(owner).value.node().relate_guard(res->0)
-                &&& final(owner).value.path == old(owner).value.path
-                &&& final(owner).value.metaregion_sound(*final(regions))
+                &&& final(owner).value().is_node()
+                &&& final(owner).level() == old(owner).level()
+                &&& final(owner).value().parent_level == old(owner).value().parent_level
+                &&& final(guards).lock_held(final(owner).value().node().meta_addr_self())
+                &&& final(owner).value().node().relate_guard(res->0)
+                &&& final(owner).value().path == old(owner).value().path
+                &&& final(owner).value().metaregion_sound(*final(regions))
                 &&& OwnerSubtree::implies(
                     CursorOwner::<'rcu, C>::node_unlocked(*old(guards)),
-                    CursorOwner::<'rcu, C>::node_unlocked_except(*final(guards), final(owner).value.node().meta_addr_self()))
-                &&& Self::metaregion_sound_neq_preserved(old(owner).value, final(owner).value, *old(regions), *final(regions))
+                    CursorOwner::<'rcu, C>::node_unlocked_except(*final(guards), final(owner).value().node().meta_addr_self()))
+                &&& Self::metaregion_sound_neq_preserved(old(owner).value(), final(owner).value(), *old(regions), *final(regions))
                 &&& Self::path_tracked_pred_preserved(*old(regions), *final(regions))
-                &&& old(regions).slots.contains_key(frame_to_index(final(owner).value.meta_slot_paddr()->0))
-                &&& final(owner).tree_predicate_map(final(owner).value.path,
-                    CursorOwner::<'rcu, C>::node_unlocked_except(*final(guards), final(owner).value.node().meta_addr_self()))
-                &&& final(owner).tree_predicate_map(final(owner).value.path, PageTableOwner::<C>::metaregion_sound_pred(*final(regions)))
-                &&& final(owner).tree_predicate_map(final(owner).value.path, PageTableOwner::<C>::path_tracked_pred(*final(regions)))
-                &&& PageTableOwner(*final(owner)).view_rec(final(owner).value.path) == set![]
+                &&& old(regions).slots.contains_key(frame_to_index(final(owner).value().meta_slot_paddr()->0))
+                &&& final(owner).tree_predicate_map(final(owner).value().path,
+                    CursorOwner::<'rcu, C>::node_unlocked_except(*final(guards), final(owner).value().node().meta_addr_self()))
+                &&& final(owner).tree_predicate_map(final(owner).value().path, PageTableOwner::<C>::metaregion_sound_pred(*final(regions)))
+                &&& final(owner).tree_predicate_map(final(owner).value().path, PageTableOwner::<C>::path_tracked_pred(*final(regions)))
+                &&& PageTableOwner(*final(owner)).view_rec(final(owner).value().path) == set![]
                 // All children of the newly allocated node are absent (empty PT node).
                 &&& forall|i: int| 0 <= i < NR_ENTRIES ==>
-                    #[trigger] final(owner).children[i] is Some && final(owner).children[i]->0.value.is_absent()
+                    #[trigger] final(owner).children()[i] is Some && final(owner).children()[i]->0.value().is_absent()
                 // Children's paths are rebased onto the cursor path. Required by
                 // `pt_edge_at` for the freshly-allocated node, since the bare
                 // `allocated_empty_node_owner` from `PageTableNode::alloc` uses
@@ -569,46 +569,46 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 // the cursor path; without rebasing the children, their paths
                 // would be `[i]` rather than `cursor_path.push_tail(i)`.
                 &&& forall|i: int| 0 <= i < NR_ENTRIES ==>
-                    (#[trigger] final(owner).children[i])->0.value.path
-                        == final(owner).value.path.push_tail(i as usize)
+                    (#[trigger] final(owner).children()[i])->0.value().path
+                        == final(owner).value().path.push_tail(i as usize)
                 // Grandchildren are all None (from `PageTableNode::alloc`'s
                 // `allocated_empty_node_grandchildren_none` ensures; the path
                 // rebasing leaves grandchildren untouched).
                 &&& crate::specs::mm::page_table::allocated_empty_node_grandchildren_none(*final(owner))
                 // Other child fields preserved from `allocated_empty_node_owner`.
                 &&& forall|i: int| 0 <= i < NR_ENTRIES ==>
-                    (#[trigger] final(owner).children[i])->0.value.parent_level
-                        == final(owner).value.node().level
+                    (#[trigger] final(owner).children()[i])->0.value().parent_level
+                        == final(owner).value().node().level
                 &&& forall|i: int| 0 <= i < NR_ENTRIES ==>
-                    (#[trigger] final(owner).children[i])->0.value.match_pte(
-                        final(owner).value.node().children_perm.value()[i],
-                        final(owner).children[i]->0.value.parent_level)
+                    (#[trigger] final(owner).children()[i])->0.value().match_pte(
+                        final(owner).value().node().children_perm.value()[i],
+                        final(owner).children()[i]->0.value().parent_level)
                 // slot_owners unchanged for all indices except the new PT node's index.
-                &&& forall|i: usize| i != frame_to_index(final(owner).value.meta_slot_paddr()->0) ==>
+                &&& forall|i: usize| i != frame_to_index(final(owner).value().meta_slot_paddr()->0) ==>
                     (#[trigger] final(regions).slot_owners[i]) == old(regions).slot_owners[i]
                 // slots keys: the new PT node was removed then re-inserted, so all old keys preserved.
                 &&& forall|i: usize| old(regions).slots.contains_key(i)
                     ==> (#[trigger] final(regions).slots.contains_key(i))
                 &&& forall|i: usize| #![trigger final(regions).slots[i]]
-                    i != frame_to_index(final(owner).value.meta_slot_paddr()->0)
+                    i != frame_to_index(final(owner).value().meta_slot_paddr()->0)
                         && old(regions).slots.contains_key(i)
                     ==> final(regions).slots[i] == old(regions).slots[i]
                 // The new PT node's ref_count is not UNUSED (was set to 1 by get_from_unused).
-                &&& final(regions).slot_owners[frame_to_index(final(owner).value.meta_slot_paddr()->0)]
+                &&& final(regions).slot_owners[frame_to_index(final(owner).value().meta_slot_paddr()->0)]
                     .inner_perms.ref_count.value() != REF_COUNT_UNUSED
                 // The allocated slot had ref_count == UNUSED before allocation (from get_from_unused).
-                &&& old(regions).slot_owners[frame_to_index(final(owner).value.meta_slot_paddr().unwrap())]
+                &&& old(regions).slot_owners[frame_to_index(final(owner).value().meta_slot_paddr().unwrap())]
                     .inner_perms.ref_count.value() == REF_COUNT_UNUSED
                 // Allocator pool is disjoint from MMIO ranges (from `PageTableNode::alloc`).
                 &&& !crate::specs::mm::frame::meta_owners::is_mmio_paddr(
-                    final(owner).value.meta_slot_paddr().unwrap())
+                    final(owner).value().meta_slot_paddr().unwrap())
             },
-            !old(owner).value.is_absent() ==> {
+            !old(owner).value().is_absent() ==> {
                 &&& res is None
                 &&& *final(owner) == *old(owner)
             },
             forall |i: usize| old(guards).lock_held(i) ==> final(guards).lock_held(i),
-            forall |i: usize| old(guards).unlocked(i) && i != final(owner).value.node().meta_addr_self() ==> final(guards).unlocked(i),
+            forall |i: usize| old(guards).unlocked(i) && i != final(owner).value().node().meta_addr_self() ==> final(guards).unlocked(i),
     )]
     #[verifier::spinoff_prover]
     pub(in crate::mm) fn alloc_if_none<A: InAtomicMode>(&mut self, guard: &'rcu A) -> Option<
@@ -627,8 +627,8 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         if entry_is_present || level <= 1 {
             None
         } else {
-            let ghost old_path = owner.value.path;
-            let ghost old_owner_val = owner.value;
+            let ghost old_path = owner.value().path;
+            let ghost old_owner_val = owner.value();
 
             proof {
                 // `nr_children < NR_ENTRIES` (needed below so the `+ 1`
@@ -658,18 +658,21 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
 
             proof {
                 let pte = C::E::new_pt_spec(
-                    meta_to_frame(new_node_owner.value.node().meta_addr_self()),
+                    meta_to_frame(new_node_owner.value().node().meta_addr_self()),
                 );
                 C::E::lemma_page_table_entry_properties();
             }
 
-            let ghost new_node_slot_idx = new_node_owner.value.node().slot_index;
+            let ghost new_node_slot_idx = new_node_owner.value().node().slot_index;
             let tracked new_node_slot_perm = regions.slots.tracked_borrow(new_node_slot_idx);
             #[verus_spec(with Tracked(new_node_slot_perm))]
             let paddr = new_page.start_paddr();
 
-            #[verus_spec(with Tracked(&mut new_node_owner.value), Tracked(regions))]
-            let new_pte = Child::PageTable(new_page).into_pte();
+            let new_pte = {
+                let tracked new_node_value = new_node_owner.tracked_borrow_mut_value();
+                #[verus_spec(with Tracked(new_node_value), Tracked(regions))]
+                Child::PageTable(new_page).into_pte()
+            };
             self.pte = new_pte;
 
             proof {
@@ -683,8 +686,11 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             };
 
             // Lock before writing the PTE, so no one else can operate on it.
-            #[verus_spec(with Tracked(&new_node_owner.value.tracked_borrow_node()), Tracked(guards))]
-            let mut pt_lock_guard = pt_ref.lock(guard);
+            let mut pt_lock_guard = {
+                let tracked new_node_value = new_node_owner.tracked_borrow_value();
+                #[verus_spec(with Tracked(new_node_value.tracked_borrow_node()), Tracked(guards))]
+                pt_ref.lock(guard)
+            };
 
             // SAFETY:
             //  1. The index is within the bounds.
@@ -725,20 +731,22 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 // `owner.level` (from `allocated_empty_node_owner` + the
                 // `owner.level + parent_owner.level == INC_LEVELS` precond), so
                 // the grafted children's levels line up with `owner.level + 1`.
-                owner.value = new_node_owner.value;
-                owner.value.parent_level = level as PagingLevel;
-                owner.value.path = old_path;
-                owner.children = new_node_owner.children;
+                {
+                    let tracked new_node_value = new_node_owner.tracked_borrow_mut_value();
+                    new_node_value.parent_level = level as PagingLevel;
+                    new_node_value.path = old_path;
+                }
+                *owner = new_node_owner;
                 // Rebase children's paths from `[i]` (rooted at empty) onto
                 // the cursor path `old_path` so `pt_edge_at`'s
                 // `child.path == parent.path.push_tail(i)` holds.
                 crate::specs::mm::page_table::rebase_freshly_allocated_children(owner, old_path);
 
-                let new_paddr = owner.value.meta_slot_paddr().unwrap();
+                let new_paddr = owner.value().meta_slot_paddr().unwrap();
                 regions.inv_implies_correct_addr(new_paddr);
                 let new_idx = frame_to_index(new_paddr);
                 let tracked mut new_meta_slot = regions.slot_owners.tracked_remove(new_idx);
-                new_meta_slot.paths_in_pt = set![owner.value.path];
+                new_meta_slot.paths_in_pt = set![owner.value().path];
                 regions.slot_owners.tracked_insert(new_idx, new_meta_slot);
             }
 
@@ -766,7 +774,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 // (which have `None` grandchildren), via
                 // `fresh_node_tree_predicate_map`.
 
-                let ghost new_node_addr = owner.value.node().meta_addr_self();
+                let ghost new_node_addr = owner.value().node().meta_addr_self();
                 let f_nu = CursorOwner::<'rcu, C>::node_unlocked_except(*guards, new_node_addr);
                 let f_ms = PageTableOwner::<C>::metaregion_sound_pred(*regions);
                 let f_pt = PageTableOwner::<C>::path_tracked_pred(*regions);
@@ -776,32 +784,32 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 // Child predicates (absent children ⟹ trivial).
                 assert forall|i: int| 0 <= i < NR_ENTRIES implies {
                     &&& #[trigger] f_nu(
-                        owner.children[i].unwrap().value,
-                        owner.value.path.push_tail(i as usize),
+                        owner.children()[i].unwrap().value(),
+                        owner.value().path.push_tail(i as usize),
                     )
                     &&& f_ms(
-                        owner.children[i].unwrap().value,
-                        owner.value.path.push_tail(i as usize),
+                        owner.children()[i].unwrap().value(),
+                        owner.value().path.push_tail(i as usize),
                     )
                     &&& f_pt(
-                        owner.children[i].unwrap().value,
-                        owner.value.path.push_tail(i as usize),
+                        owner.children()[i].unwrap().value(),
+                        owner.value().path.push_tail(i as usize),
                     )
                 } by {};
 
                 crate::specs::mm::page_table::fresh_node_tree_predicate_map(
                     *owner,
-                    owner.value.path,
+                    owner.value().path,
                     f_nu,
                 );
                 crate::specs::mm::page_table::fresh_node_tree_predicate_map(
                     *owner,
-                    owner.value.path,
+                    owner.value().path,
                     f_ms,
                 );
                 crate::specs::mm::page_table::fresh_node_tree_predicate_map(
                     *owner,
-                    owner.value.path,
+                    owner.value().path,
                     f_pt,
                 );
             }
@@ -835,10 +843,10 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         requires
             old(regions).inv(),
             old(owner).inv(),
-            old(self).wf(old(owner).value),
+            old(self).wf(old(owner).value()),
             old(parent_owner).relate_guard(*old(self).node),
             old(parent_owner).inv(),
-            old(parent_owner).level == old(owner).value.parent_level,
+            old(parent_owner).level == old(owner).value().parent_level,
             old(parent_owner).level < NR_LEVELS,
             old(parent_owner).metaregion_sound_node(*old(regions)),
             // Frame entries being split must have `metaregion_sound` for
@@ -846,18 +854,18 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             // ref_count facts at the parent slot itself (j = 0 case in the
             // split loop's invariant). Without this, those facts can't be
             // re-established after alloc.
-            old(owner).value.is_frame() && old(parent_owner).level > 1 ==>
-                old(owner).value.metaregion_sound(*old(regions)),
+            old(owner).value().is_frame() && old(parent_owner).level > 1 ==>
+                old(owner).value().metaregion_sound(*old(regions)),
             // Sub-page validity for huge-page split: each 4KB sub-page slot must
             // exist; non-MMIO sub-pages must additionally have `rc != UNUSED`.
             // (MMIO sub-pages keep `usage == MMIO` and `rc == UNUSED`.)
-            old(owner).value.is_frame() && old(parent_owner).level > 1 ==>
+            old(owner).value().is_frame() && old(parent_owner).level > 1 ==>
                 forall |j: usize| #![trigger frame_to_index(
-                    (old(owner).value.frame().mapped_pa
+                    (old(owner).value().frame().mapped_pa
                         + j * PAGE_SIZE) as usize)]
                     0 < j < page_size(old(parent_owner).level) / PAGE_SIZE ==> {
                     let sub_idx = frame_to_index(
-                        (old(owner).value.frame().mapped_pa
+                        (old(owner).value().frame().mapped_pa
                             + j * PAGE_SIZE) as usize);
                     &&& old(regions).slots.contains_key(sub_idx)
                     &&& old(regions).slot_owners[sub_idx].usage !is MMIO ==>
@@ -865,42 +873,42 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                             != REF_COUNT_UNUSED
                 },
         ensures
-            old(owner).value.is_frame() && old(parent_owner).level > 1 ==> {
+            old(owner).value().is_frame() && old(parent_owner).level > 1 ==> {
                 &&& res is Some
-                &&& final(owner).value.is_node()
-                &&& final(owner).level == old(owner).level
+                &&& final(owner).value().is_node()
+                &&& final(owner).level() == old(owner).level()
                 &&& final(parent_owner).relate_guard(*final(self).node)
-                &&& final(owner).value.node().relate_guard(res->0)
-                &&& final(owner).value.node().meta_addr_self() == res->0.inner.inner@.ptr.addr()
+                &&& final(owner).value().node().relate_guard(res->0)
+                &&& final(owner).value().node().meta_addr_self() == res->0.inner.inner@.ptr.addr()
                 &&& final(guards).lock_held(res->0.inner.inner@.ptr.addr())
                 // All children of the new node subtree are frames with the same prop (from the split loop).
                 &&& forall |j: int| 0 <= j < NR_ENTRIES ==>
-                    (#[trigger] final(owner).children[j])->0.value.is_frame()
+                    (#[trigger] final(owner).children()[j])->0.value().is_frame()
                 &&& forall |j: int| 0 <= j < NR_ENTRIES ==>
-                    (#[trigger] final(owner).children[j])->0.value.frame().prop
-                        == old(owner).value.frame().prop
-                &&& final(owner).value.path == old(owner).value.path
-                &&& final(owner).value.metaregion_sound(*final(regions))
+                    (#[trigger] final(owner).children()[j])->0.value().frame().prop
+                        == old(owner).value().frame().prop
+                &&& final(owner).value().path == old(owner).value().path
+                &&& final(owner).value().metaregion_sound(*final(regions))
                 &&& OwnerSubtree::implies(
                     CursorOwner::<'rcu, C>::node_unlocked(*old(guards)),
                     CursorOwner::<'rcu, C>::node_unlocked(*final(guards)))
                 &&& OwnerSubtree::implies(
                     PageTableOwner::<C>::metaregion_sound_pred(*old(regions)),
                     PageTableOwner::<C>::metaregion_sound_pred(*final(regions)))
-                &&& final(owner).tree_predicate_map(final(owner).value.path,
+                &&& final(owner).tree_predicate_map(final(owner).value().path,
                     CursorOwner::<'rcu, C>::node_unlocked(*final(guards)))
-                &&& final(owner).tree_predicate_map(final(owner).value.path,
+                &&& final(owner).tree_predicate_map(final(owner).value().path,
                     PageTableOwner::<C>::metaregion_sound_pred(*final(regions)))
             },
-            !old(owner).value.is_frame() || old(parent_owner).level <= 1 ==> {
+            !old(owner).value().is_frame() || old(parent_owner).level <= 1 ==> {
                 &&& res is None
                 &&& *final(owner) == *old(owner)
             },
             final(owner).inv(),
-            final(owner).value.parent_level == old(owner).value.parent_level,
+            final(owner).value().parent_level == old(owner).value().parent_level,
             final(self).idx == old(self).idx,
-            old(owner).value.is_frame() && old(parent_owner).level > 1 ==>
-                final(self).node_matching(final(owner).value, *final(parent_owner), *final(self).node),
+            old(owner).value().is_frame() && old(parent_owner).level > 1 ==>
+                final(self).node_matching(final(owner).value(), *final(parent_owner), *final(self).node),
             final(regions).inv(),
             final(parent_owner).inv(),
             final(parent_owner).level == old(parent_owner).level,
@@ -908,24 +916,24 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             forall |i: usize| old(guards).lock_held(i) ==> final(guards).lock_held(i),
             forall |i: usize| old(guards).unlocked(i) ==> final(guards).unlocked(i),
             // slot_owners unchanged for all indices except the new PT node's index.
-            old(owner).value.is_frame() && old(parent_owner).level > 1 ==> {
-                &&& forall|i: usize| i != frame_to_index(meta_to_frame(final(owner).value.node().meta_addr_self())) ==>
+            old(owner).value().is_frame() && old(parent_owner).level > 1 ==> {
+                &&& forall|i: usize| i != frame_to_index(meta_to_frame(final(owner).value().node().meta_addr_self())) ==>
                     (#[trigger] final(regions).slot_owners[i]) == old(regions).slot_owners[i]
                 // slots keys preserved (alloc removes then borrow re-inserts).
                 &&& forall|i: usize| old(regions).slots.contains_key(i)
                     ==> (#[trigger] final(regions).slots.contains_key(i))
                 // The new PT node's ref_count is not UNUSED.
-                &&& final(regions).slot_owners[frame_to_index(meta_to_frame(final(owner).value.node().meta_addr_self()))]
+                &&& final(regions).slot_owners[frame_to_index(meta_to_frame(final(owner).value().node().meta_addr_self()))]
                     .inner_perms.ref_count.value() != REF_COUNT_UNUSED
                 // The allocated slot had ref_count == UNUSED before allocation.
-                &&& old(regions).slot_owners[frame_to_index(meta_to_frame(final(owner).value.node().meta_addr_self()))]
+                &&& old(regions).slot_owners[frame_to_index(meta_to_frame(final(owner).value().node().meta_addr_self()))]
                     .inner_perms.ref_count.value() == REF_COUNT_UNUSED
             },
             // Parent's other PTEs are preserved: only the entry at self.idx
             // is overwritten (with the new PT pointer). Lets callers re-derive
             // `inv_children_rel` for the unchanged children when restoring the
             // parent NodeOwner into the cursor's continuation.
-            old(owner).value.is_frame() && old(parent_owner).level > 1 ==>
+            old(owner).value().is_frame() && old(parent_owner).level > 1 ==>
                 forall|j: int| 0 <= j < NR_ENTRIES && j != old(self).idx ==>
                     #[trigger] final(parent_owner).children_perm.value()[j]
                         == old(parent_owner).children_perm.value()[j],
@@ -946,7 +954,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         let prop = self.pte.prop();
 
         proof {
-            EntryOwner::last_pte_implies_frame_match(owner.value, self.pte, level);
+            EntryOwner::last_pte_implies_frame_match(owner.value(), self.pte, level);
         }
 
         proof_decl!{
@@ -958,7 +966,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         #[verus_spec(with Tracked(parent_owner), Tracked(regions), Tracked(guards), Ghost(self.idx) => Tracked(new_owner))]
         let new_page = PageTableNode::<C>::alloc(level - 1);
 
-        let ghost new_owner_slot_idx = new_owner.value.node().slot_index;
+        let ghost new_owner_slot_idx = new_owner.value().node().slot_index;
         let tracked new_owner_slot_perm = regions.slots.tracked_borrow(new_owner_slot_idx);
         #[verus_spec(with Tracked(new_owner_slot_perm))]
         let paddr = new_page.start_paddr();
@@ -974,12 +982,15 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         };
 
         // Lock before writing the PTE, so no one else can operate on it.
-        #[verus_spec(with Tracked(&new_owner.value.tracked_borrow_node()), Tracked(guards))]
-        let mut pt_lock_guard = pt_ref.lock(guard);
+        let mut pt_lock_guard = {
+            let tracked new_owner_value = new_owner.tracked_borrow_value();
+            #[verus_spec(with Tracked(new_owner_value.tracked_borrow_node()), Tracked(guards))]
+            pt_ref.lock(guard)
+        };
 
-        let ghost children_perm = new_owner.value.node().children_perm;
-        let ghost new_owner_path = new_owner.value.path;
-        let ghost new_owner_meta_addr = new_owner.value.node().meta_addr_self();
+        let ghost children_perm = new_owner.value().node().children_perm;
+        let ghost new_owner_path = new_owner.value().path;
+        let ghost new_owner_meta_addr = new_owner.value().node().meta_addr_self();
 
         proof {
             // Carry the huge frame's slot facts (the precondition's
@@ -1046,11 +1057,11 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             invariant
                 1 < level < NR_LEVELS,
                 owner.inv(),
-                owner.value.is_frame(),
-                owner.value.parent_level == level,
-                owner.value.frame().mapped_pa == pa,
-                owner.value.frame().prop == prop,
-                pa == old(owner).value.frame().mapped_pa,
+                owner.value().is_frame(),
+                owner.value().parent_level == level,
+                owner.value().frame().mapped_pa == pa,
+                owner.value().frame().prop == prop,
+                pa == old(owner).value().frame().mapped_pa,
                 level == old(parent_owner).level,
                 pa % page_size(level) == 0,
                 pa + page_size(level) <= MAX_PADDR,
@@ -1062,39 +1073,39 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 regions.frame_obligations.count(frame_to_index(meta_to_frame(new_owner_meta_addr)))
                     > 0,
                 parent_owner.inv(),
-                new_owner.value.is_node(),
+                new_owner.value().is_node(),
                 new_owner.inv(),
-                new_owner.value.path == new_owner_path,
-                new_owner.value.node().meta_addr_self() == new_owner_meta_addr,
-                new_owner.value.node().relate_guard(pt_lock_guard),
+                new_owner.value().path == new_owner_path,
+                new_owner.value().node().meta_addr_self() == new_owner_meta_addr,
+                new_owner.value().node().relate_guard(pt_lock_guard),
                 guards.lock_held(new_owner_meta_addr),
-                new_owner.value.node().level == (level - 1) as PagingLevel,
+                new_owner.value().node().level == (level - 1) as PagingLevel,
                 forall|j: int|
                     #![auto]
                     0 <= j < NR_ENTRIES ==> {
-                        &&& new_owner.children[j] is Some
-                        &&& new_owner.children[j].unwrap().value.match_pte(
-                            new_owner.value.node().children_perm.value()[j],
-                            new_owner.value.node().level,
+                        &&& new_owner.children()[j] is Some
+                        &&& new_owner.children()[j].unwrap().value().match_pte(
+                            new_owner.value().node().children_perm.value()[j],
+                            new_owner.value().node().level,
                         )
-                        &&& new_owner.children[j].unwrap().value.parent_level
-                            == new_owner.value.node().level
-                        &&& new_owner.children[j].unwrap().value.inv()
-                        &&& new_owner.children[j].unwrap().value.path == new_owner_path.push_tail(
+                        &&& new_owner.children()[j].unwrap().value().parent_level
+                            == new_owner.value().node().level
+                        &&& new_owner.children()[j].unwrap().value().inv()
+                        &&& new_owner.children()[j].unwrap().value().path == new_owner_path.push_tail(
                             j as usize,
                         )
                     },
                 forall|j: int|
                     #![auto]
                     i <= j < NR_ENTRIES ==> {
-                        &&& new_owner.children[j].unwrap().value.is_absent()
-                        &&& new_owner.value.node().children_perm.value()[j]
+                        &&& new_owner.children()[j].unwrap().value().is_absent()
+                        &&& new_owner.value().node().children_perm.value()[j]
                             == C::E::new_absent_spec()
                     },
                 // Children [0, i) have been replaced with frames.
                 forall|j: int|
                     #![auto]
-                    0 <= j < i ==> { new_owner.children[j].unwrap().value.is_frame() },
+                    0 <= j < i ==> { new_owner.children()[j].unwrap().value().is_frame() },
                 // Sub-page slots (4KB-grained, j > 0): slots.contains_key is unconditional;
                 // rc constraints apply only to non-MMIO sub-pages (MMIO sub-pages keep
                 // `usage == MMIO` and `rc == UNUSED`).
@@ -1124,7 +1135,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                         <= REF_COUNT_MAX
                 },
                 new_page.ptr.addr() == new_owner_meta_addr,
-                new_owner.value.node().metaregion_sound_node(*regions),
+                new_owner.value().node().metaregion_sound_node(*regions),
                 // The new node's own-slot rc + paths_in_pt — the only
                 // `metaregion_sound` conjuncts not derivable from
                 // `metaregion_sound_node` (slot_vaddr/wf derive). Carried so
@@ -1142,26 +1153,28 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 C::lemma_page_table_config_constant_properties();
                 C::lemma_paging_consts_properties();
                 // Prove required facts while we still have new_owner.value.node available.
-                let ghost the_node = new_owner.value.node();
+                let ghost the_node = new_owner.value().node();
 
-                OwnerSubtree::child_some_properties(new_owner, i as usize);
-                EntryOwner::huge_frame_split_child_at(owner.value, *regions, i as usize);
+                OwnerSubtree::lemma_child_some_properties(new_owner, i as usize);
+                EntryOwner::huge_frame_split_child_at(owner.value(), *regions, i as usize);
             }
 
             let small_pa = pa + i * page_size(level - 1);
 
             let tracked mut child_owner = EntryOwner::tracked_new_frame(
                 small_pa,
-                new_owner.value.path.push_tail(i as usize),
+                new_owner.value().path.push_tail(i as usize),
                 (level - 1) as PagingLevel,
                 prop,
                 /* is_tracked */
-                owner.value.frame().is_tracked,
+                owner.value().frame().is_tracked,
             );
 
-            let tracked mut new_owner_child = new_owner.children.tracked_remove(
+            let ghost new_owner_before_update = new_owner;
+            let tracked mut new_owner_child = new_owner.tracked_remove_child(
                 i as int,
             ).tracked_unwrap();
+            let ghost new_owner_child_before_update = new_owner_child;
 
             proof {
                 let idx = frame_to_index(small_pa);
@@ -1287,7 +1300,10 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             // loop-invariant maintenance tracking intact across the per-child
             // `replace`; the in-place `tracked_borrow_mut_node` form loses the
             // new node's own-slot facts at the loop back-edge.
-            let tracked mut new_owner_node = new_owner.value.tracked_take_node();
+            let tracked mut new_owner_node = {
+                let tracked new_owner_value = new_owner.tracked_borrow_mut_value();
+                new_owner_value.tracked_take_node()
+            };
             // Snapshot the node's own-slot facts while the loop invariant still
             // holds (regions unchanged since loop entry), so we can frame them
             // across the `replace` below.
@@ -1298,20 +1314,78 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 // here for the post-`replace` preservation step to carry forward.
             }
             let ghost regions_pre_replace = *regions;
-            #[verus_spec(with Tracked(regions),
-                Tracked(&mut new_owner_child.value),
-                Tracked(&mut child_owner),
-                Tracked(&mut new_owner_node))]
-            pt_lock_guard.replace_absent_with_frame(i, small_pa, level - 1, prop);
+            {
+                let tracked new_owner_child_value = new_owner_child.tracked_borrow_mut_value();
+                #[verus_spec(with Tracked(regions),
+                    Tracked(new_owner_child_value),
+                    Tracked(&mut child_owner),
+                    Tracked(&mut new_owner_node))]
+                pt_lock_guard.replace_absent_with_frame(i, small_pa, level - 1, prop);
+
+                proof {
+                    OwnerSubtree::lemma_set_value_property(
+                        new_owner_child_before_update,
+                        child_owner,
+                    );
+                    *new_owner_child_value = child_owner;
+                }
+            }
 
             proof {
-                new_owner.value.tracked_put_node(new_owner_node);
-                OwnerSubtree::set_value_property(new_owner_child, child_owner);
-                new_owner_child.value = child_owner;
-                new_owner.children.tracked_insert(i as int, Some(new_owner_child));
+                new_owner_child_before_update.lemma_set_value_observable_fields(child_owner);
+                OwnerSubtree::lemma_ext_equal(
+                    new_owner_child,
+                    new_owner_child_before_update.set_value(child_owner),
+                );
+                assert(new_owner_child.inv());
 
-                TreePath::push_tail_property_len(new_owner_path, i as usize);
-                OwnerSubtree::insert_preserves_inv(new_owner, i as usize, new_owner_child);
+                {
+                    let tracked new_owner_value = new_owner.tracked_borrow_mut_value();
+                    new_owner_value.tracked_put_node(new_owner_node);
+                }
+                new_owner.tracked_insert_child(i as int, Some(new_owner_child));
+
+                TreePath::lemma_push_tail_len(new_owner_path, i as usize);
+                new_owner_before_update.lemma_set_value_property(new_owner.value());
+                let owner_with_updated_value = new_owner_before_update.set_value(new_owner.value());
+                OwnerSubtree::lemma_insert_preserves_inv(
+                    owner_with_updated_value,
+                    i as usize,
+                    new_owner_child,
+                );
+                OwnerSubtree::lemma_insert_property(
+                    owner_with_updated_value,
+                    i as usize,
+                    new_owner_child,
+                );
+                vstd::seq_lib::lemma_update_is_remove_insert(
+                    new_owner_before_update.children(),
+                    i as int,
+                    Some(new_owner_child),
+                );
+                assert(new_owner.children() == new_owner_before_update.children().remove(
+                    i as int,
+                ).insert(i as int, Some(new_owner_child)));
+                assert(owner_with_updated_value.insert(
+                    i as usize,
+                    new_owner_child,
+                ).children() == new_owner_before_update.children().update(
+                    i as int,
+                    Some(new_owner_child),
+                ));
+                assert(new_owner.children() =~= owner_with_updated_value.insert(
+                    i as usize,
+                    new_owner_child,
+                ).children());
+                assert(new_owner.children() == owner_with_updated_value.insert(
+                    i as usize,
+                    new_owner_child,
+                ).children());
+                OwnerSubtree::lemma_ext_equal(
+                    new_owner,
+                    owner_with_updated_value.insert(i as usize, new_owner_child),
+                );
+                assert(new_owner.inv());
 
                 // `replace` of a frame child preserves every slot's `inner_perms`
                 // (unconditional) and `paths_in_pt` (non-node child), so the new
@@ -1327,11 +1401,13 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             // slot's meta address, discharging `into_pte`'s `count > 0`
             // precondition.
         }
-        self.pte = (#[verus_spec(with Tracked(&mut new_owner.value), Tracked(regions))]
-        Child::PageTable(new_page).into_pte());
+        self.pte = {
+            let tracked new_owner_value = new_owner.tracked_borrow_mut_value();
+            #[verus_spec(with Tracked(new_owner_value), Tracked(regions))]
+            Child::PageTable(new_page).into_pte()
+        };
 
         proof {
-            new_owner.level = owner.level;
             *owner = new_owner;
         }
 
@@ -1340,7 +1416,8 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         //  2. The new PTE is a child in `C` and at the correct paging level.
         //  3. The ownership of the child is passed to the page table node.
         unsafe {
-            #[verus_spec(with Tracked(owner.value.tracked_borrow_mut_node()), Tracked(&*regions))]
+            let tracked owner_value = owner.tracked_borrow_mut_value();
+            #[verus_spec(with Tracked(owner_value.tracked_borrow_mut_node()), Tracked(&*regions))]
             self.node.write_pte(self.idx, self.pte)
         };
 
@@ -1701,78 +1778,78 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
              Tracked(guards): Tracked<&mut Guards<'rcu>>,
         requires
             old(owner).inv(),
-            old(owner).value.is_absent(),
-            old(owner).level < INC_LEVELS - 1,
-            old(owner).value.metaregion_sound(*old(regions)),
+            old(owner).value().is_absent(),
+            old(owner).level() < INC_LEVELS - 1,
+            old(owner).value().metaregion_sound(*old(regions)),
             old(parent_owner).inv(),
             old(parent_owner).relate_guard(*old(self)),
-            old(parent_owner).level == old(owner).value.parent_level,
+            old(parent_owner).level == old(owner).value().parent_level,
             old(parent_owner).level > 1,
             old(parent_owner).metaregion_sound_node(*old(regions)),
             idx < NR_ENTRIES,
-            old(owner).value.match_pte(
+            old(owner).value().match_pte(
                 old(parent_owner).children_perm.value()[idx as int],
-                old(owner).value.parent_level,
+                old(owner).value().parent_level,
             ),
             old(regions).inv(),
             old(regions).slots.contains_key(old(parent_owner).slot_index),
         ensures
             final(owner).inv(),
-            final(owner).value.is_node(),
-            final(owner).level == old(owner).level,
-            final(owner).value.parent_level == old(owner).value.parent_level,
-            final(owner).value.path == old(owner).value.path,
-            final(owner).value.metaregion_sound(*final(regions)),
-            final(owner).value.node().relate_guard(res),
-            final(owner).value.node().meta_addr_self() == res.inner.inner@.ptr.addr(),
-            final(owner).value.match_pte(
+            final(owner).value().is_node(),
+            final(owner).level() == old(owner).level(),
+            final(owner).value().parent_level == old(owner).value().parent_level,
+            final(owner).value().path == old(owner).value().path,
+            final(owner).value().metaregion_sound(*final(regions)),
+            final(owner).value().node().relate_guard(res),
+            final(owner).value().node().meta_addr_self() == res.inner.inner@.ptr.addr(),
+            final(owner).value().match_pte(
                 final(parent_owner).children_perm.value()[idx as int],
                 final(parent_owner).level,
             ),
-            final(guards).lock_held(final(owner).value.node().meta_addr_self()),
+            final(guards).lock_held(final(owner).value().node().meta_addr_self()),
             OwnerSubtree::implies(
                 CursorOwner::<'rcu, C>::node_unlocked(*old(guards)),
-                CursorOwner::<'rcu, C>::node_unlocked_except(*final(guards), final(owner).value.node().meta_addr_self())),
+                CursorOwner::<'rcu, C>::node_unlocked_except(*final(guards), final(owner).value().node().meta_addr_self())),
             Entry::<C>::metaregion_sound_neq_preserved(
-                old(owner).value,
-                final(owner).value,
+                old(owner).value(),
+                final(owner).value(),
                 *old(regions),
                 *final(regions),
             ),
             Entry::<C>::path_tracked_pred_preserved(*old(regions), *final(regions)),
-            old(regions).slots.contains_key(frame_to_index(final(owner).value.meta_slot_paddr()->0)),
-            final(owner).tree_predicate_map(final(owner).value.path,
-                CursorOwner::<'rcu, C>::node_unlocked_except(*final(guards), final(owner).value.node().meta_addr_self())),
-            final(owner).tree_predicate_map(final(owner).value.path, PageTableOwner::<C>::metaregion_sound_pred(*final(regions))),
-            final(owner).tree_predicate_map(final(owner).value.path, PageTableOwner::<C>::path_tracked_pred(*final(regions))),
-            PageTableOwner(*final(owner)).view_rec(final(owner).value.path) == set![],
+            old(regions).slots.contains_key(frame_to_index(final(owner).value().meta_slot_paddr()->0)),
+            final(owner).tree_predicate_map(final(owner).value().path,
+                CursorOwner::<'rcu, C>::node_unlocked_except(*final(guards), final(owner).value().node().meta_addr_self())),
+            final(owner).tree_predicate_map(final(owner).value().path, PageTableOwner::<C>::metaregion_sound_pred(*final(regions))),
+            final(owner).tree_predicate_map(final(owner).value().path, PageTableOwner::<C>::path_tracked_pred(*final(regions))),
+            PageTableOwner(*final(owner)).view_rec(final(owner).value().path) == set![],
             forall|i: int| 0 <= i < NR_ENTRIES ==>
-                #[trigger] final(owner).children[i] is Some && final(owner).children[i]->0.value.is_absent(),
+                #[trigger] final(owner).children()[i] is Some && final(owner).children()[i]->0.value().is_absent(),
             forall|i: int| 0 <= i < NR_ENTRIES ==>
-                (#[trigger] final(owner).children[i])->0.value.path
-                    == final(owner).value.path.push_tail(i as usize),
+                (#[trigger] final(owner).children()[i])->0.value().path
+                    == final(owner).value().path.push_tail(i as usize),
             crate::specs::mm::page_table::allocated_empty_node_grandchildren_none(*final(owner)),
             forall|i: int| 0 <= i < NR_ENTRIES ==>
-                (#[trigger] final(owner).children[i])->0.value.parent_level
-                    == final(owner).value.node().level,
+                (#[trigger] final(owner).children()[i])->0.value().parent_level
+                    == final(owner).value().node().level,
             forall|i: int| 0 <= i < NR_ENTRIES ==>
-                (#[trigger] final(owner).children[i])->0.value.match_pte(
-                    final(owner).value.node().children_perm.value()[i],
-                    final(owner).children[i]->0.value.parent_level),
-            forall|i: usize| i != frame_to_index(final(owner).value.meta_slot_paddr()->0) ==>
+                (#[trigger] final(owner).children()[i])->0.value().match_pte(
+                    final(owner).value().node().children_perm.value()[i],
+                    final(owner).children()[i]->0.value().parent_level),
+            forall|i: usize| i != frame_to_index(final(owner).value().meta_slot_paddr()->0) ==>
                 (#[trigger] final(regions).slot_owners[i]) == old(regions).slot_owners[i],
             forall|i: usize| old(regions).slots.contains_key(i)
                 ==> (#[trigger] final(regions).slots.contains_key(i)),
             forall|i: usize| #![trigger final(regions).slots[i]]
-                i != frame_to_index(final(owner).value.meta_slot_paddr()->0)
+                i != frame_to_index(final(owner).value().meta_slot_paddr()->0)
                     && old(regions).slots.contains_key(i)
                 ==> final(regions).slots[i] == old(regions).slots[i],
-            final(regions).slot_owners[frame_to_index(final(owner).value.meta_slot_paddr()->0)]
+            final(regions).slot_owners[frame_to_index(final(owner).value().meta_slot_paddr()->0)]
                 .inner_perms.ref_count.value() != REF_COUNT_UNUSED,
-            old(regions).slot_owners[frame_to_index(final(owner).value.meta_slot_paddr().unwrap())]
+            old(regions).slot_owners[frame_to_index(final(owner).value().meta_slot_paddr().unwrap())]
                 .inner_perms.ref_count.value() == REF_COUNT_UNUSED,
             !crate::specs::mm::frame::meta_owners::is_mmio_paddr(
-                final(owner).value.meta_slot_paddr().unwrap()),
+                final(owner).value().meta_slot_paddr().unwrap()),
             final(regions).inv(),
             final(parent_owner).inv(),
             final(parent_owner).level == old(parent_owner).level,
@@ -1783,7 +1860,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
                     == old(parent_owner).children_perm.value()[j],
             *final(self) == *old(self),
             forall |i: usize| old(guards).lock_held(i) ==> final(guards).lock_held(i),
-            forall |i: usize| old(guards).unlocked(i) && i != final(owner).value.node().meta_addr_self() ==> final(guards).unlocked(i),
+            forall |i: usize| old(guards).unlocked(i) && i != final(owner).value().node().meta_addr_self() ==> final(guards).unlocked(i),
     )]
     pub(in crate::mm) fn alloc_absent_child<A: InAtomicMode>(
         &mut self,
@@ -1796,7 +1873,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
         #[verus_spec(with Tracked(parent_meta_perm))]
         let level = self.level();
 
-        let ghost old_path = owner.value.path;
+        let ghost old_path = owner.value().path;
 
         // Discharge `nr_children < NR_ENTRIES` PRE-`alloc`, while the parent
         // slot at `idx` is still absent and `count_consistent` holds (from
@@ -1812,7 +1889,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
         let ghost cp0 = parent_owner.children_perm.value();
         // The original (absent) entry value, for the fresh-node region/
         // tree-predicate discharge after `owner` is rebuilt as the new node.
-        let ghost old_owner_val = owner.value;
+        let ghost old_owner_val = owner.value();
 
         proof_decl! {
             let tracked mut new_node_owner: Tracked<OwnerSubtree<C>>;
@@ -1823,18 +1900,21 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
 
         proof {
             let pte = C::E::new_pt_spec(
-                meta_to_frame(new_node_owner.value.node().meta_addr_self()),
+                meta_to_frame(new_node_owner.value().node().meta_addr_self()),
             );
             C::E::lemma_page_table_entry_properties();
         }
 
-        let ghost new_node_slot_idx = new_node_owner.value.node().slot_index;
+        let ghost new_node_slot_idx = new_node_owner.value().node().slot_index;
         let tracked new_node_slot_perm = regions.slots.tracked_borrow(new_node_slot_idx);
         #[verus_spec(with Tracked(new_node_slot_perm))]
         let paddr = new_page.start_paddr();
 
-        #[verus_spec(with Tracked(&mut new_node_owner.value), Tracked(regions))]
-        let new_pte = Child::PageTable(new_page).into_pte();
+        let new_pte = {
+            let tracked new_node_value = new_node_owner.tracked_borrow_mut_value();
+            #[verus_spec(with Tracked(new_node_value), Tracked(regions))]
+            Child::PageTable(new_page).into_pte()
+        };
 
         proof {
             broadcast use group_page_meta;
@@ -1846,8 +1926,11 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
             PageTableNodeRef::borrow_paddr(paddr)
         };
 
-        #[verus_spec(with Tracked(&new_node_owner.value.tracked_borrow_node()), Tracked(guards))]
-        let pt_lock_guard = pt_ref.lock(guard);
+        let pt_lock_guard = {
+            let tracked new_node_value = new_node_owner.tracked_borrow_value();
+            #[verus_spec(with Tracked(new_node_value.tracked_borrow_node()), Tracked(guards))]
+            pt_ref.lock(guard)
+        };
 
         unsafe {
             #[verus_spec(with Tracked(parent_owner), Tracked(&*regions))]
@@ -1883,17 +1966,19 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
         }
 
         proof {
-            owner.value = new_node_owner.value;
-            owner.value.parent_level = level as PagingLevel;
-            owner.value.path = old_path;
-            owner.children = new_node_owner.children;
+            {
+                let tracked new_node_value = new_node_owner.tracked_borrow_mut_value();
+                new_node_value.parent_level = level as PagingLevel;
+                new_node_value.path = old_path;
+            }
+            *owner = new_node_owner;
             crate::specs::mm::page_table::rebase_freshly_allocated_children(owner, old_path);
 
-            let new_paddr = owner.value.meta_slot_paddr().unwrap();
+            let new_paddr = owner.value().meta_slot_paddr().unwrap();
             regions.inv_implies_correct_addr(new_paddr);
             let new_idx = frame_to_index(new_paddr);
             let tracked mut new_meta_slot = regions.slot_owners.tracked_remove(new_idx);
-            new_meta_slot.paths_in_pt = set![owner.value.path];
+            new_meta_slot.paths_in_pt = set![owner.value().path];
             regions.slot_owners.tracked_insert(new_idx, new_meta_slot);
         }
 
@@ -1909,7 +1994,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
             // (which have `None` grandchildren), via
             // `fresh_node_tree_predicate_map`.
 
-            let ghost new_node_addr = owner.value.node().meta_addr_self();
+            let ghost new_node_addr = owner.value().node().meta_addr_self();
             let f_nu = CursorOwner::<'rcu, C>::node_unlocked_except(*guards, new_node_addr);
             let f_ms = PageTableOwner::<C>::metaregion_sound_pred(*regions);
             let f_pt = PageTableOwner::<C>::path_tracked_pred(*regions);
@@ -1919,26 +2004,26 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
             // Child predicates (absent children ⟹ trivial).
             assert forall|i: int| 0 <= i < NR_ENTRIES implies {
                 &&& #[trigger] f_nu(
-                    owner.children[i].unwrap().value,
-                    owner.value.path.push_tail(i as usize),
+                    owner.children()[i].unwrap().value(),
+                    owner.value().path.push_tail(i as usize),
                 )
-                &&& f_ms(owner.children[i].unwrap().value, owner.value.path.push_tail(i as usize))
-                &&& f_pt(owner.children[i].unwrap().value, owner.value.path.push_tail(i as usize))
+                &&& f_ms(owner.children()[i].unwrap().value(), owner.value().path.push_tail(i as usize))
+                &&& f_pt(owner.children()[i].unwrap().value(), owner.value().path.push_tail(i as usize))
             } by {};
 
             crate::specs::mm::page_table::fresh_node_tree_predicate_map(
                 *owner,
-                owner.value.path,
+                owner.value().path,
                 f_nu,
             );
             crate::specs::mm::page_table::fresh_node_tree_predicate_map(
                 *owner,
-                owner.value.path,
+                owner.value().path,
                 f_ms,
             );
             crate::specs::mm::page_table::fresh_node_tree_predicate_map(
                 *owner,
-                owner.value.path,
+                owner.value().path,
                 f_pt,
             );
         }

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -792,24 +792,6 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 let f_ms = PageTableOwner::<C>::metaregion_sound_pred(*regions);
                 let f_pt = PageTableOwner::<C>::path_tracked_pred(*regions);
 
-                // Root predicates.
-
-                // Child predicates (absent children ⟹ trivial).
-                assert forall|i: int| 0 <= i < NR_ENTRIES implies {
-                    &&& #[trigger] f_nu(
-                        owner.children()[i].unwrap().value(),
-                        owner.value().path.push_tail(i),
-                    )
-                    &&& f_ms(
-                        owner.children()[i].unwrap().value(),
-                        owner.value().path.push_tail(i),
-                    )
-                    &&& f_pt(
-                        owner.children()[i].unwrap().value(),
-                        owner.value().path.push_tail(i),
-                    )
-                } by {};
-
                 crate::specs::mm::page_table::fresh_node_subtree_satisfies(
                     *owner,
                     owner.value().path,

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -1155,7 +1155,8 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 // Prove required facts while we still have new_owner.value.node available.
                 let ghost the_node = new_owner.value().node();
 
-                OwnerSubtree::lemma_child_some_properties(new_owner, i as usize);
+                assert(new_owner.children()[i as int]->0.inv());
+                assert(new_owner.children()[i as int]->0.level() == new_owner.level() + 1);
                 EntryOwner::huge_frame_split_child_at(owner.value(), *regions, i as usize);
             }
 

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -1187,10 +1187,10 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 let ghost the_node = new_owner.value().node();
 
                 assert(0 <= i < NR_ENTRIES);
-                assert(new_owner.children()[i as int] is Some);
+                assert(new_owner.has_child(i as int));
                 assert(new_owner.inv_children());
-                assert(new_owner.children()[i as int]->0.inv());
-                assert(new_owner.children()[i as int]->0.level() == new_owner.level() + 1);
+                assert(new_owner.child(i as int).inv());
+                assert(new_owner.child(i as int).level() == new_owner.level() + 1);
                 EntryOwner::huge_frame_split_child_at(owner.value(), *regions, i as usize);
             }
 

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -1359,29 +1359,29 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 assert(new_owner.children() == new_owner_before_update.children().remove(
                     i as int,
                 ).insert(i as int, Some(new_owner_child)));
-                assert(owner_with_updated_value.update(
+                assert(owner_with_updated_value.insert(
                     i as int,
                     new_owner_child,
                 ).children() == new_owner_before_update.children().update(
                     i as int,
                     Some(new_owner_child),
                 ));
-                assert(new_owner.children() =~= owner_with_updated_value.update(
+                assert(new_owner.children() =~= owner_with_updated_value.insert(
                     i as int,
                     new_owner_child,
                 ).children());
-                assert(new_owner.children() == owner_with_updated_value.update(
+                assert(new_owner.children() == owner_with_updated_value.insert(
                     i as int,
                     new_owner_child,
                 ).children());
                 OwnerSubtree::lemma_ext_equal(
                     new_owner,
-                    owner_with_updated_value.update(i as int, new_owner_child),
+                    owner_with_updated_value.insert(i as int, new_owner_child),
                 );
                 assert forall|j: int| 0 <= j < NR_ENTRIES implies
                     (#[trigger] new_owner.children()[j]) is Some by {
                     if j != i {
-                        assert(owner_with_updated_value.update(
+                        assert(owner_with_updated_value.insert(
                             i as int,
                             new_owner_child,
                         ).children()[j] == owner_with_updated_value.children()[j]);

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -1142,10 +1142,14 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             );
 
             let ghost new_owner_before_update = new_owner;
-            let tracked mut new_owner_child = new_owner.tracked_remove_child(
-                i as int,
-            ).tracked_unwrap();
-            let ghost new_owner_child_before_update = new_owner_child;
+            // Take the node out before borrowing the child in place so the two
+            // mutable borrows of `new_owner` do not overlap.
+            let tracked mut new_owner_node = {
+                let tracked new_owner_value = new_owner.tracked_borrow_mut_value();
+                new_owner_value.tracked_take_node()
+            };
+            let tracked mut new_owner_child = new_owner.tracked_borrow_mut_child(i as int);
+            let ghost new_owner_child_before_update = *new_owner_child;
 
             proof {
                 let idx = frame_to_index(small_pa);
@@ -1267,14 +1271,6 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 }
             }
 
-            // Take the node OUT (vs borrowing in place) to keep Verus's
-            // loop-invariant maintenance tracking intact across the per-child
-            // `replace`; the in-place `tracked_borrow_mut_node` form loses the
-            // new node's own-slot facts at the loop back-edge.
-            let tracked mut new_owner_node = {
-                let tracked new_owner_value = new_owner.tracked_borrow_mut_value();
-                new_owner_value.tracked_take_node()
-            };
             // Snapshot the node's own-slot facts while the loop invariant still
             // holds (regions unchanged since loop entry), so we can frame them
             // across the `replace` below.
@@ -1301,7 +1297,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             proof {
                 new_owner_child_before_update.lemma_set_value_observable_fields(child_owner);
                 OwnerSubtree::lemma_ext_equal(
-                    new_owner_child,
+                    *new_owner_child,
                     new_owner_child_before_update.set_value(child_owner),
                 );
                 assert(new_owner_child.inv());
@@ -1310,37 +1306,36 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                     let tracked new_owner_value = new_owner.tracked_borrow_mut_value();
                     new_owner_value.tracked_put_node(new_owner_node);
                 }
-                new_owner.tracked_insert_child(i as int, Some(new_owner_child));
 
                 let owner_with_updated_value = new_owner_before_update.set_value(new_owner.value());
                 vstd::seq_lib::lemma_update_is_remove_insert(
                     new_owner_before_update.children(),
                     i as int,
-                    Some(new_owner_child),
+                    Some(*new_owner_child),
                 );
                 assert(new_owner.children() == new_owner_before_update.children().remove(
                     i as int,
-                ).insert(i as int, Some(new_owner_child)));
-                assert(owner_with_updated_value.insert(i as int, new_owner_child).children()
-                    == new_owner_before_update.children().update(i as int, Some(new_owner_child)));
+                ).insert(i as int, Some(*new_owner_child)));
+                assert(owner_with_updated_value.insert(i as int, *new_owner_child).children()
+                    == new_owner_before_update.children().update(i as int, Some(*new_owner_child)));
                 assert(new_owner.children() =~= owner_with_updated_value.insert(
                     i as int,
-                    new_owner_child,
+                    *new_owner_child,
                 ).children());
                 assert(new_owner.children() == owner_with_updated_value.insert(
                     i as int,
-                    new_owner_child,
+                    *new_owner_child,
                 ).children());
                 OwnerSubtree::lemma_ext_equal(
                     new_owner,
-                    owner_with_updated_value.insert(i as int, new_owner_child),
+                    owner_with_updated_value.insert(i as int, *new_owner_child),
                 );
                 assert forall|j: int| 0 <= j < NR_ENTRIES implies (
                 #[trigger] new_owner.children()[j]) is Some by {
                     if j != i {
                         assert(owner_with_updated_value.insert(
                             i as int,
-                            new_owner_child,
+                            *new_owner_child,
                         ).children()[j] == owner_with_updated_value.children()[j]);
                     }
                 };

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -509,22 +509,22 @@ impl<C: PageTableConfig> PageTableNode<C> {
             final(parent_owner).inv(),
             allocated_empty_node_owner(owner@, level),
             allocated_empty_node_grandchildren_none(owner@),
-            res.ptr.addr() == owner@.value.node().meta_addr_self(),
-            guards.unlocked(owner@.value.node().meta_addr_self()),
-            MetaSlot::get_node_from_unused_spec(meta_to_frame(owner@.value.node().meta_addr_self()), *old(regions), *final(regions)),
-            MetaSlot::slot_perm_reparked_spec(meta_to_frame(owner@.value.node().meta_addr_self()), *old(regions), *final(regions)),
+            res.ptr.addr() == owner@.value().node().meta_addr_self(),
+            guards.unlocked(owner@.value().node().meta_addr_self()),
+            MetaSlot::get_node_from_unused_spec(meta_to_frame(owner@.value().node().meta_addr_self()), *old(regions), *final(regions)),
+            MetaSlot::slot_perm_reparked_spec(meta_to_frame(owner@.value().node().meta_addr_self()), *old(regions), *final(regions)),
 
             final(regions).frame_obligations == old(regions).frame_obligations.insert(
-                frame_to_index(meta_to_frame(owner@.value.node().meta_addr_self()))),
-            old(regions).slots.contains_key(frame_to_index(meta_to_frame(owner@.value.node().meta_addr_self()))),
+                frame_to_index(meta_to_frame(owner@.value().node().meta_addr_self()))),
+            old(regions).slots.contains_key(frame_to_index(meta_to_frame(owner@.value().node().meta_addr_self()))),
 
             !crate::specs::mm::frame::meta_owners::is_mmio_paddr(
-                meta_to_frame(owner@.value.node().meta_addr_self())),
-            owner@.value.metaregion_sound(*final(regions)),
+                meta_to_frame(owner@.value().node().meta_addr_self())),
+            owner@.value().metaregion_sound(*final(regions)),
             forall|i: usize|
                 #[trigger] old(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-                ==> i != frame_to_index(meta_to_frame(owner@.value.node().meta_addr_self())),
-            owner@.value.match_pte(C::E::new_pt_spec(meta_to_frame(owner@.value.node().meta_addr_self())), level as PagingLevel),
+                ==> i != frame_to_index(meta_to_frame(owner@.value().node().meta_addr_self())),
+            owner@.value().match_pte(C::E::new_pt_spec(meta_to_frame(owner@.value().node().meta_addr_self())), level as PagingLevel),
             final(parent_owner).meta_own == old(parent_owner).meta_own,
             final(parent_owner).slot_index == old(parent_owner).slot_index,
             final(parent_owner).level == old(parent_owner).level,
@@ -532,10 +532,10 @@ impl<C: PageTableConfig> PageTableNode<C> {
             final(parent_owner).children_perm.addr() == old(parent_owner).children_perm.addr(),
             final(parent_owner).children_perm.value() == old(parent_owner).children_perm.value().update(
                 idx as int,
-                C::E::new_pt_spec(meta_to_frame(owner@.value.node().meta_addr_self())),
+                C::E::new_pt_spec(meta_to_frame(owner@.value().node().meta_addr_self())),
             ),
-            final(regions).slots.contains_key(owner@.value.node().slot_index),
-            owner@.value.node().metaregion_sound_node(*final(regions)),
+            final(regions).slots.contains_key(owner@.value().node().slot_index),
+            owner@.value().node().metaregion_sound_node(*final(regions)),
     )]
     #[verifier::external_body]
     pub fn alloc<'rcu>(level: PagingLevel) -> Self {
@@ -544,7 +544,7 @@ impl<C: PageTableConfig> PageTableNode<C> {
             level,
         );
 
-        let tracked mut owner = OwnerSubtree::<C>::new_val_tracked(entry_owner, level as nat);
+        let tracked mut owner = OwnerSubtree::<C>::tracked_new_val(entry_owner, level as nat);
         let meta = PageTablePageMeta::new(level);
         let mut frame = FrameAllocOptions::new();
         frame.zeroed(true);

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -226,7 +226,7 @@ impl<'a> VmSpace<'a> {
                 -> cursor_owner: Tracked<Option<CursorOwner<'a, UserPtConfig>>>,
         requires
             self.pt.relates_owner(owner, *old(regions)),
-            owner.0.value.node().relate_guard(root_guard),
+            owner.0.value().node().relate_guard(root_guard),
             va.end > 0,
         ensures
             crate::mm::page_table::Cursor::<UserPtConfig, G>::cursor_new_success_conditions(*va) ==> (r matches Ok(_) && cursor_owner@ matches Some(_)),
@@ -287,7 +287,7 @@ impl<'a> VmSpace<'a> {
                 -> cursor_owner: Tracked<Option<CursorOwner<'a, UserPtConfig>>>,
         requires
             self.pt.relates_owner(owner, *old(regions)),
-            owner.0.value.node().relate_guard(root_guard),
+            owner.0.value().node().relate_guard(root_guard),
             va.end > 0,
         ensures
             crate::mm::page_table::Cursor::<UserPtConfig, G>::cursor_new_success_conditions(*va) ==> (r matches Ok(_) && cursor_owner@ matches Some(_)),

--- a/verified_libs/vstd_extra/src/ghost_tree.rs
+++ b/verified_libs/vstd_extra/src/ghost_tree.rs
@@ -8,9 +8,10 @@ use super::seq_extra::*;
 
 verus! {
 
-/// Path from the current node to the leaf of the tree
-/// `N` is the maximum number of children of a tree node
-/// `TreePath.index(i)` returns the `i`-th element of the path
+/// A sequence of child indices describing a path from a starting node to a target node.
+///
+/// Each element selects one child at the corresponding tree level.
+/// `N` is the maximum number of children of each node, so every index is less than `N`.
 #[verifier::ext_equal]
 pub tracked struct TreePath<const N: usize>(pub Seq<usize>);
 
@@ -26,24 +27,20 @@ impl<const N: usize> TreePath<N> {
         self.0[i]
     }
 
+    pub open spec fn spec_index(self, i:int) -> usize {
+        self.index(i)
+    }
+
     pub open spec fn elem_inv(e: usize) -> bool {
         0 <= e < N
     }
 
     pub open spec fn inv(self) -> bool {
         &&& N > 0
-        &&& forall|i: int| 0 <= i < self.len() ==> Self::elem_inv(#[trigger] self.index(i))
+        &&& forall |i: int| 0 <= i < self.len() ==> Self::elem_inv(#[trigger] self.index(i))
     }
 
-    pub broadcast proof fn inv_property(self)
-        requires
-            #[trigger] self.inv(),
-        ensures
-            forall|i: int| 0 <= i < self.len() ==> #[trigger] Self::elem_inv(self.index(i)),
-    {
-    }
-
-    pub broadcast proof fn index_satisfies_elem_inv(self, i: int)
+    pub broadcast proof fn lemma_index_satisfies_elem_inv(self, i: int)
         requires
             self.inv(),
             0 <= i < self.len(),
@@ -56,7 +53,7 @@ impl<const N: usize> TreePath<N> {
         self.len() == 0
     }
 
-    pub broadcast proof fn empty_satisfies_inv(self)
+    pub proof fn lemma_empty_satisfies_inv(self)
         requires
             N > 0,
             #[trigger] self.is_empty(),
@@ -69,28 +66,6 @@ impl<const N: usize> TreePath<N> {
         Self(self.0.add(path.0))
     }
 
-    pub broadcast proof fn drop_head_property(self)
-        requires
-            !#[trigger] self.is_empty(),
-        ensures
-            self.0.drop_first().len() == self.len() - 1,
-            forall|i: int|
-                0 <= i < self.0.drop_first().len() ==> #[trigger] self.0.drop_first().index(i)
-                    == self.index(i + 1),
-    {
-    }
-
-    pub broadcast proof fn drop_last_property(self)
-        requires
-            !#[trigger] self.is_empty(),
-        ensures
-            self.0.drop_last().len() == self.len() - 1,
-            forall|i: int|
-                0 <= i < self.0.drop_last().len() ==> #[trigger] self.0.drop_last().index(i)
-                    == self.index(i),
-    {
-    }
-
     pub open spec fn pop_head(self) -> (usize, TreePath<N>)
         recommends
             !self.is_empty(),
@@ -98,47 +73,25 @@ impl<const N: usize> TreePath<N> {
         (self.index(0), TreePath(self.0.drop_first()))
     }
 
-    pub broadcast proof fn pop_head_preserves_inv(self)
+    pub broadcast proof fn lemma_pop_head_preserves_inv(self)
         requires
-            #[trigger] self.inv(),
+            self.inv(),
             !self.is_empty(),
         ensures
             Self::elem_inv(self.pop_head().0),
-            self.pop_head().1.inv(),
+            (#[trigger] self.pop_head()).1.inv(),
     {
         let (_, s1) = self.pop_head();
         assert(forall|i: int| 0 <= i < s1.len() ==> s1.index(i) == self.index(i + 1));
     }
 
-    pub broadcast proof fn pop_head_decreases_len(self)
+    pub broadcast proof fn lemma_pop_head_index(self)
         requires
             self.inv(),
             !self.is_empty(),
         ensures
-            #[trigger] self.pop_head().1.len() == self.len() - 1,
+            (#[trigger] self.pop_head()).0 == self.index(0),
     {
-    }
-
-    pub broadcast proof fn pop_head_head_satisfies_inv(self)
-        requires
-            self.inv(),
-            !self.is_empty(),
-        ensures
-            #[trigger] Self::elem_inv(self.pop_head().0),
-    {
-    }
-
-    pub broadcast proof fn pop_head_property(self)
-        requires
-            self.inv(),
-            !self.is_empty(),
-        ensures
-            #[trigger] self.pop_head().0 == self.index(0),
-            self.pop_head().1.len() == self.len() - 1,
-            Self::elem_inv(self.pop_head().0),
-            self.pop_head().1.inv(),
-    {
-        self.pop_head_preserves_inv();
     }
 
     pub open spec fn pop_tail(self) -> (usize, TreePath<N>)
@@ -148,13 +101,13 @@ impl<const N: usize> TreePath<N> {
         (self.index(self.len() as int - 1), TreePath(self.0.drop_last()))
     }
 
-    pub broadcast proof fn pop_tail_preserves_inv(self)
+    pub broadcast proof fn lemma_pop_tail_preserves_inv(self)
         requires
-            #[trigger] self.inv(),
+            self.inv(),
             !self.is_empty(),
         ensures
             Self::elem_inv(self.pop_tail().0),
-            self.pop_tail().1.inv(),
+            (#[trigger] self.pop_tail()).1.inv(),
     {
         let (_, s1) = self.pop_tail();
         if s1.len() > 0 {
@@ -162,35 +115,13 @@ impl<const N: usize> TreePath<N> {
         }
     }
 
-    pub broadcast proof fn pop_tail_decreases_len(self)
+    pub broadcast proof fn lemma_pop_tail_index(self)
         requires
             self.inv(),
             !self.is_empty(),
         ensures
-            #[trigger] self.pop_tail().1.len() == self.len() - 1,
+            (#[trigger] self.pop_tail()).0 == self.index(self.len() as int - 1),
     {
-    }
-
-    pub broadcast proof fn pop_tail_tail_satisfies_inv(self)
-        requires
-            self.inv(),
-            !self.is_empty(),
-        ensures
-            #[trigger] Self::elem_inv(self.pop_tail().0),
-    {
-    }
-
-    pub broadcast proof fn pop_tail_property(self)
-        requires
-            self.inv(),
-            !self.is_empty(),
-        ensures
-            #[trigger] self.pop_tail().0 == self.index(self.len() as int - 1),
-            self.pop_tail().1.len() == self.len() - 1,
-            Self::elem_inv(self.pop_tail().0),
-            self.pop_tail().1.inv(),
-    {
-        self.pop_tail_preserves_inv();
     }
 
     pub open spec fn push_head(self, hd: usize) -> TreePath<N>
@@ -200,16 +131,7 @@ impl<const N: usize> TreePath<N> {
         TreePath(seq![hd].add(self.0))
     }
 
-    pub proof fn push_head_property_len(self, hd: usize)
-        requires
-            self.inv(),
-            0 <= hd < N,
-        ensures
-            self.push_head(hd).len() == self.len() + 1,
-    {
-    }
-
-    pub proof fn push_head_property_index(self, hd: usize)
+    pub proof fn lemma_push_head_index(self, hd: usize)
         requires
             self.inv(),
             0 <= hd < N,
@@ -219,12 +141,12 @@ impl<const N: usize> TreePath<N> {
     {
     }
 
-    pub proof fn push_head_preserves_inv(self, hd: usize)
+    pub broadcast proof fn lemma_push_head_preserves_inv(self, hd: usize)
         requires
             self.inv(),
             0 <= hd < N,
         ensures
-            self.push_head(hd).inv(),
+            (#[trigger] self.push_head(hd)).inv(),
     {
         let s1 = self.push_head(hd);
         assert forall|i: int| 0 <= i < s1.len() implies Self::elem_inv(#[trigger] s1.index(i)) by {
@@ -235,21 +157,6 @@ impl<const N: usize> TreePath<N> {
         }
     }
 
-    pub broadcast proof fn push_head_property(self, hd: usize)
-        requires
-            self.inv(),
-            0 <= hd < N,
-        ensures
-            #[trigger] self.push_head(hd).inv(),
-            self.push_head(hd).len() == self.len() + 1,
-            self.push_head(hd).index(0) == hd,
-            forall|i: int| 0 <= i < self.len() ==> self.push_head(hd).index(i + 1) == self.index(i),
-    {
-        self.push_head_property_len(hd);
-        self.push_head_property_index(hd);
-        self.push_head_preserves_inv(hd);
-    }
-
     pub open spec fn push_tail(self, val: usize) -> TreePath<N>
         recommends
             0 <= val < N,
@@ -257,16 +164,16 @@ impl<const N: usize> TreePath<N> {
         TreePath(self.0.push(val))
     }
 
-    pub proof fn push_tail_property_len(self, val: usize)
+    pub broadcast proof fn lemma_push_tail_len(self, val: usize)
         requires
             self.inv(),
             0 <= val < N,
         ensures
-            self.push_tail(val).len() == self.len() + 1,
+            (#[trigger] self.push_tail(val)).len() == self.len() + 1,
     {
     }
 
-    pub proof fn push_tail_property_index(self, val: usize)
+    pub proof fn lemma_push_tail_index(self, val: usize)
         requires
             self.inv(),
             0 <= val < N,
@@ -277,12 +184,12 @@ impl<const N: usize> TreePath<N> {
     {
     }
 
-    pub proof fn push_tail_preserves_inv(self, val: usize)
+    pub broadcast proof fn lemma_push_tail_preserves_inv(self, val: usize)
         requires
             self.inv(),
             0 <= val < N,
         ensures
-            self.push_tail(val).inv(),
+            (#[trigger]self.push_tail(val)).inv(),
     {
         let s1 = self.push_tail(val);
         assert forall|i: int| 0 <= i < s1.len() implies Self::elem_inv(#[trigger] s1.index(i)) by {
@@ -293,22 +200,6 @@ impl<const N: usize> TreePath<N> {
         }
     }
 
-    pub broadcast proof fn push_tail_property(self, val: usize)
-        requires
-            self.inv(),
-            0 <= val < N,
-        ensures
-            #[trigger] self.push_tail(val).inv(),
-            self.push_tail(val).len() == self.len() + 1,
-            self.push_tail(val).index(self.len() as int) == val,
-            forall|i: int|
-                0 <= i < self.len() ==> #[trigger] self.push_tail(val).index(i) == self.index(i),
-    {
-        self.push_tail_property_len(val);
-        self.push_tail_property_index(val);
-        self.push_tail_preserves_inv(val);
-    }
-
     pub open spec fn new(path: Seq<usize>) -> TreePath<N>
         recommends
             forall|i: int| 0 <= i < path.len() ==> Self::elem_inv(#[trigger] path[i]),
@@ -316,7 +207,7 @@ impl<const N: usize> TreePath<N> {
         TreePath(path)
     }
 
-    pub broadcast proof fn new_preserves_inv(path: Seq<usize>)
+    pub broadcast proof fn lemma_new_preserves_inv(path: Seq<usize>)
         requires
             N > 0,
             forall|i: int| 0 <= i < path.len() ==> Self::elem_inv(#[trigger] path[i]),
@@ -325,13 +216,6 @@ impl<const N: usize> TreePath<N> {
     {
     }
 
-    pub broadcast proof fn new_empty_preserves_inv()
-        requires
-            N > 0,
-        ensures
-            #[trigger] Self::new(Seq::empty()).inv(),
-    {
-    }
 }
 
 } // verus!
@@ -340,21 +224,21 @@ verus! {
 pub trait TreeNodeValue<const L: usize>: Sized + Inv {
     spec fn default(lv: nat) -> Self;
 
-    proof fn default_preserves_inv()
+    proof fn lemma_default_preserves_inv()
         ensures
             forall|lv: nat| #[trigger] Self::default(lv).inv(),
     ;
 
     spec fn la_inv(self, lv: nat) -> bool;
 
-    proof fn default_preserves_la_inv()
+    proof fn lemma_default_preserves_la_inv()
         ensures
             forall|lv: nat| #[trigger] Self::default(lv).la_inv(lv),
     ;
 
     spec fn rel_children(self, index: int, child: Option<Self>) -> bool;
 
-    proof fn default_preserves_rel_children(self, lv: nat)
+    proof fn lemma_default_preserves_rel_children(self, lv: nat)
         requires
             self.inv(),
             self.la_inv(lv),
@@ -367,12 +251,29 @@ pub trait TreeNodeValue<const L: usize>: Sized + Inv {
 /// the maximum depth of the tree is `L`
 /// Each tree node has a value of type `T` and a sequence of children
 pub tracked struct Node<T: TreeNodeValue<L>, const N: usize, const L: usize> {
-    pub tracked value: T,
-    pub ghost level: nat,
-    pub tracked children: Seq<Option<Node<T, N, L>>>,
+    tracked value: T,
+    ghost level: nat,
+    // FIXME: This should use tracked indirection, but that is blocked by
+    // https://github.com/verus-lang/verus/issues/2627.
+    tracked children: Ghost<Seq<Option<Node<T, N, L>>>>,
 }
 
 impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
+    /// Returns the value stored in this node.
+    pub closed spec fn value(self) -> T {
+        self.value
+    }
+
+    /// Returns the level of this node.
+    pub closed spec fn level(self) -> nat {
+        self.level
+    }
+
+    /// Returns the sequence of children.
+    pub closed spec fn children(self) -> Seq<Option<Self>> {
+        self.children@
+    }
+
     #[verifier::inline]
     pub open spec fn size() -> nat {
         N as nat
@@ -383,32 +284,187 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
         L as nat
     }
 
-    pub proof fn borrow_value(tracked &self) -> (tracked res: &T)
+    /// Constructs a node from its fields.
+    pub closed spec fn new(value: T, level: nat, children: Seq<Option<Self>>) -> Self {
+        Node { value, level, children: Ghost::new(children) }
+    }
+
+    pub open spec fn new_default(lv: nat) -> Self {
+        Self::new(T::default(lv), lv, Seq::new(N as nat, |i| None))
+    }
+
+    pub open spec fn new_val(val: T, lv: nat) -> Self
+        recommends
+            lv < L,
+    {
+        Self::new(val, lv, Seq::new(N as nat, |i| None))
+    }
+
+    /// Exposes the observable shape of a node returned by `tracked_new_val`.
+    pub proof fn lemma_new_val_properties(self, val: T, lv: nat)
+        requires
+            self == Self::new_val(val, lv),
         ensures
-            *res == self.value,
+            self.value() == val,
+            self.level() == lv,
+            self.children() == Seq::new(N as nat, |i| None),
+            self == Self::new_val(self.value(), self.level()),
+    {
+        Self::lemma_new_properties(val, lv, Seq::new(N as nat, |i| None));
+    }
+
+    pub open spec fn inv_node(self) -> bool {
+        &&& self.value().inv()
+        &&& self.value().la_inv(self.level())
+        &&& self.level() < L
+        &&& self.children().len() == Self::size()
+    }
+
+    pub open spec fn inv_children(self) -> bool {
+        if self.level() == L - 1 {
+            forall|i: int| 0 <= i < Self::size() ==> #[trigger] self.children()[i] is None
+        } else {
+            forall|i: int|
+                0 <= i < Self::size() ==> match #[trigger] self.children()[i] {
+                    Some(child) => {
+                        &&& child.level() == self.level() + 1
+                        &&& self.value().rel_children(i, Some(child.value()))
+                    },
+                    None => self.value().rel_children(i, None),
+                }
+        }
+    }
+
+    pub open spec fn inv(self) -> bool
+        decreases (L - self.level()),
+    {
+        &&& L > 0
+        &&& N > 0
+        &&& self.inv_node()
+        &&& self.inv_children()
+        &&& if L - self.level() == 1 {
+            // leaf nodes
+            true
+        } else {
+            // pass invariants to children
+            forall|i: int|
+                0 <= i < Self::size() ==> match #[trigger] self.children()[i] {
+                    Some(child) => child.inv(),
+                    None => true,
+                }
+        }
+    }
+
+    pub broadcast proof fn lemma_new_properties(
+        value: T,
+        level: nat,
+        children: Seq<Option<Self>>,
+    )
+        ensures
+            #[trigger] Self::new(value, level, children).value() == value,
+            Self::new(value, level, children).level() == level,
+            Self::new(value, level, children).children() == children,
+    {
+    }
+
+    /// Two nodes are equal when all of their observable fields are equal.
+    pub proof fn lemma_ext_equal(self, other: Self)
+        requires
+            self.value() == other.value(),
+            self.level() == other.level(),
+            self.children() == other.children(),
+        ensures
+            self == other,
+    {
+    }
+
+    /// Removes a child from the underlying sequence.
+    pub axiom fn tracked_remove_child(tracked &mut self, i: int) -> (tracked ret: Option<Self>)
+        requires
+            0 <= i < old(self).children().len(),
+        ensures
+            ret == old(self).children()[i],
+            final(self).children().len() == old(self).children().len() - 1,
+            final(self).children() == old(self).children().remove(i),
+            final(self).value() == old(self).value(),
+            final(self).level() == old(self).level(),
+    ;
+
+    /// Inserts a child into the underlying sequence.
+    pub axiom fn tracked_insert_child(
+        tracked &mut self,
+        i: int,
+        tracked child: Option<Self>,
+    )
+        requires
+            0 <= i <= old(self).children().len(),
+        ensures
+            final(self).children().len() == old(self).children().len() + 1,
+            final(self).children() == old(self).children().insert(i, child),
+            final(self).value() == old(self).value(),
+            final(self).level() == old(self).level(),
+    ;
+
+    /// Borrows a child from the underlying sequence.
+    pub axiom fn tracked_borrow_child(tracked &self, i: int) -> (tracked ret: &Self)
+        requires
+            0 <= i < self.children().len(),
+            self.children()[i] is Some,
+        ensures
+            *ret == self.children()[i] -> 0,
+    ;
+
+    pub axiom fn tracked_borrow_mut_child(tracked &mut self, i: int) -> (tracked ret: &mut Self)
+        requires
+            0 <= i < self.children().len(),
+            self.children()[i] is Some,
+        ensures
+            *ret == old(self).children()[i]->0,
+            final(self).value() == old(self).value(),
+            final(self).level() == old(self).level(),
+            final(self).children() == old(self).children().update(i, Some(*final(ret))),
+            ;
+
+    pub proof fn tracked_borrow_value(tracked &self) -> (tracked res: &T)
+        ensures
+            *res == self.value(),
     {
         &self.value
     }
 
+    pub proof fn tracked_borrow_mut_value(tracked &mut self) -> (tracked res: &mut T)
+        ensures
+            *res == old(self).value(),
+            final(self).value() == *final(res),
+            final(self).level() == old(self).level(),
+            final(self).children() == old(self).children(),
+    {
+        &mut self.value
+    }
+
+    /// Requires `f` to hold for this node and every present descendant.
+    ///
+    /// `path` identifies the current node. When descending through child index `i`, the
+    /// corresponding child path is `path.push_tail(i)`.
     pub open spec fn tree_predicate_map(
         self,
         path: TreePath<N>,
         f: spec_fn(T, TreePath<N>) -> bool,
     ) -> bool
-        decreases L - self.level,
+        decreases L - self.level(),
         when self.inv()
     {
-        if self.level < L - 1 {
-            &&& f(self.value, path)
+        if self.level() < L - 1 {
+            &&& f(self.value(), path)
             &&& forall|i: int|
-                0 <= i < self.children.len() ==> (#[trigger] self.children[i]) is Some
-                    ==> self.children[i]->0.tree_predicate_map(path.push_tail(i as usize), f)
+                0 <= i < self.children().len() ==> (#[trigger] self.children()[i]) is Some
+                    ==> self.children()[i]->0.tree_predicate_map(path.push_tail(i as usize), f)
         } else {
-            &&& f(self.value, path)
+            &&& f(self.value(), path)
         }
     }
 
-    pub proof fn map_unroll_once(
+    pub proof fn lemma_map_unroll_once(
         self,
         path: TreePath<N>,
         f: spec_fn(T, TreePath<N>) -> bool,
@@ -416,12 +472,12 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
     )
         requires
             self.inv(),
-            self.level < L - 1,
-            0 <= i < self.children.len(),
-            self.children[i] is Some,
+            self.level() < L - 1,
+            0 <= i < self.children().len(),
+            self.children()[i] is Some,
             self.tree_predicate_map(path, f),
         ensures
-            self.children[i]->0.tree_predicate_map(path.push_tail(i as usize), f),
+            self.children()[i]->0.tree_predicate_map(path.push_tail(i as usize), f),
     {
     }
 
@@ -429,11 +485,11 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
         f: spec_fn(T, TreePath<N>) -> bool,
         g: spec_fn(T, TreePath<N>) -> bool,
     ) -> bool {
-        forall|value: T, path: TreePath<N>|
+        forall |value: T, path: TreePath<N>|
             value.inv() ==> f(value, path) ==> #[trigger] g(value, path)
     }
 
-    pub proof fn map_implies(
+    pub proof fn lemma_map_implies(
         self,
         path: TreePath<N>,
         f: spec_fn(T, TreePath<N>) -> bool,
@@ -445,49 +501,49 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             Self::tree_predicate_map(self, path, f),
         ensures
             Self::tree_predicate_map(self, path, g),
-        decreases L - self.level,
+        decreases L - self.level(),
     {
-        if self.level < L - 1 {
+        if self.level() < L - 1 {
             assert forall|i: int|
-                #![trigger self.children[i]->0]
-                0 <= i < self.children.len()
-                    && self.children[i] is Some implies self.children[i]->0.tree_predicate_map(
+                #![trigger self.children()[i]->0]
+                0 <= i < self.children().len()
+                    && self.children()[i] is Some implies self.children()[i]->0.tree_predicate_map(
                 path.push_tail(i as usize),
                 g,
             ) by {
-                self.children[i]->0.map_implies(path.push_tail(i as usize), f, g);
+                self.children()[i]->0.lemma_map_implies(path.push_tail(i as usize), f, g);
             }
         }
     }
 
-    /// `Node::new(lv)` has all-None children, so `tree_predicate_map` reduces to `f(default(lv), path)`.
-    pub proof fn new_tree_predicate_map(
+    /// `Node::new_default(lv)` has all-None children, so `tree_predicate_map` reduces to `f(default(lv), path)`.
+    pub proof fn lemma_new_tree_predicate_map(
         lv: nat,
         path: TreePath<N>,
         f: spec_fn(T, TreePath<N>) -> bool,
     )
         requires
             lv < L,
-            Self::new(lv).inv(),
+            Self::new_default(lv).inv(),
             f(T::default(lv), path),
         ensures
-            Self::new(lv).tree_predicate_map(path, f),
+            Self::new_default(lv).tree_predicate_map(path, f),
     {
-        // Self::new(lv).children[i] = None for all i, so the forall in tree_predicate_map is vacuous.
+        // Self::new_default(lv).children()[i] = None for all i, so the forall in tree_predicate_map is vacuous.
     }
 
     /// `Node::new_val(val, lv)` has all-None children.
     /// `tree_predicate_map` holds trivially: `f(val, path)` at the root,
     /// no children to recurse into.
-    pub proof fn new_val_tree_predicate_map(
+    pub proof fn lemma_new_val_tree_predicate_map(
         self,
         path: TreePath<N>,
         f: spec_fn(T, TreePath<N>) -> bool,
     )
         requires
             self.inv(),
-            self == Self::new_val(self.value, self.level),
-            f(self.value, path),
+            self == Self::new_val(self.value(), self.level()),
+            f(self.value(), path),
         ensures
             self.tree_predicate_map(path, f),
     {
@@ -496,7 +552,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
 
     /// Proves `tree_predicate_map(self, path, g)` from two source predicates `f1`, `f2`,
     /// and the implication `forall |v, p| v.inv() && f1(v, p) && f2(v, p) ==> g(v, p)`.
-    pub proof fn map_implies_and(
+    pub proof fn lemma_map_implies_and(
         self,
         path: TreePath<N>,
         f1: spec_fn(T, TreePath<N>) -> bool,
@@ -510,75 +566,22 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             Self::tree_predicate_map(self, path, f2),
         ensures
             Self::tree_predicate_map(self, path, g),
-        decreases L - self.level,
+        decreases L - self.level(),
     {
-        if self.level < L - 1 {
+        if self.level() < L - 1 {
             assert forall|i: int|
-                #![trigger self.children[i]->0]
-                0 <= i < self.children.len()
-                    && self.children[i] is Some implies self.children[i]->0.tree_predicate_map(
+                #![trigger self.children()[i]->0]
+                0 <= i < self.children().len()
+                    && self.children()[i] is Some implies self.children()[i]->0.tree_predicate_map(
                 path.push_tail(i as usize),
                 g,
             ) by {
-                self.children[i]->0.map_implies_and(path.push_tail(i as usize), f1, f2, g);
+                self.children()[i]->0.lemma_map_implies_and(path.push_tail(i as usize), f1, f2, g);
             }
         }
     }
 
-    pub open spec fn inv_node(self) -> bool {
-        &&& self.value.inv()
-        &&& self.value.la_inv(self.level)
-        &&& self.level < L
-        &&& self.children.len() == Self::size()
-    }
-
-    pub open spec fn inv_children(self) -> bool {
-        if self.level == L - 1 {
-            forall|i: int| 0 <= i < Self::size() ==> #[trigger] self.children[i] is None
-        } else {
-            forall|i: int|
-                0 <= i < Self::size() ==> match #[trigger] self.children[i] {
-                    Some(child) => {
-                        &&& child.level == self.level + 1
-                        &&& self.value.rel_children(i, Some(child.value))
-                    },
-                    None => self.value.rel_children(i, None),
-                }
-        }
-    }
-
-    pub open spec fn inv(self) -> bool
-        decreases (L - self.level),
-    {
-        &&& L > 0
-        &&& N > 0
-        &&& self.inv_node()
-        &&& self.inv_children()
-        &&& if L - self.level == 1 {
-            // leaf nodes
-            true
-        } else {
-            // pass invariants to children
-            forall|i: int|
-                0 <= i < Self::size() ==> match #[trigger] self.children[i] {
-                    Some(child) => child.inv(),
-                    None => true,
-                }
-        }
-    }
-
-    pub open spec fn new(lv: nat) -> Self {
-        Node { value: T::default(lv), level: lv, children: Seq::new(N as nat, |i| None) }
-    }
-
-    pub open spec fn new_val(val: T, lv: nat) -> Self
-        recommends
-            lv < L,
-    {
-        Node { value: val, level: lv, children: Seq::new(N as nat, |i| None) }
-    }
-
-    pub axiom fn new_val_tracked(tracked val: T, lv: nat) -> (tracked res: Self)
+    pub axiom fn tracked_new_val(tracked val: T, lv: nat) -> (tracked res: Self)
         requires
             0 <= lv < L,
             N > 0,
@@ -589,17 +592,16 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             Self::new_val(val, lv),
     ;
 
-    pub broadcast proof fn new_preserves_inv(lv: nat)
+    pub broadcast proof fn lemma_new_default_preserves_inv(lv: nat)
         requires
             0 <= lv < L,
             N > 0,
             forall|i: int| 0 <= i < N ==> #[trigger] T::default(lv).rel_children(i, None),
         ensures
-            #[trigger] Self::new(lv).inv(),
-            forall|i: int| 0 <= i < N ==> #[trigger] Self::new(lv).value.rel_children(i, None),
+            (#[trigger] Self::new_default(lv)).inv(),
     {
-        T::default_preserves_inv();
-        T::default_preserves_la_inv();
+        T::lemma_default_preserves_inv();
+        T::lemma_default_preserves_la_inv();
     }
 
     pub open spec fn insert(self, key: usize, node: Self) -> Self
@@ -607,42 +609,46 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             0 <= key < Self::size(),
             self.inv(),
             node.inv(),
-            self.level < L - 1,
-            node.level == self.level + 1,
+            self.level() < L - 1,
+            node.level() == self.level() + 1,
     {
-        Node { children: self.children.update(key as int, Some(node)), ..self }
+        Self::new(
+            self.value(),
+            self.level(),
+            self.children().update(key as int, Some(node)),
+        )
     }
 
-    pub broadcast proof fn insert_preserves_inv(self, key: usize, node: Self)
+    pub broadcast proof fn lemma_insert_preserves_inv(self, key: usize, node: Self)
         requires
             0 <= key < Self::size(),
             self.inv(),
             node.inv(),
-            self.level < L - 1,
-            node.level == self.level + 1,
-            self.value.rel_children(key as int, Some(node.value)),
+            self.level() < L - 1,
+            node.level() == self.level() + 1,
+            self.value().rel_children(key as int, Some(node.value())),
         ensures
             #[trigger] self.insert(key, node).inv(),
     {
     }
 
-    pub broadcast proof fn insert_property(self, key: usize, node: Self)
+    pub broadcast proof fn lemma_insert_property(self, key: usize, node: Self)
         requires
             0 <= key < Self::size(),
             self.inv(),
             node.inv(),
-            self.level < L - 1,
-            node.level == self.level + 1,
+            self.level() < L - 1,
+            node.level() == self.level() + 1,
         ensures
-            #[trigger] self.insert(key, node).value == self.value,
-            self.insert(key, node).children[key as int] == Some(node),
+            #[trigger] self.insert(key, node).value() == self.value(),
+            self.insert(key, node).children()[key as int] == Some(node),
             forall|i: int|
-                0 <= i < Self::size() && i != key ==> #[trigger] self.insert(key, node).children[i]
-                    == self.children[i],
+                0 <= i < Self::size() && i != key ==> #[trigger] self.insert(key, node).children()[i]
+                    == self.children()[i],
     {
     }
 
-    pub broadcast proof fn insert_same_child_identical(self, key: usize, node: Self)
+    pub broadcast proof fn lemma_insert_same_child_identical(self, key: usize, node: Self)
         requires
             0 <= key < Self::size(),
             self.inv(),
@@ -650,9 +656,9 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
         ensures
             #[trigger] self.insert(key, node) == self,
     {
-        self.child_some_properties(key);
-        self.insert_property(key, node);
-        assert(self.insert(key, node).children == self.children);
+        self.lemma_child_some_properties(key);
+        self.lemma_insert_property(key, node);
+        assert(self.insert(key, node).children() == self.children());
     }
 
     pub open spec fn remove(self, key: usize) -> Self
@@ -660,29 +666,29 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             0 <= key < Self::size(),
             self.inv(),
     {
-        Node { children: self.children.update(key as int, None), ..self }
+        Self::new(self.value(), self.level(), self.children().update(key as int, None))
     }
 
-    pub broadcast proof fn remove_preserves_inv(self, key: usize)
+    pub broadcast proof fn lemma_remove_preserves_inv(self, key: usize)
         requires
             0 <= key < Self::size(),
             self.inv(),
-            self.children[key as int] is None || self.value.rel_children(key as int, None),
+            self.children()[key as int] is None || self.value().rel_children(key as int, None),
         ensures
             #[trigger] self.remove(key).inv(),
     {
     }
 
-    pub broadcast proof fn remove_property(self, key: usize)
+    pub broadcast proof fn lemma_remove_property(self, key: usize)
         requires
             0 <= key < Self::size(),
             self.inv(),
         ensures
-            #[trigger] self.remove(key).value == self.value,
-            self.remove(key).children[key as int] is None,
+            #[trigger] self.remove(key).value() == self.value(),
+            self.remove(key).children()[key as int] is None,
             forall|i: int|
-                0 <= i < Self::size() && i != key ==> #[trigger] self.remove(key).children[i]
-                    == self.children[i],
+                0 <= i < Self::size() && i != key ==> #[trigger] self.remove(key).children()[i]
+                    == self.children()[i],
     {
     }
 
@@ -691,45 +697,45 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             0 <= key < Self::size(),
             self.inv(),
     {
-        self.children[key as int]
+        self.children()[key as int]
     }
 
-    pub broadcast proof fn child_property(self, key: usize)
+    pub broadcast proof fn lemma_child_property(self, key: usize)
         requires
             0 <= key < Self::size(),
             self.inv(),
         ensures
-            #[trigger] self.child(key) == self.children[key as int],
+            #[trigger] self.child(key) == self.children()[key as int],
     {
     }
 
-    pub broadcast proof fn child_property_cases(self, key: usize)
+    pub broadcast proof fn lemma_child_property_cases(self, key: usize)
         requires
             0 <= key < Self::size(),
             self.inv(),
         ensures
-            self.level == L - 1 ==> #[trigger] self.child(key) is None,
-            self.level < L - 1 && self.children[key as int] is None ==> #[trigger] self.child(
+            self.level() == L - 1 ==> #[trigger] self.child(key) is None,
+            self.level() < L - 1 && self.children()[key as int] is None ==> #[trigger] self.child(
                 key,
             ) is None,
-            self.level < L - 1 && self.children[key as int] is Some ==> #[trigger] self.child(
+            self.level() < L - 1 && self.children()[key as int] is Some ==> #[trigger] self.child(
                 key,
-            ) is Some && self.child(key)->0.level == self.level + 1 && self.child(key)->0.inv(),
+            ) is Some && self.child(key)->0.level() == self.level() + 1 && self.child(key)->0.inv(),
     {
     }
 
-    pub proof fn child_some_properties(self, key: usize)
+    pub proof fn lemma_child_some_properties(self, key: usize)
         requires
             0 <= key < Self::size(),
             self.inv(),
             self.child(key) is Some,
         ensures
-            self.level < L - 1,
-            self.child(key)->0.level == self.level + 1,
+            self.level() < L - 1,
+            self.child(key)->0.level() == self.level() + 1,
             self.child(key)->0.inv(),
     {
-        self.child_property(key);
-        self.child_property_cases(key);
+        self.lemma_child_property(key);
+        self.lemma_child_property_cases(key);
     }
 
     pub broadcast proof fn lemma_insert_child_is_child(self, key: usize, node: Self)
@@ -737,13 +743,13 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             0 <= key < Self::size(),
             self.inv(),
             node.inv(),
-            self.level < L - 1,
-            node.level == self.level + 1,
+            self.level() < L - 1,
+            node.level() == self.level() + 1,
         ensures
             #[trigger] self.insert(key, node).child(key) == Some(node),
     {
-        self.insert_property(key, node);
-        self.child_property(key);
+        self.lemma_insert_property(key, node);
+        self.lemma_child_property(key);
     }
 
     pub broadcast proof fn lemma_remove_child_is_none(self, key: usize)
@@ -753,19 +759,19 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
         ensures
             #[trigger] self.remove(key).child(key) is None,
     {
-        self.remove_property(key);
-        self.child_property(key);
+        self.lemma_remove_property(key);
+        self.lemma_child_property(key);
     }
 
     pub open spec fn get_value(self) -> T {
-        self.value
+        self.value()
     }
 
-    pub broadcast proof fn get_value_property(self)
+    pub broadcast proof fn lemma_get_value_property(self)
         requires
             self.inv(),
         ensures
-            #[trigger] self.get_value() == self.value,
+            #[trigger] self.get_value() == self.value(),
             self.get_value().inv(),
     {
     }
@@ -775,48 +781,70 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             self.inv(),
             value.inv(),
     {
-        Node { value: value, ..self }
+        Self::new(value, self.level(), self.children())
     }
 
-    pub broadcast proof fn set_value_property(self, value: T)
+    /// Exposes the observable fields changed and preserved by `set_value`.
+    pub proof fn lemma_set_value_observable_fields(self, value: T)
+        ensures
+            self.set_value(value).value() == value,
+            self.set_value(value).level() == self.level(),
+            self.set_value(value).children() == self.children(),
+    {
+        Self::lemma_new_properties(value, self.level(), self.children());
+    }
+
+    /// Replacing the value of a childless node preserves its `new_val` shape.
+    pub proof fn lemma_set_value_preserves_new_val_shape(self, value: T)
+        requires
+            self == Self::new_val(self.value(), self.level()),
+        ensures
+            self.set_value(value) == Self::new_val(value, self.level()),
+    {
+        self.lemma_set_value_observable_fields(value);
+        Self::lemma_new_properties(value, self.level(), Seq::new(N as nat, |i| None));
+        Self::lemma_ext_equal(self.set_value(value), Self::new_val(value, self.level()));
+    }
+
+    pub broadcast proof fn lemma_set_value_property(self, value: T)
         requires
             self.inv(),
             value.inv(),
-            value.la_inv(self.level),
+            value.la_inv(self.level()),
             forall|i: int|
-                0 <= i < N ==> #[trigger] self.children[i] is Some ==> value.rel_children(
+                0 <= i < N ==> #[trigger] self.children()[i] is Some ==> value.rel_children(
                     i,
-                    Some(self.children[i]->0.value),
+                    Some(self.children()[i]->0.value()),
                 ),
             forall|i: int|
-                0 <= i < N ==> #[trigger] self.children[i] is None ==> value.rel_children(i, None),
+                0 <= i < N ==> #[trigger] self.children()[i] is None ==> value.rel_children(i, None),
         ensures
-            #[trigger] self.set_value(value).value == value,
-            self.set_value(value).children == self.children,
+            #[trigger] self.set_value(value).value() == value,
+            self.set_value(value).children() == self.children(),
             self.set_value(value).inv(),
     {
-        if self.level == L - 1 {
+        if self.level() == L - 1 {
         } else {
             assert forall|i: int| 0 <= i < Self::size() implies match #[trigger] self.set_value(
                 value,
-            ).children[i] {
+            ).children()[i] {
                 Some(child) => {
-                    &&& child.level == self.set_value(value).level + 1
-                    &&& self.set_value(value).value.rel_children(i, Some(child.value))
+                    &&& child.level() == self.set_value(value).level() + 1
+                    &&& self.set_value(value).value().rel_children(i, Some(child.value()))
                 },
-                None => self.set_value(value).value.rel_children(i, None),
+                None => self.set_value(value).value().rel_children(i, None),
             } by {}
         }
     }
 
     pub open spec fn is_leaf(self) -> bool {
-        forall|i: int| 0 <= i < Self::size() ==> self.children[i] is None
+        forall|i: int| 0 <= i < Self::size() ==> self.children()[i] is None
     }
 
-    pub broadcast proof fn is_leaf_bounded(self)
+    pub broadcast proof fn lemma_is_leaf_bounded(self)
         requires
             self.inv(),
-            self.level == L - 1,
+            self.level() == L - 1,
         ensures
             #[trigger] self.is_leaf(),
     {
@@ -827,8 +855,8 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             self.inv(),
             path.inv(),
             node.inv(),
-            path.len() < L - self.level,
-            node.level == self.level + path.len() as nat,
+            path.len() < L - self.level(),
+            node.level() == self.level() + path.len() as nat,
         decreases path.len(),
     {
         if path.is_empty() {
@@ -839,7 +867,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             let (hd, tl) = path.pop_head();
             let child = match self.child(hd) {
                 Some(child) => child,
-                None => Node::new(self.level + 1),
+                None => Node::new_default(self.level() + 1),
             };
             let updated_child = child.recursive_insert(tl, node);
             self.insert(hd, updated_child)
@@ -867,8 +895,8 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             node.inv(),
             path.inv(),
             path.len() == 1,
-            1 < L - self.level,
-            node.level == self.level + 1,
+            1 < L - self.level(),
+            node.level() == self.level() + 1,
         ensures
             #[trigger] self.recursive_insert(path, node) == self.insert(path.index(0), node),
     {
@@ -879,8 +907,8 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             self.inv(),
             path.inv(),
             node.inv(),
-            path.len() < L - self.level,
-            node.level == self.level + path.len() as nat,
+            path.len() < L - self.level(),
+            node.level() == self.level() + path.len() as nat,
             path.len() > 1,
         ensures
             self.child(path.index(0)) is Some ==> #[trigger] self.recursive_insert(path, node)
@@ -891,7 +919,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             self.child(path.index(0)) is None ==> #[trigger] self.recursive_insert(path, node)
                 == self.insert(
                 path.index(0),
-                Node::new(self.level + 1).recursive_insert(path.pop_head().1, node),
+                Node::new_default(self.level() + 1).recursive_insert(path.pop_head().1, node),
             ),
     {
     }
@@ -905,31 +933,31 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             self.inv(),
             path.inv(),
             node.inv(),
-            path.len() < L - self.level,
-            node.level == self.level + path.len() as nat,
+            path.len() < L - self.level(),
+            node.level() == self.level() + path.len() as nat,
             forall|lv: nat|
                 lv < L ==> #[trigger] T::default(lv).rel_children(path.pop_tail().0 as int, None),
         ensures
-            #[trigger] self.recursive_insert(path, node).level == self.level,
+            #[trigger] self.recursive_insert(path, node).level() == self.level(),
         decreases path.len(),
     {
         if path.is_empty() {
             self.lemma_recursive_insert_path_empty_identical(path, node);
         } else if path.len() == 1 {
-            path.index_satisfies_elem_inv(0);
+            path.lemma_index_satisfies_elem_inv(0);
             self.lemma_recursive_insert_path_len_1(path, node);
-            assert(self.insert(path.index(0), node).level == self.level);
+            assert(self.insert(path.index(0), node).level() == self.level());
         } else {
             self.lemma_recursive_insert_path_len_step(path, node);
             let (hd, tl) = path.pop_head();
-            path.pop_head_preserves_inv();
+            path.lemma_pop_head_preserves_inv();
             if self.child(hd) is Some {
                 let c = self.child(hd)->0;
-                self.child_some_properties(hd);
-                assert(self.insert(hd, c.recursive_insert(tl, node)).level == self.level);
+                self.lemma_child_some_properties(hd);
+                assert(self.insert(hd, c.recursive_insert(tl, node)).level() == self.level());
             } else {
-                let c = Node::new(self.level + 1);
-                assert(self.insert(hd, c.recursive_insert(tl, node)).level == self.level);
+                let c = Node::new_default(self.level() + 1);
+                assert(self.insert(hd, c.recursive_insert(tl, node)).level() == self.level());
             }
         }
     }
@@ -943,30 +971,30 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             self.inv(),
             path.inv(),
             node.inv(),
-            path.len() < L - self.level,
-            node.level == self.level + path.len() as nat,
+            path.len() < L - self.level(),
+            node.level() == self.level() + path.len() as nat,
             forall|lv: nat, i: int|
                 lv < L && 0 <= i < N ==> #[trigger] T::default(lv).rel_children(i, None),
         ensures
-            #[trigger] self.recursive_insert(path, node).value == self.value,
+            #[trigger] self.recursive_insert(path, node).value() == self.value(),
         decreases path.len(),
     {
         if path.is_empty() {
             self.lemma_recursive_insert_path_empty_identical(path, node);
         } else if path.len() == 1 {
-            path.index_satisfies_elem_inv(0);
+            path.lemma_index_satisfies_elem_inv(0);
             self.lemma_recursive_insert_path_len_1(path, node);
         } else {
             self.lemma_recursive_insert_path_len_step(path, node);
             let (hd, tl) = path.pop_head();
-            path.pop_head_preserves_inv();
+            path.lemma_pop_head_preserves_inv();
             if self.child(hd) is Some {
                 let c = self.child(hd)->0;
-                self.child_some_properties(hd);
+                self.lemma_child_some_properties(hd);
                 c.lemma_recursive_insert_preserves_value(tl, node);
             } else {
-                let c = Node::new(self.level + 1);
-                Self::new_preserves_inv(self.level + 1);
+                let c = Node::new_default(self.level() + 1);
+                Self::lemma_new_default_preserves_inv(self.level() + 1);
                 c.lemma_recursive_insert_preserves_value(tl, node);
             }
         }
@@ -977,14 +1005,14 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             self.inv(),
             path.inv(),
             node.inv(),
-            path.len() < L - self.level,
-            node.level == self.level + path.len() as nat,
+            path.len() < L - self.level(),
+            node.level() == self.level() + path.len() as nat,
             self.recursive_seek(path.pop_tail().1) is Some ==> self.recursive_seek(
                 path.pop_tail().1,
-            )->0.value.rel_children(path.pop_tail().0 as int, Some(node.value)),
+            )->0.value().rel_children(path.pop_tail().0 as int, Some(node.value())),
             self.recursive_seek(path.pop_tail().1) is None ==> T::default(
-                (node.level - 1) as nat,
-            ).rel_children(path.pop_tail().0 as int, Some(node.value)),
+                (node.level() - 1) as nat,
+            ).rel_children(path.pop_tail().0 as int, Some(node.value())),
             forall|lv: nat, i: int|
                 lv < L ==> 0 <= i < N ==> #[trigger] T::default(lv).rel_children(i, None),
         ensures
@@ -994,31 +1022,31 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
         if path.is_empty() {
             self.lemma_recursive_insert_path_empty_identical(path, node);
         } else if path.len() == 1 {
-            path.index_satisfies_elem_inv(0);
+            path.lemma_index_satisfies_elem_inv(0);
             self.lemma_recursive_insert_path_len_1(path, node);
-            self.insert_preserves_inv(path.index(0), node);
+            self.lemma_insert_preserves_inv(path.index(0), node);
         } else {
             self.lemma_recursive_insert_path_len_step(path, node);
             let (hd, tl) = path.pop_head();
-            path.pop_head_preserves_inv();
+            path.lemma_pop_head_preserves_inv();
             if self.child(hd) is Some {
                 let c = self.child(hd)->0;
-                self.child_some_properties(hd);
+                self.lemma_child_some_properties(hd);
                 assert(path.pop_tail().1.pop_head().1 == path.pop_head().1.pop_tail().1);
                 c.lemma_recursive_insert_preserves_inv(tl, node);
                 c.lemma_recursive_insert_preserves_level(tl, node);
                 c.lemma_recursive_insert_preserves_value(tl, node);
                 let updated_child = c.recursive_insert(tl, node);
-                self.insert_preserves_inv(hd, updated_child);
+                self.lemma_insert_preserves_inv(hd, updated_child);
             } else {
-                let c = Node::new(self.level + 1);
-                Self::new_preserves_inv(self.level + 1);
-                self.value.default_preserves_rel_children(self.level);
+                let c = Node::new_default(self.level() + 1);
+                Self::lemma_new_default_preserves_inv(self.level() + 1);
+                self.value().lemma_default_preserves_rel_children(self.level());
                 c.lemma_recursive_insert_preserves_inv(tl, node);
                 c.lemma_recursive_insert_preserves_level(tl, node);
                 c.lemma_recursive_insert_preserves_value(tl, node);
                 let updated_child = c.recursive_insert(tl, node);
-                self.insert_preserves_inv(hd, updated_child);
+                self.lemma_insert_preserves_inv(hd, updated_child);
             }
         }
     }
@@ -1031,16 +1059,16 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
         recommends
             self.inv(),
             path.inv(),
-            path.len() < L - self.level,
+            path.len() < L - self.level(),
         decreases path.len(),
     {
         if path.is_empty() {
-            seq![self.value]
+            seq![self.value()]
         } else {
             let (hd, tl) = path.pop_head();
             match self.child(hd) {
-                Some(child) => seq![self.value].add(child.recursive_trace(tl)),
-                None => seq![self.value],
+                Some(child) => seq![self.value()].add(child.recursive_trace(tl)),
+                None => seq![self.value()],
             }
         }
     }
@@ -1056,7 +1084,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
         if path.len() == 0 {
         } else {
             let (hd, tl) = path.pop_head();
-            path.pop_head_preserves_inv();
+            path.lemma_pop_head_preserves_inv();
             match self.child(hd) {
                 None => {},
                 Some(child) => {
@@ -1088,8 +1116,8 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             match self.child(hd1) {
                 None => {},
                 Some(child) => {
-                    path1.pop_head_preserves_inv();
-                    path2.pop_head_preserves_inv();
+                    path1.lemma_pop_head_preserves_inv();
+                    path2.lemma_pop_head_preserves_inv();
                     child.lemma_recursive_trace_up_to(tl1, tl2, n - 1);
                 },
             }
@@ -1103,7 +1131,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
         recommends
             self.inv(),
             path.inv(),
-            path.len() < L - self.level,
+            path.len() < L - self.level(),
         decreases path.len(),
     {
         if path.is_empty() {
@@ -1121,7 +1149,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
         requires
             self.inv(),
             path.inv(),
-            path.len() < L - self.level,
+            path.len() < L - self.level(),
             self.recursive_seek(path) is Some,
         ensures
             self.recursive_trace(path).len() == path.len() + 1,
@@ -1133,7 +1161,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             match self.child(hd) {
                 None => {},
                 Some(child) => {
-                    path.pop_head_preserves_inv();
+                    path.lemma_pop_head_preserves_inv();
                     child.lemma_recursive_seek_trace_length(tl)
                 },
             }
@@ -1143,14 +1171,14 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
     pub proof fn lemma_recursive_seek_trace_next(self, path: TreePath<N>, idx: usize)
         requires
             self.recursive_seek(path) is Some,
-            self.recursive_seek(path)->0.children[idx as int] is Some,
+            self.recursive_seek(path)->0.children()[idx as int] is Some,
             self.inv(),
             path.inv(),
-            path.len() < L - self.level,
+            path.len() < L - self.level(),
             0 <= idx < N,
         ensures
             self.recursive_trace(path.push_tail(idx)).len() == path.len() + 2,
-            self.recursive_seek(path)->0.children[idx as int]->0.value == self.recursive_trace(
+            self.recursive_seek(path)->0.children()[idx as int]->0.value() == self.recursive_trace(
                 path.push_tail(idx),
             )[path.len() as int + 1],
         decreases path.len(),
@@ -1159,14 +1187,14 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
 
         if path.len() == 0 {
             assert(self.recursive_trace(path2) == seq![
-                self.value,
-                self.children[idx as int]->0.value,
+                self.value(),
+                self.children()[idx as int]->0.value(),
             ]) by { reveal_with_fuel(Node::recursive_trace, 2) }
         } else {
             let (_, tl1) = path.pop_head();
             let (hd2, tl2) = path2.pop_head();
             assert(tl2 == tl1.push_tail(idx)) by {}
-            assert(tl1.inv()) by { path.pop_head_preserves_inv() }
+            assert(tl1.inv()) by { path.lemma_pop_head_preserves_inv() }
             match self.child(hd2) {
                 None => {},
                 Some(child) => {
@@ -1185,7 +1213,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
         recommends
             self.inv(),
             path.inv(),
-            path.len() < L - self.level,
+            path.len() < L - self.level(),
         decreases path.len(),
     {
         if path.is_empty() {
@@ -1208,7 +1236,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
         requires
             #[trigger] self.inv(),
             #[trigger] path.inv(),
-            path.len() < L - self.level,
+            path.len() < L - self.level(),
         ensures
             forall|i: int|
                 0 <= i < self.recursive_visit(path).len() ==> #[trigger] self.recursive_visit(
@@ -1222,7 +1250,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             }
         } else {
             let (hd, tl) = path.pop_head();
-            path.pop_head_preserves_inv();
+            path.lemma_pop_head_preserves_inv();
             if self.child(hd) is Some {
                 let c = self.child(hd)->0;
                 assert(self.recursive_visit(path) == seq![c].add(c.recursive_visit(tl)));
@@ -1235,12 +1263,12 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
         requires
             #[trigger] self.inv(),
             #[trigger] path.inv(),
-            path.len() < L - self.level,
+            path.len() < L - self.level(),
         ensures
             forall|i: int|
                 0 <= i < self.recursive_visit(path).len() ==> #[trigger] self.recursive_visit(
                     path,
-                ).index(i).level == self.level + i + 1,
+                ).index(i).level() == self.level() + i + 1,
         decreases path.len(),
     {
         if path.is_empty() {
@@ -1249,7 +1277,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             }
         } else {
             let (hd, tl) = path.pop_head();
-            path.pop_head_preserves_inv();
+            path.lemma_pop_head_preserves_inv();
             if self.child(hd) is Some {
                 let c = self.child(hd)->0;
                 assert(self.recursive_visit(path) == seq![c].add(c.recursive_visit(tl)));
@@ -1262,7 +1290,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
         requires
             #[trigger] self.inv(),
             #[trigger] path.inv(),
-            path.len() < L - self.level,
+            path.len() < L - self.level(),
             !path.is_empty(),
             self.recursive_visit(path).len() > 0,
         ensures
@@ -1274,7 +1302,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
         requires
             self.inv(),
             path.inv(),
-            path.len() < L - self.level,
+            path.len() < L - self.level(),
             !path.is_empty(),
             self.recursive_visit(path).len() > 0,
         ensures
@@ -1283,10 +1311,10 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             ),
     {
         if path.len() == 1 {
-            path.pop_head_preserves_inv();
+            path.lemma_pop_head_preserves_inv();
         } else {
             let (hd, _) = path.pop_head();
-            path.pop_head_preserves_inv();
+            path.lemma_pop_head_preserves_inv();
             if self.child(hd) is Some {
                 self.lemma_recursive_visit_head(path);
             }
@@ -1297,7 +1325,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
         requires
             self.inv(),
             path.inv(),
-            path.len() < L - self.level,
+            path.len() < L - self.level(),
             path.len() == 1,
         ensures
             self.child(path.index(0)) is Some ==> #[trigger] self.recursive_visit(path) == seq![
@@ -1311,40 +1339,40 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
         recommends
             self.inv(),
             node.inv(),
-            node.level >= self.level,
-            node.level < L,
+            node.level() >= self.level(),
+            node.level() < L,
     {
         node == self || exists|path: TreePath<N>| #[trigger]
-            path.inv() && path.len() > 0 && path.len() == node.level - self.level
+            path.inv() && path.len() > 0 && path.len() == node.level() - self.level()
                 && self.recursive_visit(path).last() == node
     }
 
-    pub broadcast proof fn on_subtree_property(self, node: Self)
+    pub broadcast proof fn lemma_on_subtree_property(self, node: Self)
         requires
             self.inv(),
             node.inv(),
-            node.level >= self.level,
-            node.level < L,
+            node.level() >= self.level(),
+            node.level() < L,
             #[trigger] self.on_subtree(node),
         ensures
-            node.level == self.level ==> self == node,
-            node.level > self.level ==> exists|path: TreePath<N>| #[trigger]
-                path.inv() && path.len() == node.level - self.level && self.recursive_visit(
+            node.level() == self.level() ==> self == node,
+            node.level() > self.level() ==> exists|path: TreePath<N>| #[trigger]
+                path.inv() && path.len() == node.level() - self.level() && self.recursive_visit(
                     path,
                 ).last() == node,
     {
     }
 
-    pub broadcast proof fn not_on_subtree_property(self, node: Self)
+    pub broadcast proof fn lemma_not_on_subtree_property(self, node: Self)
         requires
             self.inv(),
             node.inv(),
-            node.level < L,
+            node.level() < L,
             !#[trigger] self.on_subtree(node),
         ensures
             self != node,
-            node.level > self.level ==> forall|path: TreePath<N>| #[trigger]
-                path.inv() && path.len() == node.level - self.level ==> self.recursive_visit(
+            node.level() > self.level() ==> forall|path: TreePath<N>| #[trigger]
+                path.inv() && path.len() == node.level() - self.level() ==> self.recursive_visit(
                     path,
                 ).last() != node,
     {
@@ -1374,9 +1402,9 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             0 <= key < Self::size(),
             self.inv(),
             node.inv(),
-            self.level < L - 1,
-            node.level == self.level + 1,
-            self.value.rel_children(key as int, Some(node.value)),
+            self.level() < L - 1,
+            node.level() == self.level() + 1,
+            self.value().rel_children(key as int, Some(node.value())),
         ensures
             #[trigger] self.insert(key, node).on_subtree(node),
     {
@@ -1393,7 +1421,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
         recommends
             self.inv(),
             path.inv(),
-            path.len() < L - self.level,
+            path.len() < L - self.level(),
         decreases path.len(),
     {
         if path.is_empty() {
@@ -1416,19 +1444,19 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
         requires
             self.inv(),
             path.inv(),
-            path.len() < L - self.level,
+            path.len() < L - self.level(),
         ensures
-            #[trigger] self.recursive_remove(path).level == self.level,
+            #[trigger] self.recursive_remove(path).level() == self.level(),
         decreases path.len(),
     {
         if path.is_empty() {
         } else if path.len() == 1 {
         } else {
             let (hd, tl) = path.pop_head();
-            path.pop_head_preserves_inv();
+            path.lemma_pop_head_preserves_inv();
             if self.child(hd) is Some {
                 let c = self.child(hd)->0;
-                self.child_some_properties(hd);
+                self.lemma_child_some_properties(hd);
                 c.lemma_recursive_remove_preserves_level(tl);
             }
         }
@@ -1438,19 +1466,19 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
         requires
             self.inv(),
             path.inv(),
-            path.len() < L - self.level,
+            path.len() < L - self.level(),
         ensures
-            #[trigger] self.recursive_remove(path).value == self.value,
+            #[trigger] self.recursive_remove(path).value() == self.value(),
         decreases path.len(),
     {
         if path.is_empty() {
         } else if path.len() == 1 {
         } else {
             let (hd, tl) = path.pop_head();
-            path.pop_head_preserves_inv();
+            path.lemma_pop_head_preserves_inv();
             if self.child(hd) is Some {
                 let c = self.child(hd)->0;
-                self.child_some_properties(hd);
+                self.lemma_child_some_properties(hd);
                 c.lemma_recursive_remove_preserves_value(tl);
             }
         }
@@ -1460,32 +1488,32 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
         requires
             self.inv(),
             path.inv(),
-            path.len() < L - self.level,
+            path.len() < L - self.level(),
             path.len() > 0 ==> self.recursive_seek(path.pop_tail().1) is Some
                 ==> self.recursive_seek(
                 path.pop_tail().1,
-            )->0.children[path.pop_tail().0 as int] is None || self.recursive_seek(
+            )->0.children()[path.pop_tail().0 as int] is None || self.recursive_seek(
                 path.pop_tail().1,
-            )->0.value.rel_children(path.pop_tail().0 as int, None),
+            )->0.value().rel_children(path.pop_tail().0 as int, None),
         ensures
             #[trigger] self.recursive_remove(path).inv(),
         decreases path.len(),
     {
         if path.is_empty() {
         } else if path.len() == 1 {
-            self.remove_preserves_inv(path.index(0));
+            self.lemma_remove_preserves_inv(path.index(0));
         } else {
             let (hd, tl) = path.pop_head();
-            path.pop_head_preserves_inv();
+            path.lemma_pop_head_preserves_inv();
             if self.child(hd) is Some {
                 let c = self.child(hd)->0;
-                self.child_some_properties(hd);
+                self.lemma_child_some_properties(hd);
                 assert(path.pop_tail().1.pop_head().1 == path.pop_head().1.pop_tail().1);
                 c.lemma_recursive_remove_preserves_inv(tl);
                 c.lemma_recursive_remove_preserves_level(tl);
                 c.lemma_recursive_remove_preserves_value(tl);
                 let updated_child = c.recursive_remove(tl);
-                self.insert_preserves_inv(hd, updated_child);
+                self.lemma_insert_preserves_inv(hd, updated_child);
             }
         }
     }
@@ -1501,15 +1529,15 @@ pub closed spec fn path_between<T: TreeNodeValue<L>, const N: usize, const L: us
     recommends
         src.inv(),
         dst.inv(),
-        src.level <= dst.level,
+        src.level() <= dst.level(),
         src.on_subtree(dst),
 {
-    if src.inv() && dst.inv() && dst.level >= src.level && dst.level < L && src.on_subtree(dst) {
+    if src.inv() && dst.inv() && dst.level() >= src.level() && dst.level() < L && src.on_subtree(dst) {
         if src == dst {
             TreePath::new(seq![])
         } else {
             choose|path: TreePath<N>| #[trigger]
-                path.inv() && path.len() > 0 && path.len() == dst.level - src.level
+                path.inv() && path.len() > 0 && path.len() == dst.level() - src.level()
                     && src.recursive_visit(path).last() == dst
         }
     } else {
@@ -1517,20 +1545,20 @@ pub closed spec fn path_between<T: TreeNodeValue<L>, const N: usize, const L: us
     }
 }
 
-pub broadcast proof fn path_between_properties<T: TreeNodeValue<L>, const N: usize, const L: usize>(
+pub broadcast proof fn lemma_path_between_properties<T: TreeNodeValue<L>, const N: usize, const L: usize>(
     src: Node<T, N, L>,
     dst: Node<T, N, L>,
 )
     requires
         src.inv(),
         dst.inv(),
-        src.level <= dst.level,
+        src.level() <= dst.level(),
         #[trigger] src.on_subtree(dst),
     ensures
         path_between(src, dst).inv(),
-        path_between(src, dst).len() == dst.level - src.level,
-        dst.level == src.level ==> path_between(src, dst).is_empty() && src == dst,
-        dst.level > src.level ==> src.recursive_visit(path_between(src, dst)).last() == dst,
+        path_between(src, dst).len() == dst.level() - src.level(),
+        dst.level() == src.level() ==> path_between(src, dst).is_empty() && src == dst,
+        dst.level() > src.level() ==> src.recursive_visit(path_between(src, dst)).last() == dst,
 {
 }
 
@@ -1546,14 +1574,14 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
         &&& L > 0
         &&& N > 0
         &&& self.root.inv()
-        &&& self.root.level == 0
+        &&& self.root.level() == 0
     }
 
     pub open spec fn new() -> Self {
-        Tree { root: Node::new(0) }
+        Tree { root: Node::new_default(0) }
     }
 
-    pub broadcast proof fn new_preserves_inv()
+    pub broadcast proof fn lemma_new_preserves_inv()
         requires
             N > 0,
             L > 0,
@@ -1561,7 +1589,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
         ensures
             #[trigger] Self::new().inv(),
     {
-        Node::<T, N, L>::new_preserves_inv(0);
+        Node::<T, N, L>::lemma_new_default_preserves_inv(0);
     }
 
     pub open spec fn insert(self, path: TreePath<N>, node: Node<T, N, L>) -> Self
@@ -1570,7 +1598,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
             path.inv(),
             node.inv(),
             path.len() < L,
-            node.level == path.len() as nat,
+            node.level() == path.len() as nat,
         decreases path.len(),
     {
         Tree { root: self.root.recursive_insert(path, node), ..self }
@@ -1596,7 +1624,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
         self.root.recursive_visit(path)
     }
 
-    pub broadcast proof fn visit_is_recursive_visit(self, path: TreePath<N>)
+    pub broadcast proof fn lemma_visit_is_recursive_visit(self, path: TreePath<N>)
         requires
             self.inv(),
             path.inv(),
@@ -1616,11 +1644,11 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
         self.root.recursive_trace(path)
     }
 
-    pub broadcast proof fn trace_empty_is_head(self, path: TreePath<N>)
+    pub broadcast proof fn lemma_trace_empty_is_head(self, path: TreePath<N>)
         requires
             path.len() == 0,
         ensures
-            #[trigger] self.trace(path) == seq![self.root.value],
+            #[trigger] self.trace(path) == seq![self.root.value()],
     {
     }
 
@@ -1669,33 +1697,33 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
     pub proof fn lemma_seek_trace_next(self, path: TreePath<N>, idx: usize)
         requires
             self.seek(path) is Some,
-            self.seek(path)->0.children[idx as int] is Some,
+            self.seek(path)->0.children()[idx as int] is Some,
             self.inv(),
             path.inv(),
             path.len() < L,
             0 <= idx < N,
         ensures
             self.trace(path.push_tail(idx)).len() == path.len() + 2,
-            self.seek(path)->0.children[idx as int]->0.value == self.trace(
+            self.seek(path)->0.children()[idx as int]->0.value() == self.trace(
                 path.push_tail(idx),
             )[path.len() as int + 1],
     {
         self.root.lemma_recursive_seek_trace_next(path, idx)
     }
 
-    pub broadcast proof fn insert_preserves_inv(self, path: TreePath<N>, node: Node<T, N, L>)
+    pub broadcast proof fn lemma_insert_preserves_inv(self, path: TreePath<N>, node: Node<T, N, L>)
         requires
             self.inv(),
             path.inv(),
             node.inv(),
             path.len() < L,
-            node.level == path.len() as nat,
+            node.level() == path.len() as nat,
             self.seek(path.pop_tail().1) is Some ==> self.seek(
                 path.pop_tail().1,
-            )->0.value.rel_children(path.index(path.len() - 1) as int, Some(node.value)),
+            )->0.value().rel_children(path.index(path.len() - 1) as int, Some(node.value())),
             self.seek(path.pop_tail().1) is None ==> T::default(
                 (path.len() - 1) as nat,
-            ).rel_children(path.index(path.len() - 1) as int, Some(node.value)),
+            ).rel_children(path.index(path.len() - 1) as int, Some(node.value())),
             forall|lv: nat, i: int|
                 lv < L ==> 0 <= i < N ==> #[trigger] T::default(lv).rel_children(i, None),
         ensures
@@ -1704,23 +1732,23 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
         self.root.lemma_recursive_insert_preserves_inv(path, node);
     }
 
-    pub broadcast proof fn remove_preserves_inv(self, path: TreePath<N>)
+    pub broadcast proof fn lemma_remove_preserves_inv(self, path: TreePath<N>)
         requires
             self.inv(),
             path.inv(),
             path.len() < L,
             path.len() > 0 ==> self.seek(path.pop_tail().1) is Some ==> self.seek(
                 path.pop_tail().1,
-            )->0.children[path.pop_tail().0 as int] is None || self.seek(
+            )->0.children()[path.pop_tail().0 as int] is None || self.seek(
                 path.pop_tail().1,
-            )->0.value.rel_children(path.index(path.len() - 1) as int, None),
+            )->0.value().rel_children(path.index(path.len() - 1) as int, None),
         ensures
             #[trigger] self.remove(path).inv(),
     {
         self.root.lemma_recursive_remove_preserves_inv(path);
     }
 
-    pub broadcast proof fn visited_nodes_inv(self, path: TreePath<N>)
+    pub broadcast proof fn lemma_visited_nodes_inv(self, path: TreePath<N>)
         requires
             #[trigger] self.inv(),
             #[trigger] path.inv(),
@@ -1741,27 +1769,27 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
         self.root.on_subtree(node)
     }
 
-    pub broadcast proof fn on_tree_property(self, node: Node<T, N, L>)
+    pub broadcast proof fn lemma_on_tree_property(self, node: Node<T, N, L>)
         requires
             self.inv(),
             node.inv(),
             #[trigger] self.on_tree(node),
         ensures
-            node.level == 0 ==> self.root == node,
-            node.level > 0 ==> exists|path: TreePath<N>| #[trigger]
-                path.inv() && path.len() == node.level && self.visit(path).last() == node,
+            node.level() == 0 ==> self.root == node,
+            node.level() > 0 ==> exists|path: TreePath<N>| #[trigger]
+                path.inv() && path.len() == node.level() && self.visit(path).last() == node,
     {
     }
 
-    pub broadcast proof fn not_on_tree_property(self, node: Node<T, N, L>)
+    pub broadcast proof fn lemma_not_on_tree_property(self, node: Node<T, N, L>)
         requires
             self.inv(),
             node.inv(),
             !#[trigger] self.on_tree(node),
         ensures
             node != self.root,
-            node.level > 0 ==> forall|path: TreePath<N>| #[trigger]
-                path.inv() && path.len() == node.level ==> self.visit(path).last() != node,
+            node.level() > 0 ==> forall|path: TreePath<N>| #[trigger]
+                path.inv() && path.len() == node.level() ==> self.visit(path).last() != node,
     {
     }
 
@@ -1775,18 +1803,18 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
         path_between::<T, N, L>(self.root, node)
     }
 
-    pub broadcast proof fn get_path_properties(self, node: Node<T, N, L>)
+    pub broadcast proof fn lemma_get_path_properties(self, node: Node<T, N, L>)
         requires
             self.inv(),
             node.inv(),
             self.on_tree(node),
         ensures
             #[trigger] self.get_path(node).inv(),
-            #[trigger] self.get_path(node).len() == node.level,
-            node.level == 0 ==> #[trigger] self.get_path(node).is_empty(),
-            node.level > 0 ==> #[trigger] self.visit(self.get_path(node)).last() == node,
+            #[trigger] self.get_path(node).len() == node.level(),
+            node.level() == 0 ==> #[trigger] self.get_path(node).is_empty(),
+            node.level() > 0 ==> #[trigger] self.visit(self.get_path(node)).last() == node,
     {
-        path_between_properties(self.root, node);
+        lemma_path_between_properties(self.root, node);
     }
 }
 
@@ -1794,53 +1822,47 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
 verus! {
 
 pub broadcast group group_ghost_tree {
-    TreePath::inv_property,
-    TreePath::index_satisfies_elem_inv,
-    TreePath::empty_satisfies_inv,
-    TreePath::drop_head_property,
-    TreePath::drop_last_property,
-    TreePath::pop_head_preserves_inv,
-    TreePath::pop_head_decreases_len,
-    TreePath::pop_head_head_satisfies_inv,
-    TreePath::pop_head_property,
-    TreePath::pop_tail_preserves_inv,
-    TreePath::pop_tail_decreases_len,
-    TreePath::pop_tail_tail_satisfies_inv,
-    TreePath::pop_tail_property,
-    TreePath::push_head_property,
-    TreePath::new_empty_preserves_inv,
-    TreePath::new_preserves_inv,
-    Node::insert_preserves_inv,
-    Node::insert_property,
-    Node::insert_same_child_identical,
-    Node::remove_preserves_inv,
-    Node::remove_property,
-    Node::child_property,
-    Node::child_property_cases,
+    TreePath::lemma_index_satisfies_elem_inv,
+    TreePath::lemma_pop_head_preserves_inv,
+    TreePath::lemma_pop_head_index,
+    TreePath::lemma_pop_tail_preserves_inv,
+    TreePath::lemma_pop_tail_index,
+    TreePath::lemma_push_tail_preserves_inv,
+    TreePath::lemma_push_tail_len,
+    TreePath::lemma_push_head_preserves_inv,
+    TreePath::lemma_new_preserves_inv,
+    Node::lemma_new_properties,
+    Node::lemma_insert_preserves_inv,
+    Node::lemma_insert_property,
+    Node::lemma_insert_same_child_identical,
+    Node::lemma_remove_preserves_inv,
+    Node::lemma_remove_property,
+    Node::lemma_child_property,
+    Node::lemma_child_property_cases,
     Node::lemma_insert_child_is_child,
     Node::lemma_remove_child_is_none,
-    Node::get_value_property,
-    Node::set_value_property,
-    Node::is_leaf_bounded,
+    Node::lemma_get_value_property,
+    Node::lemma_set_value_property,
+    Node::lemma_is_leaf_bounded,
     Node::lemma_recursive_visited_node_inv,
     Node::lemma_recursive_visited_node_levels,
     Node::lemma_recursive_visit_head,
     Node::lemma_recursive_visit_induction,
     Node::lemma_recursive_visit_one_is_child,
-    Node::on_subtree_property,
-    Node::not_on_subtree_property,
+    Node::lemma_on_subtree_property,
+    Node::lemma_not_on_subtree_property,
     Node::lemma_on_subtree_reflexive,
     Node::lemma_child_on_subtree,
     Node::lemma_insert_on_subtree,
     Node::lemma_recursive_remove_preserves_inv,
-    path_between_properties,
-    Tree::new_preserves_inv,
-    Tree::visit_is_recursive_visit,
-    Tree::insert_preserves_inv,
-    Tree::remove_preserves_inv,
-    Tree::visited_nodes_inv,
-    Tree::on_tree_property,
-    Tree::not_on_tree_property,
+    lemma_path_between_properties,
+    Tree::lemma_new_preserves_inv,
+    Tree::lemma_visit_is_recursive_visit,
+    Tree::lemma_insert_preserves_inv,
+    Tree::lemma_remove_preserves_inv,
+    Tree::lemma_visited_nodes_inv,
+    Tree::lemma_on_tree_property,
+    Tree::lemma_not_on_tree_property,
 }
 
 } // verus!

--- a/verified_libs/vstd_extra/src/ghost_tree.rs
+++ b/verified_libs/vstd_extra/src/ghost_tree.rs
@@ -33,7 +33,7 @@ impl<const N: usize> TreePath<N> {
     }
 
     // Do NOT inline, it is used as trigger.
-    pub open spec fn spec_index(self, i:int) -> int {
+    pub open spec fn spec_index(self, i: int) -> int {
         self.index(i)
     }
 
@@ -44,7 +44,7 @@ impl<const N: usize> TreePath<N> {
 
     pub open spec fn inv(self) -> bool {
         &&& N > 0
-        &&& forall |i: int| 0 <= i < self.len() ==> Self::elem_inv(#[trigger] self[i])
+        &&& forall|i: int| 0 <= i < self.len() ==> Self::elem_inv(#[trigger] self[i])
     }
 
     pub broadcast proof fn lemma_index_satisfies_elem_inv(self, i: int)
@@ -188,8 +188,7 @@ impl<const N: usize> TreePath<N> {
         ensures
             #![trigger self.push_tail(val)]
             self.push_tail(val)[self.len() as int] == val,
-            forall|i: int|
-                0 <= i < self.len() ==> #[trigger] self.push_tail(val)[i] == self[i],
+            forall|i: int| 0 <= i < self.len() ==> #[trigger] self.push_tail(val)[i] == self[i],
     {
     }
 
@@ -210,20 +209,18 @@ impl<const N: usize> TreePath<N> {
         }
     }
 
-    pub open spec fn new(path: Seq<int>) -> TreePath<N>
-    {
+    pub open spec fn new(path: Seq<int>) -> TreePath<N> {
         TreePath(path)
     }
 
     pub broadcast proof fn lemma_new_preserves_inv(path: Seq<int>)
         requires
             N > 0,
-            forall |i: int| 0 <= i < path.len() ==> Self::elem_inv(#[trigger] path[i]),
+            forall|i: int| 0 <= i < path.len() ==> Self::elem_inv(#[trigger] path[i]),
         ensures
             (#[trigger] Self::new(path)).inv(),
     {
     }
-
 }
 
 } // verus!
@@ -256,10 +253,10 @@ pub trait TreeNodeValue<const L: usize>: Sized + Inv {
 }
 
 /// A ghost tree node with depth `L` and `N` children.
-/// 
+///
 /// Each tree node has a value of type `T` and a sequence of children, forming a subtree.
 /// The length of the child seuquence is fixed at `N`, while the absence of a child is represeneted with `Option::None`.
-/// The maximum depth of the tree is `L`. 
+/// The maximum depth of the tree is `L`.
 pub tracked struct TreeNode<T: TreeNodeValue<L>, const N: usize, const L: usize> {
     tracked value: T,
     ghost level: nat,
@@ -290,7 +287,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
 
     /// Returns the `i`-th child. Only valid when it exists.
     pub open spec fn child(self, i: int) -> Self {
-        self.children()[i] -> 0
+        self.children()[i]->0
     }
 
     #[verifier::inline]
@@ -363,11 +360,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         }
     }
 
-    pub broadcast proof fn lemma_new_properties(
-        value: T,
-        level: nat,
-        children: Seq<Option<Self>>,
-    )
+    pub broadcast proof fn lemma_new_properties(value: T, level: nat, children: Seq<Option<Self>>)
         ensures
             #![trigger Self::new(value, level, children)]
             Self::new(value, level, children).value() == value,
@@ -380,8 +373,8 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         ensures
             #![trigger Self::new_val(val,lv)]
             Self::new_val(val, lv).value() == val,
-            Self::new_val(val,lv).level() == lv,
-            Self::new_val(val,lv).children() == Seq::new(N as nat, |i| None),
+            Self::new_val(val, lv).level() == lv,
+            Self::new_val(val, lv).children() == Seq::new(N as nat, |i| None),
     {
         Self::lemma_new_properties(val, lv, Seq::new(N as nat, |i| None));
     }
@@ -404,7 +397,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             0 <= i < self.children().len(),
             self.children()[i] is Some,
         ensures
-            *ret == self.children()[i] -> 0,
+            *ret == self.children()[i]->0,
     {
         self.children.tracked_borrow(i).tracked_borrow()
     }
@@ -420,8 +413,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             final(self).value() == old(self).value(),
             final(self).level() == old(self).level(),
             final(self).children() == old(self).children().update(i, Some(*final(ret))),
-        ;
-
+    ;
 
     pub proof fn tracked_borrow_value(tracked &self) -> (tracked res: &T)
         ensures
@@ -455,8 +447,9 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         if self.level() < L - 1 {
             &&& f(self.value(), path)
             &&& forall|i: int|
-                0 <= i < self.children().len() ==> (#[trigger] self.has_child(i))
-                    ==> self.child(i).subtree_satisfies(path.push_tail(i), f)
+                0 <= i < self.children().len() ==> (#[trigger] self.has_child(i)) ==> self.child(
+                    i,
+                ).subtree_satisfies(path.push_tail(i), f)
         } else {
             &&& f(self.value(), path)
         }
@@ -483,7 +476,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         f: spec_fn(T, TreePath<N>) -> bool,
         g: spec_fn(T, TreePath<N>) -> bool,
     ) -> bool {
-        forall |value: T, path: TreePath<N>|
+        forall|value: T, path: TreePath<N>|
             value.inv() ==> f(value, path) ==> #[trigger] g(value, path)
     }
 
@@ -504,11 +497,9 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         if self.level() < L - 1 {
             assert forall|i: int|
                 #![trigger self.has_child(i)]
-                0 <= i < self.children().len()
-                    && self.has_child(i) implies self.child(i).subtree_satisfies(
-                path.push_tail(i),
-                g,
-            ) by {
+                0 <= i < self.children().len() && self.has_child(i) implies self.child(
+                i,
+            ).subtree_satisfies(path.push_tail(i), g) by {
                 self.child(i).lemma_subtree_satisfies_implies(path.push_tail(i), f, g);
             }
         }
@@ -532,7 +523,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
     /// If `f(val, path)`, then  `TreeNode::new_val(val,lv).subtree_satisifies(path,f)`.
     pub proof fn lemma_new_val_subtree_satisfies(
         val: T,
-        lv: nat, 
+        lv: nat,
         path: TreePath<N>,
         f: spec_fn(T, TreePath<N>) -> bool,
     )
@@ -565,11 +556,9 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         if self.level() < L - 1 {
             assert forall|i: int|
                 #![trigger self.children()[i]->0]
-                0 <= i < self.children().len()
-                    && self.has_child(i) implies self.child(i).subtree_satisfies(
-                path.push_tail(i),
-                g,
-            ) by {
+                0 <= i < self.children().len() && self.has_child(i) implies self.child(
+                i,
+            ).subtree_satisfies(path.push_tail(i), g) by {
                 self.child(i).lemma_subtree_satisfies_implies_and(path.push_tail(i), f1, f2, g);
             }
         }
@@ -604,11 +593,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             0 <= key < Self::size(),
             node.level() == self.level() + 1,
     {
-        Self::new(
-            self.value(),
-            self.level(),
-            self.children().update(key, Some(node)),
-        )
+        Self::new(self.value(), self.level(), self.children().update(key, Some(node)))
     }
 
     pub broadcast proof fn lemma_insert_preserves_inv(self, key: int, node: Self)
@@ -631,7 +616,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             #![trigger self.insert(key, node)]
             self.insert(key, node).value() == self.value(),
             self.insert(key, node).children()[key] == Some(node),
-            self.insert(key,node).children() == self.children().update(key, Some(node)),
+            self.insert(key, node).children() == self.children().update(key, Some(node)),
     {
     }
 
@@ -733,7 +718,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
     }
 
     pub open spec fn is_leaf(self) -> bool {
-        forall |i: int| 0 <= i < Self::size() ==> ! #[trigger] self.has_child(i)
+        forall|i: int| 0 <= i < Self::size() ==> !#[trigger] self.has_child(i)
     }
 
     pub broadcast proof fn lemma_is_leaf_bounded(self)
@@ -769,11 +754,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         }
     }
 
-    pub proof fn lemma_recursive_insert_path_empty_identical(
-        self,
-        path: TreePath<N>,
-        node: Self,
-    )
+    pub proof fn lemma_recursive_insert_path_empty_identical(self, path: TreePath<N>, node: Self)
         requires
             self.inv(),
             node.inv(),
@@ -806,24 +787,18 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             node.level() == self.level() + path.len() as nat,
             path.len() > 1,
         ensures
-            self.has_child(path[0]) ==> self.recursive_insert(path, node)
-                == self.insert(
+            self.has_child(path[0]) ==> self.recursive_insert(path, node) == self.insert(
                 path[0],
                 self.child(path[0]).recursive_insert(path.pop_head().1, node),
             ),
-            !self.has_child(path[0]) ==> self.recursive_insert(path, node)
-                == self.insert(
+            !self.has_child(path[0]) ==> self.recursive_insert(path, node) == self.insert(
                 path[0],
                 TreeNode::new_default(self.level() + 1).recursive_insert(path.pop_head().1, node),
             ),
     {
     }
 
-    pub proof fn lemma_recursive_insert_preserves_level(
-        self,
-        path: TreePath<N>,
-        node: Self,
-    )
+    pub proof fn lemma_recursive_insert_preserves_level(self, path: TreePath<N>, node: Self)
         requires
             self.inv(),
             path.inv(),
@@ -856,11 +831,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         }
     }
 
-    pub proof fn lemma_recursive_insert_preserves_value(
-        self,
-        path: TreePath<N>,
-        node: Self,
-    )
+    pub proof fn lemma_recursive_insert_preserves_value(self, path: TreePath<N>, node: Self)
         requires
             self.inv(),
             path.inv(),
@@ -1213,9 +1184,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             path.len() < L - self.level(),
             path.len() == 1,
         ensures
-            self.has_child(path[0]) ==> self.recursive_visit(path) == seq![
-                self.child(path[0]),
-            ],
+            self.has_child(path[0]) ==> self.recursive_visit(path) == seq![self.child(path[0])],
             !self.has_child(path[0]) ==> self.recursive_visit(path) == seq![],
     {
     }
@@ -1227,7 +1196,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             node.level() >= self.level(),
             node.level() < L,
     {
-        node == self || exists |path: TreePath<N>| #[trigger]
+        node == self || exists|path: TreePath<N>| #[trigger]
             path.inv() && path.len() > 0 && path.len() == node.level() - self.level()
                 && self.recursive_visit(path).last() == node
     }
@@ -1241,7 +1210,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             #[trigger] self.on_subtree(node),
         ensures
             node.level() == self.level() ==> self == node,
-            node.level() > self.level() ==> exists |path: TreePath<N>| #[trigger]
+            node.level() > self.level() ==> exists|path: TreePath<N>| #[trigger]
                 path.inv() && path.len() == node.level() - self.level() && self.recursive_visit(
                     path,
                 ).last() == node,
@@ -1256,7 +1225,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             !#[trigger] self.on_subtree(node),
         ensures
             self != node,
-            node.level() > self.level() ==> forall |path: TreePath<N>| #[trigger]
+            node.level() > self.level() ==> forall|path: TreePath<N>| #[trigger]
                 path.inv() && path.len() == node.level() - self.level() ==> self.recursive_visit(
                     path,
                 ).last() != node,
@@ -1411,7 +1380,9 @@ pub closed spec fn path_between<T: TreeNodeValue<L>, const N: usize, const L: us
         src.level() <= dst.level(),
         src.on_subtree(dst),
 {
-    if src.inv() && dst.inv() && dst.level() >= src.level() && dst.level() < L && src.on_subtree(dst) {
+    if src.inv() && dst.inv() && dst.level() >= src.level() && dst.level() < L && src.on_subtree(
+        dst,
+    ) {
         if src == dst {
             TreePath::new(seq![])
         } else {
@@ -1424,10 +1395,11 @@ pub closed spec fn path_between<T: TreeNodeValue<L>, const N: usize, const L: us
     }
 }
 
-pub broadcast proof fn lemma_path_between_properties<T: TreeNodeValue<L>, const N: usize, const L: usize>(
-    src: TreeNode<T, N, L>,
-    dst: TreeNode<T, N, L>,
-)
+pub broadcast proof fn lemma_path_between_properties<
+    T: TreeNodeValue<L>,
+    const N: usize,
+    const L: usize,
+>(src: TreeNode<T, N, L>, dst: TreeNode<T, N, L>)
     requires
         src.inv(),
         dst.inv(),
@@ -1580,7 +1552,11 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
         self.root.lemma_recursive_seek_trace_next(path, idx)
     }
 
-    pub broadcast proof fn lemma_insert_preserves_inv(self, path: TreePath<N>, node: TreeNode<T, N, L>)
+    pub broadcast proof fn lemma_insert_preserves_inv(
+        self,
+        path: TreePath<N>,
+        node: TreeNode<T, N, L>,
+    )
         requires
             self.inv(),
             path.inv(),

--- a/verified_libs/vstd_extra/src/ghost_tree.rs
+++ b/verified_libs/vstd_extra/src/ghost_tree.rs
@@ -619,7 +619,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         T::lemma_default_preserves_la_inv();
     }
 
-    pub open spec fn insert(self, key: int, node: Self) -> Self
+    pub open spec fn update(self, key: int, node: Self) -> Self
         recommends
             0 <= key < Self::size(),
             self.inv(),
@@ -634,7 +634,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         )
     }
 
-    pub broadcast proof fn lemma_insert_preserves_inv(self, key: int, node: Self)
+    pub broadcast proof fn lemma_update_preserves_inv(self, key: int, node: Self)
         requires
             0 <= key < Self::size(),
             self.inv(),
@@ -643,11 +643,11 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             node.level() == self.level() + 1,
             self.value().rel_children(key, Some(node.value())),
         ensures
-            (#[trigger] self.insert(key, node)).inv(),
+            (#[trigger] self.update(key, node)).inv(),
     {
     }
 
-    pub broadcast proof fn lemma_insert_property(self, key: int, node: Self)
+    pub broadcast proof fn lemma_update_property(self, key: int, node: Self)
         requires
             0 <= key < Self::size(),
             self.inv(),
@@ -655,25 +655,25 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             self.level() < L - 1,
             node.level() == self.level() + 1,
         ensures
-            #[trigger] self.insert(key, node).value() == self.value(),
-            self.insert(key, node).children()[key] == Some(node),
+            #[trigger] self.update(key, node).value() == self.value(),
+            self.update(key, node).children()[key] == Some(node),
             forall|i: int|
-                0 <= i < Self::size() && i != key ==> #[trigger] self.insert(key, node).children()[i]
+                0 <= i < Self::size() && i != key ==> #[trigger] self.update(key, node).children()[i]
                     == self.children()[i],
     {
     }
 
-    pub proof fn lemma_insert_same_child_identical(self, key: int, node: Self)
+    pub proof fn lemma_update_same_child_identical(self, key: int, node: Self)
         requires
             0 <= key < Self::size(),
             self.inv(),
             self.has_child(key),
             self.child(key) == node,
         ensures
-            self.insert(key, node) == self,
+            self.update(key, node) == self,
     {
-        self.lemma_insert_property(key, node);
-        assert(self.insert(key, node).children() == self.children());
+        self.lemma_update_property(key, node);
+        assert(self.update(key, node).children() == self.children());
     }
 
     pub open spec fn remove(self, key: int) -> Self
@@ -707,7 +707,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
     {
     }
 
-    pub broadcast proof fn lemma_insert_child_is_child(self, key: int, node: Self)
+    pub broadcast proof fn lemma_update_child_is_child(self, key: int, node: Self)
         requires
             0 <= key < Self::size(),
             self.inv(),
@@ -715,10 +715,10 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             self.level() < L - 1,
             node.level() == self.level() + 1,
         ensures
-            #[trigger] self.insert(key, node).has_child(key),
-            self.insert(key, node).child(key) == node,
+            #[trigger] self.update(key, node).has_child(key),
+            self.update(key, node).child(key) == node,
     {
-        self.lemma_insert_property(key, node);
+        self.lemma_update_property(key, node);
     }
 
     pub broadcast proof fn lemma_remove_child_is_none(self, key: int)
@@ -817,7 +817,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         if path.is_empty() {
             self
         } else if path.len() == 1 {
-            self.insert(path[0], node)
+            self.update(path[0], node)
         } else {
             let (hd, tl) = path.pop_head();
             let child = if self.has_child(hd) {
@@ -826,7 +826,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
                 TreeNode::new_default(self.level() + 1)
             };
             let updated_child = child.recursive_insert(tl, node);
-            self.insert(hd, updated_child)
+            self.update(hd, updated_child)
         }
     }
 
@@ -854,7 +854,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             1 < L - self.level(),
             node.level() == self.level() + 1,
         ensures
-            #[trigger] self.recursive_insert(path, node) == self.insert(path[0], node),
+            #[trigger] self.recursive_insert(path, node) == self.update(path[0], node),
     {
     }
 
@@ -868,12 +868,12 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             path.len() > 1,
         ensures
             self.has_child(path[0]) ==> #[trigger] self.recursive_insert(path, node)
-                == self.insert(
+                == self.update(
                 path[0],
                 self.child(path[0]).recursive_insert(path.pop_head().1, node),
             ),
             !self.has_child(path[0]) ==> #[trigger] self.recursive_insert(path, node)
-                == self.insert(
+                == self.update(
                 path[0],
                 TreeNode::new_default(self.level() + 1).recursive_insert(path.pop_head().1, node),
             ),
@@ -902,17 +902,17 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         } else if path.len() == 1 {
             path.lemma_index_satisfies_elem_inv(0);
             self.lemma_recursive_insert_path_len_1(path, node);
-            assert(self.insert(path[0], node).level() == self.level());
+            assert(self.update(path[0], node).level() == self.level());
         } else {
             self.lemma_recursive_insert_path_len_step(path, node);
             let (hd, tl) = path.pop_head();
             path.lemma_pop_head_preserves_inv();
             if self.has_child(hd) {
                 let c = self.child(hd);
-                assert(self.insert(hd, c.recursive_insert(tl, node)).level() == self.level());
+                assert(self.update(hd, c.recursive_insert(tl, node)).level() == self.level());
             } else {
                 let c = TreeNode::new_default(self.level() + 1);
-                assert(self.insert(hd, c.recursive_insert(tl, node)).level() == self.level());
+                assert(self.update(hd, c.recursive_insert(tl, node)).level() == self.level());
             }
         }
     }
@@ -978,7 +978,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         } else if path.len() == 1 {
             path.lemma_index_satisfies_elem_inv(0);
             self.lemma_recursive_insert_path_len_1(path, node);
-            self.lemma_insert_preserves_inv(path[0], node);
+            self.lemma_update_preserves_inv(path[0], node);
         } else {
             self.lemma_recursive_insert_path_len_step(path, node);
             let (hd, tl) = path.pop_head();
@@ -990,7 +990,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
                 c.lemma_recursive_insert_preserves_level(tl, node);
                 c.lemma_recursive_insert_preserves_value(tl, node);
                 let updated_child = c.recursive_insert(tl, node);
-                self.lemma_insert_preserves_inv(hd, updated_child);
+                self.lemma_update_preserves_inv(hd, updated_child);
             } else {
                 let c = TreeNode::new_default(self.level() + 1);
                 Self::lemma_new_default_preserves_inv(self.level() + 1);
@@ -999,7 +999,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
                 c.lemma_recursive_insert_preserves_level(tl, node);
                 c.lemma_recursive_insert_preserves_value(tl, node);
                 let updated_child = c.recursive_insert(tl, node);
-                self.lemma_insert_preserves_inv(hd, updated_child);
+                self.lemma_update_preserves_inv(hd, updated_child);
             }
         }
     }
@@ -1343,7 +1343,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         assert(TreePath::<N>::new(seq![key]).inv());
     }
 
-    pub broadcast proof fn lemma_insert_on_subtree(self, key: int, node: Self)
+    pub broadcast proof fn lemma_update_on_subtree(self, key: int, node: Self)
         requires
             0 <= key < Self::size(),
             self.inv(),
@@ -1352,10 +1352,10 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             node.level() == self.level() + 1,
             self.value().rel_children(key, Some(node.value())),
         ensures
-            #[trigger] self.insert(key, node).on_subtree(node),
+            #[trigger] self.update(key, node).on_subtree(node),
     {
-        self.lemma_insert_child_is_child(key, node);
-        self.insert(key, node).lemma_child_on_subtree(key);
+        self.lemma_update_child_is_child(key, node);
+        self.update(key, node).lemma_child_on_subtree(key);
     }
 
     /// Remove the tree node at the end of the path
@@ -1381,7 +1381,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             } else {
                 let child = self.child(hd);
                 let updated_child = child.recursive_remove(tl);
-                self.insert(hd, updated_child)
+                self.update(hd, updated_child)
             }
         }
     }
@@ -1456,7 +1456,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
                 c.lemma_recursive_remove_preserves_level(tl);
                 c.lemma_recursive_remove_preserves_value(tl);
                 let updated_child = c.recursive_remove(tl);
-                self.lemma_insert_preserves_inv(hd, updated_child);
+                self.lemma_update_preserves_inv(hd, updated_child);
             }
         }
     }
@@ -1775,11 +1775,11 @@ pub broadcast group group_ghost_tree {
     TreePath::lemma_push_head_preserves_inv,
     TreePath::lemma_new_preserves_inv,
     TreeNode::lemma_new_properties,
-    TreeNode::lemma_insert_preserves_inv,
-    TreeNode::lemma_insert_property,
+    TreeNode::lemma_update_preserves_inv,
+    TreeNode::lemma_update_property,
     TreeNode::lemma_remove_preserves_inv,
     TreeNode::lemma_remove_property,
-    TreeNode::lemma_insert_child_is_child,
+    TreeNode::lemma_update_child_is_child,
     TreeNode::lemma_remove_child_is_none,
     TreeNode::lemma_set_value_property,
     TreeNode::lemma_set_value_observable_fields,
@@ -1793,7 +1793,7 @@ pub broadcast group group_ghost_tree {
     TreeNode::lemma_not_on_subtree_property,
     TreeNode::lemma_on_subtree_reflexive,
     TreeNode::lemma_child_on_subtree,
-    TreeNode::lemma_insert_on_subtree,
+    TreeNode::lemma_update_on_subtree,
     TreeNode::lemma_recursive_remove_preserves_inv,
     lemma_path_between_properties,
     Tree::lemma_new_preserves_inv,

--- a/verified_libs/vstd_extra/src/ghost_tree.rs
+++ b/verified_libs/vstd_extra/src/ghost_tree.rs
@@ -52,7 +52,8 @@ impl<const N: usize> TreePath<N> {
             self.inv(),
             0 <= i < self.len(),
         ensures
-            Self::elem_inv(#[trigger] self[i]),
+            #![trigger self.spec_index(i)]
+            Self::elem_inv(self[i]),
     {
     }
 

--- a/verified_libs/vstd_extra/src/ghost_tree.rs
+++ b/verified_libs/vstd_extra/src/ghost_tree.rs
@@ -13,25 +13,25 @@ verus! {
 /// Each element selects one child at the corresponding tree level.
 /// `N` is the maximum number of children of each node, so every index is less than `N`.
 #[verifier::ext_equal]
-pub tracked struct TreePath<const N: usize>(pub Seq<usize>);
+pub tracked struct TreePath<const N: usize>(pub Seq<int>);
 
 impl<const N: usize> TreePath<N> {
     pub open spec fn len(self) -> nat {
         self.0.len()
     }
 
-    pub open spec fn index(self, i: int) -> usize
+    pub open spec fn index(self, i: int) -> int
         recommends
             0 <= i < self.len(),
     {
         self.0[i]
     }
 
-    pub open spec fn spec_index(self, i:int) -> usize {
+    pub open spec fn spec_index(self, i:int) -> int {
         self.index(i)
     }
 
-    pub open spec fn elem_inv(e: usize) -> bool {
+    pub open spec fn elem_inv(e: int) -> bool {
         0 <= e < N
     }
 
@@ -45,7 +45,7 @@ impl<const N: usize> TreePath<N> {
             self.inv(),
             0 <= i < self.len(),
         ensures
-            #[trigger] Self::elem_inv(self.index(i)),
+            Self::elem_inv(#[trigger] self.index(i)),
     {
     }
 
@@ -66,7 +66,7 @@ impl<const N: usize> TreePath<N> {
         Self(self.0.add(path.0))
     }
 
-    pub open spec fn pop_head(self) -> (usize, TreePath<N>)
+    pub open spec fn pop_head(self) -> (int, TreePath<N>)
         recommends
             !self.is_empty(),
     {
@@ -94,7 +94,7 @@ impl<const N: usize> TreePath<N> {
     {
     }
 
-    pub open spec fn pop_tail(self) -> (usize, TreePath<N>)
+    pub open spec fn pop_tail(self) -> (int, TreePath<N>)
         recommends
             !self.is_empty(),
     {
@@ -124,14 +124,14 @@ impl<const N: usize> TreePath<N> {
     {
     }
 
-    pub open spec fn push_head(self, hd: usize) -> TreePath<N>
+    pub open spec fn push_head(self, hd: int) -> TreePath<N>
         recommends
             0 <= hd < N,
     {
         TreePath(seq![hd].add(self.0))
     }
 
-    pub proof fn lemma_push_head_index(self, hd: usize)
+    pub proof fn lemma_push_head_index(self, hd: int)
         requires
             self.inv(),
             0 <= hd < N,
@@ -141,7 +141,7 @@ impl<const N: usize> TreePath<N> {
     {
     }
 
-    pub broadcast proof fn lemma_push_head_preserves_inv(self, hd: usize)
+    pub broadcast proof fn lemma_push_head_preserves_inv(self, hd: int)
         requires
             self.inv(),
             0 <= hd < N,
@@ -157,14 +157,14 @@ impl<const N: usize> TreePath<N> {
         }
     }
 
-    pub open spec fn push_tail(self, val: usize) -> TreePath<N>
+    pub open spec fn push_tail(self, val: int) -> TreePath<N>
         recommends
             0 <= val < N,
     {
         TreePath(self.0.push(val))
     }
 
-    pub broadcast proof fn lemma_push_tail_len(self, val: usize)
+    pub broadcast proof fn lemma_push_tail_len(self, val: int)
         requires
             self.inv(),
             0 <= val < N,
@@ -173,7 +173,7 @@ impl<const N: usize> TreePath<N> {
     {
     }
 
-    pub proof fn lemma_push_tail_index(self, val: usize)
+    pub proof fn lemma_push_tail_index(self, val: int)
         requires
             self.inv(),
             0 <= val < N,
@@ -184,7 +184,7 @@ impl<const N: usize> TreePath<N> {
     {
     }
 
-    pub broadcast proof fn lemma_push_tail_preserves_inv(self, val: usize)
+    pub broadcast proof fn lemma_push_tail_preserves_inv(self, val: int)
         requires
             self.inv(),
             0 <= val < N,
@@ -200,19 +200,19 @@ impl<const N: usize> TreePath<N> {
         }
     }
 
-    pub open spec fn new(path: Seq<usize>) -> TreePath<N>
+    pub open spec fn new(path: Seq<int>) -> TreePath<N>
         recommends
             forall|i: int| 0 <= i < path.len() ==> Self::elem_inv(#[trigger] path[i]),
     {
         TreePath(path)
     }
 
-    pub broadcast proof fn lemma_new_preserves_inv(path: Seq<usize>)
+    pub broadcast proof fn lemma_new_preserves_inv(path: Seq<int>)
         requires
             N > 0,
             forall|i: int| 0 <= i < path.len() ==> Self::elem_inv(#[trigger] path[i]),
         ensures
-            #[trigger] Self::new(path).inv(),
+            (#[trigger] Self::new(path)).inv(),
     {
     }
 
@@ -275,13 +275,13 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
     }
 
     /// Returns whether the `i`-th child exists.
-    pub open spec fn has_child(self, i: usize) -> bool {
-        self.children()[i as int] is Some
+    pub open spec fn has_child(self, i: int) -> bool {
+        self.children()[i] is Some
     }
 
     /// Returns the `i`-th child. Only valid when it exists.
-    pub open spec fn child(self, i: usize) -> Self {
-        self.children()[i as int] -> 0
+    pub open spec fn child(self, i: int) -> Self {
+        self.children()[i] -> 0
     }
 
     #[verifier::inline]
@@ -371,7 +371,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         children: Seq<Option<Self>>,
     )
         ensures
-            #[trigger] Self::new(value, level, children).value() == value,
+            (#[trigger] Self::new(value, level, children)).value() == value,
             Self::new(value, level, children).level() == level,
             Self::new(value, level, children).children() == children,
     {
@@ -382,7 +382,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         requires
             self.value() == other.value(),
             self.level() == other.level(),
-            self.children() == other.children(),
+            self.children() =~= other.children(),
         ensures
             self == other,
     {
@@ -468,7 +468,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             &&& f(self.value(), path)
             &&& forall|i: int|
                 0 <= i < self.children().len() ==> (#[trigger] self.children()[i]) is Some
-                    ==> self.children()[i]->0.subtree_satisfies(path.push_tail(i as usize), f)
+                    ==> self.children()[i]->0.subtree_satisfies(path.push_tail(i), f)
         } else {
             &&& f(self.value(), path)
         }
@@ -487,7 +487,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             self.children()[i] is Some,
             self.subtree_satisfies(path, f),
         ensures
-            self.children()[i]->0.subtree_satisfies(path.push_tail(i as usize), f),
+            self.children()[i]->0.subtree_satisfies(path.push_tail(i), f),
     {
     }
 
@@ -518,10 +518,10 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
                 #![trigger self.children()[i]->0]
                 0 <= i < self.children().len()
                     && self.children()[i] is Some implies self.children()[i]->0.subtree_satisfies(
-                path.push_tail(i as usize),
+                path.push_tail(i),
                 g,
             ) by {
-                self.children()[i]->0.lemma_map_implies(path.push_tail(i as usize), f, g);
+                self.children()[i]->0.lemma_map_implies(path.push_tail(i), f, g);
             }
         }
     }
@@ -583,10 +583,10 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
                 #![trigger self.children()[i]->0]
                 0 <= i < self.children().len()
                     && self.children()[i] is Some implies self.children()[i]->0.subtree_satisfies(
-                path.push_tail(i as usize),
+                path.push_tail(i),
                 g,
             ) by {
-                self.children()[i]->0.lemma_map_implies_and(path.push_tail(i as usize), f1, f2, g);
+                self.children()[i]->0.lemma_map_implies_and(path.push_tail(i), f1, f2, g);
             }
         }
     }
@@ -614,7 +614,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         T::lemma_default_preserves_la_inv();
     }
 
-    pub open spec fn insert(self, key: usize, node: Self) -> Self
+    pub open spec fn insert(self, key: int, node: Self) -> Self
         recommends
             0 <= key < Self::size(),
             self.inv(),
@@ -625,24 +625,24 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         Self::new(
             self.value(),
             self.level(),
-            self.children().update(key as int, Some(node)),
+            self.children().update(key, Some(node)),
         )
     }
 
-    pub broadcast proof fn lemma_insert_preserves_inv(self, key: usize, node: Self)
+    pub broadcast proof fn lemma_insert_preserves_inv(self, key: int, node: Self)
         requires
             0 <= key < Self::size(),
             self.inv(),
             node.inv(),
             self.level() < L - 1,
             node.level() == self.level() + 1,
-            self.value().rel_children(key as int, Some(node.value())),
+            self.value().rel_children(key, Some(node.value())),
         ensures
-            #[trigger] self.insert(key, node).inv(),
+            (#[trigger] self.insert(key, node)).inv(),
     {
     }
 
-    pub broadcast proof fn lemma_insert_property(self, key: usize, node: Self)
+    pub broadcast proof fn lemma_insert_property(self, key: int, node: Self)
         requires
             0 <= key < Self::size(),
             self.inv(),
@@ -651,58 +651,58 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             node.level() == self.level() + 1,
         ensures
             #[trigger] self.insert(key, node).value() == self.value(),
-            self.insert(key, node).children()[key as int] == Some(node),
+            self.insert(key, node).children()[key] == Some(node),
             forall|i: int|
                 0 <= i < Self::size() && i != key ==> #[trigger] self.insert(key, node).children()[i]
                     == self.children()[i],
     {
     }
 
-    pub broadcast proof fn lemma_insert_same_child_identical(self, key: usize, node: Self)
+    pub proof fn lemma_insert_same_child_identical(self, key: int, node: Self)
         requires
             0 <= key < Self::size(),
             self.inv(),
             self.has_child(key),
             self.child(key) == node,
         ensures
-            #[trigger] self.insert(key, node) == self,
+            self.insert(key, node) == self,
     {
         self.lemma_insert_property(key, node);
         assert(self.insert(key, node).children() == self.children());
     }
 
-    pub open spec fn remove(self, key: usize) -> Self
+    pub open spec fn remove(self, key: int) -> Self
         recommends
             0 <= key < Self::size(),
             self.inv(),
     {
-        Self::new(self.value(), self.level(), self.children().update(key as int, None))
+        Self::new(self.value(), self.level(), self.children().update(key, None))
     }
 
-    pub broadcast proof fn lemma_remove_preserves_inv(self, key: usize)
+    pub broadcast proof fn lemma_remove_preserves_inv(self, key: int)
         requires
             0 <= key < Self::size(),
             self.inv(),
-            self.children()[key as int] is None || self.value().rel_children(key as int, None),
+            self.children()[key] is None || self.value().rel_children(key, None),
         ensures
-            #[trigger] self.remove(key).inv(),
+            (#[trigger] self.remove(key)).inv(),
     {
     }
 
-    pub broadcast proof fn lemma_remove_property(self, key: usize)
+    pub broadcast proof fn lemma_remove_property(self, key: int)
         requires
             0 <= key < Self::size(),
             self.inv(),
         ensures
             #[trigger] self.remove(key).value() == self.value(),
-            self.remove(key).children()[key as int] is None,
+            self.remove(key).children()[key] is None,
             forall|i: int|
                 0 <= i < Self::size() && i != key ==> #[trigger] self.remove(key).children()[i]
                     == self.children()[i],
     {
     }
 
-    pub broadcast proof fn lemma_insert_child_is_child(self, key: usize, node: Self)
+    pub broadcast proof fn lemma_insert_child_is_child(self, key: int, node: Self)
         requires
             0 <= key < Self::size(),
             self.inv(),
@@ -716,7 +716,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         self.lemma_insert_property(key, node);
     }
 
-    pub broadcast proof fn lemma_remove_child_is_none(self, key: usize)
+    pub broadcast proof fn lemma_remove_child_is_none(self, key: int)
         requires
             0 <= key < Self::size(),
             self.inv(),
@@ -724,19 +724,6 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             !#[trigger] self.remove(key).has_child(key),
     {
         self.lemma_remove_property(key);
-    }
-
-    pub open spec fn get_value(self) -> T {
-        self.value()
-    }
-
-    pub broadcast proof fn lemma_get_value_property(self)
-        requires
-            self.inv(),
-        ensures
-            #[trigger] self.get_value() == self.value(),
-            self.get_value().inv(),
-    {
     }
 
     pub open spec fn set_value(self, value: T) -> Self
@@ -748,9 +735,9 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
     }
 
     /// Exposes the observable fields changed and preserved by `set_value`.
-    pub proof fn lemma_set_value_observable_fields(self, value: T)
+    pub broadcast proof fn lemma_set_value_observable_fields(self, value: T)
         ensures
-            self.set_value(value).value() == value,
+            (#[trigger] self.set_value(value)).value() == value,
             self.set_value(value).level() == self.level(),
             self.set_value(value).children() == self.children(),
     {
@@ -1131,13 +1118,13 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             path.len() < L - self.level(),
             0 <= idx < N,
         ensures
-            self.recursive_trace(path.push_tail(idx)).len() == path.len() + 2,
+            self.recursive_trace(path.push_tail(idx as int)).len() == path.len() + 2,
             self.recursive_seek(path)->0.children()[idx as int]->0.value() == self.recursive_trace(
-                path.push_tail(idx),
+                path.push_tail(idx as int),
             )[path.len() as int + 1],
         decreases path.len(),
     {
-        let path2 = path.push_tail(idx);
+        let path2 = path.push_tail(idx as int);
 
         if path.len() == 0 {
             assert(self.recursive_trace(path2) == seq![
@@ -1147,7 +1134,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         } else {
             let (_, tl1) = path.pop_head();
             let (hd2, tl2) = path2.pop_head();
-            assert(tl2 == tl1.push_tail(idx)) by {}
+            assert(tl2 == tl1.push_tail(idx as int)) by {}
             assert(tl1.inv()) by { path.lemma_pop_head_preserves_inv() }
             if self.has_child(hd2) {
                 self.child(hd2).lemma_recursive_seek_trace_next(tl1, idx);
@@ -1340,7 +1327,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
     {
     }
 
-    pub broadcast proof fn lemma_child_on_subtree(self, key: usize)
+    pub broadcast proof fn lemma_child_on_subtree(self, key: int)
         requires
             0 <= key < Self::size(),
             self.inv(),
@@ -1351,14 +1338,14 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         assert(TreePath::<N>::new(seq![key]).inv());
     }
 
-    pub broadcast proof fn lemma_insert_on_subtree(self, key: usize, node: Self)
+    pub broadcast proof fn lemma_insert_on_subtree(self, key: int, node: Self)
         requires
             0 <= key < Self::size(),
             self.inv(),
             node.inv(),
             self.level() < L - 1,
             node.level() == self.level() + 1,
-            self.value().rel_children(key as int, Some(node.value())),
+            self.value().rel_children(key, Some(node.value())),
         ensures
             #[trigger] self.insert(key, node).on_subtree(node),
     {
@@ -1654,9 +1641,9 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
             path.len() < L,
             0 <= idx < N,
         ensures
-            self.trace(path.push_tail(idx)).len() == path.len() + 2,
+            self.trace(path.push_tail(idx as int)).len() == path.len() + 2,
             self.seek(path)->0.children()[idx as int]->0.value() == self.trace(
-                path.push_tail(idx),
+                path.push_tail(idx as int),
             )[path.len() as int + 1],
     {
         self.root.lemma_recursive_seek_trace_next(path, idx)
@@ -1785,13 +1772,12 @@ pub broadcast group group_ghost_tree {
     TreeNode::lemma_new_properties,
     TreeNode::lemma_insert_preserves_inv,
     TreeNode::lemma_insert_property,
-    TreeNode::lemma_insert_same_child_identical,
     TreeNode::lemma_remove_preserves_inv,
     TreeNode::lemma_remove_property,
     TreeNode::lemma_insert_child_is_child,
     TreeNode::lemma_remove_child_is_none,
-    TreeNode::lemma_get_value_property,
     TreeNode::lemma_set_value_property,
+    TreeNode::lemma_set_value_observable_fields,
     TreeNode::lemma_is_leaf_bounded,
     TreeNode::lemma_recursive_visited_node_inv,
     TreeNode::lemma_recursive_visited_node_levels,

--- a/verified_libs/vstd_extra/src/ghost_tree.rs
+++ b/verified_libs/vstd_extra/src/ghost_tree.rs
@@ -489,10 +489,10 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             self.inv(),
             self.level() < L - 1,
             0 <= i < self.children().len(),
-            self.children()[i] is Some,
+            self.has_child(i),
             self.subtree_satisfies(path, f),
         ensures
-            self.children()[i]->0.subtree_satisfies(path.push_tail(i), f),
+            self.child(i).subtree_satisfies(path.push_tail(i), f),
     {
     }
 
@@ -522,11 +522,11 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             assert forall|i: int|
                 #![trigger self.children()[i]->0]
                 0 <= i < self.children().len()
-                    && self.children()[i] is Some implies self.children()[i]->0.subtree_satisfies(
+                    && self.has_child(i) implies self.child(i).subtree_satisfies(
                 path.push_tail(i),
                 g,
             ) by {
-                self.children()[i]->0.lemma_map_implies(path.push_tail(i), f, g);
+                self.child(i).lemma_map_implies(path.push_tail(i), f, g);
             }
         }
     }
@@ -587,11 +587,11 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             assert forall|i: int|
                 #![trigger self.children()[i]->0]
                 0 <= i < self.children().len()
-                    && self.children()[i] is Some implies self.children()[i]->0.subtree_satisfies(
+                    && self.has_child(i) implies self.child(i).subtree_satisfies(
                 path.push_tail(i),
                 g,
             ) by {
-                self.children()[i]->0.lemma_map_implies_and(path.push_tail(i), f1, f2, g);
+                self.child(i).lemma_map_implies_and(path.push_tail(i), f1, f2, g);
             }
         }
     }
@@ -769,7 +769,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             forall|i: int|
                 0 <= i < N ==> #[trigger] self.children()[i] is Some ==> value.rel_children(
                     i,
-                    Some(self.children()[i]->0.value()),
+                    Some(self.child(i).value()),
                 ),
             forall|i: int|
                 0 <= i < N ==> #[trigger] self.children()[i] is None ==> value.rel_children(i, None),
@@ -1117,14 +1117,14 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
     pub proof fn lemma_recursive_seek_trace_next(self, path: TreePath<N>, idx: usize)
         requires
             self.recursive_seek(path) is Some,
-            self.recursive_seek(path)->0.children()[idx as int] is Some,
+            self.recursive_seek(path)->0.has_child(idx as int),
             self.inv(),
             path.inv(),
             path.len() < L - self.level(),
             0 <= idx < N,
         ensures
             self.recursive_trace(path.push_tail(idx as int)).len() == path.len() + 2,
-            self.recursive_seek(path)->0.children()[idx as int]->0.value() == self.recursive_trace(
+            self.recursive_seek(path)->0.child(idx as int).value() == self.recursive_trace(
                 path.push_tail(idx as int),
             )[path.len() as int + 1],
         decreases path.len(),
@@ -1134,7 +1134,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         if path.len() == 0 {
             assert(self.recursive_trace(path2) == seq![
                 self.value(),
-                self.children()[idx as int]->0.value(),
+                self.child(idx as int).value(),
             ]) by { reveal_with_fuel(TreeNode::recursive_trace, 2) }
         } else {
             let (_, tl1) = path.pop_head();
@@ -1400,7 +1400,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         } else {
             let (hd, tl) = path.pop_head();
             path.lemma_pop_head_preserves_inv();
-            if self.children()[hd as int] is Some {
+            if self.has_child(hd) {
                 let c = self.child(hd);
                 c.lemma_recursive_remove_preserves_level(tl);
             }
@@ -1421,7 +1421,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         } else {
             let (hd, tl) = path.pop_head();
             path.lemma_pop_head_preserves_inv();
-            if self.children()[hd as int] is Some {
+            if self.has_child(hd) {
                 let c = self.child(hd);
                 c.lemma_recursive_remove_preserves_value(tl);
             }
@@ -1449,7 +1449,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         } else {
             let (hd, tl) = path.pop_head();
             path.lemma_pop_head_preserves_inv();
-            if self.children()[hd as int] is Some {
+            if self.has_child(hd) {
                 let c = self.child(hd);
                 assert(path.pop_tail().1.pop_head().1 == path.pop_head().1.pop_tail().1);
                 c.lemma_recursive_remove_preserves_inv(tl);
@@ -1640,14 +1640,14 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
     pub proof fn lemma_seek_trace_next(self, path: TreePath<N>, idx: usize)
         requires
             self.seek(path) is Some,
-            self.seek(path)->0.children()[idx as int] is Some,
+            self.seek(path)->0.has_child(idx as int),
             self.inv(),
             path.inv(),
             path.len() < L,
             0 <= idx < N,
         ensures
             self.trace(path.push_tail(idx as int)).len() == path.len() + 2,
-            self.seek(path)->0.children()[idx as int]->0.value() == self.trace(
+            self.seek(path)->0.child(idx as int).value() == self.trace(
                 path.push_tail(idx as int),
             )[path.len() as int + 1],
     {

--- a/verified_libs/vstd_extra/src/ghost_tree.rs
+++ b/verified_libs/vstd_extra/src/ghost_tree.rs
@@ -16,12 +16,10 @@ verus! {
 pub tracked struct TreePath<const N: usize>(pub Seq<int>);
 
 impl<const N: usize> TreePath<N> {
-    #[verifier::inline]
     pub open spec fn len(self) -> nat {
         self.0.len()
     }
 
-    #[verifier::inline]
     pub open spec fn is_empty(self) -> bool {
         self.len() == 0
     }
@@ -58,12 +56,12 @@ impl<const N: usize> TreePath<N> {
     {
     }
 
-    pub proof fn lemma_empty_satisfies_inv(self)
+    pub broadcast proof fn lemma_empty_satisfies_inv(self)
         requires
             N > 0,
             #[trigger] self.is_empty(),
         ensures
-            #[trigger] self.inv(),
+            self.inv(),
     {
     }
 
@@ -83,8 +81,8 @@ impl<const N: usize> TreePath<N> {
             self.inv(),
             !self.is_empty(),
         ensures
-            Self::elem_inv(self.pop_head().0),
-            (#[trigger] self.pop_head()).1.inv(),
+            #![trigger self.pop_head()]
+            self.pop_head().1.inv(),
     {
         let (_, s1) = self.pop_head();
         assert(forall|i: int| 0 <= i < s1.len() ==> s1[i] == self[i + 1]);
@@ -95,7 +93,8 @@ impl<const N: usize> TreePath<N> {
             self.inv(),
             !self.is_empty(),
         ensures
-            (#[trigger] self.pop_head()).0 == self[0],
+            #![trigger self.pop_head()]
+            self.pop_head().0 == self[0],
     {
     }
 
@@ -111,8 +110,8 @@ impl<const N: usize> TreePath<N> {
             self.inv(),
             !self.is_empty(),
         ensures
-            Self::elem_inv(self.pop_tail().0),
-            (#[trigger] self.pop_tail()).1.inv(),
+            #![trigger self.pop_tail()]
+            self.pop_tail().1.inv(),
     {
         let (_, s1) = self.pop_tail();
         if s1.len() > 0 {
@@ -136,13 +135,14 @@ impl<const N: usize> TreePath<N> {
         TreePath(seq![hd].add(self.0))
     }
 
-    pub proof fn lemma_push_head_index(self, hd: int)
+    pub broadcast proof fn lemma_push_head_index(self, hd: int)
         requires
             self.inv(),
             0 <= hd < N,
         ensures
+            #![trigger self.push_head(hd)]
             self.push_head(hd)[0] == hd,
-            forall|i: int| 0 <= i < self.len() ==> self.push_head(hd)[i + 1] == self[i],
+            forall|i: int| 0 <= i < self.len() ==> #[trigger] self.push_head(hd)[i + 1] == self[i],
     {
     }
 
@@ -151,7 +151,8 @@ impl<const N: usize> TreePath<N> {
             self.inv(),
             0 <= hd < N,
         ensures
-            (#[trigger] self.push_head(hd)).inv(),
+            #![trigger self.push_head(hd)]
+            self.push_head(hd).inv(),
     {
         let s1 = self.push_head(hd);
         assert forall|i: int| 0 <= i < s1.len() implies Self::elem_inv(#[trigger] s1[i]) by {
@@ -174,15 +175,17 @@ impl<const N: usize> TreePath<N> {
             self.inv(),
             0 <= val < N,
         ensures
-            (#[trigger] self.push_tail(val)).len() == self.len() + 1,
+            #![trigger self.push_tail(val)]
+            self.push_tail(val).len() == self.len() + 1,
     {
     }
 
-    pub proof fn lemma_push_tail_index(self, val: int)
+    pub broadcast proof fn lemma_push_tail_index(self, val: int)
         requires
             self.inv(),
             0 <= val < N,
         ensures
+            #![trigger self.push_tail(val)]
             self.push_tail(val)[self.len() as int] == val,
             forall|i: int|
                 0 <= i < self.len() ==> #[trigger] self.push_tail(val)[i] == self[i],
@@ -194,7 +197,8 @@ impl<const N: usize> TreePath<N> {
             self.inv(),
             0 <= val < N,
         ensures
-            (#[trigger]self.push_tail(val)).inv(),
+            #![trigger self.push_tail(val)]
+            self.push_tail(val).inv(),
     {
         let s1 = self.push_tail(val);
         assert forall|i: int| 0 <= i < s1.len() implies Self::elem_inv(#[trigger] s1[i]) by {
@@ -206,8 +210,6 @@ impl<const N: usize> TreePath<N> {
     }
 
     pub open spec fn new(path: Seq<int>) -> TreePath<N>
-        recommends
-            forall|i: int| 0 <= i < path.len() ==> Self::elem_inv(#[trigger] path[i]),
     {
         TreePath(path)
     }
@@ -215,7 +217,7 @@ impl<const N: usize> TreePath<N> {
     pub broadcast proof fn lemma_new_preserves_inv(path: Seq<int>)
         requires
             N > 0,
-            forall|i: int| 0 <= i < path.len() ==> Self::elem_inv(#[trigger] path[i]),
+            forall |i: int| 0 <= i < path.len() ==> Self::elem_inv(#[trigger] path[i]),
         ensures
             (#[trigger] Self::new(path)).inv(),
     {
@@ -304,28 +306,17 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         TreeNode { value, level, children: Ghost::new(children) }
     }
 
+    /// Constructs a node at the given level with default value and no children.
     pub open spec fn new_default(lv: nat) -> Self {
         Self::new(T::default(lv), lv, Seq::new(N as nat, |i| None))
     }
 
+    /// Constructs a node with a given value and level, without childrens.
     pub open spec fn new_val(val: T, lv: nat) -> Self
         recommends
             lv < L,
     {
         Self::new(val, lv, Seq::new(N as nat, |i| None))
-    }
-
-    /// Exposes the observable shape of a node returned by `tracked_new_val`.
-    pub proof fn lemma_new_val_properties(self, val: T, lv: nat)
-        requires
-            self == Self::new_val(val, lv),
-        ensures
-            self.value() == val,
-            self.level() == lv,
-            self.children() == Seq::new(N as nat, |i| None),
-            self == Self::new_val(self.value(), self.level()),
-    {
-        Self::lemma_new_properties(val, lv, Seq::new(N as nat, |i| None));
     }
 
     pub open spec fn inv_node(self) -> bool {
@@ -376,19 +367,31 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         children: Seq<Option<Self>>,
     )
         ensures
-            (#[trigger] Self::new(value, level, children)).value() == value,
+            #![trigger Self::new(value, level, children)]
+            Self::new(value, level, children).value() == value,
             Self::new(value, level, children).level() == level,
             Self::new(value, level, children).children() == children,
     {
     }
 
+    pub broadcast proof fn lemma_new_val_properties(val: T, lv: nat)
+        ensures
+            #![trigger Self::new_val(val,lv)]
+            Self::new_val(val, lv).value() == val,
+            Self::new_val(val,lv).level() == lv,
+            Self::new_val(val,lv).children() == Seq::new(N as nat, |i| None),
+    {
+        Self::lemma_new_properties(val, lv, Seq::new(N as nat, |i| None));
+    }
+
     /// Two nodes are equal when all of their observable fields are equal.
-    pub proof fn lemma_ext_equal(self, other: Self)
+    pub broadcast proof fn lemma_ext_equal(self, other: Self)
         requires
             self.value() == other.value(),
             self.level() == other.level(),
             self.children() =~= other.children(),
         ensures
+            #![trigger self.children(), other.children()]
             self == other,
     {
     }
@@ -472,14 +475,14 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         if self.level() < L - 1 {
             &&& f(self.value(), path)
             &&& forall|i: int|
-                0 <= i < self.children().len() ==> (#[trigger] self.children()[i]) is Some
-                    ==> self.children()[i]->0.subtree_satisfies(path.push_tail(i), f)
+                0 <= i < self.children().len() ==> (#[trigger] self.has_child(i))
+                    ==> self.child(i).subtree_satisfies(path.push_tail(i), f)
         } else {
             &&& f(self.value(), path)
         }
     }
 
-    pub proof fn lemma_map_unroll_once(
+    pub proof fn lemma_subtree_satisfies_unroll_once(
         self,
         path: TreePath<N>,
         f: spec_fn(T, TreePath<N>) -> bool,
@@ -504,7 +507,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             value.inv() ==> f(value, path) ==> #[trigger] g(value, path)
     }
 
-    pub proof fn lemma_map_implies(
+    pub proof fn lemma_subtree_satisfies_implies(
         self,
         path: TreePath<N>,
         f: spec_fn(T, TreePath<N>) -> bool,
@@ -520,19 +523,19 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
     {
         if self.level() < L - 1 {
             assert forall|i: int|
-                #![trigger self.children()[i]->0]
+                #![trigger self.has_child(i)]
                 0 <= i < self.children().len()
                     && self.has_child(i) implies self.child(i).subtree_satisfies(
                 path.push_tail(i),
                 g,
             ) by {
-                self.child(i).lemma_map_implies(path.push_tail(i), f, g);
+                self.child(i).lemma_subtree_satisfies_implies(path.push_tail(i), f, g);
             }
         }
     }
 
-    /// `TreeNode::new_default(lv)` has all-None children, so `subtree_satisfies` reduces to `f(default(lv), path)`.
-    pub proof fn lemma_new_subtree_satisfies(
+    /// If `f(T::default(lv), path)`, then  `TreeNode::new_default(lv).subtree_satisifies(path,f)`.
+    pub proof fn lemma_new_default_subtree_satisfies(
         lv: nat,
         path: TreePath<N>,
         f: spec_fn(T, TreePath<N>) -> bool,
@@ -544,30 +547,26 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         ensures
             Self::new_default(lv).subtree_satisfies(path, f),
     {
-        // Self::new_default(lv).children()[i] = None for all i, so the forall in subtree_satisfies is vacuous.
     }
 
-    /// `TreeNode::new_val(val, lv)` has all-None children.
-    /// `subtree_satisfies` holds trivially: `f(val, path)` at the root,
-    /// no children to recurse into.
+    /// If `f(val, path)`, then  `TreeNode::new_val(val,lv).subtree_satisifies(path,f)`.
     pub proof fn lemma_new_val_subtree_satisfies(
-        self,
+        val: T,
+        lv: nat, 
         path: TreePath<N>,
         f: spec_fn(T, TreePath<N>) -> bool,
     )
         requires
-            self.inv(),
-            self == Self::new_val(self.value(), self.level()),
-            f(self.value(), path),
+            Self::new_val(val, lv).inv(),
+            f(val, path),
         ensures
-            self.subtree_satisfies(path, f),
+            Self::new_val(val, lv).subtree_satisfies(path, f),
     {
-        // All children are None, so the forall in subtree_satisfies is vacuous.
     }
 
     /// Proves `subtree_satisfies(self, path, g)` from two source predicates `f1`, `f2`,
     /// and the implication `forall |v, p| v.inv() && f1(v, p) && f2(v, p) ==> g(v, p)`.
-    pub proof fn lemma_map_implies_and(
+    pub proof fn lemma_subtree_satisfies_implies_and(
         self,
         path: TreePath<N>,
         f1: spec_fn(T, TreePath<N>) -> bool,
@@ -591,7 +590,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
                 path.push_tail(i),
                 g,
             ) by {
-                self.child(i).lemma_map_implies_and(path.push_tail(i), f1, f2, g);
+                self.child(i).lemma_subtree_satisfies_implies_and(path.push_tail(i), f1, f2, g);
             }
         }
     }
@@ -607,24 +606,22 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             Self::new_val(val, lv),
     ;
 
-    pub broadcast proof fn lemma_new_default_preserves_inv(lv: nat)
+    pub proof fn lemma_new_default_preserves_inv(lv: nat)
         requires
             0 <= lv < L,
             N > 0,
             forall|i: int| 0 <= i < N ==> #[trigger] T::default(lv).rel_children(i, None),
         ensures
-            (#[trigger] Self::new_default(lv)).inv(),
+            Self::new_default(lv).inv(),
     {
         T::lemma_default_preserves_inv();
         T::lemma_default_preserves_la_inv();
     }
 
-    pub open spec fn update(self, key: int, node: Self) -> Self
+    /// Insert the child at the given index.
+    pub open spec fn insert(self, key: int, node: Self) -> Self
         recommends
             0 <= key < Self::size(),
-            self.inv(),
-            node.inv(),
-            self.level() < L - 1,
             node.level() == self.level() + 1,
     {
         Self::new(
@@ -634,52 +631,45 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         )
     }
 
-    pub broadcast proof fn lemma_update_preserves_inv(self, key: int, node: Self)
+    pub broadcast proof fn lemma_insert_preserves_inv(self, key: int, node: Self)
         requires
-            0 <= key < Self::size(),
             self.inv(),
             node.inv(),
-            self.level() < L - 1,
             node.level() == self.level() + 1,
             self.value().rel_children(key, Some(node.value())),
         ensures
-            (#[trigger] self.update(key, node)).inv(),
+            #![trigger self.insert(key, node)]
+            self.insert(key, node).inv(),
     {
     }
 
-    pub broadcast proof fn lemma_update_property(self, key: int, node: Self)
+    pub proof fn lemma_insert_property(self, key: int, node: Self)
         requires
             0 <= key < Self::size(),
             self.inv(),
-            node.inv(),
-            self.level() < L - 1,
-            node.level() == self.level() + 1,
         ensures
-            #[trigger] self.update(key, node).value() == self.value(),
-            self.update(key, node).children()[key] == Some(node),
-            forall|i: int|
-                0 <= i < Self::size() && i != key ==> #[trigger] self.update(key, node).children()[i]
-                    == self.children()[i],
+            self.insert(key, node).value() == self.value(),
+            self.insert(key, node).children()[key] == Some(node),
+            self.insert(key,node).children() == self.children().update(key, Some(node)),
     {
     }
 
-    pub proof fn lemma_update_same_child_identical(self, key: int, node: Self)
+    pub proof fn lemma_insert_same_child_identical(self, key: int, node: Self)
         requires
             0 <= key < Self::size(),
             self.inv(),
             self.has_child(key),
             self.child(key) == node,
         ensures
-            self.update(key, node) == self,
+            self.insert(key, node) == self,
     {
-        self.lemma_update_property(key, node);
-        assert(self.update(key, node).children() == self.children());
+        self.lemma_insert_property(key, node);
+        assert(self.insert(key, node).children() == self.children());
     }
 
     pub open spec fn remove(self, key: int) -> Self
         recommends
             0 <= key < Self::size(),
-            self.inv(),
     {
         Self::new(self.value(), self.level(), self.children().update(key, None))
     }
@@ -694,20 +684,18 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
     {
     }
 
-    pub broadcast proof fn lemma_remove_property(self, key: int)
+    pub proof fn lemma_remove_property(self, key: int)
         requires
             0 <= key < Self::size(),
             self.inv(),
         ensures
-            #[trigger] self.remove(key).value() == self.value(),
+            self.remove(key).value() == self.value(),
             self.remove(key).children()[key] is None,
-            forall|i: int|
-                0 <= i < Self::size() && i != key ==> #[trigger] self.remove(key).children()[i]
-                    == self.children()[i],
+            self.remove(key).children() == self.children().update(key, None),
     {
     }
 
-    pub broadcast proof fn lemma_update_child_is_child(self, key: int, node: Self)
+    pub proof fn lemma_insert_child_is_child(self, key: int, node: Self)
         requires
             0 <= key < Self::size(),
             self.inv(),
@@ -715,18 +703,18 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             self.level() < L - 1,
             node.level() == self.level() + 1,
         ensures
-            #[trigger] self.update(key, node).has_child(key),
-            self.update(key, node).child(key) == node,
+            self.insert(key, node).has_child(key),
+            self.insert(key, node).child(key) == node,
     {
-        self.lemma_update_property(key, node);
+        self.lemma_insert_property(key, node);
     }
 
-    pub broadcast proof fn lemma_remove_child_is_none(self, key: int)
+    pub proof fn lemma_remove_child_is_none(self, key: int)
         requires
             0 <= key < Self::size(),
             self.inv(),
         ensures
-            !#[trigger] self.remove(key).has_child(key),
+            !self.remove(key).has_child(key),
     {
         self.lemma_remove_property(key);
     }
@@ -742,6 +730,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
     /// Exposes the observable fields changed and preserved by `set_value`.
     pub broadcast proof fn lemma_set_value_observable_fields(self, value: T)
         ensures
+            #![trigger self.set_value(value)]
             (#[trigger] self.set_value(value)).value() == value,
             self.set_value(value).level() == self.level(),
             self.set_value(value).children() == self.children(),
@@ -761,39 +750,8 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         Self::lemma_ext_equal(self.set_value(value), Self::new_val(value, self.level()));
     }
 
-    pub broadcast proof fn lemma_set_value_property(self, value: T)
-        requires
-            self.inv(),
-            value.inv(),
-            value.la_inv(self.level()),
-            forall|i: int|
-                0 <= i < N ==> #[trigger] self.children()[i] is Some ==> value.rel_children(
-                    i,
-                    Some(self.child(i).value()),
-                ),
-            forall|i: int|
-                0 <= i < N ==> #[trigger] self.children()[i] is None ==> value.rel_children(i, None),
-        ensures
-            #[trigger] self.set_value(value).value() == value,
-            self.set_value(value).children() == self.children(),
-            self.set_value(value).inv(),
-    {
-        if self.level() == L - 1 {
-        } else {
-            assert forall|i: int| 0 <= i < Self::size() implies match #[trigger] self.set_value(
-                value,
-            ).children()[i] {
-                Some(child) => {
-                    &&& child.level() == self.set_value(value).level() + 1
-                    &&& self.set_value(value).value().rel_children(i, Some(child.value()))
-                },
-                None => self.set_value(value).value().rel_children(i, None),
-            } by {}
-        }
-    }
-
     pub open spec fn is_leaf(self) -> bool {
-        forall|i: int| 0 <= i < Self::size() ==> self.children()[i] is None
+        forall |i: int| 0 <= i < Self::size() ==> ! #[trigger] self.has_child(i)
     }
 
     pub broadcast proof fn lemma_is_leaf_bounded(self)
@@ -809,7 +767,6 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         recommends
             self.inv(),
             path.inv(),
-            node.inv(),
             path.len() < L - self.level(),
             node.level() == self.level() + path.len() as nat,
         decreases path.len(),
@@ -817,7 +774,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         if path.is_empty() {
             self
         } else if path.len() == 1 {
-            self.update(path[0], node)
+            self.insert(path[0], node)
         } else {
             let (hd, tl) = path.pop_head();
             let child = if self.has_child(hd) {
@@ -826,11 +783,11 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
                 TreeNode::new_default(self.level() + 1)
             };
             let updated_child = child.recursive_insert(tl, node);
-            self.update(hd, updated_child)
+            self.insert(hd, updated_child)
         }
     }
 
-    pub broadcast proof fn lemma_recursive_insert_path_empty_identical(
+    pub proof fn lemma_recursive_insert_path_empty_identical(
         self,
         path: TreePath<N>,
         node: Self,
@@ -841,11 +798,11 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             path.inv(),
             path.is_empty(),
         ensures
-            #[trigger] self.recursive_insert(path, node) == self,
+            self.recursive_insert(path, node) == self,
     {
     }
 
-    pub broadcast proof fn lemma_recursive_insert_path_len_1(self, path: TreePath<N>, node: Self)
+    pub proof fn lemma_recursive_insert_path_len_1(self, path: TreePath<N>, node: Self)
         requires
             self.inv(),
             node.inv(),
@@ -854,11 +811,11 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             1 < L - self.level(),
             node.level() == self.level() + 1,
         ensures
-            #[trigger] self.recursive_insert(path, node) == self.update(path[0], node),
+            self.recursive_insert(path, node) == self.insert(path[0], node),
     {
     }
 
-    pub broadcast proof fn lemma_recursive_insert_path_len_step(self, path: TreePath<N>, node: Self)
+    pub proof fn lemma_recursive_insert_path_len_step(self, path: TreePath<N>, node: Self)
         requires
             self.inv(),
             path.inv(),
@@ -867,20 +824,20 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             node.level() == self.level() + path.len() as nat,
             path.len() > 1,
         ensures
-            self.has_child(path[0]) ==> #[trigger] self.recursive_insert(path, node)
-                == self.update(
+            self.has_child(path[0]) ==> self.recursive_insert(path, node)
+                == self.insert(
                 path[0],
                 self.child(path[0]).recursive_insert(path.pop_head().1, node),
             ),
-            !self.has_child(path[0]) ==> #[trigger] self.recursive_insert(path, node)
-                == self.update(
+            !self.has_child(path[0]) ==> self.recursive_insert(path, node)
+                == self.insert(
                 path[0],
                 TreeNode::new_default(self.level() + 1).recursive_insert(path.pop_head().1, node),
             ),
     {
     }
 
-    pub broadcast proof fn lemma_recursive_insert_preserves_level(
+    pub proof fn lemma_recursive_insert_preserves_level(
         self,
         path: TreePath<N>,
         node: Self,
@@ -894,7 +851,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             forall|lv: nat|
                 lv < L ==> #[trigger] T::default(lv).rel_children(path.pop_tail().0 as int, None),
         ensures
-            #[trigger] self.recursive_insert(path, node).level() == self.level(),
+            self.recursive_insert(path, node).level() == self.level(),
         decreases path.len(),
     {
         if path.is_empty() {
@@ -902,22 +859,22 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         } else if path.len() == 1 {
             path.lemma_index_satisfies_elem_inv(0);
             self.lemma_recursive_insert_path_len_1(path, node);
-            assert(self.update(path[0], node).level() == self.level());
+            assert(self.insert(path[0], node).level() == self.level());
         } else {
             self.lemma_recursive_insert_path_len_step(path, node);
             let (hd, tl) = path.pop_head();
             path.lemma_pop_head_preserves_inv();
             if self.has_child(hd) {
                 let c = self.child(hd);
-                assert(self.update(hd, c.recursive_insert(tl, node)).level() == self.level());
+                assert(self.insert(hd, c.recursive_insert(tl, node)).level() == self.level());
             } else {
                 let c = TreeNode::new_default(self.level() + 1);
-                assert(self.update(hd, c.recursive_insert(tl, node)).level() == self.level());
+                assert(self.insert(hd, c.recursive_insert(tl, node)).level() == self.level());
             }
         }
     }
 
-    pub broadcast proof fn lemma_recursive_insert_preserves_value(
+    pub proof fn lemma_recursive_insert_preserves_value(
         self,
         path: TreePath<N>,
         node: Self,
@@ -931,7 +888,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             forall|lv: nat, i: int|
                 lv < L && 0 <= i < N ==> #[trigger] T::default(lv).rel_children(i, None),
         ensures
-            #[trigger] self.recursive_insert(path, node).value() == self.value(),
+            self.recursive_insert(path, node).value() == self.value(),
         decreases path.len(),
     {
         if path.is_empty() {
@@ -954,7 +911,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         }
     }
 
-    pub broadcast proof fn lemma_recursive_insert_preserves_inv(self, path: TreePath<N>, node: Self)
+    pub proof fn lemma_recursive_insert_preserves_inv(self, path: TreePath<N>, node: Self)
         requires
             self.inv(),
             path.inv(),
@@ -970,7 +927,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             forall|lv: nat, i: int|
                 lv < L ==> 0 <= i < N ==> #[trigger] T::default(lv).rel_children(i, None),
         ensures
-            #[trigger] self.recursive_insert(path, node).inv(),
+            self.recursive_insert(path, node).inv(),
         decreases path.len(),
     {
         if path.is_empty() {
@@ -978,7 +935,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         } else if path.len() == 1 {
             path.lemma_index_satisfies_elem_inv(0);
             self.lemma_recursive_insert_path_len_1(path, node);
-            self.lemma_update_preserves_inv(path[0], node);
+            self.lemma_insert_preserves_inv(path[0], node);
         } else {
             self.lemma_recursive_insert_path_len_step(path, node);
             let (hd, tl) = path.pop_head();
@@ -990,7 +947,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
                 c.lemma_recursive_insert_preserves_level(tl, node);
                 c.lemma_recursive_insert_preserves_value(tl, node);
                 let updated_child = c.recursive_insert(tl, node);
-                self.lemma_update_preserves_inv(hd, updated_child);
+                self.lemma_insert_preserves_inv(hd, updated_child);
             } else {
                 let c = TreeNode::new_default(self.level() + 1);
                 Self::lemma_new_default_preserves_inv(self.level() + 1);
@@ -999,7 +956,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
                 c.lemma_recursive_insert_preserves_level(tl, node);
                 c.lemma_recursive_insert_preserves_value(tl, node);
                 let updated_child = c.recursive_insert(tl, node);
-                self.lemma_update_preserves_inv(hd, updated_child);
+                self.lemma_insert_preserves_inv(hd, updated_child);
             }
         }
     }
@@ -1178,16 +1135,16 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         }
     }
 
-    pub broadcast proof fn lemma_recursive_visited_node_inv(self, path: TreePath<N>)
+    pub proof fn lemma_recursive_visited_node_inv(self, path: TreePath<N>)
         requires
-            #[trigger] self.inv(),
-            #[trigger] path.inv(),
+            self.inv(),
+            path.inv(),
             path.len() < L - self.level(),
         ensures
             forall|i: int|
                 0 <= i < self.recursive_visit(path).len() ==> #[trigger] self.recursive_visit(
                     path,
-                ).index(i).inv(),
+                )[i].inv(),
         decreases path.len(),
     {
         if path.is_empty() {
@@ -1205,16 +1162,16 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         }
     }
 
-    pub broadcast proof fn lemma_recursive_visited_node_levels(self, path: TreePath<N>)
+    pub proof fn lemma_recursive_visited_node_levels(self, path: TreePath<N>)
         requires
-            #[trigger] self.inv(),
-            #[trigger] path.inv(),
+            self.inv(),
+            path.inv(),
             path.len() < L - self.level(),
         ensures
             forall|i: int|
                 0 <= i < self.recursive_visit(path).len() ==> #[trigger] self.recursive_visit(
                     path,
-                ).index(i).level() == self.level() + i + 1,
+                )[i].level() == self.level() + i + 1,
         decreases path.len(),
     {
         if path.is_empty() {
@@ -1232,19 +1189,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         }
     }
 
-    pub broadcast proof fn lemma_recursive_visit_head(self, path: TreePath<N>)
-        requires
-            #[trigger] self.inv(),
-            #[trigger] path.inv(),
-            path.len() < L - self.level(),
-            !path.is_empty(),
-            self.recursive_visit(path).len() > 0,
-        ensures
-            self.recursive_visit(path).index(0) == self.child(path[0]),
-    {
-    }
-
-    pub broadcast proof fn lemma_recursive_visit_induction(self, path: TreePath<N>)
+    pub proof fn lemma_recursive_visit_head(self, path: TreePath<N>)
         requires
             self.inv(),
             path.inv(),
@@ -1252,7 +1197,19 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             !path.is_empty(),
             self.recursive_visit(path).len() > 0,
         ensures
-            #[trigger] self.recursive_visit(path) == seq![self.child(path.pop_head().0)].add(
+            self.recursive_visit(path)[0] == self.child(path[0]),
+    {
+    }
+
+    pub proof fn lemma_recursive_visit_induction(self, path: TreePath<N>)
+        requires
+            self.inv(),
+            path.inv(),
+            path.len() < L - self.level(),
+            !path.is_empty(),
+            self.recursive_visit(path).len() > 0,
+        ensures
+            self.recursive_visit(path) == seq![self.child(path.pop_head().0)].add(
                 self.child(path.pop_head().0).recursive_visit(path.pop_head().1),
             ),
     {
@@ -1267,17 +1224,17 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         }
     }
 
-    pub broadcast proof fn lemma_recursive_visit_one_is_child(self, path: TreePath<N>)
+    pub proof fn lemma_recursive_visit_one_is_child(self, path: TreePath<N>)
         requires
             self.inv(),
             path.inv(),
             path.len() < L - self.level(),
             path.len() == 1,
         ensures
-            self.has_child(path[0]) ==> #[trigger] self.recursive_visit(path) == seq![
+            self.has_child(path[0]) ==> self.recursive_visit(path) == seq![
                 self.child(path[0]),
             ],
-            !self.has_child(path[0]) ==> #[trigger] self.recursive_visit(path) == seq![],
+            !self.has_child(path[0]) ==> self.recursive_visit(path) == seq![],
     {
     }
 
@@ -1288,7 +1245,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             node.level() >= self.level(),
             node.level() < L,
     {
-        node == self || exists|path: TreePath<N>| #[trigger]
+        node == self || exists |path: TreePath<N>| #[trigger]
             path.inv() && path.len() > 0 && path.len() == node.level() - self.level()
                 && self.recursive_visit(path).last() == node
     }
@@ -1302,7 +1259,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             #[trigger] self.on_subtree(node),
         ensures
             node.level() == self.level() ==> self == node,
-            node.level() > self.level() ==> exists|path: TreePath<N>| #[trigger]
+            node.level() > self.level() ==> exists |path: TreePath<N>| #[trigger]
                 path.inv() && path.len() == node.level() - self.level() && self.recursive_visit(
                     path,
                 ).last() == node,
@@ -1317,7 +1274,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             !#[trigger] self.on_subtree(node),
         ensures
             self != node,
-            node.level() > self.level() ==> forall|path: TreePath<N>| #[trigger]
+            node.level() > self.level() ==> forall |path: TreePath<N>| #[trigger]
                 path.inv() && path.len() == node.level() - self.level() ==> self.recursive_visit(
                     path,
                 ).last() != node,
@@ -1343,7 +1300,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         assert(TreePath::<N>::new(seq![key]).inv());
     }
 
-    pub broadcast proof fn lemma_update_on_subtree(self, key: int, node: Self)
+    pub broadcast proof fn lemma_insert_on_subtree(self, key: int, node: Self)
         requires
             0 <= key < Self::size(),
             self.inv(),
@@ -1352,10 +1309,10 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             node.level() == self.level() + 1,
             self.value().rel_children(key, Some(node.value())),
         ensures
-            #[trigger] self.update(key, node).on_subtree(node),
+            #[trigger] self.insert(key, node).on_subtree(node),
     {
-        self.lemma_update_child_is_child(key, node);
-        self.update(key, node).lemma_child_on_subtree(key);
+        self.lemma_insert_child_is_child(key, node);
+        self.insert(key, node).lemma_child_on_subtree(key);
     }
 
     /// Remove the tree node at the end of the path
@@ -1381,18 +1338,18 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             } else {
                 let child = self.child(hd);
                 let updated_child = child.recursive_remove(tl);
-                self.update(hd, updated_child)
+                self.insert(hd, updated_child)
             }
         }
     }
 
-    pub broadcast proof fn lemma_recursive_remove_preserves_level(self, path: TreePath<N>)
+    pub proof fn lemma_recursive_remove_preserves_level(self, path: TreePath<N>)
         requires
             self.inv(),
             path.inv(),
             path.len() < L - self.level(),
         ensures
-            #[trigger] self.recursive_remove(path).level() == self.level(),
+            self.recursive_remove(path).level() == self.level(),
         decreases path.len(),
     {
         if path.is_empty() {
@@ -1407,13 +1364,13 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         }
     }
 
-    pub broadcast proof fn lemma_recursive_remove_preserves_value(self, path: TreePath<N>)
+    pub proof fn lemma_recursive_remove_preserves_value(self, path: TreePath<N>)
         requires
             self.inv(),
             path.inv(),
             path.len() < L - self.level(),
         ensures
-            #[trigger] self.recursive_remove(path).value() == self.value(),
+            self.recursive_remove(path).value() == self.value(),
         decreases path.len(),
     {
         if path.is_empty() {
@@ -1428,7 +1385,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         }
     }
 
-    pub broadcast proof fn lemma_recursive_remove_preserves_inv(self, path: TreePath<N>)
+    pub proof fn lemma_recursive_remove_preserves_inv(self, path: TreePath<N>)
         requires
             self.inv(),
             path.inv(),
@@ -1440,7 +1397,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
                 path.pop_tail().1,
             )->0.value().rel_children(path.pop_tail().0 as int, None),
         ensures
-            #[trigger] self.recursive_remove(path).inv(),
+            self.recursive_remove(path).inv(),
         decreases path.len(),
     {
         if path.is_empty() {
@@ -1456,14 +1413,11 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
                 c.lemma_recursive_remove_preserves_level(tl);
                 c.lemma_recursive_remove_preserves_value(tl);
                 let updated_child = c.recursive_remove(tl);
-                self.lemma_update_preserves_inv(hd, updated_child);
+                self.lemma_insert_preserves_inv(hd, updated_child);
             }
         }
     }
 }
-
-} // verus!
-verus! {
 
 pub closed spec fn path_between<T: TreeNodeValue<L>, const N: usize, const L: usize>(
     src: TreeNode<T, N, L>,
@@ -1530,7 +1484,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
             L > 0,
             forall|i: int| 0 <= i < N ==> #[trigger] T::default(0).rel_children(i, None),
         ensures
-            #[trigger] Self::new().inv(),
+            (#[trigger] Self::new()).inv(),
     {
         TreeNode::<T, N, L>::lemma_new_default_preserves_inv(0);
     }
@@ -1565,16 +1519,6 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
         decreases path.len(),
     {
         self.root.recursive_visit(path)
-    }
-
-    pub broadcast proof fn lemma_visit_is_recursive_visit(self, path: TreePath<N>)
-        requires
-            self.inv(),
-            path.inv(),
-            path.len() < L,
-        ensures
-            #[trigger] self.visit(path) == self.root.recursive_visit(path),
-    {
     }
 
     pub open spec fn trace(self, path: TreePath<N>) -> Seq<T>
@@ -1670,7 +1614,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
             forall|lv: nat, i: int|
                 lv < L ==> 0 <= i < N ==> #[trigger] T::default(lv).rel_children(i, None),
         ensures
-            #[trigger] self.insert(path, node).inv(),
+            (#[trigger] self.insert(path, node)).inv(),
     {
         self.root.lemma_recursive_insert_preserves_inv(path, node);
     }
@@ -1686,24 +1630,24 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
                 path.pop_tail().1,
             )->0.value().rel_children(path[path.len() - 1] as int, None),
         ensures
-            #[trigger] self.remove(path).inv(),
+            (#[trigger] self.remove(path)).inv(),
     {
         self.root.lemma_recursive_remove_preserves_inv(path);
     }
 
     pub broadcast proof fn lemma_visited_nodes_inv(self, path: TreePath<N>)
         requires
-            #[trigger] self.inv(),
-            #[trigger] path.inv(),
+            self.inv(),
+            path.inv(),
             path.len() < L,
         ensures
+            #![trigger self.visit(path)]
             forall|i: int|
-                0 <= i < self.visit(path).len() ==> #[trigger] self.visit(path).index(i).inv(),
+                0 <= i < self.visit(path).len() ==> #[trigger] self.visit(path)[i].inv(),
     {
         self.root.lemma_recursive_visited_node_inv(path);
     }
 
-    #[verifier::inline]
     pub open spec fn on_tree(self, node: TreeNode<T, N, L>) -> bool
         recommends
             self.inv(),
@@ -1736,7 +1680,6 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
     {
     }
 
-    #[verifier::inline]
     pub open spec fn get_path(self, node: TreeNode<T, N, L>) -> TreePath<N>
         recommends
             self.inv(),
@@ -1766,43 +1709,30 @@ verus! {
 
 pub broadcast group group_ghost_tree {
     TreePath::lemma_index_satisfies_elem_inv,
+    TreePath::lemma_empty_satisfies_inv,
     TreePath::lemma_pop_head_preserves_inv,
     TreePath::lemma_pop_head_index,
     TreePath::lemma_pop_tail_preserves_inv,
     TreePath::lemma_pop_tail_index,
-    TreePath::lemma_push_tail_preserves_inv,
-    TreePath::lemma_push_tail_len,
+    TreePath::lemma_push_head_index,
     TreePath::lemma_push_head_preserves_inv,
+    TreePath::lemma_push_tail_len,
+    TreePath::lemma_push_tail_index,
+    TreePath::lemma_push_tail_preserves_inv,
     TreePath::lemma_new_preserves_inv,
     TreeNode::lemma_new_properties,
-    TreeNode::lemma_update_preserves_inv,
-    TreeNode::lemma_update_property,
+    TreeNode::lemma_new_val_properties,
+    TreeNode::lemma_ext_equal,
+    TreeNode::lemma_insert_preserves_inv,
     TreeNode::lemma_remove_preserves_inv,
-    TreeNode::lemma_remove_property,
-    TreeNode::lemma_update_child_is_child,
-    TreeNode::lemma_remove_child_is_none,
-    TreeNode::lemma_set_value_property,
     TreeNode::lemma_set_value_observable_fields,
     TreeNode::lemma_is_leaf_bounded,
-    TreeNode::lemma_recursive_visited_node_inv,
-    TreeNode::lemma_recursive_visited_node_levels,
-    TreeNode::lemma_recursive_visit_head,
-    TreeNode::lemma_recursive_visit_induction,
-    TreeNode::lemma_recursive_visit_one_is_child,
     TreeNode::lemma_on_subtree_property,
     TreeNode::lemma_not_on_subtree_property,
     TreeNode::lemma_on_subtree_reflexive,
     TreeNode::lemma_child_on_subtree,
-    TreeNode::lemma_update_on_subtree,
-    TreeNode::lemma_recursive_remove_preserves_inv,
+    TreeNode::lemma_insert_on_subtree,
     lemma_path_between_properties,
-    Tree::lemma_new_preserves_inv,
-    Tree::lemma_visit_is_recursive_visit,
-    Tree::lemma_insert_preserves_inv,
-    Tree::lemma_remove_preserves_inv,
-    Tree::lemma_visited_nodes_inv,
-    Tree::lemma_on_tree_property,
-    Tree::lemma_not_on_tree_property,
 }
 
 } // verus!

--- a/verified_libs/vstd_extra/src/ghost_tree.rs
+++ b/verified_libs/vstd_extra/src/ghost_tree.rs
@@ -643,11 +643,12 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
     {
     }
 
-    pub proof fn lemma_insert_property(self, key: int, node: Self)
+    pub broadcast proof fn lemma_insert_property(self, key: int, node: Self)
         requires
             0 <= key < Self::size(),
             self.inv(),
         ensures
+            #![trigger self.insert(key, node)]
             self.insert(key, node).value() == self.value(),
             self.insert(key, node).children()[key] == Some(node),
             self.insert(key,node).children() == self.children().update(key, Some(node)),
@@ -684,11 +685,12 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
     {
     }
 
-    pub proof fn lemma_remove_property(self, key: int)
+    pub broadcast proof fn lemma_remove_property(self, key: int)
         requires
             0 <= key < Self::size(),
             self.inv(),
         ensures
+            #![trigger self.remove(key)]
             self.remove(key).value() == self.value(),
             self.remove(key).children()[key] is None,
             self.remove(key).children() == self.children().update(key, None),
@@ -1724,7 +1726,9 @@ pub broadcast group group_ghost_tree_lemmas {
     TreeNode::lemma_new_val_properties,
     TreeNode::lemma_ext_equal,
     TreeNode::lemma_insert_preserves_inv,
+    TreeNode::lemma_insert_property,
     TreeNode::lemma_remove_preserves_inv,
+    TreeNode::lemma_remove_property,
     TreeNode::lemma_set_value_observable_fields,
     TreeNode::lemma_is_leaf_bounded,
     TreeNode::lemma_on_subtree_property,

--- a/verified_libs/vstd_extra/src/ghost_tree.rs
+++ b/verified_libs/vstd_extra/src/ghost_tree.rs
@@ -446,7 +446,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
     ///
     /// `path` identifies the current node. When descending through child index `i`, the
     /// corresponding child path is `path.push_tail(i)`.
-    pub open spec fn tree_predicate_map(
+    pub open spec fn subtree_satisfies(
         self,
         path: TreePath<N>,
         f: spec_fn(T, TreePath<N>) -> bool,
@@ -458,7 +458,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             &&& f(self.value(), path)
             &&& forall|i: int|
                 0 <= i < self.children().len() ==> (#[trigger] self.children()[i]) is Some
-                    ==> self.children()[i]->0.tree_predicate_map(path.push_tail(i as usize), f)
+                    ==> self.children()[i]->0.subtree_satisfies(path.push_tail(i as usize), f)
         } else {
             &&& f(self.value(), path)
         }
@@ -475,9 +475,9 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             self.level() < L - 1,
             0 <= i < self.children().len(),
             self.children()[i] is Some,
-            self.tree_predicate_map(path, f),
+            self.subtree_satisfies(path, f),
         ensures
-            self.children()[i]->0.tree_predicate_map(path.push_tail(i as usize), f),
+            self.children()[i]->0.subtree_satisfies(path.push_tail(i as usize), f),
     {
     }
 
@@ -498,16 +498,16 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
         requires
             self.inv(),
             Self::implies(f, g),
-            Self::tree_predicate_map(self, path, f),
+            Self::subtree_satisfies(self, path, f),
         ensures
-            Self::tree_predicate_map(self, path, g),
+            Self::subtree_satisfies(self, path, g),
         decreases L - self.level(),
     {
         if self.level() < L - 1 {
             assert forall|i: int|
                 #![trigger self.children()[i]->0]
                 0 <= i < self.children().len()
-                    && self.children()[i] is Some implies self.children()[i]->0.tree_predicate_map(
+                    && self.children()[i] is Some implies self.children()[i]->0.subtree_satisfies(
                 path.push_tail(i as usize),
                 g,
             ) by {
@@ -516,8 +516,8 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
         }
     }
 
-    /// `Node::new_default(lv)` has all-None children, so `tree_predicate_map` reduces to `f(default(lv), path)`.
-    pub proof fn lemma_new_tree_predicate_map(
+    /// `Node::new_default(lv)` has all-None children, so `subtree_satisfies` reduces to `f(default(lv), path)`.
+    pub proof fn lemma_new_subtree_satisfies(
         lv: nat,
         path: TreePath<N>,
         f: spec_fn(T, TreePath<N>) -> bool,
@@ -527,15 +527,15 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             Self::new_default(lv).inv(),
             f(T::default(lv), path),
         ensures
-            Self::new_default(lv).tree_predicate_map(path, f),
+            Self::new_default(lv).subtree_satisfies(path, f),
     {
-        // Self::new_default(lv).children()[i] = None for all i, so the forall in tree_predicate_map is vacuous.
+        // Self::new_default(lv).children()[i] = None for all i, so the forall in subtree_satisfies is vacuous.
     }
 
     /// `Node::new_val(val, lv)` has all-None children.
-    /// `tree_predicate_map` holds trivially: `f(val, path)` at the root,
+    /// `subtree_satisfies` holds trivially: `f(val, path)` at the root,
     /// no children to recurse into.
-    pub proof fn lemma_new_val_tree_predicate_map(
+    pub proof fn lemma_new_val_subtree_satisfies(
         self,
         path: TreePath<N>,
         f: spec_fn(T, TreePath<N>) -> bool,
@@ -545,12 +545,12 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             self == Self::new_val(self.value(), self.level()),
             f(self.value(), path),
         ensures
-            self.tree_predicate_map(path, f),
+            self.subtree_satisfies(path, f),
     {
-        // All children are None, so the forall in tree_predicate_map is vacuous.
+        // All children are None, so the forall in subtree_satisfies is vacuous.
     }
 
-    /// Proves `tree_predicate_map(self, path, g)` from two source predicates `f1`, `f2`,
+    /// Proves `subtree_satisfies(self, path, g)` from two source predicates `f1`, `f2`,
     /// and the implication `forall |v, p| v.inv() && f1(v, p) && f2(v, p) ==> g(v, p)`.
     pub proof fn lemma_map_implies_and(
         self,
@@ -562,17 +562,17 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
         requires
             self.inv(),
             Self::implies(|v: T, p: TreePath<N>| f1(v, p) && f2(v, p), g),
-            Self::tree_predicate_map(self, path, f1),
-            Self::tree_predicate_map(self, path, f2),
+            Self::subtree_satisfies(self, path, f1),
+            Self::subtree_satisfies(self, path, f2),
         ensures
-            Self::tree_predicate_map(self, path, g),
+            Self::subtree_satisfies(self, path, g),
         decreases L - self.level(),
     {
         if self.level() < L - 1 {
             assert forall|i: int|
                 #![trigger self.children()[i]->0]
                 0 <= i < self.children().len()
-                    && self.children()[i] is Some implies self.children()[i]->0.tree_predicate_map(
+                    && self.children()[i] is Some implies self.children()[i]->0.subtree_satisfies(
                 path.push_tail(i as usize),
                 g,
             ) by {

--- a/verified_libs/vstd_extra/src/ghost_tree.rs
+++ b/verified_libs/vstd_extra/src/ghost_tree.rs
@@ -274,6 +274,16 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         self.children@
     }
 
+    /// Returns whether the `i`-th child exists.
+    pub open spec fn has_child(self, i: usize) -> bool {
+        self.children()[i as int] is Some
+    }
+
+    /// Returns the `i`-th child. Only valid when it exists.
+    pub open spec fn child(self, i: usize) -> Self {
+        self.children()[i as int] -> 0
+    }
+
     #[verifier::inline]
     pub open spec fn size() -> nat {
         N as nat
@@ -652,11 +662,11 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         requires
             0 <= key < Self::size(),
             self.inv(),
-            self.child(key) == Some(node),
+            self.has_child(key),
+            self.child(key) == node,
         ensures
             #[trigger] self.insert(key, node) == self,
     {
-        self.lemma_child_some_properties(key);
         self.lemma_insert_property(key, node);
         assert(self.insert(key, node).children() == self.children());
     }
@@ -692,52 +702,6 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
     {
     }
 
-    pub open spec fn child(self, key: usize) -> Option<Self>
-        recommends
-            0 <= key < Self::size(),
-            self.inv(),
-    {
-        self.children()[key as int]
-    }
-
-    pub broadcast proof fn lemma_child_property(self, key: usize)
-        requires
-            0 <= key < Self::size(),
-            self.inv(),
-        ensures
-            #[trigger] self.child(key) == self.children()[key as int],
-    {
-    }
-
-    pub broadcast proof fn lemma_child_property_cases(self, key: usize)
-        requires
-            0 <= key < Self::size(),
-            self.inv(),
-        ensures
-            self.level() == L - 1 ==> #[trigger] self.child(key) is None,
-            self.level() < L - 1 && self.children()[key as int] is None ==> #[trigger] self.child(
-                key,
-            ) is None,
-            self.level() < L - 1 && self.children()[key as int] is Some ==> #[trigger] self.child(
-                key,
-            ) is Some && self.child(key)->0.level() == self.level() + 1 && self.child(key)->0.inv(),
-    {
-    }
-
-    pub proof fn lemma_child_some_properties(self, key: usize)
-        requires
-            0 <= key < Self::size(),
-            self.inv(),
-            self.child(key) is Some,
-        ensures
-            self.level() < L - 1,
-            self.child(key)->0.level() == self.level() + 1,
-            self.child(key)->0.inv(),
-    {
-        self.lemma_child_property(key);
-        self.lemma_child_property_cases(key);
-    }
-
     pub broadcast proof fn lemma_insert_child_is_child(self, key: usize, node: Self)
         requires
             0 <= key < Self::size(),
@@ -746,10 +710,10 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             self.level() < L - 1,
             node.level() == self.level() + 1,
         ensures
-            #[trigger] self.insert(key, node).child(key) == Some(node),
+            #[trigger] self.insert(key, node).has_child(key),
+            self.insert(key, node).child(key) == node,
     {
         self.lemma_insert_property(key, node);
-        self.lemma_child_property(key);
     }
 
     pub broadcast proof fn lemma_remove_child_is_none(self, key: usize)
@@ -757,10 +721,9 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             0 <= key < Self::size(),
             self.inv(),
         ensures
-            #[trigger] self.remove(key).child(key) is None,
+            !#[trigger] self.remove(key).has_child(key),
     {
         self.lemma_remove_property(key);
-        self.lemma_child_property(key);
     }
 
     pub open spec fn get_value(self) -> T {
@@ -865,9 +828,10 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             self.insert(path.index(0), node)
         } else {
             let (hd, tl) = path.pop_head();
-            let child = match self.child(hd) {
-                Some(child) => child,
-                None => TreeNode::new_default(self.level() + 1),
+            let child = if self.has_child(hd) {
+                self.child(hd)
+            } else {
+                TreeNode::new_default(self.level() + 1)
             };
             let updated_child = child.recursive_insert(tl, node);
             self.insert(hd, updated_child)
@@ -911,12 +875,12 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             node.level() == self.level() + path.len() as nat,
             path.len() > 1,
         ensures
-            self.child(path.index(0)) is Some ==> #[trigger] self.recursive_insert(path, node)
+            self.has_child(path.index(0)) ==> #[trigger] self.recursive_insert(path, node)
                 == self.insert(
                 path.index(0),
-                self.child(path.index(0))->0.recursive_insert(path.pop_head().1, node),
+                self.child(path.index(0)).recursive_insert(path.pop_head().1, node),
             ),
-            self.child(path.index(0)) is None ==> #[trigger] self.recursive_insert(path, node)
+            !self.has_child(path.index(0)) ==> #[trigger] self.recursive_insert(path, node)
                 == self.insert(
                 path.index(0),
                 TreeNode::new_default(self.level() + 1).recursive_insert(path.pop_head().1, node),
@@ -951,9 +915,8 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             self.lemma_recursive_insert_path_len_step(path, node);
             let (hd, tl) = path.pop_head();
             path.lemma_pop_head_preserves_inv();
-            if self.child(hd) is Some {
-                let c = self.child(hd)->0;
-                self.lemma_child_some_properties(hd);
+            if self.has_child(hd) {
+                let c = self.child(hd);
                 assert(self.insert(hd, c.recursive_insert(tl, node)).level() == self.level());
             } else {
                 let c = TreeNode::new_default(self.level() + 1);
@@ -988,9 +951,8 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             self.lemma_recursive_insert_path_len_step(path, node);
             let (hd, tl) = path.pop_head();
             path.lemma_pop_head_preserves_inv();
-            if self.child(hd) is Some {
-                let c = self.child(hd)->0;
-                self.lemma_child_some_properties(hd);
+            if self.has_child(hd) {
+                let c = self.child(hd);
                 c.lemma_recursive_insert_preserves_value(tl, node);
             } else {
                 let c = TreeNode::new_default(self.level() + 1);
@@ -1029,9 +991,8 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             self.lemma_recursive_insert_path_len_step(path, node);
             let (hd, tl) = path.pop_head();
             path.lemma_pop_head_preserves_inv();
-            if self.child(hd) is Some {
-                let c = self.child(hd)->0;
-                self.lemma_child_some_properties(hd);
+            if self.has_child(hd) {
+                let c = self.child(hd);
                 assert(path.pop_tail().1.pop_head().1 == path.pop_head().1.pop_tail().1);
                 c.lemma_recursive_insert_preserves_inv(tl, node);
                 c.lemma_recursive_insert_preserves_level(tl, node);
@@ -1066,9 +1027,10 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             seq![self.value()]
         } else {
             let (hd, tl) = path.pop_head();
-            match self.child(hd) {
-                Some(child) => seq![self.value()].add(child.recursive_trace(tl)),
-                None => seq![self.value()],
+            if self.has_child(hd) {
+                seq![self.value()].add(self.child(hd).recursive_trace(tl))
+            } else {
+                seq![self.value()]
             }
         }
     }
@@ -1085,11 +1047,8 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         } else {
             let (hd, tl) = path.pop_head();
             path.lemma_pop_head_preserves_inv();
-            match self.child(hd) {
-                None => {},
-                Some(child) => {
-                    child.lemma_recursive_trace_length(tl);
-                },
+            if self.has_child(hd) {
+                self.child(hd).lemma_recursive_trace_length(tl);
             }
         }
     }
@@ -1113,13 +1072,10 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         } else {
             let (hd1, tl1) = path1.pop_head();
             let (hd2, tl2) = path2.pop_head();
-            match self.child(hd1) {
-                None => {},
-                Some(child) => {
-                    path1.lemma_pop_head_preserves_inv();
-                    path2.lemma_pop_head_preserves_inv();
-                    child.lemma_recursive_trace_up_to(tl1, tl2, n - 1);
-                },
+            if self.has_child(hd1) {
+                path1.lemma_pop_head_preserves_inv();
+                path2.lemma_pop_head_preserves_inv();
+                self.child(hd1).lemma_recursive_trace_up_to(tl1, tl2, n - 1);
             }
         }
     }
@@ -1138,9 +1094,10 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             Some(self)
         } else {
             let (hd, tl) = path.pop_head();
-            match self.child(hd) {
-                Some(child) => child.recursive_seek(tl),
-                None => None,
+            if self.has_child(hd) {
+                self.child(hd).recursive_seek(tl)
+            } else {
+                None
             }
         }
     }
@@ -1158,12 +1115,9 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         if path.len() == 0 {
         } else {
             let (hd, tl) = path.pop_head();
-            match self.child(hd) {
-                None => {},
-                Some(child) => {
-                    path.lemma_pop_head_preserves_inv();
-                    child.lemma_recursive_seek_trace_length(tl)
-                },
+            if self.has_child(hd) {
+                path.lemma_pop_head_preserves_inv();
+                self.child(hd).lemma_recursive_seek_trace_length(tl)
             }
         }
     }
@@ -1195,11 +1149,8 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             let (hd2, tl2) = path2.pop_head();
             assert(tl2 == tl1.push_tail(idx)) by {}
             assert(tl1.inv()) by { path.lemma_pop_head_preserves_inv() }
-            match self.child(hd2) {
-                None => {},
-                Some(child) => {
-                    child.lemma_recursive_seek_trace_next(tl1, idx);
-                },
+            if self.has_child(hd2) {
+                self.child(hd2).lemma_recursive_seek_trace_next(tl1, idx);
             }
         }
     }
@@ -1219,15 +1170,18 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         if path.is_empty() {
             Seq::empty()
         } else if path.len() == 1 {
-            match self.child(path.index(0)) {
-                Some(child) => seq![child],
-                None => Seq::empty(),
+            if self.has_child(path.index(0)) {
+                seq![self.child(path.index(0))]
+            } else {
+                Seq::empty()
             }
         } else {
             let (hd, tl) = path.pop_head();
-            match self.child(hd) {
-                Some(child) => seq![child].add(child.recursive_visit(tl)),
-                None => Seq::empty(),
+            if self.has_child(hd) {
+                let child = self.child(hd);
+                seq![child].add(child.recursive_visit(tl))
+            } else {
+                Seq::empty()
             }
         }
     }
@@ -1246,13 +1200,13 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
     {
         if path.is_empty() {
         } else if path.len() == 1 {
-            if self.child(path.index(0)) is Some {
+            if self.has_child(path.index(0)) {
             }
         } else {
             let (hd, tl) = path.pop_head();
             path.lemma_pop_head_preserves_inv();
-            if self.child(hd) is Some {
-                let c = self.child(hd)->0;
+            if self.has_child(hd) {
+                let c = self.child(hd);
                 assert(self.recursive_visit(path) == seq![c].add(c.recursive_visit(tl)));
                 c.lemma_recursive_visited_node_inv(tl);
             }
@@ -1273,13 +1227,13 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
     {
         if path.is_empty() {
         } else if path.len() == 1 {
-            if self.child(path.index(0)) is Some {
+            if self.has_child(path.index(0)) {
             }
         } else {
             let (hd, tl) = path.pop_head();
             path.lemma_pop_head_preserves_inv();
-            if self.child(hd) is Some {
-                let c = self.child(hd)->0;
+            if self.has_child(hd) {
+                let c = self.child(hd);
                 assert(self.recursive_visit(path) == seq![c].add(c.recursive_visit(tl)));
                 c.lemma_recursive_visited_node_levels(tl);
             }
@@ -1294,7 +1248,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             !path.is_empty(),
             self.recursive_visit(path).len() > 0,
         ensures
-            self.recursive_visit(path).index(0) == self.child(path.index(0))->0,
+            self.recursive_visit(path).index(0) == self.child(path.index(0)),
     {
     }
 
@@ -1306,8 +1260,8 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             !path.is_empty(),
             self.recursive_visit(path).len() > 0,
         ensures
-            #[trigger] self.recursive_visit(path) == seq![self.child(path.pop_head().0)->0].add(
-                self.child(path.pop_head().0)->0.recursive_visit(path.pop_head().1),
+            #[trigger] self.recursive_visit(path) == seq![self.child(path.pop_head().0)].add(
+                self.child(path.pop_head().0).recursive_visit(path.pop_head().1),
             ),
     {
         if path.len() == 1 {
@@ -1315,7 +1269,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         } else {
             let (hd, _) = path.pop_head();
             path.lemma_pop_head_preserves_inv();
-            if self.child(hd) is Some {
+            if self.has_child(hd) {
                 self.lemma_recursive_visit_head(path);
             }
         }
@@ -1328,10 +1282,10 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             path.len() < L - self.level(),
             path.len() == 1,
         ensures
-            self.child(path.index(0)) is Some ==> #[trigger] self.recursive_visit(path) == seq![
-                self.child(path.index(0))->0,
+            self.has_child(path.index(0)) ==> #[trigger] self.recursive_visit(path) == seq![
+                self.child(path.index(0)),
             ],
-            self.child(path.index(0)) is None ==> #[trigger] self.recursive_visit(path) == seq![],
+            !self.has_child(path.index(0)) ==> #[trigger] self.recursive_visit(path) == seq![],
     {
     }
 
@@ -1390,9 +1344,9 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         requires
             0 <= key < Self::size(),
             self.inv(),
-            self.child(key) is Some,
+            self.has_child(key),
         ensures
-            #[trigger] self.on_subtree(self.child(key)->0),
+            #[trigger] self.on_subtree(self.child(key)),
     {
         assert(TreePath::<N>::new(seq![key]).inv());
     }
@@ -1430,10 +1384,10 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             self.remove(path.index(0))
         } else {
             let (hd, tl) = path.pop_head();
-            if self.child(hd) is None {
+            if self.children()[hd as int] is None {
                 self
             } else {
-                let child = self.child(hd)->0;
+                let child = self.child(hd);
                 let updated_child = child.recursive_remove(tl);
                 self.insert(hd, updated_child)
             }
@@ -1454,9 +1408,8 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         } else {
             let (hd, tl) = path.pop_head();
             path.lemma_pop_head_preserves_inv();
-            if self.child(hd) is Some {
-                let c = self.child(hd)->0;
-                self.lemma_child_some_properties(hd);
+            if self.children()[hd as int] is Some {
+                let c = self.child(hd);
                 c.lemma_recursive_remove_preserves_level(tl);
             }
         }
@@ -1476,9 +1429,8 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         } else {
             let (hd, tl) = path.pop_head();
             path.lemma_pop_head_preserves_inv();
-            if self.child(hd) is Some {
-                let c = self.child(hd)->0;
-                self.lemma_child_some_properties(hd);
+            if self.children()[hd as int] is Some {
+                let c = self.child(hd);
                 c.lemma_recursive_remove_preserves_value(tl);
             }
         }
@@ -1505,9 +1457,8 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         } else {
             let (hd, tl) = path.pop_head();
             path.lemma_pop_head_preserves_inv();
-            if self.child(hd) is Some {
-                let c = self.child(hd)->0;
-                self.lemma_child_some_properties(hd);
+            if self.children()[hd as int] is Some {
+                let c = self.child(hd);
                 assert(path.pop_tail().1.pop_head().1 == path.pop_head().1.pop_tail().1);
                 c.lemma_recursive_remove_preserves_inv(tl);
                 c.lemma_recursive_remove_preserves_level(tl);
@@ -1837,8 +1788,6 @@ pub broadcast group group_ghost_tree {
     TreeNode::lemma_insert_same_child_identical,
     TreeNode::lemma_remove_preserves_inv,
     TreeNode::lemma_remove_property,
-    TreeNode::lemma_child_property,
-    TreeNode::lemma_child_property_cases,
     TreeNode::lemma_insert_child_is_child,
     TreeNode::lemma_remove_child_is_none,
     TreeNode::lemma_get_value_property,

--- a/verified_libs/vstd_extra/src/ghost_tree.rs
+++ b/verified_libs/vstd_extra/src/ghost_tree.rs
@@ -52,7 +52,7 @@ impl<const N: usize> TreePath<N> {
             self.inv(),
             0 <= i < self.len(),
         ensures
-            #![trigger self.spec_index(i)]
+            #![trigger self[i]]
             Self::elem_inv(self[i]),
     {
     }

--- a/verified_libs/vstd_extra/src/ghost_tree.rs
+++ b/verified_libs/vstd_extra/src/ghost_tree.rs
@@ -1707,7 +1707,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
 } // verus!
 verus! {
 
-pub broadcast group group_ghost_tree {
+pub broadcast group group_ghost_tree_lemmas {
     TreePath::lemma_index_satisfies_elem_inv,
     TreePath::lemma_empty_satisfies_inv,
     TreePath::lemma_pop_head_preserves_inv,

--- a/verified_libs/vstd_extra/src/ghost_tree.rs
+++ b/verified_libs/vstd_extra/src/ghost_tree.rs
@@ -250,15 +250,15 @@ pub trait TreeNodeValue<const L: usize>: Sized + Inv {
 /// A ghost tree node with maximum `N` children,
 /// the maximum depth of the tree is `L`
 /// Each tree node has a value of type `T` and a sequence of children
-pub tracked struct Node<T: TreeNodeValue<L>, const N: usize, const L: usize> {
+pub tracked struct TreeNode<T: TreeNodeValue<L>, const N: usize, const L: usize> {
     tracked value: T,
     ghost level: nat,
     // FIXME: This should use tracked indirection, but that is blocked by
     // https://github.com/verus-lang/verus/issues/2627.
-    tracked children: Ghost<Seq<Option<Node<T, N, L>>>>,
+    tracked children: Ghost<Seq<Option<TreeNode<T, N, L>>>>,
 }
 
-impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
+impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
     /// Returns the value stored in this node.
     pub closed spec fn value(self) -> T {
         self.value
@@ -286,7 +286,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
 
     /// Constructs a node from its fields.
     pub closed spec fn new(value: T, level: nat, children: Seq<Option<Self>>) -> Self {
-        Node { value, level, children: Ghost::new(children) }
+        TreeNode { value, level, children: Ghost::new(children) }
     }
 
     pub open spec fn new_default(lv: nat) -> Self {
@@ -516,7 +516,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
         }
     }
 
-    /// `Node::new_default(lv)` has all-None children, so `subtree_satisfies` reduces to `f(default(lv), path)`.
+    /// `TreeNode::new_default(lv)` has all-None children, so `subtree_satisfies` reduces to `f(default(lv), path)`.
     pub proof fn lemma_new_subtree_satisfies(
         lv: nat,
         path: TreePath<N>,
@@ -532,7 +532,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
         // Self::new_default(lv).children()[i] = None for all i, so the forall in subtree_satisfies is vacuous.
     }
 
-    /// `Node::new_val(val, lv)` has all-None children.
+    /// `TreeNode::new_val(val, lv)` has all-None children.
     /// `subtree_satisfies` holds trivially: `f(val, path)` at the root,
     /// no children to recurse into.
     pub proof fn lemma_new_val_subtree_satisfies(
@@ -867,7 +867,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             let (hd, tl) = path.pop_head();
             let child = match self.child(hd) {
                 Some(child) => child,
-                None => Node::new_default(self.level() + 1),
+                None => TreeNode::new_default(self.level() + 1),
             };
             let updated_child = child.recursive_insert(tl, node);
             self.insert(hd, updated_child)
@@ -919,7 +919,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             self.child(path.index(0)) is None ==> #[trigger] self.recursive_insert(path, node)
                 == self.insert(
                 path.index(0),
-                Node::new_default(self.level() + 1).recursive_insert(path.pop_head().1, node),
+                TreeNode::new_default(self.level() + 1).recursive_insert(path.pop_head().1, node),
             ),
     {
     }
@@ -956,7 +956,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
                 self.lemma_child_some_properties(hd);
                 assert(self.insert(hd, c.recursive_insert(tl, node)).level() == self.level());
             } else {
-                let c = Node::new_default(self.level() + 1);
+                let c = TreeNode::new_default(self.level() + 1);
                 assert(self.insert(hd, c.recursive_insert(tl, node)).level() == self.level());
             }
         }
@@ -993,7 +993,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
                 self.lemma_child_some_properties(hd);
                 c.lemma_recursive_insert_preserves_value(tl, node);
             } else {
-                let c = Node::new_default(self.level() + 1);
+                let c = TreeNode::new_default(self.level() + 1);
                 Self::lemma_new_default_preserves_inv(self.level() + 1);
                 c.lemma_recursive_insert_preserves_value(tl, node);
             }
@@ -1039,7 +1039,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
                 let updated_child = c.recursive_insert(tl, node);
                 self.lemma_insert_preserves_inv(hd, updated_child);
             } else {
-                let c = Node::new_default(self.level() + 1);
+                let c = TreeNode::new_default(self.level() + 1);
                 Self::lemma_new_default_preserves_inv(self.level() + 1);
                 self.value().lemma_default_preserves_rel_children(self.level());
                 c.lemma_recursive_insert_preserves_inv(tl, node);
@@ -1189,7 +1189,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
             assert(self.recursive_trace(path2) == seq![
                 self.value(),
                 self.children()[idx as int]->0.value(),
-            ]) by { reveal_with_fuel(Node::recursive_trace, 2) }
+            ]) by { reveal_with_fuel(TreeNode::recursive_trace, 2) }
         } else {
             let (_, tl1) = path.pop_head();
             let (hd2, tl2) = path2.pop_head();
@@ -1523,8 +1523,8 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Node<T, N, L> {
 verus! {
 
 pub closed spec fn path_between<T: TreeNodeValue<L>, const N: usize, const L: usize>(
-    src: Node<T, N, L>,
-    dst: Node<T, N, L>,
+    src: TreeNode<T, N, L>,
+    dst: TreeNode<T, N, L>,
 ) -> TreePath<N>
     recommends
         src.inv(),
@@ -1546,8 +1546,8 @@ pub closed spec fn path_between<T: TreeNodeValue<L>, const N: usize, const L: us
 }
 
 pub broadcast proof fn lemma_path_between_properties<T: TreeNodeValue<L>, const N: usize, const L: usize>(
-    src: Node<T, N, L>,
-    dst: Node<T, N, L>,
+    src: TreeNode<T, N, L>,
+    dst: TreeNode<T, N, L>,
 )
     requires
         src.inv(),
@@ -1566,7 +1566,7 @@ pub broadcast proof fn lemma_path_between_properties<T: TreeNodeValue<L>, const 
 verus! {
 
 pub tracked struct Tree<T: TreeNodeValue<L>, const N: usize, const L: usize> {
-    pub tracked root: Node<T, N, L>,
+    pub tracked root: TreeNode<T, N, L>,
 }
 
 impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
@@ -1578,7 +1578,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
     }
 
     pub open spec fn new() -> Self {
-        Tree { root: Node::new_default(0) }
+        Tree { root: TreeNode::new_default(0) }
     }
 
     pub broadcast proof fn lemma_new_preserves_inv()
@@ -1589,10 +1589,10 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
         ensures
             #[trigger] Self::new().inv(),
     {
-        Node::<T, N, L>::lemma_new_default_preserves_inv(0);
+        TreeNode::<T, N, L>::lemma_new_default_preserves_inv(0);
     }
 
-    pub open spec fn insert(self, path: TreePath<N>, node: Node<T, N, L>) -> Self
+    pub open spec fn insert(self, path: TreePath<N>, node: TreeNode<T, N, L>) -> Self
         recommends
             self.inv(),
             path.inv(),
@@ -1614,7 +1614,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
         Tree { root: self.root.recursive_remove(path), ..self }
     }
 
-    pub open spec fn visit(self, path: TreePath<N>) -> Seq<Node<T, N, L>>
+    pub open spec fn visit(self, path: TreePath<N>) -> Seq<TreeNode<T, N, L>>
         recommends
             self.inv(),
             path.inv(),
@@ -1678,7 +1678,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
         self.root.lemma_recursive_trace_length(path);
     }
 
-    pub open spec fn seek(self, path: TreePath<N>) -> Option<Node<T, N, L>> {
+    pub open spec fn seek(self, path: TreePath<N>) -> Option<TreeNode<T, N, L>> {
         self.root.recursive_seek(path)
     }
 
@@ -1711,7 +1711,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
         self.root.lemma_recursive_seek_trace_next(path, idx)
     }
 
-    pub broadcast proof fn lemma_insert_preserves_inv(self, path: TreePath<N>, node: Node<T, N, L>)
+    pub broadcast proof fn lemma_insert_preserves_inv(self, path: TreePath<N>, node: TreeNode<T, N, L>)
         requires
             self.inv(),
             path.inv(),
@@ -1761,7 +1761,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
     }
 
     #[verifier::inline]
-    pub open spec fn on_tree(self, node: Node<T, N, L>) -> bool
+    pub open spec fn on_tree(self, node: TreeNode<T, N, L>) -> bool
         recommends
             self.inv(),
             node.inv(),
@@ -1769,7 +1769,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
         self.root.on_subtree(node)
     }
 
-    pub broadcast proof fn lemma_on_tree_property(self, node: Node<T, N, L>)
+    pub broadcast proof fn lemma_on_tree_property(self, node: TreeNode<T, N, L>)
         requires
             self.inv(),
             node.inv(),
@@ -1781,7 +1781,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
     {
     }
 
-    pub broadcast proof fn lemma_not_on_tree_property(self, node: Node<T, N, L>)
+    pub broadcast proof fn lemma_not_on_tree_property(self, node: TreeNode<T, N, L>)
         requires
             self.inv(),
             node.inv(),
@@ -1794,7 +1794,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
     }
 
     #[verifier::inline]
-    pub open spec fn get_path(self, node: Node<T, N, L>) -> TreePath<N>
+    pub open spec fn get_path(self, node: TreeNode<T, N, L>) -> TreePath<N>
         recommends
             self.inv(),
             node.inv(),
@@ -1803,7 +1803,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
         path_between::<T, N, L>(self.root, node)
     }
 
-    pub broadcast proof fn lemma_get_path_properties(self, node: Node<T, N, L>)
+    pub broadcast proof fn lemma_get_path_properties(self, node: TreeNode<T, N, L>)
         requires
             self.inv(),
             node.inv(),
@@ -1831,30 +1831,30 @@ pub broadcast group group_ghost_tree {
     TreePath::lemma_push_tail_len,
     TreePath::lemma_push_head_preserves_inv,
     TreePath::lemma_new_preserves_inv,
-    Node::lemma_new_properties,
-    Node::lemma_insert_preserves_inv,
-    Node::lemma_insert_property,
-    Node::lemma_insert_same_child_identical,
-    Node::lemma_remove_preserves_inv,
-    Node::lemma_remove_property,
-    Node::lemma_child_property,
-    Node::lemma_child_property_cases,
-    Node::lemma_insert_child_is_child,
-    Node::lemma_remove_child_is_none,
-    Node::lemma_get_value_property,
-    Node::lemma_set_value_property,
-    Node::lemma_is_leaf_bounded,
-    Node::lemma_recursive_visited_node_inv,
-    Node::lemma_recursive_visited_node_levels,
-    Node::lemma_recursive_visit_head,
-    Node::lemma_recursive_visit_induction,
-    Node::lemma_recursive_visit_one_is_child,
-    Node::lemma_on_subtree_property,
-    Node::lemma_not_on_subtree_property,
-    Node::lemma_on_subtree_reflexive,
-    Node::lemma_child_on_subtree,
-    Node::lemma_insert_on_subtree,
-    Node::lemma_recursive_remove_preserves_inv,
+    TreeNode::lemma_new_properties,
+    TreeNode::lemma_insert_preserves_inv,
+    TreeNode::lemma_insert_property,
+    TreeNode::lemma_insert_same_child_identical,
+    TreeNode::lemma_remove_preserves_inv,
+    TreeNode::lemma_remove_property,
+    TreeNode::lemma_child_property,
+    TreeNode::lemma_child_property_cases,
+    TreeNode::lemma_insert_child_is_child,
+    TreeNode::lemma_remove_child_is_none,
+    TreeNode::lemma_get_value_property,
+    TreeNode::lemma_set_value_property,
+    TreeNode::lemma_is_leaf_bounded,
+    TreeNode::lemma_recursive_visited_node_inv,
+    TreeNode::lemma_recursive_visited_node_levels,
+    TreeNode::lemma_recursive_visit_head,
+    TreeNode::lemma_recursive_visit_induction,
+    TreeNode::lemma_recursive_visit_one_is_child,
+    TreeNode::lemma_on_subtree_property,
+    TreeNode::lemma_not_on_subtree_property,
+    TreeNode::lemma_on_subtree_reflexive,
+    TreeNode::lemma_child_on_subtree,
+    TreeNode::lemma_insert_on_subtree,
+    TreeNode::lemma_recursive_remove_preserves_inv,
     lemma_path_between_properties,
     Tree::lemma_new_preserves_inv,
     Tree::lemma_visit_is_recursive_visit,

--- a/verified_libs/vstd_extra/src/ghost_tree.rs
+++ b/verified_libs/vstd_extra/src/ghost_tree.rs
@@ -255,15 +255,16 @@ pub trait TreeNodeValue<const L: usize>: Sized + Inv {
     ;
 }
 
-/// A ghost tree node with maximum `N` children,
-/// the maximum depth of the tree is `L`
-/// Each tree node has a value of type `T` and a sequence of children
+/// A ghost tree node with depth `L` and `N` children.
+/// 
+/// Each tree node has a value of type `T` and a sequence of children, forming a subtree.
+/// The length of the child seuquence is fixed at `N`, while the absence of a child is represeneted with `Option::None`.
+/// The maximum depth of the tree is `L`. 
 pub tracked struct TreeNode<T: TreeNodeValue<L>, const N: usize, const L: usize> {
     tracked value: T,
     ghost level: nat,
-    // FIXME: This should use tracked indirection, but that is blocked by
-    // https://github.com/verus-lang/verus/issues/2627.
-    tracked children: Ghost<Seq<Option<TreeNode<T, N, L>>>>,
+    // See https://github.com/verus-lang/verus/issues/2627.
+    tracked children: Tracked<Seq<Option<TreeNode<T, N, L>>>>,
 }
 
 impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
@@ -304,7 +305,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
 
     /// Constructs a node from its fields.
     pub closed spec fn new(value: T, level: nat, children: Seq<Option<Self>>) -> Self {
-        TreeNode { value, level, children: Ghost::new(children) }
+        TreeNode { value, level, children: Tracked(children) }
     }
 
     /// Constructs a node at the given level with default value and no children.
@@ -397,42 +398,19 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
     {
     }
 
-    /// Removes a child from the underlying sequence.
-    pub axiom fn tracked_remove_child(tracked &mut self, i: int) -> (tracked ret: Option<Self>)
-        requires
-            0 <= i < old(self).children().len(),
-        ensures
-            ret == old(self).children()[i],
-            final(self).children().len() == old(self).children().len() - 1,
-            final(self).children() == old(self).children().remove(i),
-            final(self).value() == old(self).value(),
-            final(self).level() == old(self).level(),
-    ;
-
-    /// Inserts a child into the underlying sequence.
-    pub axiom fn tracked_insert_child(
-        tracked &mut self,
-        i: int,
-        tracked child: Option<Self>,
-    )
-        requires
-            0 <= i <= old(self).children().len(),
-        ensures
-            final(self).children().len() == old(self).children().len() + 1,
-            final(self).children() == old(self).children().insert(i, child),
-            final(self).value() == old(self).value(),
-            final(self).level() == old(self).level(),
-    ;
-
     /// Borrows a child from the underlying sequence.
-    pub axiom fn tracked_borrow_child(tracked &self, i: int) -> (tracked ret: &Self)
+    pub proof fn tracked_borrow_child(tracked &self, i: int) -> (tracked ret: &Self)
         requires
             0 <= i < self.children().len(),
             self.children()[i] is Some,
         ensures
             *ret == self.children()[i] -> 0,
-    ;
+    {
+        self.children.tracked_borrow(i).tracked_borrow()
+    }
 
+    /// Mutably borrows a child from the underlying sequence.
+    // FIXME: There is currenly no `tracked_borrow_mut` method for `Seq`.
     pub axiom fn tracked_borrow_mut_child(tracked &mut self, i: int) -> (tracked ret: &mut Self)
         requires
             0 <= i < self.children().len(),
@@ -442,7 +420,8 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             final(self).value() == old(self).value(),
             final(self).level() == old(self).level(),
             final(self).children() == old(self).children().update(i, Some(*final(ret))),
-            ;
+        ;
+
 
     pub proof fn tracked_borrow_value(tracked &self) -> (tracked res: &T)
         ensures

--- a/verified_libs/vstd_extra/src/ghost_tree.rs
+++ b/verified_libs/vstd_extra/src/ghost_tree.rs
@@ -16,10 +16,17 @@ verus! {
 pub tracked struct TreePath<const N: usize>(pub Seq<int>);
 
 impl<const N: usize> TreePath<N> {
+    #[verifier::inline]
     pub open spec fn len(self) -> nat {
         self.0.len()
     }
 
+    #[verifier::inline]
+    pub open spec fn is_empty(self) -> bool {
+        self.len() == 0
+    }
+
+    #[verifier::inline]
     pub open spec fn index(self, i: int) -> int
         recommends
             0 <= i < self.len(),
@@ -27,17 +34,19 @@ impl<const N: usize> TreePath<N> {
         self.0[i]
     }
 
+    // Do NOT inline, it is used as trigger.
     pub open spec fn spec_index(self, i:int) -> int {
         self.index(i)
     }
 
+    #[verifier::inline]
     pub open spec fn elem_inv(e: int) -> bool {
         0 <= e < N
     }
 
     pub open spec fn inv(self) -> bool {
         &&& N > 0
-        &&& forall |i: int| 0 <= i < self.len() ==> Self::elem_inv(#[trigger] self.index(i))
+        &&& forall |i: int| 0 <= i < self.len() ==> Self::elem_inv(#[trigger] self[i])
     }
 
     pub broadcast proof fn lemma_index_satisfies_elem_inv(self, i: int)
@@ -45,12 +54,8 @@ impl<const N: usize> TreePath<N> {
             self.inv(),
             0 <= i < self.len(),
         ensures
-            Self::elem_inv(#[trigger] self.index(i)),
+            Self::elem_inv(#[trigger] self[i]),
     {
-    }
-
-    pub open spec fn is_empty(self) -> bool {
-        self.len() == 0
     }
 
     pub proof fn lemma_empty_satisfies_inv(self)
@@ -70,7 +75,7 @@ impl<const N: usize> TreePath<N> {
         recommends
             !self.is_empty(),
     {
-        (self.index(0), TreePath(self.0.drop_first()))
+        (self[0], TreePath(self.0.drop_first()))
     }
 
     pub broadcast proof fn lemma_pop_head_preserves_inv(self)
@@ -82,7 +87,7 @@ impl<const N: usize> TreePath<N> {
             (#[trigger] self.pop_head()).1.inv(),
     {
         let (_, s1) = self.pop_head();
-        assert(forall|i: int| 0 <= i < s1.len() ==> s1.index(i) == self.index(i + 1));
+        assert(forall|i: int| 0 <= i < s1.len() ==> s1[i] == self[i + 1]);
     }
 
     pub broadcast proof fn lemma_pop_head_index(self)
@@ -90,7 +95,7 @@ impl<const N: usize> TreePath<N> {
             self.inv(),
             !self.is_empty(),
         ensures
-            (#[trigger] self.pop_head()).0 == self.index(0),
+            (#[trigger] self.pop_head()).0 == self[0],
     {
     }
 
@@ -98,7 +103,7 @@ impl<const N: usize> TreePath<N> {
         recommends
             !self.is_empty(),
     {
-        (self.index(self.len() as int - 1), TreePath(self.0.drop_last()))
+        (self[self.len() - 1], TreePath(self.0.drop_last()))
     }
 
     pub broadcast proof fn lemma_pop_tail_preserves_inv(self)
@@ -111,7 +116,7 @@ impl<const N: usize> TreePath<N> {
     {
         let (_, s1) = self.pop_tail();
         if s1.len() > 0 {
-            assert(forall|i: int| 0 <= i < s1.len() ==> s1.index(i) == self.index(i));
+            assert(forall|i: int| 0 <= i < s1.len() ==> s1[i] == self[i]);
         }
     }
 
@@ -120,7 +125,7 @@ impl<const N: usize> TreePath<N> {
             self.inv(),
             !self.is_empty(),
         ensures
-            (#[trigger] self.pop_tail()).0 == self.index(self.len() as int - 1),
+            (#[trigger] self.pop_tail()).0 == self[self.len() - 1],
     {
     }
 
@@ -136,8 +141,8 @@ impl<const N: usize> TreePath<N> {
             self.inv(),
             0 <= hd < N,
         ensures
-            self.push_head(hd).index(0) == hd,
-            forall|i: int| 0 <= i < self.len() ==> self.push_head(hd).index(i + 1) == self.index(i),
+            self.push_head(hd)[0] == hd,
+            forall|i: int| 0 <= i < self.len() ==> self.push_head(hd)[i + 1] == self[i],
     {
     }
 
@@ -149,10 +154,10 @@ impl<const N: usize> TreePath<N> {
             (#[trigger] self.push_head(hd)).inv(),
     {
         let s1 = self.push_head(hd);
-        assert forall|i: int| 0 <= i < s1.len() implies Self::elem_inv(#[trigger] s1.index(i)) by {
+        assert forall|i: int| 0 <= i < s1.len() implies Self::elem_inv(#[trigger] s1[i]) by {
             if i == 0 {
             } else {
-                assert(Self::elem_inv(self.index(i - 1)));
+                assert(Self::elem_inv(self[i - 1]));
             }
         }
     }
@@ -178,9 +183,9 @@ impl<const N: usize> TreePath<N> {
             self.inv(),
             0 <= val < N,
         ensures
-            self.push_tail(val).index(self.len() as int) == val,
+            self.push_tail(val)[self.len() as int] == val,
             forall|i: int|
-                0 <= i < self.len() ==> #[trigger] self.push_tail(val).index(i) == self.index(i),
+                0 <= i < self.len() ==> #[trigger] self.push_tail(val)[i] == self[i],
     {
     }
 
@@ -192,10 +197,10 @@ impl<const N: usize> TreePath<N> {
             (#[trigger]self.push_tail(val)).inv(),
     {
         let s1 = self.push_tail(val);
-        assert forall|i: int| 0 <= i < s1.len() implies Self::elem_inv(#[trigger] s1.index(i)) by {
+        assert forall|i: int| 0 <= i < s1.len() implies Self::elem_inv(#[trigger] s1[i]) by {
             if i == self.len() {
             } else {
-                assert(Self::elem_inv(self.index(i)));
+                assert(Self::elem_inv(self[i]));
             }
         }
     }
@@ -812,7 +817,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         if path.is_empty() {
             self
         } else if path.len() == 1 {
-            self.insert(path.index(0), node)
+            self.insert(path[0], node)
         } else {
             let (hd, tl) = path.pop_head();
             let child = if self.has_child(hd) {
@@ -849,7 +854,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             1 < L - self.level(),
             node.level() == self.level() + 1,
         ensures
-            #[trigger] self.recursive_insert(path, node) == self.insert(path.index(0), node),
+            #[trigger] self.recursive_insert(path, node) == self.insert(path[0], node),
     {
     }
 
@@ -862,14 +867,14 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             node.level() == self.level() + path.len() as nat,
             path.len() > 1,
         ensures
-            self.has_child(path.index(0)) ==> #[trigger] self.recursive_insert(path, node)
+            self.has_child(path[0]) ==> #[trigger] self.recursive_insert(path, node)
                 == self.insert(
-                path.index(0),
-                self.child(path.index(0)).recursive_insert(path.pop_head().1, node),
+                path[0],
+                self.child(path[0]).recursive_insert(path.pop_head().1, node),
             ),
-            !self.has_child(path.index(0)) ==> #[trigger] self.recursive_insert(path, node)
+            !self.has_child(path[0]) ==> #[trigger] self.recursive_insert(path, node)
                 == self.insert(
-                path.index(0),
+                path[0],
                 TreeNode::new_default(self.level() + 1).recursive_insert(path.pop_head().1, node),
             ),
     {
@@ -897,7 +902,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         } else if path.len() == 1 {
             path.lemma_index_satisfies_elem_inv(0);
             self.lemma_recursive_insert_path_len_1(path, node);
-            assert(self.insert(path.index(0), node).level() == self.level());
+            assert(self.insert(path[0], node).level() == self.level());
         } else {
             self.lemma_recursive_insert_path_len_step(path, node);
             let (hd, tl) = path.pop_head();
@@ -973,7 +978,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         } else if path.len() == 1 {
             path.lemma_index_satisfies_elem_inv(0);
             self.lemma_recursive_insert_path_len_1(path, node);
-            self.lemma_insert_preserves_inv(path.index(0), node);
+            self.lemma_insert_preserves_inv(path[0], node);
         } else {
             self.lemma_recursive_insert_path_len_step(path, node);
             let (hd, tl) = path.pop_head();
@@ -1157,8 +1162,8 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         if path.is_empty() {
             Seq::empty()
         } else if path.len() == 1 {
-            if self.has_child(path.index(0)) {
-                seq![self.child(path.index(0))]
+            if self.has_child(path[0]) {
+                seq![self.child(path[0])]
             } else {
                 Seq::empty()
             }
@@ -1187,7 +1192,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
     {
         if path.is_empty() {
         } else if path.len() == 1 {
-            if self.has_child(path.index(0)) {
+            if self.has_child(path[0]) {
             }
         } else {
             let (hd, tl) = path.pop_head();
@@ -1214,7 +1219,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
     {
         if path.is_empty() {
         } else if path.len() == 1 {
-            if self.has_child(path.index(0)) {
+            if self.has_child(path[0]) {
             }
         } else {
             let (hd, tl) = path.pop_head();
@@ -1235,7 +1240,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             !path.is_empty(),
             self.recursive_visit(path).len() > 0,
         ensures
-            self.recursive_visit(path).index(0) == self.child(path.index(0)),
+            self.recursive_visit(path).index(0) == self.child(path[0]),
     {
     }
 
@@ -1269,10 +1274,10 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
             path.len() < L - self.level(),
             path.len() == 1,
         ensures
-            self.has_child(path.index(0)) ==> #[trigger] self.recursive_visit(path) == seq![
-                self.child(path.index(0)),
+            self.has_child(path[0]) ==> #[trigger] self.recursive_visit(path) == seq![
+                self.child(path[0]),
             ],
-            !self.has_child(path.index(0)) ==> #[trigger] self.recursive_visit(path) == seq![],
+            !self.has_child(path[0]) ==> #[trigger] self.recursive_visit(path) == seq![],
     {
     }
 
@@ -1368,7 +1373,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
         if path.is_empty() {
             self
         } else if path.len() == 1 {
-            self.remove(path.index(0))
+            self.remove(path[0])
         } else {
             let (hd, tl) = path.pop_head();
             if self.children()[hd as int] is None {
@@ -1440,7 +1445,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> TreeNode<T, N, L> {
     {
         if path.is_empty() {
         } else if path.len() == 1 {
-            self.lemma_remove_preserves_inv(path.index(0));
+            self.lemma_remove_preserves_inv(path[0]);
         } else {
             let (hd, tl) = path.pop_head();
             path.lemma_pop_head_preserves_inv();
@@ -1658,10 +1663,10 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
             node.level() == path.len() as nat,
             self.seek(path.pop_tail().1) is Some ==> self.seek(
                 path.pop_tail().1,
-            )->0.value().rel_children(path.index(path.len() - 1) as int, Some(node.value())),
+            )->0.value().rel_children(path[path.len() - 1] as int, Some(node.value())),
             self.seek(path.pop_tail().1) is None ==> T::default(
                 (path.len() - 1) as nat,
-            ).rel_children(path.index(path.len() - 1) as int, Some(node.value())),
+            ).rel_children(path[path.len() - 1] as int, Some(node.value())),
             forall|lv: nat, i: int|
                 lv < L ==> 0 <= i < N ==> #[trigger] T::default(lv).rel_children(i, None),
         ensures
@@ -1679,7 +1684,7 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
                 path.pop_tail().1,
             )->0.children()[path.pop_tail().0 as int] is None || self.seek(
                 path.pop_tail().1,
-            )->0.value().rel_children(path.index(path.len() - 1) as int, None),
+            )->0.value().rel_children(path[path.len() - 1] as int, None),
         ensures
             #[trigger] self.remove(path).inv(),
     {
@@ -1747,10 +1752,10 @@ impl<T: TreeNodeValue<L>, const N: usize, const L: usize> Tree<T, N, L> {
             node.inv(),
             self.on_tree(node),
         ensures
-            #[trigger] self.get_path(node).inv(),
-            #[trigger] self.get_path(node).len() == node.level(),
-            node.level() == 0 ==> #[trigger] self.get_path(node).is_empty(),
-            node.level() > 0 ==> #[trigger] self.visit(self.get_path(node)).last() == node,
+            (#[trigger] self.get_path(node)).inv(),
+            self.get_path(node).len() == node.level(),
+            node.level() == 0 ==> self.get_path(node).is_empty(),
+            node.level() > 0 ==> self.visit(self.get_path(node)).last() == node,
     {
         lemma_path_between_properties(self.root, node);
     }


### PR DESCRIPTION
## ChangeLog
- [x] Rename `ghost_tree::Node` to `TreeNode`.
- [x] Use a `tracked children: Tracked<Seq<...>` to fix #629 and hide the fields. 
- [x] Optimize the ghost tree library APIs accordingly, including:
  - [x] Rename `tree_predicate_map` to `subtree_satisfies`.
  - [x] ~~Rename `TreeNode::insert` to `TreeNode::update` following the `Seq` convention.~~
  - [x] Adjust broadcast lemmas and simplify proofs.
  - [x] Add `TreePath::spec_index` so that we can use the `[]` operator
  - [x] Add `spec fn TreeNode::child(i)` to simplify the specification.
  - [x] Add missing `lemma/tracked` prefix.
  - [x] Change the internal representation of `TreePath` from `Seq<usize>` to `Seq<int>`.