### PR TITLE
fix an unsound assumption while constructin PTEs

### DIFF
--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -550,6 +550,7 @@ impl<'rcu, C: PageTableConfig> CursorContinuation<'rcu, C> {
             paddr % page_size(self.level()) == 0,
             paddr + page_size(self.level()) <= MAX_PADDR,
             C::raw_item_well_formed(paddr, self.level(), prop),
+            C::E::new_page_req(paddr, self.level(), prop),
             self.path().push_tail(self.idx as int).inv(),
         ensures
             final(regions).slot_owners == old(regions).slot_owners,

--- a/ostd/specs/mm/page_table/node/child.rs
+++ b/ostd/specs/mm/page_table/node/child.rs
@@ -102,6 +102,10 @@ impl<C: PageTableConfig> Child<C> {
         &&& owner.inv_base()
         &&& regions.inv()
         &&& self.wf(owner)
+        &&& match self {
+            Self::Frame(paddr, level, prop) => C::E::new_page_req(paddr, level, prop),
+            _ => true,
+        }
         &&& owner.metaregion_sound(regions)
     }
 }

--- a/ostd/specs/mm/page_table/node/entry_owners.rs
+++ b/ostd/specs/mm/page_table/node/entry_owners.rs
@@ -854,6 +854,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
                 self.parent_level,
                 self.frame().prop,
             )
+            &&& C::E::new_page_req(self.frame().mapped_pa, self.parent_level, self.frame().prop)
         }
         &&& self.is_borrowed() ==> { true }
         &&& self.path.inv()

--- a/ostd/src/mm/kspace/mod.rs
+++ b/ostd/src/mm/kspace/mod.rs
@@ -340,6 +340,16 @@ unsafe impl PageTableConfig for KernelPtConfig {
         child_pa: Paddr,
         child_idx: usize,
     ) {
+        assert(<PageTableEntry as crate::mm::page_table::PageTableEntryTrait>::new_page_req(
+            pa,
+            level,
+            prop,
+        ));
+        assert(<PageTableEntry as crate::mm::page_table::PageTableEntryTrait>::new_page_req(
+            child_pa,
+            (level - 1) as PagingLevel,
+            prop,
+        ));
     }
 
     proof fn lemma_item_from_raw_well_formed(pa: Paddr, level: PagingLevel, prop: PageProperty) {

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -2121,6 +2121,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 op.ensures((p_in,), p_out) ==>
                     C::tracked(C::item_from_raw_spec(pa, level, p_out))
                     == C::tracked(C::item_from_raw_spec(pa, level, p_in)),
+            forall |pa: Paddr, level: PagingLevel, p_in: PageProperty, p_out: PageProperty| #![auto]
+                op.ensures((p_in,), p_out) && C::E::new_page_req(pa, level, p_in) ==>
+                    C::E::new_page_req(pa, level, p_out),
         ensures
             final(self).0.invariants(*final(owner), *final(regions), *final(guards)),
             final(self).0.barrier_va == old(self).0.barrier_va,
@@ -3813,6 +3816,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 op.ensures((p_in,), p_out) ==>
                     C::tracked(C::item_from_raw_spec(pa, level, p_out))
                     == C::tracked(C::item_from_raw_spec(pa, level, p_in)),
+            forall |pa: Paddr, level: PagingLevel, p_in: PageProperty, p_out: PageProperty| #![auto]
+                op.ensures((p_in,), p_out) && C::E::new_page_req(pa, level, p_in) ==>
+                    C::E::new_page_req(pa, level, p_out),
             // `find_next_impl` diverges on the find-next panic condition.
             old(self).0.find_next_panic_condition(len) ==> may_panic(),
         ensures

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -214,6 +214,7 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
             paddr % page_size(level) == 0,
             paddr + page_size(level) <= MAX_PADDR,
             Self::raw_item_well_formed(paddr, level, prop),
+            Self::E::new_page_req(paddr, level, prop),
         returns
             Self::item_into_raw_spec(item),
     ;
@@ -298,11 +299,13 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
         requires
             has_safe_slot(pa),
             Self::raw_item_well_formed(pa, level, prop),
+            Self::E::new_page_req(pa, level, prop),
             level > 1,
             child_idx < NR_ENTRIES,
             child_pa == pa + child_idx * page_size((level - 1) as PagingLevel),
         ensures
             Self::raw_item_well_formed(child_pa, (level - 1) as PagingLevel, prop),
+            Self::E::new_page_req(child_pa, (level - 1) as PagingLevel, prop),
     ;
 
     /// The item produced by [`PageTableConfig::item_from_raw`] is well-formed.

--- a/ostd/src/mm/page_table/node/child.rs
+++ b/ostd/src/mm/page_table/node/child.rs
@@ -103,10 +103,7 @@ impl<C: PageTableConfig> Child<C> {
 
                 C::E::new_pt(paddr)
             },
-            Child::Frame(paddr, level, prop) => {
-                assume(C::E::new_page_req(paddr, level, prop));
-                C::E::new_page(paddr, level, prop)
-            },
+            Child::Frame(paddr, level, prop) => { C::E::new_page(paddr, level, prop) },
             Child::None => { C::E::new_absent() },
         }
     }

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -218,6 +218,10 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 #![auto]
                 op.ensures((p_in,), p_out) ==> C::tracked(C::item_from_raw_spec(pa, level, p_out))
                     == C::tracked(C::item_from_raw_spec(pa, level, p_in)),
