### PR TITLE
fix: Redesign `TrackDrop`

### DIFF
--- a/ostd/specs/mm/frame/frame_specs.rs
+++ b/ostd/specs/mm/frame/frame_specs.rs
@@ -216,7 +216,6 @@ impl<M: ?Sized> TrackDrop for Frame<M> {
         self,
         s0: Self::State,
         s1: Self::State,
-        obl_key: Self::Key,
     ) -> bool {
         let slot_own = s0.slot_owners[self.index()];
         &&& s1.slot_owners[self.index()] == slot_own
@@ -230,7 +229,7 @@ impl<M: ?Sized> TrackDrop for Frame<M> {
         // not affect the segment obligation ledger.
         // Frame-side ledger: `constructor_spec` adds one entry at the
         // slot index via the paired mint axiom (multiset semantics).
-        &&& s1.frame_obligations =~= s0.frame_obligations.insert(obl_key)
+        &&& s1.frame_obligations =~= s0.frame_obligations.insert(self.index())
     }
 
     proof fn constructor_spec(self, tracked s: &mut Self::State) -> (tracked obl: DropObligation<
@@ -283,7 +282,7 @@ impl<M: ?Sized> TrackDrop for Frame<M> {
         }
     }
 
-    open spec fn drop_ensures(self, s0: Self::State, s1: Self::State, obl_key: Self::Key) -> bool {
+    open spec fn drop_ensures(self, s0: Self::State, s1: Self::State) -> bool {
         let idx = frame_to_index(meta_to_frame(self.ptr.addr()));
         let so0 = s0.slot_owners[idx];
         let so1 = s1.slot_owners[idx];
@@ -314,25 +313,24 @@ impl<M: ?Sized> TrackDrop for Frame<M> {
         // Frame-side ledger: routed through `consume_obligation` (called
         // by Drop::drop's body first), the count at `obl_key` shrinks
         // by 1.
-        &&& s1.frame_obligations =~= s0.frame_obligations.remove(obl_key)
+        &&& s1.frame_obligations =~= s0.frame_obligations.remove(self.index())
     }
 
     /// `ManuallyDrop::new` / `Drop::drop` require the ledger to contain
     /// at least one entry at this slot — preventing a forged token
     /// from being used to "consume" a non-existent obligation.
-    open spec fn consume_requires(self, s: Self::State, obl_key: Self::Key) -> bool {
-        s.frame_obligations.count(obl_key) > 0
+    open spec fn consume_requires(self, s: Self::State) -> bool {
+        s.frame_obligations.count(self.index()) > 0
     }
 
     open spec fn consume_ensures(
         self,
         s0: Self::State,
         s1: Self::State,
-        obl_key: Self::Key,
     ) -> bool {
         // Multiset count at the slot shrinks by 1; everything else
         // (slots, slot_owners, segment ledger) is preserved.
-        &&& s1.frame_obligations =~= s0.frame_obligations.remove(obl_key)
+        &&& s1.frame_obligations =~= s0.frame_obligations.remove(self.index())
         &&& s1.slots =~= s0.slots
         &&& s1.slot_owners =~= s0.slot_owners
     }

--- a/ostd/specs/mm/frame/frame_specs.rs
+++ b/ostd/specs/mm/frame/frame_specs.rs
@@ -201,18 +201,19 @@ impl<M: ?Sized> TrackDrop for Frame<M> {
     /// (Full per-instance ledger enforcement is a follow-up; for now
     /// `consume_obligation` is a no-op so the token's identity is
     /// documentary rather than gated against a multiset.)
-    type Key = usize;
+    type Obligation = DropObligation<usize>;
 
-    open spec fn key(self) -> Self::Key {
-        self.index()
-    }
-
-    open spec fn constructor_requires(self, s: Self::State) -> bool {
+    open spec fn tracked_redeem_requires(self, s: Self::State) -> bool {
         &&& s.slot_owners.contains_key(self.index())
         &&& s.inv()
     }
 
-    open spec fn constructor_ensures(self, s0: Self::State, s1: Self::State) -> bool {
+    open spec fn tracked_redeem_ensures(
+        self,
+        s0: Self::State,
+        s1: Self::State,
+        obl: Self::Obligation,
+    ) -> bool {
         let slot_own = s0.slot_owners[self.index()];
         &&& s1.slot_owners[self.index()] == slot_own
         &&& forall|i: usize|
@@ -226,11 +227,10 @@ impl<M: ?Sized> TrackDrop for Frame<M> {
         // Frame-side ledger: `constructor_spec` adds one entry at the
         // slot index via the paired mint axiom (multiset semantics).
         &&& s1.frame_obligations =~= s0.frame_obligations.insert(self.index())
+        &&& obl.value() == self.index()
     }
 
-    proof fn constructor_spec(self, tracked s: &mut Self::State) -> (tracked obl: DropObligation<
-        Self::Key,
-    >) {
+    proof fn tracked_redeem(self, tracked s: &mut Self::State) -> (tracked obl: Self::Obligation) {
         let meta_addr = self.ptr.addr();
         let index = frame_to_index(meta_to_frame(meta_addr));
         let tracked mut slot_own = s.slot_owners.tracked_remove(index);
@@ -245,7 +245,7 @@ impl<M: ?Sized> TrackDrop for Frame<M> {
     // outstanding (`raw_count > 0`), since those raw paddrs could be revived
     // via `from_raw` after the slot has been torn down. Hence the drop is
     // only permitted when `raw_count == 0`.
-    open spec fn drop_requires(self, s: Self::State) -> bool {
+    open spec fn drop_requires(self, s: Self::State, obl: Self::Obligation) -> bool {
         let idx = frame_to_index(meta_to_frame(self.ptr.addr()));
         let slot_own = s.slot_owners[idx];
         // Cross-object validity: this Frame is consistent with `s` and
@@ -276,9 +276,16 @@ impl<M: ?Sized> TrackDrop for Frame<M> {
         &&& slot_own.inner_perms.ref_count.value() == 1 ==> {
             &&& slot_own.paths_in_pt.is_empty()
         }
+        &&& s.frame_obligations.count(self.index()) > 0
+        &&& obl.value() == self.index()
     }
 
-    open spec fn drop_ensures(self, s0: Self::State, s1: Self::State) -> bool {
+    open spec fn drop_ensures(
+        self,
+        s0: Self::State,
+        s1: Self::State,
+        obl: Self::Obligation,
+    ) -> bool {
         let idx = frame_to_index(meta_to_frame(self.ptr.addr()));
         let so0 = s0.slot_owners[idx];
         let so1 = s1.slot_owners[idx];
@@ -310,32 +317,6 @@ impl<M: ?Sized> TrackDrop for Frame<M> {
         // by Drop::drop's body first), the count at `obl_key` shrinks
         // by 1.
         &&& s1.frame_obligations =~= s0.frame_obligations.remove(self.index())
-    }
-
-    /// `ManuallyDrop::new` / `Drop::drop` require the ledger to contain
-    /// at least one entry at this slot — preventing a forged token
-    /// from being used to "consume" a non-existent obligation.
-    open spec fn consume_requires(self, s: Self::State) -> bool {
-        s.frame_obligations.count(self.index()) > 0
-    }
-
-    open spec fn consume_ensures(self, s0: Self::State, s1: Self::State) -> bool {
-        // Multiset count at the slot shrinks by 1; everything else
-        // (slots, slot_owners, segment ledger) is preserved.
-        &&& s1.frame_obligations =~= s0.frame_obligations.remove(self.index())
-        &&& s1.slots =~= s0.slots
-        &&& s1.slot_owners =~= s0.slot_owners
-    }
-
-    proof fn consume_obligation(
-        self,
-        tracked s: &mut Self::State,
-        tracked obl: DropObligation<Self::Key>,
-    ) {
-        // Paired redeem axiom: removes one entry at `obl.value()` from
-        // `frame_obligations`. Leaves `slot_owners` (including
-        // `raw_count`) untouched — the deliberate-leak semantic.
-        s.tracked_redeem_frame_obligation(obl);
     }
 }
 

--- a/ostd/specs/mm/frame/frame_specs.rs
+++ b/ostd/specs/mm/frame/frame_specs.rs
@@ -212,11 +212,7 @@ impl<M: ?Sized> TrackDrop for Frame<M> {
         &&& s.inv()
     }
 
-    open spec fn constructor_ensures(
-        self,
-        s0: Self::State,
-        s1: Self::State,
-    ) -> bool {
+    open spec fn constructor_ensures(self, s0: Self::State, s1: Self::State) -> bool {
         let slot_own = s0.slot_owners[self.index()];
         &&& s1.slot_owners[self.index()] == slot_own
         &&& forall|i: usize|
@@ -323,11 +319,7 @@ impl<M: ?Sized> TrackDrop for Frame<M> {
         s.frame_obligations.count(self.index()) > 0
     }
 
-    open spec fn consume_ensures(
-        self,
-        s0: Self::State,
-        s1: Self::State,
-    ) -> bool {
+    open spec fn consume_ensures(self, s0: Self::State, s1: Self::State) -> bool {
         // Multiset count at the slot shrinks by 1; everything else
         // (slots, slot_owners, segment ledger) is preserved.
         &&& s1.frame_obligations =~= s0.frame_obligations.remove(self.index())

--- a/ostd/specs/mm/frame/segment.rs
+++ b/ostd/specs/mm/frame/segment.rs
@@ -53,11 +53,7 @@ impl<M: AnyFrameMeta + ?Sized> TrackDrop for Segment<M> {
         true
     }
 
-    open spec fn constructor_ensures(
-        self,
-        s0: Self::State,
-        s1: Self::State,
-    ) -> bool {
+    open spec fn constructor_ensures(self, s0: Self::State, s1: Self::State) -> bool {
         &&& s0 =~= s1
     }
 
@@ -79,11 +75,7 @@ impl<M: AnyFrameMeta + ?Sized> TrackDrop for Segment<M> {
         true
     }
 
-    open spec fn consume_ensures(
-        self,
-        s0: Self::State,
-        s1: Self::State,
-    ) -> bool {
+    open spec fn consume_ensures(self, s0: Self::State, s1: Self::State) -> bool {
         s0 =~= s1
     }
 

--- a/ostd/specs/mm/frame/segment.rs
+++ b/ostd/specs/mm/frame/segment.rs
@@ -57,10 +57,8 @@ impl<M: AnyFrameMeta + ?Sized> TrackDrop for Segment<M> {
         self,
         s0: Self::State,
         s1: Self::State,
-        obl_key: Self::Key,
     ) -> bool {
         &&& s0 =~= s1
-        &&& obl_key == self.range
     }
 
     proof fn constructor_spec(self, tracked s: &mut Self::State) -> (tracked obl: DropObligation<
@@ -73,11 +71,11 @@ impl<M: AnyFrameMeta + ?Sized> TrackDrop for Segment<M> {
         s.inv()
     }
 
-    open spec fn drop_ensures(self, s0: Self::State, s1: Self::State, obl_key: Self::Key) -> bool {
+    open spec fn drop_ensures(self, s0: Self::State, s1: Self::State) -> bool {
         true
     }
 
-    open spec fn consume_requires(self, s: Self::State, obl_key: Self::Key) -> bool {
+    open spec fn consume_requires(self, s: Self::State) -> bool {
         true
     }
 
@@ -85,7 +83,6 @@ impl<M: AnyFrameMeta + ?Sized> TrackDrop for Segment<M> {
         self,
         s0: Self::State,
         s1: Self::State,
-        obl_key: Self::Key,
     ) -> bool {
         s0 =~= s1
     }

--- a/ostd/specs/mm/frame/segment.rs
+++ b/ostd/specs/mm/frame/segment.rs
@@ -30,7 +30,7 @@ impl<M: AnyFrameMeta + ?Sized> TrackDrop for Segment<M> {
     /// [`MetaRegionOwners`]. The real per-segment obligation is represented
     /// by one entry per frame in `MetaRegionOwners::frame_obligations`, not
     /// by this `TrackDrop` impl. That keeps
-    /// `ManuallyDrop::new(self, Tracked(regions))` callable in places like
+    /// `ManuallyDrop::new(self)` callable in places like
     /// `Segment::split` / `Segment::into_raw` where the segment is
     /// "temporarily forgotten" without an actual ledger event.
     type State = MetaRegionOwners;
@@ -43,49 +43,38 @@ impl<M: AnyFrameMeta + ?Sized> TrackDrop for Segment<M> {
     /// discipline: a token forged for one segment can't masquerade as
     /// belonging to another (the `consume_requires`/`drop_requires`
     /// checks would refuse the mismatched key).
-    type Key = Range<Paddr>;
+    type Obligation = DropObligation<Range<Paddr>>;
 
-    open spec fn key(self) -> Self::Key {
-        self.range
-    }
-
-    open spec fn constructor_requires(self, s: Self::State) -> bool {
+    open spec fn tracked_redeem_requires(self, s: Self::State) -> bool {
         true
     }
 
-    open spec fn constructor_ensures(self, s0: Self::State, s1: Self::State) -> bool {
+    open spec fn tracked_redeem_ensures(
+        self,
+        s0: Self::State,
+        s1: Self::State,
+        obl: Self::Obligation,
+    ) -> bool {
         &&& s0 =~= s1
+        &&& obl.value() == self.range
     }
 
-    proof fn constructor_spec(self, tracked s: &mut Self::State) -> (tracked obl: DropObligation<
-        Self::Key,
-    >) {
+    proof fn tracked_redeem(self, tracked s: &mut Self::State) -> (tracked obl: Self::Obligation) {
         DropObligation::tracked_mint(self.range)
     }
 
-    open spec fn drop_requires(self, s: Self::State) -> bool {
-        s.inv()
+    open spec fn drop_requires(self, s: Self::State, obl: Self::Obligation) -> bool {
+        &&& s.inv()
+        &&& obl.value() == self.range
     }
 
-    open spec fn drop_ensures(self, s0: Self::State, s1: Self::State) -> bool {
-        true
-    }
-
-    open spec fn consume_requires(self, s: Self::State) -> bool {
-        true
-    }
-
-    open spec fn consume_ensures(self, s0: Self::State, s1: Self::State) -> bool {
-        s0 =~= s1
-    }
-
-    proof fn consume_obligation(
+    open spec fn drop_ensures(
         self,
-        tracked s: &mut Self::State,
-        tracked obl: DropObligation<Self::Key>,
-    ) {
-        // No-op: the token is ledger-less identity. Segment drop accounting is
-        // handled by `Segment::drop` against `frame_obligations` directly.
+        s0: Self::State,
+        s1: Self::State,
+        obl: Self::Obligation,
+    ) -> bool {
+        true
     }
 }
 

--- a/ostd/specs/mm/frame/unique.rs
+++ b/ostd/specs/mm/frame/unique.rs
@@ -221,7 +221,6 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> TrackDrop for UniqueFram
         self,
         s0: Self::State,
         s1: Self::State,
-        obl_key: Self::Key,
     ) -> bool {
         &&& s1.slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].inner_perms
             == s0.slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].inner_perms
@@ -240,7 +239,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> TrackDrop for UniqueFram
         // Linear-drop discipline: minting a UniqueFrame (`MD::new`) adds
         // one entry at the slot index via the paired mint axiom — same
         // ledger Frame uses.
-        &&& s1.frame_obligations =~= s0.frame_obligations.insert(obl_key)
+        &&& s1.frame_obligations =~= s0.frame_obligations.insert(frame_to_index(meta_to_frame(self.ptr.addr())))
         &&& s1.inv()
     }
 
@@ -261,7 +260,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> TrackDrop for UniqueFram
         &&& s.inv()
     }
 
-    open spec fn drop_ensures(self, s0: Self::State, s1: Self::State, obl_key: Self::Key) -> bool {
+    open spec fn drop_ensures(self, s0: Self::State, s1: Self::State) -> bool {
         &&& forall|i: usize|
             #![trigger s1.slot_owners[i]]
             i != frame_to_index(meta_to_frame(self.ptr.addr())) ==> s1.slot_owners[i]
@@ -272,24 +271,23 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> TrackDrop for UniqueFram
         // ledger contribution: one entry at `obl_key` is removed via
         // `consume_obligation`. (`UniqueFrame`'s inherent `drop` exec
         // function is responsible for arranging this in the body.)
-        &&& s1.frame_obligations =~= s0.frame_obligations.remove(obl_key)
+        &&& s1.frame_obligations =~= s0.frame_obligations.remove(frame_to_index(meta_to_frame(self.ptr.addr())))
         &&& s1.inv()
     }
 
     /// `ManuallyDrop::new` / `Drop::drop` require the ledger to contain
     /// at least one entry at this slot — preventing a forged token
     /// from being used to "consume" a non-existent obligation.
-    open spec fn consume_requires(self, s: Self::State, obl_key: Self::Key) -> bool {
-        s.frame_obligations.count(obl_key) > 0
+    open spec fn consume_requires(self, s: Self::State) -> bool {
+        s.frame_obligations.count(frame_to_index(meta_to_frame(self.ptr.addr()))) > 0
     }
 
     open spec fn consume_ensures(
         self,
         s0: Self::State,
         s1: Self::State,
-        obl_key: Self::Key,
     ) -> bool {
-        &&& s1.frame_obligations =~= s0.frame_obligations.remove(obl_key)
+        &&& s1.frame_obligations =~= s0.frame_obligations.remove(frame_to_index(meta_to_frame(self.ptr.addr())))
         &&& s1.slots =~= s0.slots
         &&& s1.slot_owners =~= s0.slot_owners
     }

--- a/ostd/specs/mm/frame/unique.rs
+++ b/ostd/specs/mm/frame/unique.rs
@@ -217,11 +217,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> TrackDrop for UniqueFram
         &&& s.inv()
     }
 
-    open spec fn constructor_ensures(
-        self,
-        s0: Self::State,
-        s1: Self::State,
-    ) -> bool {
+    open spec fn constructor_ensures(self, s0: Self::State, s1: Self::State) -> bool {
         &&& s1.slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].inner_perms
             == s0.slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].inner_perms
         &&& s1.slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].slot_vaddr
@@ -239,7 +235,9 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> TrackDrop for UniqueFram
         // Linear-drop discipline: minting a UniqueFrame (`MD::new`) adds
         // one entry at the slot index via the paired mint axiom — same
         // ledger Frame uses.
-        &&& s1.frame_obligations =~= s0.frame_obligations.insert(frame_to_index(meta_to_frame(self.ptr.addr())))
+        &&& s1.frame_obligations =~= s0.frame_obligations.insert(
+            frame_to_index(meta_to_frame(self.ptr.addr())),
+        )
         &&& s1.inv()
     }
 
@@ -271,7 +269,9 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> TrackDrop for UniqueFram
         // ledger contribution: one entry at `obl_key` is removed via
         // `consume_obligation`. (`UniqueFrame`'s inherent `drop` exec
         // function is responsible for arranging this in the body.)
-        &&& s1.frame_obligations =~= s0.frame_obligations.remove(frame_to_index(meta_to_frame(self.ptr.addr())))
+        &&& s1.frame_obligations =~= s0.frame_obligations.remove(
+            frame_to_index(meta_to_frame(self.ptr.addr())),
+        )
         &&& s1.inv()
     }
 
@@ -282,12 +282,10 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> TrackDrop for UniqueFram
         s.frame_obligations.count(frame_to_index(meta_to_frame(self.ptr.addr()))) > 0
     }
 
-    open spec fn consume_ensures(
-        self,
-        s0: Self::State,
-        s1: Self::State,
-    ) -> bool {
-        &&& s1.frame_obligations =~= s0.frame_obligations.remove(frame_to_index(meta_to_frame(self.ptr.addr())))
+    open spec fn consume_ensures(self, s0: Self::State, s1: Self::State) -> bool {
+        &&& s1.frame_obligations =~= s0.frame_obligations.remove(
+            frame_to_index(meta_to_frame(self.ptr.addr())),
+        )
         &&& s1.slots =~= s0.slots
         &&& s1.slot_owners =~= s0.slot_owners
     }

--- a/ostd/specs/mm/frame/unique.rs
+++ b/ostd/specs/mm/frame/unique.rs
@@ -203,13 +203,9 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> TrackDrop for UniqueFram
     /// at any moment a slot is in either Frame-SHARED mode (ref_count in
     /// [1, MAX]) or UniqueFrame-UNIQUE mode (ref_count == UNIQUE), never
     /// both, so the multiset semantics are unambiguous.
-    type Key = usize;
+    type Obligation = DropObligation<usize>;
 
-    open spec fn key(self) -> Self::Key {
-        frame_to_index(meta_to_frame(self.ptr.addr()))
-    }
-
-    open spec fn constructor_requires(self, s: Self::State) -> bool {
+    open spec fn tracked_redeem_requires(self, s: Self::State) -> bool {
         &&& s.slot_owners.contains_key(frame_to_index(meta_to_frame(self.ptr.addr())))
         &&& s.slot_owners[frame_to_index(
             meta_to_frame(self.ptr.addr()),
@@ -217,7 +213,12 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> TrackDrop for UniqueFram
         &&& s.inv()
     }
 
-    open spec fn constructor_ensures(self, s0: Self::State, s1: Self::State) -> bool {
+    open spec fn tracked_redeem_ensures(
+        self,
+        s0: Self::State,
+        s1: Self::State,
+        obl: Self::Obligation,
+    ) -> bool {
         &&& s1.slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].inner_perms
             == s0.slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].inner_perms
         &&& s1.slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].slot_vaddr
@@ -238,12 +239,11 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> TrackDrop for UniqueFram
         &&& s1.frame_obligations =~= s0.frame_obligations.insert(
             frame_to_index(meta_to_frame(self.ptr.addr())),
         )
+        &&& obl.value() == frame_to_index(meta_to_frame(self.ptr.addr()))
         &&& s1.inv()
     }
 
-    proof fn constructor_spec(self, tracked s: &mut Self::State) -> (tracked obl: DropObligation<
-        Self::Key,
-    >) {
+    proof fn tracked_redeem(self, tracked s: &mut Self::State) -> (tracked obl: Self::Obligation) {
         let index = frame_to_index(meta_to_frame(self.ptr.addr()));
         let tracked mut slot_own = s.slot_owners.tracked_remove(index);
         s.slot_owners.tracked_insert(index, slot_own);
@@ -253,12 +253,19 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> TrackDrop for UniqueFram
         s.tracked_mint_frame_obligation(index)
     }
 
-    open spec fn drop_requires(self, s: Self::State) -> bool {
+    open spec fn drop_requires(self, s: Self::State, obl: Self::Obligation) -> bool {
         &&& s.slot_owners.contains_key(frame_to_index(meta_to_frame(self.ptr.addr())))
         &&& s.inv()
+        &&& s.frame_obligations.count(frame_to_index(meta_to_frame(self.ptr.addr()))) > 0
+        &&& obl.value() == frame_to_index(meta_to_frame(self.ptr.addr()))
     }
 
-    open spec fn drop_ensures(self, s0: Self::State, s1: Self::State) -> bool {
+    open spec fn drop_ensures(
+        self,
+        s0: Self::State,
+        s1: Self::State,
+        obl: Self::Obligation,
+    ) -> bool {
         &&& forall|i: usize|
             #![trigger s1.slot_owners[i]]
             i != frame_to_index(meta_to_frame(self.ptr.addr())) ==> s1.slot_owners[i]
@@ -273,31 +280,6 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> TrackDrop for UniqueFram
             frame_to_index(meta_to_frame(self.ptr.addr())),
         )
         &&& s1.inv()
-    }
-
-    /// `ManuallyDrop::new` / `Drop::drop` require the ledger to contain
-    /// at least one entry at this slot — preventing a forged token
-    /// from being used to "consume" a non-existent obligation.
-    open spec fn consume_requires(self, s: Self::State) -> bool {
-        s.frame_obligations.count(frame_to_index(meta_to_frame(self.ptr.addr()))) > 0
-    }
-
-    open spec fn consume_ensures(self, s0: Self::State, s1: Self::State) -> bool {
-        &&& s1.frame_obligations =~= s0.frame_obligations.remove(
-            frame_to_index(meta_to_frame(self.ptr.addr())),
-        )
-        &&& s1.slots =~= s0.slots
-        &&& s1.slot_owners =~= s0.slot_owners
-    }
-
-    proof fn consume_obligation(
-        self,
-        tracked s: &mut Self::State,
-        tracked obl: DropObligation<Self::Key>,
-    ) {
-        // Paired redeem axiom: removes one entry at `obl.value()` from
-        // `frame_obligations`. Leaves `slot_owners` untouched.
-        s.tracked_redeem_frame_obligation(obl);
     }
 }
 

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -825,11 +825,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.inv(),
             self.only_current_locked(guards0),
             <PageTableGuard<'rcu, C> as TrackDrop>::constructor_requires(guard, guards0),
-            <PageTableGuard<'rcu, C> as TrackDrop>::constructor_ensures(
-                guard,
-                guards0,
-                guards1,
-            ),
+            <PageTableGuard<'rcu, C> as TrackDrop>::constructor_ensures(guard, guards0, guards1),
             // The dropped guard is for the current entry's node (from pop_level).
             self.cur_entry_owner().is_node(),
             guard.inner.inner@.ptr.addr() == self.cur_entry_owner().node().meta_addr_self(),
@@ -856,11 +852,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.inv(),
             self.nodes_locked(guards0),
             <PageTableGuard<'rcu, C> as TrackDrop>::constructor_requires(guard, guards0),
-            <PageTableGuard<'rcu, C> as TrackDrop>::constructor_ensures(
-                guard,
-                guards0,
-                guards1,
-            ),
+            <PageTableGuard<'rcu, C> as TrackDrop>::constructor_ensures(guard, guards0, guards1),
             forall|i: int|
                 #![trigger self.continuations[i]]
                 self.level - 1 <= i < NR_LEVELS

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -824,8 +824,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         requires
             self.inv(),
             self.only_current_locked(guards0),
-            <PageTableGuard<'rcu, C> as TrackDrop>::constructor_requires(guard, guards0),
-            <PageTableGuard<'rcu, C> as TrackDrop>::constructor_ensures(guard, guards0, guards1),
+            guards0.lock_held(guard.inner.inner@.ptr.addr()),
+            guards1.guards == guards0.guards.remove(guard.inner.inner@.ptr.addr()),
             // The dropped guard is for the current entry's node (from pop_level).
             self.cur_entry_owner().is_node(),
             guard.inner.inner@.ptr.addr() == self.cur_entry_owner().node().meta_addr_self(),
@@ -851,8 +851,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         requires
             self.inv(),
             self.nodes_locked(guards0),
-            <PageTableGuard<'rcu, C> as TrackDrop>::constructor_requires(guard, guards0),
-            <PageTableGuard<'rcu, C> as TrackDrop>::constructor_ensures(guard, guards0, guards1),
+            guards0.lock_held(guard.inner.inner@.ptr.addr()),
+            guards1.guards == guards0.guards.remove(guard.inner.inner@.ptr.addr()),
             forall|i: int|
                 #![trigger self.continuations[i]]
                 self.level - 1 <= i < NR_LEVELS

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -820,7 +820,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         guard: PageTableGuard<'rcu, C>,
         guards0: Guards<'rcu>,
         guards1: Guards<'rcu>,
-        obl_key: usize,
     )
         requires
             self.inv(),
@@ -830,7 +829,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 guard,
                 guards0,
                 guards1,
-                obl_key,
             ),
             // The dropped guard is for the current entry's node (from pop_level).
             self.cur_entry_owner().is_node(),
@@ -853,7 +851,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         guard: PageTableGuard<'rcu, C>,
         guards0: Guards<'rcu>,
         guards1: Guards<'rcu>,
-        obl_key: usize,
     )
         requires
             self.inv(),
@@ -863,7 +860,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 guard,
                 guards0,
                 guards1,
-                obl_key,
             ),
             forall|i: int|
                 #![trigger self.continuations[i]]

--- a/ostd/specs/mm/page_table/node/child.rs
+++ b/ostd/specs/mm/page_table/node/child.rs
@@ -42,7 +42,7 @@ impl<'a, C: PageTableConfig> OwnerOf for ChildRef<'a, C> {
         match self {
             Self::PageTable(node) => {
                 &&& owner.is_node()
-                &&& node.inner.0.ptr.addr() == owner.node().meta_addr_self()
+                &&& node.inner@.ptr.addr() == owner.node().meta_addr_self()
             },
             Self::Frame(paddr, level, prop) => {
                 &&& owner.is_frame()

--- a/ostd/specs/mm/page_table/node/mod.rs
+++ b/ostd/specs/mm/page_table/node/mod.rs
@@ -60,11 +60,7 @@ impl<'rcu, C: PageTableConfig> TrackDrop for PageTableGuard<'rcu, C> {
         s.lock_held(self.inner.inner@.ptr.addr())
     }
 
-    open spec fn constructor_ensures(
-        self,
-        s0: Self::State,
-        s1: Self::State,
-    ) -> bool {
+    open spec fn constructor_ensures(self, s0: Self::State, s1: Self::State) -> bool {
         &&& s1.guards == s0.guards.remove(self.inner.inner@.ptr.addr())
     }
 
@@ -87,11 +83,7 @@ impl<'rcu, C: PageTableConfig> TrackDrop for PageTableGuard<'rcu, C> {
         true
     }
 
-    open spec fn consume_ensures(
-        self,
-        s0: Self::State,
-        s1: Self::State,
-    ) -> bool {
+    open spec fn consume_ensures(self, s0: Self::State, s1: Self::State) -> bool {
         s1.guards == s0.guards.remove(self.inner.inner@.ptr.addr())
     }
 

--- a/ostd/specs/mm/page_table/node/mod.rs
+++ b/ostd/specs/mm/page_table/node/mod.rs
@@ -64,10 +64,8 @@ impl<'rcu, C: PageTableConfig> TrackDrop for PageTableGuard<'rcu, C> {
         self,
         s0: Self::State,
         s1: Self::State,
-        obl_key: Self::Key,
     ) -> bool {
         &&& s1.guards == s0.guards.remove(self.inner.inner@.ptr.addr())
-        &&& obl_key == self.inner.inner@.ptr.addr()
     }
 
     proof fn constructor_spec(self, tracked s: &mut Self::State) -> (tracked obl: DropObligation<
@@ -81,21 +79,18 @@ impl<'rcu, C: PageTableConfig> TrackDrop for PageTableGuard<'rcu, C> {
         s.unlocked(self.inner.inner@.ptr.addr())
     }
 
-    open spec fn drop_ensures(self, s0: Self::State, s1: Self::State, obl_key: Self::Key) -> bool {
+    open spec fn drop_ensures(self, s0: Self::State, s1: Self::State) -> bool {
         s1.guards == s0.guards.insert(self.inner.inner@.ptr.addr())
     }
 
-    open spec fn consume_requires(self, s: Self::State, obl_key: Self::Key) -> bool {
-        // The token must identify this guard's locked address — prevents
-        // a token forged for a different guard from discharging this one.
-        obl_key == self.inner.inner@.ptr.addr()
+    open spec fn consume_requires(self, s: Self::State) -> bool {
+        true
     }
 
     open spec fn consume_ensures(
         self,
         s0: Self::State,
         s1: Self::State,
-        obl_key: Self::Key,
     ) -> bool {
         s1.guards == s0.guards.remove(self.inner.inner@.ptr.addr())
     }

--- a/ostd/specs/mm/page_table/node/mod.rs
+++ b/ostd/specs/mm/page_table/node/mod.rs
@@ -50,50 +50,39 @@ impl<'rcu, C: PageTableConfig> TrackDrop for PageTableGuard<'rcu, C> {
     /// different guard. The real lock-set ledger is `Guards::guards`;
     /// this trait's discipline lifts the existing state-side discipline
     /// onto the obligation token by carrying the locked address.
-    type Key = usize;
+    type Obligation = DropObligation<usize>;
 
-    open spec fn key(self) -> Self::Key {
-        self.inner.inner@.ptr.addr()
-    }
-
-    open spec fn constructor_requires(self, s: Self::State) -> bool {
+    open spec fn tracked_redeem_requires(self, s: Self::State) -> bool {
         s.lock_held(self.inner.inner@.ptr.addr())
     }
 
-    open spec fn constructor_ensures(self, s0: Self::State, s1: Self::State) -> bool {
+    open spec fn tracked_redeem_ensures(
+        self,
+        s0: Self::State,
+        s1: Self::State,
+        obl: Self::Obligation,
+    ) -> bool {
         &&& s1.guards == s0.guards.remove(self.inner.inner@.ptr.addr())
+        &&& obl.value() == self.inner.inner@.ptr.addr()
     }
 
-    proof fn constructor_spec(self, tracked s: &mut Self::State) -> (tracked obl: DropObligation<
-        Self::Key,
-    >) {
+    proof fn tracked_redeem(self, tracked s: &mut Self::State) -> (tracked obl: Self::Obligation) {
         s.guards = s.guards.remove(self.inner.inner@.ptr.addr());
         DropObligation::tracked_mint(self.inner.inner@.ptr.addr())
     }
 
-    open spec fn drop_requires(self, s: Self::State) -> bool {
-        s.unlocked(self.inner.inner@.ptr.addr())
+    open spec fn drop_requires(self, s: Self::State, obl: Self::Obligation) -> bool {
+        &&& s.unlocked(self.inner.inner@.ptr.addr())
+        &&& obl.value() == self.inner.inner@.ptr.addr()
     }
 
-    open spec fn drop_ensures(self, s0: Self::State, s1: Self::State) -> bool {
-        s1.guards == s0.guards.insert(self.inner.inner@.ptr.addr())
-    }
-
-    open spec fn consume_requires(self, s: Self::State) -> bool {
-        true
-    }
-
-    open spec fn consume_ensures(self, s0: Self::State, s1: Self::State) -> bool {
-        s1.guards == s0.guards.remove(self.inner.inner@.ptr.addr())
-    }
-
-    proof fn consume_obligation(
+    open spec fn drop_ensures(
         self,
-        tracked s: &mut Self::State,
-        tracked obl: DropObligation<Self::Key>,
-    ) {
-        // Release this guard's lock from the held-lock ledger.
-        s.guards = s.guards.remove(self.inner.inner@.ptr.addr());
+        s0: Self::State,
+        s1: Self::State,
+        obl: Self::Obligation,
+    ) -> bool {
+        s1.guards == s0.guards.insert(self.inner.inner@.ptr.addr())
     }
 }
 

--- a/ostd/src/mm/frame/frame_ref.rs
+++ b/ostd/src/mm/frame/frame_ref.rs
@@ -50,7 +50,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage>> FrameRef<'_, M> {
             Frame::<M>::from_raw_requires_safety(*old(regions), raw),
         ensures
             final(regions).inv(),
-            r.inner.0.ptr.addr() == frame_to_meta(raw),
+            r.inner@.ptr.addr() == frame_to_meta(raw),
             final(regions).slot_owners == old(regions).slot_owners,
             final(regions).slots == old(regions).slots,
             final(regions).frame_obligations == old(regions).frame_obligations,
@@ -72,7 +72,12 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage>> FrameRef<'_, M> {
             Frame::from_raw(raw)
         };
 
-        let inner = ManuallyDrop::new(frame, Tracked(regions));
+        proof_decl! {
+            regions.tracked_redeem_frame_obligation(from_raw_obl);
+            let tracked md_obl = DropObligation::tracked_mint(frame.index());
+        }
+        proof_with!(Tracked(md_obl));
+        let inner = ManuallyDrop::new(frame);
 
         Self { inner, _marker: PhantomData }
     }
@@ -81,7 +86,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage>> FrameRef<'_, M> {
 impl<M: AnyFrameMeta + ?Sized + Repr<MetaSlotStorage>> Deref for FrameRef<'_, M> {
     type Target = Frame<M>;
 
-    #[verus_spec(ensures returns &self.inner.0)]
+    #[verus_spec(r => ensures *r == self.inner@)]
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
@@ -123,7 +128,7 @@ pub unsafe trait NonNullPtr: 'static + Sized + TrackDrop<State = MetaRegionOwner
     /// `1 << Self::ALIGN_BITS`.
     fn into_raw(self, Tracked(regions): Tracked<&mut MetaRegionOwners>) -> PPtr<Self::Target>
         requires
-            self.constructor_requires(*old(regions)),
+            self.tracked_redeem_requires(*old(regions)),
     ;
 
     /// Converts back from a raw pointer.
@@ -175,15 +180,18 @@ unsafe impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + 'static> NonNullPtr for Fr
 
     fn into_raw(self, Tracked(regions): Tracked<&mut MetaRegionOwners>) -> PPtr<Self::Target> {
         let ptr = self.ptr;
-        proof {
+        proof_decl! {
             // Mint the obligation that `MD::new` will immediately
             // consume — net-zero on the ledger; the Frame value is
             // forgotten inside the wrapper, and `ref_count` (set by the
             // original producer) stays elevated to balance the eventual
             // `from_raw + drop`.
-            let tracked _ = regions.tracked_mint_frame_obligation(self.index());
+            let tracked redeem_obl = regions.tracked_mint_frame_obligation(self.index());
+            regions.tracked_redeem_frame_obligation(redeem_obl);
+            let tracked md_obl = DropObligation::tracked_mint(self.index());
         }
-        let _ = ManuallyDrop::new(self, Tracked(regions));
+        #[verus_spec(with Tracked(md_obl))]
+        let _ = ManuallyDrop::new(self);
         PPtr::<Self::Target>::from_addr(ptr.addr())
     }
 
@@ -199,10 +207,13 @@ unsafe impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + 'static> NonNullPtr for Fr
             ptr: PPtr::<MetaSlot>::from_addr(raw.addr()),
             _marker: PhantomData,
         };
-        proof {
-            let tracked _ = regions.tracked_mint_frame_obligation(frame.index());
+        proof_decl! {
+            let tracked redeem_obl = regions.tracked_mint_frame_obligation(frame.index());
+            regions.tracked_redeem_frame_obligation(redeem_obl);
+            let tracked md_obl = DropObligation::tracked_mint(frame.index());
         }
-        let dropped = ManuallyDrop::<Frame<M>>::new(frame, Tracked(regions));
+        #[verus_spec(with Tracked(md_obl))]
+        let dropped = ManuallyDrop::<Frame<M>>::new(frame);
         Self::Ref { inner: dropped, _marker: PhantomData }
     }
 

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -1364,27 +1364,27 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> TrackDrop for LinkedList<M> {
     /// added because every live `LinkedList` already has a unique
     /// `LinkedListOwner` in scope — the per-instance discipline is
     /// state-side, not ledger-side.
-    type Key = u64;
+    type Obligation = DropObligation<u64>;
 
-    open spec fn key(self) -> Self::Key {
-        self.list_id
-    }
-
-    open spec fn constructor_requires(self, s: Self::State) -> bool {
+    open spec fn tracked_redeem_requires(self, s: Self::State) -> bool {
         true
     }
 
-    open spec fn constructor_ensures(self, s0: Self::State, s1: Self::State) -> bool {
+    open spec fn tracked_redeem_ensures(
+        self,
+        s0: Self::State,
+        s1: Self::State,
+        obl: Self::Obligation,
+    ) -> bool {
         &&& s0 =~= s1
+        &&& obl.value() == self.list_id
     }
 
-    proof fn constructor_spec(self, tracked s: &mut Self::State) -> (tracked obl: DropObligation<
-        Self::Key,
-    >) {
+    proof fn tracked_redeem(self, tracked s: &mut Self::State) -> (tracked obl: Self::Obligation) {
         DropObligation::tracked_mint(self.list_id)
     }
 
-    open spec fn drop_requires(self, s: Self::State) -> bool {
+    open spec fn drop_requires(self, s: Self::State, obl: Self::Obligation) -> bool {
         &&& self.wf(s.0)
         &&& s.0.inv()
         &&& s.1.inv()
@@ -1422,9 +1422,15 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> TrackDrop for LinkedList<M> {
             0 <= i < j < s.0.list.len() ==> frame_to_index(meta_to_frame(s.0.list[i].paddr))
                 != frame_to_index(meta_to_frame(s.0.list[j].paddr))
         &&& s.0.relate_region(s.1)
+        &&& obl.value() == self.list_id
     }
 
-    open spec fn drop_ensures(self, s0: Self::State, s1: Self::State) -> bool {
+    open spec fn drop_ensures(
+        self,
+        s0: Self::State,
+        s1: Self::State,
+        obl: Self::Obligation,
+    ) -> bool {
         &&& s1.0.list.len() == 0
         &&& forall|i: int|
             #![trigger s0.0.list[i]]
@@ -1447,23 +1453,6 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> TrackDrop for LinkedList<M> {
         &&& s1.1.slots.dom() =~= s0.1.slots.dom()
         &&& s1.1.inv()
     }
-
-    open spec fn consume_requires(self, s: Self::State) -> bool {
-        true
-    }
-
-    open spec fn consume_ensures(self, s0: Self::State, s1: Self::State) -> bool {
-        s0 =~= s1
-    }
-
-    proof fn consume_obligation(
-        self,
-        tracked s: &mut Self::State,
-        tracked obl: DropObligation<Self::Key>,
-    ) {
-        // No-op on the ledger; the per-instance discipline lives in
-        // `LinkedListOwner`'s state-side invariants.
-    }
 }
 
 impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> Drop for LinkedList<M> {
@@ -1473,12 +1462,6 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> Drop for LinkedList<M> {
         Tracked(s): Tracked<&mut Self::State>,
         Tracked(obl): Tracked<DropObligation<u64>>,
     ) {
-        // Single redeem path: route through `consume_obligation` before
-        // running the destructor body.
-        proof {
-            self.consume_obligation(s, obl);
-        }
-
         proof_decl! {
             let tracked mut list_own: LinkedListOwner<M>;
         }

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -1374,11 +1374,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> TrackDrop for LinkedList<M> {
         true
     }
 
-    open spec fn constructor_ensures(
-        self,
-        s0: Self::State,
-        s1: Self::State,
-    ) -> bool {
+    open spec fn constructor_ensures(self, s0: Self::State, s1: Self::State) -> bool {
         &&& s0 =~= s1
     }
 
@@ -1456,11 +1452,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> TrackDrop for LinkedList<M> {
         true
     }
 
-    open spec fn consume_ensures(
-        self,
-        s0: Self::State,
-        s1: Self::State,
-    ) -> bool {
+    open spec fn consume_ensures(self, s0: Self::State, s1: Self::State) -> bool {
         s0 =~= s1
     }
 

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -1378,10 +1378,8 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> TrackDrop for LinkedList<M> {
         self,
         s0: Self::State,
         s1: Self::State,
-        obl_key: Self::Key,
     ) -> bool {
         &&& s0 =~= s1
-        &&& obl_key == self.list_id
     }
 
     proof fn constructor_spec(self, tracked s: &mut Self::State) -> (tracked obl: DropObligation<
@@ -1430,7 +1428,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> TrackDrop for LinkedList<M> {
         &&& s.0.relate_region(s.1)
     }
 
-    open spec fn drop_ensures(self, s0: Self::State, s1: Self::State, obl_key: Self::Key) -> bool {
+    open spec fn drop_ensures(self, s0: Self::State, s1: Self::State) -> bool {
         &&& s1.0.list.len() == 0
         &&& forall|i: int|
             #![trigger s0.0.list[i]]
@@ -1454,17 +1452,14 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> TrackDrop for LinkedList<M> {
         &&& s1.1.inv()
     }
 
-    open spec fn consume_requires(self, s: Self::State, obl_key: Self::Key) -> bool {
-        // The token must match this list's identity — prevents a token
-        // forged for a different list from discharging this one.
-        obl_key == self.list_id
+    open spec fn consume_requires(self, s: Self::State) -> bool {
+        true
     }
 
     open spec fn consume_ensures(
         self,
         s0: Self::State,
         s1: Self::State,
-        obl_key: Self::Key,
     ) -> bool {
         s0 =~= s1
     }

--- a/ostd/src/mm/frame/mod.rs
+++ b/ostd/src/mm/frame/mod.rs
@@ -509,7 +509,13 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + ?Sized> Frame<M> {
         #[verus_spec(with Tracked(perm))]
         let paddr = self.start_paddr();
 
-        let _ = ManuallyDrop::new(self, Tracked(regions));
+        proof_decl! {
+            let tracked redeem_obl = DropObligation::tracked_mint(self.index());
+            regions.tracked_redeem_frame_obligation(redeem_obl);
+            let tracked md_obl = DropObligation::tracked_mint(self.index());
+        }
+        proof_with!(Tracked(md_obl));
+        let _ = ManuallyDrop::new(self);
 
         paddr
     }
@@ -671,13 +677,8 @@ impl<M: ?Sized> Drop for Frame<M> {
         Tracked(regions): Tracked<&mut MetaRegionOwners>,
         Tracked(obl): Tracked<DropObligation<usize>>,
     ) {
-        // Single redeem path: route through `consume_obligation` before
-        // running the destructor body. For Frame's current
-        // ledger-less `Key = usize`, this is a no-op on state; for
-        // future ledger-enforcing variants, this is where the ledger
-        // entry is removed.
         proof {
-            self.consume_obligation(regions, obl);
+            regions.tracked_redeem_frame_obligation(obl);
         }
         let ghost idx = frame_to_index(meta_to_frame(self.ptr.addr()));
         let ghost old_regions = *regions;

--- a/ostd/src/mm/frame/segment.rs
+++ b/ostd/src/mm/frame/segment.rs
@@ -395,7 +395,13 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                 },
             };
 
-            let _ = ManuallyDrop::new(frame, Tracked(regions));
+            proof_decl! {
+                let tracked redeem_obl = DropObligation::tracked_mint(frame.index());
+                regions.tracked_redeem_frame_obligation(redeem_obl);
+                let tracked md_obl = DropObligation::tracked_mint(frame.index());
+            }
+            proof_with!(Tracked(md_obl));
+            let _ = ManuallyDrop::new(frame);
             segment.range.end = paddr + PAGE_SIZE;
             proof {
                 broadcast use group_page_meta;
@@ -593,7 +599,11 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
 
         let ghost old_regions = *regions;
 
-        let old = ManuallyDrop::new(self, Tracked(regions));
+        proof_decl! {
+            let tracked md_obl = DropObligation::tracked_mint(self.range);
+        }
+        proof_with!(Tracked(md_obl));
+        let old = ManuallyDrop::new(self);
         let at = old.range.start + offset;
 
         let ghost old_start = old@.start_paddr();
@@ -824,7 +834,11 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
     )]
     pub(crate) fn into_raw(self) -> Range<Paddr> {
         let range = self.range.clone();
-        let _ = ManuallyDrop::new(self, Tracked(regions));
+        proof_decl! {
+            let tracked md_obl = DropObligation::tracked_mint(self.range);
+        }
+        proof_with!(Tracked(md_obl));
+        let _ = ManuallyDrop::new(self);
 
         range
     }

--- a/ostd/src/mm/frame/unique.rs
+++ b/ostd/src/mm/frame/unique.rs
@@ -435,9 +435,14 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> 
         #[verus_spec(with Tracked(owner), Tracked(&*regions))]
         let paddr = self.start_paddr();
 
-        // `ManuallyDrop::new` consumes `self`'s pending-Drop obligation; the
-        // caller's `count > 0` precondition guarantees it is outstanding.
-        let _ = ManuallyDrop::new(self, Tracked(regions));
+        proof_decl! {
+            let ghost idx = frame_to_index(meta_to_frame(self.ptr.addr()));
+            let tracked redeem_obl = DropObligation::tracked_mint(idx);
+            regions.tracked_redeem_frame_obligation(redeem_obl);
+            let tracked md_obl = DropObligation::tracked_mint(idx);
+        }
+        proof_with!(Tracked(md_obl));
+        let _ = ManuallyDrop::new(self);
 
         paddr
     }

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -34,7 +34,7 @@ use vstd::math::abs;
 use vstd::simple_pptr::*;
 
 use vstd_extra::arithmetic::*;
-use vstd_extra::drop_tracking::ManuallyDrop;
+use vstd_extra::drop_tracking::{DropObligation, ManuallyDrop, TrackDrop};
 use vstd_extra::ghost_tree::*;
 use vstd_extra::ownership::*;
 use vstd_extra::panic::*;
@@ -1148,7 +1148,11 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                         let ghost guards_before_drop = *guards;
                         let ghost locked_addr = child_node_owner.meta_addr_self();
 
-                        let _ = ManuallyDrop::new(pt_guard, Tracked(guards));
+                        proof_decl! {
+                            let tracked guard_obl = pt_guard.tracked_redeem(guards);
+                        }
+                        proof_with!(Tracked(guard_obl));
+                        let _ = ManuallyDrop::new(pt_guard);
 
                         proof {
                             owner.map_children_implies(
@@ -1870,7 +1874,11 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
         let ghost owner0 = *owner;
         let ghost guards0 = *guards;
 
-        let md = ManuallyDrop::new(taken, Tracked(guards));
+        proof_decl! {
+            let tracked guard_obl = taken.tracked_redeem(guards);
+        }
+        proof_with!(Tracked(guard_obl));
+        let md = ManuallyDrop::new(taken);
 
         proof {
             // `ManuallyDrop` is single-field now; the consumed obligation
@@ -4371,15 +4379,20 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             Child::PageTable(pt) => {
                 // debug_assert_eq!(pt.level(), level - 1);
                 if !C::TOP_LEVEL_CAN_UNMAP() && level as usize == NR_LEVELS {
-                    proof {
+                    proof_decl! {
                         // The PT-node model tracks `raw_count`, not the
                         // per-frame ledger; mint the entry that `MD::new`
                         // consumes (net-zero), mirroring `into_pte`.
-                        let tracked _ = regions.tracked_mint_frame_obligation(
+                        let tracked redeem_obl = regions.tracked_mint_frame_obligation(
+                            frame_to_index(meta_to_frame(pt.ptr.addr())),
+                        );
+                        regions.tracked_redeem_frame_obligation(redeem_obl);
+                        let tracked md_obl = DropObligation::tracked_mint(
                             frame_to_index(meta_to_frame(pt.ptr.addr())),
                         );
                     }
-                    let _ = ManuallyDrop::new(pt, Tracked(regions));  // leak it to make shared PTs stay `'static`.
+                    proof_with!(Tracked(md_obl));
+                    let _ = ManuallyDrop::new(pt);  // leak it to make shared PTs stay `'static`.
                     // Runtime panic. Discharges the conditional postcondition
                     // `res matches Some(StrayPageTable) && !TOP_LEVEL_CAN_UNMAP
                     // ==> old.level < NR_LEVELS` via `panic_diverge`'s `-> !`.

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -1875,8 +1875,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
         proof {
             // `ManuallyDrop` is single-field now; the consumed obligation
             // matched `taken.key()` (the locked node's address).
-            let ghost obl_key = md.0.inner.inner@.ptr.addr();
-            owner.never_drop_restores_children_not_locked(guard, guards0, *guards, obl_key);
+            owner.never_drop_restores_children_not_locked(guard, guards0, *guards);
             let ghost pre_pop = *old(owner);
             let ghost dropped_addr = guard.inner.inner@.ptr.addr();
             assert forall|i: int|
@@ -1884,7 +1883,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                 owner.level - 1 <= i
                     < NR_LEVELS implies owner.continuations[i].guard.inner.inner@.ptr.addr()
                 != dropped_addr by {};
-            owner.never_drop_restores_nodes_locked(guard, guards0, *guards, obl_key);
+            owner.never_drop_restores_nodes_locked(guard, guards0, *guards);
         }
 
         self.level = self.level + 1;

--- a/ostd/src/mm/page_table/node/child.rs
+++ b/ostd/src/mm/page_table/node/child.rs
@@ -93,7 +93,13 @@ impl<C: PageTableConfig> Child<C> {
 
                 let ghost fo0 = regions.frame_obligations;
 
-                let _ = ManuallyDrop::new(node, Tracked(regions));
+                proof_decl! {
+                    let tracked redeem_obl = DropObligation::tracked_mint(node_index);
+                    regions.tracked_redeem_frame_obligation(redeem_obl);
+                    let tracked md_obl = DropObligation::tracked_mint(node_index);
+                }
+                proof_with!(Tracked(md_obl));
+                let _ = ManuallyDrop::new(node);
 
                 proof {
                     // `MD::new` removed one entry at `node_index`, matching

--- a/verified_libs/vstd_extra/src/drop_tracking.rs
+++ b/verified_libs/vstd_extra/src/drop_tracking.rs
@@ -16,17 +16,13 @@ verus! {
 ///
 /// 1. **Token (this type)**: an `ExclusiveGhost<R>` wrapper. Each `alloc`
 ///    produces a unique [`Loc`]; two outstanding tokens can be proven
-///    distinct via [`DropObligation::validate_with_other`]. No external_body
-///    axioms — the allocation is verified by `vstd`'s resource algebra.
+///    distinct via [`DropObligation::validate_with_other`].
 /// 2. **Ledger (in State)**: optional. For impls that opt in, the State
 ///    carries a set/multiset of outstanding keys; mint adds, redeem removes,
 ///    and the State's `clean_inv()` (or any boundary predicate) requires the
-///    set to be empty (or the per-slot counter to be zero). Combined with
+///    set to be empty. Combined with
 ///    `1`, the linear guarantee is sound: silently dropping the token leaves
 ///    the ledger non-empty and breaks the boundary check.
-///
-/// Impls that don't add a per-state ledger still pass tokens through —
-/// they get the API uniformity but not the enforcement.
 #[verifier::reject_recursive_types(R)]
 pub tracked struct DropObligation<R> {
     inner: ExclusiveGhost<R>,
@@ -37,21 +33,12 @@ impl<R> DropObligation<R> {
         self.inner.view()
     }
 
-    /// Unique identifier of this token. Two outstanding `DropObligation`s
-    /// can be proven distinct via [`Self::validate_with_other`].
+    /// Unique identifier of this token.
     pub closed spec fn id(self) -> Loc {
         self.inner.id()
     }
 
-    /// Mint a fresh obligation token. Sound on its own (no axiom — the
-    /// allocation goes through `vstd`'s resource algebra and is verified).
-    /// Two legitimate uses:
-    ///
-    /// - Inside an impl that opts out of per-state-ledger enforcement
-    ///   (e.g. `Key = ()` impls): the token is a no-op marker; the trait
-    ///   API stays uniform but no `clean_inv()` enforcement applies.
-    /// - As the underlying allocator for a paired mint axiom on
-    ///   [`HasObligations`] — the axiom adds the ledger entry alongside.
+    /// Mint a fresh obligation token. S.
     pub proof fn tracked_mint(value: R) -> (tracked res: DropObligation<R>)
         ensures
             res.value() == value,
@@ -69,11 +56,6 @@ impl<R> DropObligation<R> {
     }
 }
 
-/// State that carries an obligation ledger keyed by `K`.
-pub trait HasObligations<K> {
-    spec fn obligations(self) -> Set<K>;
-}
-
 pub trait TrackDrop: Sized {
     type State;
 
@@ -86,7 +68,7 @@ pub trait TrackDrop: Sized {
 
     spec fn constructor_requires(self, s: Self::State) -> bool;
 
-    spec fn constructor_ensures(self, s0: Self::State, s1: Self::State, obl_key: Self::Key) -> bool;
+    spec fn constructor_ensures(self, s0: Self::State, s1: Self::State) -> bool;
 
     proof fn constructor_spec(self, tracked s: &mut Self::State) -> (tracked obl: DropObligation<
         Self::Key,
@@ -94,47 +76,32 @@ pub trait TrackDrop: Sized {
         requires
             self.constructor_requires(*old(s)),
         ensures
-            self.constructor_ensures(*old(s), *final(s), obl.value()),
+            self.constructor_ensures(*old(s), *final(s)),
             obl.value() == self.key(),
     ;
 
     spec fn drop_requires(self, s: Self::State) -> bool;
 
-    /// Postcondition of [`Drop::drop`]. `obl_id` is the [`Loc`] of the
-    /// consumed obligation token — ledger-enforcing impls reference it
-    /// to pin the ledger transition (e.g. "the entry at `obl_id` was
-    /// removed"); ledger-less impls ignore it.
-    spec fn drop_ensures(self, s0: Self::State, s1: Self::State, obl_key: Self::Key) -> bool;
+    /// Postcondition of [`Drop::drop`].
+    spec fn drop_ensures(self, s0: Self::State, s1: Self::State) -> bool;
 
-    /// Precondition for "consume the obligation without running the
-    /// destructor" (see [`ConsumeDrop`]). `obl_id` is exposed so
-    /// ledger-enforcing impls can require the entry to be outstanding.
-    spec fn consume_requires(self, s: Self::State, obl_key: Self::Key) -> bool;
+    /// Precondition for consuming the obligation without running the destructor.
+    spec fn consume_requires(self, s: Self::State) -> bool;
 
-    /// Postcondition for consuming an obligation. Encodes any ledger
-    /// mutation (e.g. redeeming the entry at `obl_id`). Impls without
-    /// a ledger keep `s0 == s1`.
-    spec fn consume_ensures(self, s0: Self::State, s1: Self::State, obl_key: Self::Key) -> bool;
+    /// Postcondition for consuming the obligation.
+    spec fn consume_ensures(self, s0: Self::State, s1: Self::State) -> bool;
 
     /// Consume the obligation token without running the destructor body.
-    /// Used by [`ConsumeDrop::new`] to discharge the verifier's
-    /// linear-drop obligation when the underlying resource is
-    /// intentionally leaked (or freed via a separate path).
-    ///
-    /// Impls with a real ledger should call a paired redeem axiom here;
-    /// impls without (`Key = ()`) can leave the body empty — `obl` is
-    /// silently dropped, which is fine because no ledger entry needs to
-    /// shrink to match.
     proof fn consume_obligation(
         self,
         tracked s: &mut Self::State,
         tracked obl: DropObligation<Self::Key>,
     )
         requires
-            self.consume_requires(*old(s), obl.value()),
+            self.consume_requires(*old(s)),
             obl.value() == self.key(),
         ensures
-            self.consume_ensures(*old(s), *final(s), obl.value()),
+            self.consume_ensures(*old(s), *final(s)),
     ;
 }
 
@@ -148,12 +115,11 @@ pub trait Drop: TrackDrop {
     // The body must call `self.consume_obligation(s, obl)` first
     // (redeeming the token / shrinking the ledger), then run the
     // destructor work. Both preconditions are required up front.
-
-            self.consume_requires(*old(s), obl.value()),
+            self.consume_requires(*old(s)),
             self.drop_requires(*old(s)),
             obl.value() == self.key(),
         ensures
-            self.drop_ensures(*old(s), *final(s), obl.value()),
+            self.drop_ensures(*old(s), *final(s)),
     ;
 }
 
@@ -193,9 +159,9 @@ impl<T: TrackDrop> ManuallyDrop<T> {
     #[verifier::external_body]
     pub fn new(t: T, Tracked(s): Tracked<&mut T::State>) -> (res: Self)
         requires
-            t.consume_requires(*old(s), t.key()),
+            t.consume_requires(*old(s)),
         ensures
-            t.consume_ensures(*old(s), *final(s), t.key()),
+            t.consume_ensures(*old(s), *final(s)),
             res.0 == t,
     {
         proof {

--- a/verified_libs/vstd_extra/src/drop_tracking.rs
+++ b/verified_libs/vstd_extra/src/drop_tracking.rs
@@ -89,7 +89,9 @@ impl<T: TrackDrop> ManuallyDrop<T> {
     )]
     pub fn new(t: T) -> Self {
         proof_with! { tracked_obligation: Tracked(obligation) }
-        Self { value: core::mem::ManuallyDrop::new(t) }
+        Self {
+            value: core::mem::ManuallyDrop::new(t),
+        }
     }
 
     #[verus_spec(res =>

--- a/verified_libs/vstd_extra/src/drop_tracking.rs
+++ b/verified_libs/vstd_extra/src/drop_tracking.rs
@@ -115,6 +115,7 @@ pub trait Drop: TrackDrop {
     // The body must call `self.consume_obligation(s, obl)` first
     // (redeeming the token / shrinking the ledger), then run the
     // destructor work. Both preconditions are required up front.
+
             self.consume_requires(*old(s)),
             self.drop_requires(*old(s)),
             obl.value() == self.key(),

--- a/verified_libs/vstd_extra/src/drop_tracking.rs
+++ b/verified_libs/vstd_extra/src/drop_tracking.rs
@@ -73,7 +73,7 @@ pub trait Drop: TrackDrop {
 } // verus!
 #[verus_verify]
 pub struct ManuallyDrop<T: TrackDrop> {
-    value: T,
+    value: core::mem::ManuallyDrop<T>,
     #[cfg(verus_keep_ghost_body)]
     tracked_obligation: Tracked<T::Obligation>,
 }
@@ -89,22 +89,22 @@ impl<T: TrackDrop> ManuallyDrop<T> {
     )]
     pub fn new(t: T) -> Self {
         proof_with! { tracked_obligation: Tracked(obligation) }
-        Self { value: t }
+        Self { value: core::mem::ManuallyDrop::new(t) }
     }
 
     #[verus_spec(res =>
         with
             -> obligation: Tracked<T::Obligation>,
         ensures
-            res == self@,
-            obligation@ == self.obligation(),
+            res == slot@,
+            obligation@ == slot.obligation(),
     )]
-    pub fn into_inner(self) -> T {
+    pub fn into_inner(slot: Self) -> T {
         proof_decl! {
-            let tracked obligation = self.tracked_obligation.get();
+            let tracked obligation = slot.tracked_obligation.get();
         }
         proof_with!(|= Tracked(obligation));
-        self.value
+        std::mem::ManuallyDrop::<T>::into_inner(slot.value)
     }
 }
 
@@ -127,7 +127,7 @@ impl<T: TrackDrop> View for ManuallyDrop<T> {
     type V = T;
 
     closed spec fn view(&self) -> (res: Self::V) {
-        self.value
+        self.value@
     }
 }
 

--- a/verified_libs/vstd_extra/src/drop_tracking.rs
+++ b/verified_libs/vstd_extra/src/drop_tracking.rs
@@ -1,4 +1,4 @@
-use core::{marker::PhantomData, ops::Deref};
+use core::ops::Deref;
 use vstd::prelude::*;
 use vstd::resource::Loc;
 
@@ -70,39 +70,58 @@ pub trait Drop: TrackDrop {
     ;
 }
 
+} // verus!
+#[verus_verify]
 pub struct ManuallyDrop<T: TrackDrop> {
     value: T,
+    #[cfg(verus_keep_ghost_body)]
     tracked_obligation: Tracked<T::Obligation>,
 }
 
+#[verus_verify]
 impl<T: TrackDrop> ManuallyDrop<T> {
-    pub fn new(t: T, obligaton: Tracked<T::Obligation>) -> (res: Self)
+    #[verus_spec(res =>
+        with
+            Tracked(obligation): Tracked<T::Obligation>,
         ensures
             res@ == t,
-            res.obligation() == obligaton@,
-    {
-        Self { value: t, tracked_obligation: obligaton }
+            res.obligation() == obligation,
+    )]
+    pub fn new(t: T) -> Self {
+        proof_with! { tracked_obligation: Tracked(obligation) }
+        Self { value: t }
     }
 
-    pub fn into_inner(self) -> (res: (T, Tracked<T::Obligation>))
+    #[verus_spec(res =>
+        with
+            -> obligation: Tracked<T::Obligation>,
         ensures
-            res.0 == self@,
-            res.1@ == self.obligation(),
-    {
-        (self.value, self.tracked_obligation)
+            res == self@,
+            obligation@ == self.obligation(),
+    )]
+    pub fn into_inner(self) -> T {
+        proof_decl! {
+            let tracked obligation = self.tracked_obligation.get();
+        }
+        proof_with!(|= Tracked(obligation));
+        self.value
     }
 }
 
+#[verus_verify]
 impl<T: TrackDrop> Deref for ManuallyDrop<T> {
     type Target = T;
 
-    fn deref(&self) -> (res: &Self::Target)
+    #[verus_spec(res =>
         ensures
             *res == self@,
-    {
+    )]
+    fn deref(&self) -> &Self::Target {
         &self.value
     }
 }
+
+verus! {
 
 impl<T: TrackDrop> View for ManuallyDrop<T> {
     type V = T;

--- a/verified_libs/vstd_extra/src/drop_tracking.rs
+++ b/verified_libs/vstd_extra/src/drop_tracking.rs
@@ -6,23 +6,121 @@ use crate::resource::ghost_resource::excl::ExclusiveGhost;
 
 verus! {
 
-/// A linear-looking "must drop" obligation tied to a value of type `R`.
+/// A protocol for associating a value with a permission used by its verified
+/// drop implementation.
 ///
-/// `R` is the *key* type used to identify the resource in the State's
-/// obligation ledger — e.g. `Range<Paddr>` for a `Segment<M>`, `usize` for a
-/// per-slot resource, `()` for impls that pipe the token through without a
-/// per-instance ledger. Two-layer enforcement (the design that survives
-/// Verus's affineness):
+/// This trait only defines the shape of the protocol. Implementing it does not
+/// by itself guarantee that [`TrackDrop::Obligation`] is linear, unforgeable,
+/// or authoritatively tied to [`TrackDrop::State`]. In particular, an
+/// implementation may intentionally use a trivial obligation and perform no
+/// drop-permission checking.
 ///
-/// 1. **Token (this type)**: an `ExclusiveGhost<R>` wrapper. Each `alloc`
-///    produces a unique [`Loc`]; two outstanding tokens can be proven
-///    distinct via [`DropObligation::validate_with_other`].
-/// 2. **Ledger (in State)**: optional. For impls that opt in, the State
-///    carries a set/multiset of outstanding keys; mint adds, redeem removes,
-///    and the State's `clean_inv()` (or any boundary predicate) requires the
-///    set to be empty. Combined with
-///    `1`, the linear guarantee is sound: silently dropping the token leaves
-///    the ledger non-empty and breaks the boundary check.
+/// Implementations that rely on this protocol for safety are responsible for
+/// establishing all of the following properties in their concrete
+/// specifications and proofs:
+///
+/// - an issued obligation is associated with the value for which it was
+///   issued;
+/// - the obligation cannot be forged or duplicated;
+/// - the state records enough authoritative information to detect a lost
+///   outstanding obligation; and
+/// - [`Drop::drop`] consumes the obligation and performs the corresponding
+///   state transition exactly once.
+pub trait TrackDrop: Sized {
+    /// A ghost state that originally holds the authoritative drop permission.
+    type State;
+
+    /// The type of the drop permission.
+    ///
+    /// This permission does not necessarily represent the full permission to
+    /// drop the value, as [`TrackDrop::drop_requires`] still takes a
+    /// [`TrackDrop::State`] parameter.
+    type Obligation;
+
+    spec fn tracked_redeem_requires(self, s: Self::State) -> bool;
+
+    spec fn tracked_redeem_ensures(
+        self,
+        s0: Self::State,
+        s1: Self::State,
+        obl: Self::Obligation,
+    ) -> bool;
+
+    /// Gives the drop permission to the value.
+    proof fn tracked_redeem(self, tracked s: &mut Self::State) -> (tracked obl: Self::Obligation)
+        requires
+            self.tracked_redeem_requires(*old(s)),
+        ensures
+            self.tracked_redeem_ensures(*old(s), *final(s), obl),
+    ;
+
+    /// Precondition of [`Drop::drop`].
+    spec fn drop_requires(self, s: Self::State, obl: Self::Obligation) -> bool;
+
+    /// Postcondition of [`Drop::drop`].
+    spec fn drop_ensures(self, s0: Self::State, s1: Self::State, obl: Self::Obligation) -> bool;
+}
+
+pub trait Drop: TrackDrop {
+    fn drop(self, Tracked(s): Tracked<&mut Self::State>, Tracked(obl): Tracked<Self::Obligation>)
+        requires
+            self.drop_requires(*old(s), obl),
+        ensures
+            self.drop_ensures(*old(s), *final(s), obl),
+    ;
+}
+
+pub struct ManuallyDrop<T: TrackDrop> {
+    value: T,
+    tracked_obligation: Tracked<T::Obligation>,
+}
+
+impl<T: TrackDrop> ManuallyDrop<T> {
+    pub fn new(t: T, obligaton: Tracked<T::Obligation>) -> (res: Self)
+        ensures
+            res@ == t,
+            res.obligation() == obligaton@,
+    {
+        Self { value: t, tracked_obligation: obligaton }
+    }
+
+    pub fn into_inner(self) -> (res: (T, Tracked<T::Obligation>))
+        ensures
+            res.0 == self@,
+            res.1@ == self.obligation(),
+    {
+        (self.value, self.tracked_obligation)
+    }
+}
+
+impl<T: TrackDrop> Deref for ManuallyDrop<T> {
+    type Target = T;
+
+    fn deref(&self) -> (res: &Self::Target)
+        ensures
+            *res == self@,
+    {
+        &self.value
+    }
+}
+
+impl<T: TrackDrop> View for ManuallyDrop<T> {
+    type V = T;
+
+    closed spec fn view(&self) -> (res: Self::V) {
+        self.value
+    }
+}
+
+impl<T: TrackDrop> ManuallyDrop<T> {
+    pub closed spec fn obligation(self) -> T::Obligation {
+        self.tracked_obligation@
+    }
+}
+
+} // verus!
+verus! {
+
 #[verifier::reject_recursive_types(R)]
 pub tracked struct DropObligation<R> {
     inner: ExclusiveGhost<R>,
@@ -53,148 +151,6 @@ impl<R> DropObligation<R> {
             final(self).id() != other.id(),
     {
         self.inner.validate_with_other(&other.inner);
-    }
-}
-
-pub trait TrackDrop: Sized {
-    type State;
-
-    /// Identifies which obligation this resource holds in the ledger.
-    type Key;
-
-    /// The ledger key for *this* instance. Pinned by
-    /// `constructor_spec`'s ensures and `Drop::drop`'s requires.
-    spec fn key(self) -> Self::Key;
-
-    spec fn constructor_requires(self, s: Self::State) -> bool;
-
-    spec fn constructor_ensures(self, s0: Self::State, s1: Self::State) -> bool;
-
-    proof fn constructor_spec(self, tracked s: &mut Self::State) -> (tracked obl: DropObligation<
-        Self::Key,
-    >)
-        requires
-            self.constructor_requires(*old(s)),
-        ensures
-            self.constructor_ensures(*old(s), *final(s)),
-            obl.value() == self.key(),
-    ;
-
-    spec fn drop_requires(self, s: Self::State) -> bool;
-
-    /// Postcondition of [`Drop::drop`].
-    spec fn drop_ensures(self, s0: Self::State, s1: Self::State) -> bool;
-
-    /// Precondition for consuming the obligation without running the destructor.
-    spec fn consume_requires(self, s: Self::State) -> bool;
-
-    /// Postcondition for consuming the obligation.
-    spec fn consume_ensures(self, s0: Self::State, s1: Self::State) -> bool;
-
-    /// Consume the obligation token without running the destructor body.
-    proof fn consume_obligation(
-        self,
-        tracked s: &mut Self::State,
-        tracked obl: DropObligation<Self::Key>,
-    )
-        requires
-            self.consume_requires(*old(s)),
-            obl.value() == self.key(),
-        ensures
-            self.consume_ensures(*old(s), *final(s)),
-    ;
-}
-
-pub trait Drop: TrackDrop {
-    fn drop(
-        self,
-        Tracked(s): Tracked<&mut Self::State>,
-        Tracked(obl): Tracked<DropObligation<Self::Key>>,
-    )
-        requires
-    // The body must call `self.consume_obligation(s, obl)` first
-    // (redeeming the token / shrinking the ledger), then run the
-    // destructor work. Both preconditions are required up front.
-
-            self.consume_requires(*old(s)),
-            self.drop_requires(*old(s)),
-            obl.value() == self.key(),
-        ensures
-            self.drop_ensures(*old(s), *final(s)),
-    ;
-}
-
-/// Linear-drop obligation wrapper. `ManuallyDrop::new(t, regions)`
-/// **consumes** the State-side obligation entry for `t.key()` (via
-/// `T::consume_obligation`) and wraps the value. The wrapper carries only
-/// the value — no embedded obligation — and can be silently dropped
-/// affinely; the linear-drop guarantee comes from the State-side ledger.
-///
-/// The precondition `consume_requires` (e.g. `frame_obligations.count(idx)
-/// > 0` for Frame) is the load-bearing safety check: callers must
-/// establish an outstanding obligation entry at `t.key()`. Producers
-/// like `Frame::from_raw`, `Frame::clone`, `Frame::from_unused`,
-/// `Frame::from_in_use` mint that entry. The mint + consume pair is
-/// net-zero on the ledger — "the borrow ends here."
-///
-/// # Unsoundness warning
-///
-/// **It is unsound to extract the inner `T` from `ManuallyDrop<T>` via
-/// `take`/`into_inner`-style operations** without minting a fresh
-/// obligation at the extraction site. A `ManuallyDrop<T>` carries no
-/// obligation, so the extracted `T` would have none either — but
-/// `T::drop` (e.g. `Frame::drop`) requires an obligation as input, so the
-/// extracted value cannot legally be dropped. Any extraction site must
-/// mint a fresh entry into the State-side ledger, gated by a soundness
-/// justification (typically `ref_count >= 1` for `MD<Frame>`, mirroring
-/// `Frame::from_raw`'s safety condition).
-///
-/// At the time of this redesign no ostd callsite extracts a `Frame` from
-/// a `ManuallyDrop<Frame>` (only `Deref` borrows are taken; the one
-/// `into_inner` is on `MD<Arc<T>>`, not `MD<Frame>`). Adding such an
-/// extraction without the matching mint resurrects the double-counting
-/// bug that motivated this redesign.
-pub struct ManuallyDrop<T: TrackDrop>(pub T);
-
-impl<T: TrackDrop> ManuallyDrop<T> {
-    #[verifier::external_body]
-    pub fn new(t: T, Tracked(s): Tracked<&mut T::State>) -> (res: Self)
-        requires
-            t.consume_requires(*old(s)),
-        ensures
-            t.consume_ensures(*old(s), *final(s)),
-            res.0 == t,
-    {
-        proof {
-            // Materialize a ledger-less identity token for `t.key()` and
-            // immediately discharge it via `T::consume_obligation`. The
-            // caller's `consume_requires` precondition guarantees there
-            // is an outstanding ledger entry at this key for the redeem
-            // axiom to remove.
-            let tracked obl = DropObligation::tracked_mint(t.key());
-            t.consume_obligation(s, obl);
-        }
-        Self(t)
-    }
-}
-
-impl<T: TrackDrop> Deref for ManuallyDrop<T> {
-    type Target = T;
-
-    #[verifier::external_body]
-    fn deref(&self) -> (res: &Self::Target)
-        ensures
-            res == &self.0,
-    {
-        &self.0
-    }
-}
-
-impl<T: TrackDrop> View for ManuallyDrop<T> {
-    type V = T;
-
-    open spec fn view(&self) -> (res: Self::V) {
-        self.0
     }
 }
 


### PR DESCRIPTION
The current `ManuallyDrop<T: TrackDrop>` is unsound. It consumes the obligation immediately after `ManuallyDrop::new`, so the `Drop` can never be called because the obligation is leaked! This PR completely redesigns the `TrackDrop` infrastructure:
- `Key` and `DropObligation<Self::Key>` in `TrackDrop` are replaced by a general `Obligation` associated type, because `DropObligation` can be created from nowhere, violating the linear requirement of the permission if the user needs it.
- `ManuallyDrop<T: TrackedDrop>` now carries the obligation with it, instead of consuming it immediately, so that the obligation can be returned.
- `constructor_*/ consume_*` are removed because they are not used anymore.
- A `tracked_redeem(State) -> Obligation` method is added so that the state can emit an obligation.

Note1: The unsound `frame_obligation` design in `MetaRegionOwners` is not changed in this PR. Its replacement with fractional permission is left for a future PR.

Note2: This new design retains the ability to track whether a memory leak occurs. It is just the responsibility of the trait implementor, like before.