+            forall|pa: Paddr, level: PagingLevel, p_in: PageProperty, p_out: PageProperty|
+                #![auto]
+                op.ensures((p_in,), p_out) && C::E::new_page_req(pa, level, p_in)
+                    ==> C::E::new_page_req(pa, level, p_out),
         ensures
             final(owner).inv(),
             final(self).wf(*final(owner)),
@@ -1432,6 +1436,10 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
                 #![auto]
                 op.ensures((p_in,), p_out) ==> C::tracked(C::item_from_raw_spec(pa, level, p_out))
                     == C::tracked(C::item_from_raw_spec(pa, level, p_in)),
+            forall|pa: Paddr, level: PagingLevel, p_in: PageProperty, p_out: PageProperty|
+                #![auto]
+                op.ensures((p_in,), p_out) && C::E::new_page_req(pa, level, p_in)
+                    ==> C::E::new_page_req(pa, level, p_out),
         ensures
             final(owner).inv(),
             final(owner).is_frame(),
@@ -1489,6 +1497,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
                 prop,
                 new_prop,
             );
+            assert(C::E::new_page_req(owner.frame().mapped_pa, owner.parent_level, new_prop));
         }
 
         assume(pte.set_prop_req(new_prop));

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -1497,7 +1497,6 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
                 prop,
                 new_prop,
             );
-            assert(C::E::new_page_req(owner.frame().mapped_pa, owner.parent_level, new_prop));
         }
 
         assume(pte.set_prop_req(new_prop));

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -1535,6 +1535,10 @@ impl<'a, A: InAtomicMode> CursorMut<'a, A> {
                 op.ensures((p_in,), p_out) ==>
                     UserPtConfig::tracked(UserPtConfig::item_from_raw_spec(pa, level, p_out))
                     == UserPtConfig::tracked(UserPtConfig::item_from_raw_spec(pa, level, p_in)),
+            forall |pa: Paddr, level: PagingLevel, p_in: PageProperty, p_out: PageProperty| #![auto]
+                op.ensures((p_in,), p_out)
+                    && <PageTableEntry as PageTableEntryTrait>::new_page_req(pa, level, p_in) ==>
+                        <PageTableEntry as PageTableEntryTrait>::new_page_req(pa, level, p_out),
 
             old(self).pt_cursor.0.find_next_panic_condition(len) ==> may_panic(),
         ensures


### PR DESCRIPTION
Fix #624 as the current invariant is weak and allows us to construct invalid PTEs.