### PR TITLE
fix: Minor improvement in spec naming

### DIFF
--- a/ostd/specs/mm/embedding/cursor.rs
+++ b/ostd/specs/mm/embedding/cursor.rs
@@ -121,7 +121,7 @@ pub axiom fn vm_space_cursor_embedded<'a, 'rcu>(
             final(regions).slot_owners[i] != old(regions).slot_owners[i] ==> {
                 &&& old(regions).slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNUSED
                 &&& final(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-                &&& final(regions).slot_owners[i].usage != PageUsage::Frame
+                &&& final(regions).slot_owners[i].usage !is Frame
             },
         forall|c: CursorOwner<'rcu, UserPtConfig>|
             #![auto]
@@ -168,7 +168,7 @@ pub axiom fn vm_space_cursor_mut_embedded<'a, 'rcu>(
             final(regions).slot_owners[i] != old(regions).slot_owners[i] ==> {
                 &&& old(regions).slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNUSED
                 &&& final(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-                &&& final(regions).slot_owners[i].usage != PageUsage::Frame
+                &&& final(regions).slot_owners[i].usage !is Frame
             },
         forall|c: CursorOwner<'rcu, UserPtConfig>|
             #![auto]
@@ -237,7 +237,7 @@ pub axiom fn cursor_query_embedded<'rcu>(
         // (non-MMIO) data Frame whose slot is in-bound and active.
         res matches Some(paddr) ==> {
             &&& has_safe_slot(paddr)
-            &&& old(regions).slot_owners[frame_to_index(paddr)].usage == PageUsage::Frame
+            &&& old(regions).slot_owners[frame_to_index(paddr)].usage is Frame
             &&& final(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() == (
             old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
                 + 1) as nat
@@ -438,7 +438,7 @@ pub axiom fn cursor_mut_map_embedded<'rcu>(
             #![trigger final(regions).slot_owners[i]]
             i != frame_to_index(paddr) && old(regions).slot_owners[i].inner_perms.ref_count.value()
                 == REF_COUNT_UNUSED && final(regions).slot_owners[i].inner_perms.ref_count.value()
-                != REF_COUNT_UNUSED ==> final(regions).slot_owners[i].usage != PageUsage::Frame,
+                != REF_COUNT_UNUSED ==> final(regions).slot_owners[i].usage !is Frame,
         forall|c: CursorOwner<'rcu, UserPtConfig>|
             #![auto]
             c.metaregion_sound(*old(regions)) ==> c.metaregion_sound(*final(regions)),
@@ -528,7 +528,7 @@ pub axiom fn cursor_mut_unmap_embedded<'rcu>(
         // atomically; the embedding sees the post-teardown state.
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
-            old(regions).slot_owners[i].usage == PageUsage::Frame ==> {
+            old(regions).slot_owners[i].usage is Frame ==> {
                 &&& final(regions).slot_owners[i].inner_perms.ref_count.value() + old(
                     regions,
                 ).slot_owners[i].paths_in_pt.len() == old(
@@ -614,7 +614,7 @@ pub(super) proof fn open_cursor_step<'a, 'rcu>(
             final(regions).slot_owners[i] != old(regions).slot_owners[i] ==> {
                 &&& old(regions).slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNUSED
                 &&& final(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-                &&& final(regions).slot_owners[i].usage != PageUsage::Frame
+                &&& final(regions).slot_owners[i].usage !is Frame
             },
         forall|c: CursorOwner<'rcu, UserPtConfig>|
             #![auto]
@@ -666,7 +666,7 @@ pub(super) proof fn open_cursor_mut_step<'a, 'rcu>(
             final(regions).slot_owners[i] != old(regions).slot_owners[i] ==> {
                 &&& old(regions).slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNUSED
                 &&& final(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-                &&& final(regions).slot_owners[i].usage != PageUsage::Frame
+                &&& final(regions).slot_owners[i].usage !is Frame
             },
         forall|c: CursorOwner<'rcu, UserPtConfig>|
             #![auto]
@@ -733,7 +733,7 @@ pub(super) proof fn cursor_query_step<'rcu>(
             final(regions).slot_owners[i] == old(regions).slot_owners[i],
         res matches Some(paddr) ==> {
             &&& has_safe_slot(paddr)
-            &&& old(regions).slot_owners[frame_to_index(paddr)].usage == PageUsage::Frame
+            &&& old(regions).slot_owners[frame_to_index(paddr)].usage is Frame
             &&& final(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() == (
             old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
                 + 1) as nat
@@ -911,7 +911,7 @@ pub(super) proof fn cursor_mut_regions_step<'rcu>(
             ).slot_owners[i],
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
-            old(regions).slot_owners[i].usage == PageUsage::Frame ==> {
+            old(regions).slot_owners[i].usage is Frame ==> {
                 &&& final(regions).slot_owners[i].inner_perms.ref_count.value() + old(
                     regions,
                 ).slot_owners[i].paths_in_pt.len() == old(
@@ -1007,7 +1007,7 @@ pub(super) proof fn map_step<'rcu>(
             #![trigger final(regions).slot_owners[i]]
             i != frame_to_index(paddr) && old(regions).slot_owners[i].inner_perms.ref_count.value()
                 == REF_COUNT_UNUSED && final(regions).slot_owners[i].inner_perms.ref_count.value()
-                != REF_COUNT_UNUSED ==> final(regions).slot_owners[i].usage != PageUsage::Frame,
+                != REF_COUNT_UNUSED ==> final(regions).slot_owners[i].usage !is Frame,
         forall|c: CursorOwner<'rcu, UserPtConfig>|
             #![auto]
             c.metaregion_sound(*old(regions)) ==> c.metaregion_sound(*final(regions)),

--- a/ostd/specs/mm/embedding/cursor.rs
+++ b/ostd/specs/mm/embedding/cursor.rs
@@ -107,7 +107,7 @@ pub axiom fn vm_space_cursor_embedded<'a, 'rcu>(
         // partial) keeps `VmStore::inv`'s coverage clauses chainable
         // across cursor methods.
         final(regions).slots == old(regions).slots,
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners[i].inner_perms.in_list == old(
                 regions,
@@ -116,7 +116,7 @@ pub axiom fn vm_space_cursor_embedded<'a, 'rcu>(
         // every *changed* slot was UNUSED before and becomes a
         // non-UNUSED PT node (usage != Frame). `accounting_inv` chains
         // from this single clause.
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners[i] != old(regions).slot_owners[i] ==> {
                 &&& old(regions).slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNUSED
@@ -154,7 +154,7 @@ pub axiom fn vm_space_cursor_mut_embedded<'a, 'rcu>(
         // partial) keeps `VmStore::inv`'s coverage clauses chainable
         // across cursor methods.
         final(regions).slots == old(regions).slots,
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners[i].inner_perms.in_list == old(
                 regions,
@@ -163,7 +163,7 @@ pub axiom fn vm_space_cursor_mut_embedded<'a, 'rcu>(
         // every *changed* slot was UNUSED before and becomes a
         // non-UNUSED PT node (usage != Frame). `accounting_inv` chains
         // from this single clause.
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners[i] != old(regions).slot_owners[i] ==> {
                 &&& old(regions).slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNUSED
@@ -229,7 +229,7 @@ pub axiom fn cursor_query_embedded<'rcu>(
         // `slots` preserved (the boot-fixed metadata perm map).
         final(regions).slots == old(regions).slots,
         // `None` ⟹ slot_owners fully preserved (no clone happened).
-        res is None ==> forall|i: usize|
+        res is None ==> forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners[i] == old(regions).slot_owners[i],
         // `Some(paddr)` ⟹ `rc++` at the cloned leaf's slot; all other
@@ -243,7 +243,7 @@ pub axiom fn cursor_query_embedded<'rcu>(
                 + 1) as nat
             &&& final(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
                 <= REF_COUNT_MAX
-            &&& forall|i: usize|
+            &&& forall|i: int|
                 #![trigger final(regions).slot_owners[i]]
                 i != frame_to_index(paddr) ==> final(regions).slot_owners[i] == old(
                     regions,
@@ -310,7 +310,7 @@ pub proof fn lemma_cursor_jump_embedded<'rcu>(
         // PTE writes, no leaf clone. Full `slot_owners` preservation,
         // same shape as `find_next`.
         final(regions).slots == old(regions).slots,
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners[i] == old(regions).slot_owners[i],
         forall|c: CursorOwner<'rcu, UserPtConfig>|
@@ -368,7 +368,7 @@ pub axiom fn cursor_mut_map_embedded<'rcu>(
         final(regions).slots == old(regions).slots,
         // Universal `raw_count` / `in_list` preservation (map doesn't
         // forget references or touch the free-list).
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners[i].inner_perms.in_list == old(
                 regions,
@@ -378,7 +378,7 @@ pub axiom fn cursor_mut_map_embedded<'rcu>(
         // slot_owner is preserved. NB: slots that were UNUSED pre may
         // transition to non-UNUSED as the cursor allocates fresh PT
         // nodes, so the "fully preserved" guard requires `pre rc != UNUSED`.
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             i != frame_to_index(paddr) && old(regions).slot_owners[i].inner_perms.ref_count.value()
                 != REF_COUNT_UNUSED ==> final(regions).slot_owners[i] == old(
@@ -386,7 +386,7 @@ pub axiom fn cursor_mut_map_embedded<'rcu>(
             ).slot_owners[i],
         // Per exec cursor/mod.rs:2844-2846: any pre-non-UNUSED slot
         // stays non-UNUSED.
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i].inner_perms.ref_count.value()]
             old(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
                 ==> final(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED,
@@ -422,7 +422,7 @@ pub axiom fn cursor_mut_map_embedded<'rcu>(
             regions,
         ).slot_owners[frame_to_index(paddr)].inner_perms.storage,
         // Slots that stay UNUSED are fully preserved.
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNUSED
                 ==> final(regions).slot_owners[i] == old(regions).slot_owners[i],
@@ -434,7 +434,7 @@ pub axiom fn cursor_mut_map_embedded<'rcu>(
         // become vacuous at newly-allocated PT-node slots; the
         // mapped slot itself is handled by the per-slot ensures
         // above.
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             i != frame_to_index(paddr) && old(regions).slot_owners[i].inner_perms.ref_count.value()
                 == REF_COUNT_UNUSED && final(regions).slot_owners[i].inner_perms.ref_count.value()
@@ -482,7 +482,7 @@ pub axiom fn cursor_mut_unmap_embedded<'rcu>(
         // `vtable_ptr`) and never bumps `rc` to `UNIQUE` (UNIQUE is a
         // unique-handle sentinel produced only by
         // `Frame::into_unique`, not by unmap).
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             {
                 &&& final(regions).slot_owners[i].slot_vaddr == old(
@@ -510,7 +510,7 @@ pub axiom fn cursor_mut_unmap_embedded<'rcu>(
         // of (hence outside) the unmapped range, so unmap leaves its
         // `slot_owner` (rc/usage/…) intact. Preserves the embedding's
         // slot-perm coverage exception.
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             !old(regions).slots.contains_key(i) ==> final(regions).slot_owners[i] == old(
                 regions,
@@ -526,7 +526,7 @@ pub axiom fn cursor_mut_unmap_embedded<'rcu>(
         // rules out the transient "rc == 0" state at Frame slots:
         // exec teardown collapses Frame ∧ rc==0 to `REF_COUNT_UNUSED`
         // atomically; the embedding sees the post-teardown state.
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             old(regions).slot_owners[i].usage == PageUsage::Frame ==> {
                 &&& final(regions).slot_owners[i].inner_perms.ref_count.value() + old(
@@ -550,7 +550,7 @@ pub axiom fn cursor_mut_unmap_embedded<'rcu>(
         // non-empty `paths_in_pt`) would block
         // `accounting_inv` clause 1 (UNUSED ⟹ paths empty) at
         // post-UNUSED MMIO slots.
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             old(regions).slot_owners[i].usage == PageUsage::MMIO ==> final(regions).slot_owners[i]
                 == old(regions).slot_owners[i],
@@ -600,7 +600,7 @@ pub(super) proof fn open_cursor_step<'a, 'rcu>(
         // partial) keeps `VmStore::inv`'s coverage clauses chainable
         // across cursor methods.
         final(regions).slots == old(regions).slots,
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners[i].inner_perms.in_list == old(
                 regions,
@@ -609,7 +609,7 @@ pub(super) proof fn open_cursor_step<'a, 'rcu>(
         // every *changed* slot was UNUSED before and becomes a
         // non-UNUSED PT node (usage != Frame). `accounting_inv` chains
         // from this single clause.
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners[i] != old(regions).slot_owners[i] ==> {
                 &&& old(regions).slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNUSED
@@ -656,12 +656,12 @@ pub(super) proof fn open_cursor_mut_step<'a, 'rcu>(
     ensures
         final(regions).inv(),
         final(regions).slots == old(regions).slots,
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners[i].inner_perms.in_list == old(
                 regions,
             ).slot_owners[i].inner_perms.in_list,
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners[i] != old(regions).slot_owners[i] ==> {
                 &&& old(regions).slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNUSED
@@ -728,7 +728,7 @@ pub(super) proof fn cursor_query_step<'rcu>(
         final(regions).inv(),
         final(entry).owner.metaregion_sound(*final(regions)),
         final(regions).slots == old(regions).slots,
-        res is None ==> forall|i: usize|
+        res is None ==> forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners[i] == old(regions).slot_owners[i],
         res matches Some(paddr) ==> {
@@ -739,7 +739,7 @@ pub(super) proof fn cursor_query_step<'rcu>(
                 + 1) as nat
             &&& final(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
                 <= REF_COUNT_MAX
-            &&& forall|i: usize|
+            &&& forall|i: int|
                 #![trigger final(regions).slot_owners[i]]
                 i != frame_to_index(paddr) ==> final(regions).slot_owners[i] == old(
                     regions,
@@ -785,7 +785,7 @@ pub(super) proof fn cursor_find_next_step<'rcu>(
         final(regions).slots == old(regions).slots,
         // Full `slot_owners` preservation — `find_next` writes no PTE
         // and clones no leaf.
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners[i] == old(regions).slot_owners[i],
         forall|c: CursorOwner<'rcu, UserPtConfig>|
@@ -813,7 +813,7 @@ pub(super) proof fn cursor_jump_step<'rcu>(
         final(regions).inv(),
         final(entry).owner.metaregion_sound(*final(regions)),
         final(regions).slots == old(regions).slots,
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners[i] == old(regions).slot_owners[i],
         forall|c: CursorOwner<'rcu, UserPtConfig>|
@@ -843,7 +843,7 @@ pub(super) proof fn cursor_protect_next_step<'rcu>(
         final(regions).inv(),
         final(entry).owner.metaregion_sound(*final(regions)),
         final(regions).slots == old(regions).slots,
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners[i] == old(regions).slot_owners[i],
         forall|c: CursorOwner<'rcu, UserPtConfig>|
@@ -881,7 +881,7 @@ pub(super) proof fn cursor_mut_regions_step<'rcu>(
         // "non-mapping count" `rc - paths.len()` is invariant with
         // `rc` and `paths.len` monotonically non-increasing.
         final(regions).slots == old(regions).slots,
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             {
                 &&& final(regions).slot_owners[i].slot_vaddr == old(
@@ -904,12 +904,12 @@ pub(super) proof fn cursor_mut_regions_step<'rcu>(
             },
         // Unparked (page-table-node) slots untouched (see
         // `cursor_mut_unmap_embedded`); preserves the coverage exception.
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             !old(regions).slots.contains_key(i) ==> final(regions).slot_owners[i] == old(
                 regions,
             ).slot_owners[i],
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             old(regions).slot_owners[i].usage == PageUsage::Frame ==> {
                 &&& final(regions).slot_owners[i].inner_perms.ref_count.value() + old(
@@ -926,7 +926,7 @@ pub(super) proof fn cursor_mut_regions_step<'rcu>(
                 ).slot_owners[i].paths_in_pt.len()
                 &&& final(regions).slot_owners[i].inner_perms.ref_count.value() != 0
             },
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             old(regions).slot_owners[i].usage == PageUsage::MMIO ==> final(regions).slot_owners[i]
                 == old(regions).slot_owners[i],
@@ -972,18 +972,18 @@ pub(super) proof fn map_step<'rcu>(
         final(tlb_model).inv(),
         final(regions).slots == old(regions).slots,
         // Mirror the strengthened `cursor_mut_map_embedded` ensures.
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners[i].inner_perms.in_list == old(
                 regions,
             ).slot_owners[i].inner_perms.in_list,
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             i != frame_to_index(paddr) && old(regions).slot_owners[i].inner_perms.ref_count.value()
                 != REF_COUNT_UNUSED ==> final(regions).slot_owners[i] == old(
                 regions,
             ).slot_owners[i],
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i].inner_perms.ref_count.value()]
             old(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
                 ==> final(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED,
@@ -999,11 +999,11 @@ pub(super) proof fn map_step<'rcu>(
         final(regions).slot_owners[frame_to_index(paddr)].inner_perms.storage == old(
             regions,
         ).slot_owners[frame_to_index(paddr)].inner_perms.storage,
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNUSED
                 ==> final(regions).slot_owners[i] == old(regions).slot_owners[i],
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             i != frame_to_index(paddr) && old(regions).slot_owners[i].inner_perms.ref_count.value()
                 == REF_COUNT_UNUSED && final(regions).slot_owners[i].inner_perms.ref_count.value()

--- a/ostd/specs/mm/embedding/frame.rs
+++ b/ostd/specs/mm/embedding/frame.rs
@@ -209,7 +209,7 @@ pub axiom fn frame_drop_embedded(tracked regions: &mut MetaRegionOwners, paddr: 
 // ---- mirrors strengthened `Frame::drop_ensures` ----
 
         final(regions).inv(),
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             i != frame_to_index(paddr) ==> final(regions).slot_owners[i] == old(
                 regions,
@@ -374,7 +374,7 @@ pub(super) proof fn drop_step(tracked regions: &mut MetaRegionOwners, tracked en
     ensures
         final(regions).inv(),
         final(regions).slots == old(regions).slots,
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             i != frame_to_index(entry.paddr) ==> final(regions).slot_owners[i] == old(
                 regions,

--- a/ostd/specs/mm/embedding/frame.rs
+++ b/ostd/specs/mm/embedding/frame.rs
@@ -20,7 +20,7 @@
 //! - **Generic `M: AnyFrameMeta`**: `Frame::from_unused` takes a
 //!   `metadata: M` parameter and threads it through `PointsTo<MetaSlot, Metadata<M>>`.
 //!   We don't model the metadata type — `get_from_unused_spec` itself
-//!   ignores `M` and just commits to `usage == PageUsage::Frame`.
+//!   ignores `M` and just commits to `usage is Frame`.
 //! - **Drop-last-in-place teardown**: when `ref_count == 1`, dropping
 //!   the handle invokes the metadata destructor (which may require
 //!   `storage.is_init`, `in_list.value() == 0`). We model this by
@@ -150,7 +150,7 @@ pub axiom fn frame_from_in_use_embedded(
             // is Frame-usage. This matches `VmStore::structural_inv`'s
             // FrameId⟹Frame-usage clause and lets [`from_in_use_step`]
             // discharge `insert_frame`'s usage precondition.
-            &&& so.usage == PageUsage::Frame
+            &&& so.usage is Frame
         },
         // `from_in_use` only `inc_ref_count`s — it never touches the
         // slot-perm map, so the `slots` domain is preserved on *both*
@@ -331,7 +331,7 @@ pub(super) proof fn from_in_use_step(
             &&& so.inner_perms.ref_count.value() != REF_COUNT_UNUSED
             &&& so.inner_perms.ref_count.value() != REF_COUNT_UNIQUE
             &&& so.inner_perms.storage.is_init()
-            &&& so.usage == PageUsage::Frame
+            &&& so.usage is Frame
         },
         final(regions).slots == old(regions).slots,
         forall|c: CursorOwner<'_, UserPtConfig>|

--- a/ostd/specs/mm/embedding/list_store.rs
+++ b/ostd/specs/mm/embedding/list_store.rs
@@ -111,7 +111,7 @@ pub open spec fn list_registry_ok<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
         0 <= i < lo.list.len() ==> regions.slot_owners[lo.slot_index_at(
             i,
         )].inner_perms.in_list.value() == lo.list_id
-    &&& lo.list_id != 0 ==> forall|idx: usize|
+    &&& lo.list_id != 0 ==> forall|idx: int|
         #![trigger regions.slot_owners[idx]]
         regions.slot_owners.contains_key(idx)
             && regions.slot_owners[idx].inner_perms.in_list.value() == lo.list_id ==> exists|i: int|
@@ -311,7 +311,7 @@ pub proof fn push_front_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
         final(regions).frame_obligations =~= old(regions).frame_obligations.remove(
             old(frame_own).slot_index,
         ),
-        forall|k: usize|
+        forall|k: int|
             #![trigger final(regions).slots[k]]
             #![trigger final(regions).slot_owners[k]]
             k != old(frame_own).slot_index && (old(owner).list.len() > 0 ==> k != old(
@@ -409,7 +409,7 @@ pub proof fn tracked_pop_front_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
         ),
         // Outside-the-list slot preservation (front specialisation:
         // popped slot + the new front at `slot_index_at(1)`).
-        forall|j: usize|
+        forall|j: int|
             #![trigger final(regions).slots[j]]
             #![trigger final(regions).slot_owners[j]]
             j != old(owner).slot_index_at(0) && (old(owner).list.len() > 1 ==> j != old(
@@ -487,7 +487,7 @@ pub proof fn lemma_push_back_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
         final(regions).frame_obligations =~= old(regions).frame_obligations.remove(
             old(frame_own).slot_index,
         ),
-        forall|k: usize|
+        forall|k: int|
             #![trigger final(regions).slots[k]]
             #![trigger final(regions).slot_owners[k]]
             k != old(frame_own).slot_index && (old(owner).list.len() > 1 ==> k != old(
@@ -557,7 +557,7 @@ pub proof fn tracked_pop_back_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
         final(regions).frame_obligations =~= old(regions).frame_obligations.insert(
             old(owner).slot_index_at(old(owner).list.len() - 1),
         ),
-        forall|j: usize|
+        forall|j: int|
             #![trigger final(regions).slots[j]]
             #![trigger final(regions).slot_owners[j]]
             j != old(owner).slot_index_at(old(owner).list.len() - 1) && (old(owner).list.len() > 1
@@ -629,7 +629,7 @@ pub axiom fn insert_before_at_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
         final(regions).frame_obligations =~= old(regions).frame_obligations.remove(
             old(frame_own).slot_index,
         ),
-        forall|k: usize|
+        forall|k: int|
             #![trigger final(regions).slots[k]]
             #![trigger final(regions).slot_owners[k]]
             k != old(frame_own).slot_index && (n > 0 ==> k != old(owner).slot_index_at(n - 1)) && (n
@@ -691,7 +691,7 @@ pub axiom fn take_at_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
         final(regions).frame_obligations =~= old(regions).frame_obligations.insert(
             old(owner).slot_index_at(n),
         ),
-        forall|j: usize|
+        forall|j: int|
             #![trigger final(regions).slots[j]]
             #![trigger final(regions).slot_owners[j]]
             j != old(owner).slot_index_at(n) && (n > 0 ==> j != old(owner).slot_index_at(n - 1))
@@ -781,7 +781,7 @@ pub axiom fn list_drop_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
                 &&& final(regions).slot_owners[idx].inner_perms.in_list.value() == 0
             },
         // Every slot outside the dropped list is fully preserved.
-        forall|idx: usize|
+        forall|idx: int|
             #![trigger final(regions).slot_owners[idx]]
             (forall|i: int| 0 <= i < owner.list.len() ==> idx != owner.slot_index_at(i))
                 ==> final(regions).slot_owners[idx] == old(regions).slot_owners[idx]

--- a/ostd/specs/mm/embedding/list_store.rs
+++ b/ostd/specs/mm/embedding/list_store.rs
@@ -977,7 +977,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
             self.lists[id].relate_region_at_facts(self.regions, i);
             assert(self.regions.slot_owners.contains_key(idx));
             assert(self.regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
-            assert(self.regions.slot_owners[idx].usage == PageUsage::Frame);
+            assert(self.regions.slot_owners[idx].usage is Frame);
         };
 
         let tracked owner = self.lists.tracked_remove(id);

--- a/ostd/specs/mm/embedding/mod.rs
+++ b/ostd/specs/mm/embedding/mod.rs
@@ -643,7 +643,7 @@ impl<'a, 'rcu> VmStore<'rcu> {
         // `slots.contains_key` directly.
         &&& forall|idx: int|
             0 <= idx < max_meta_slots() ==> #[trigger] self.regions.slots.contains_key(idx) || (
-            self.regions.slot_owners[idx].usage == PageUsage::PageTable
+            self.regions.slot_owners[idx].usage is PageTable
                 && self.regions.slot_owners[idx].inner_perms.ref_count.value()
                 != REF_COUNT_UNUSED)
             // Segment-cover info is sourced directly from the `segments` map
@@ -687,7 +687,7 @@ impl<'a, 'rcu> VmStore<'rcu> {
             self.frames.dom().contains(fid) ==> has_safe_slot(
                 self.frames[fid].paddr,
             )
-        // Every registered handle's slot has `usage == PageUsage::Frame`.
+        // Every registered handle's slot has `usage is Frame`.
         // True by construction: every `Op` that adds a `FrameId`
         // (`FrameFromUnused`, `FrameFromInUse`, `Query` on a tracked
         // leaf) commits to a Frame-usage slot. Carrying this in
@@ -698,8 +698,7 @@ impl<'a, 'rcu> VmStore<'rcu> {
         &&& forall|fid: FrameId| #[trigger]
             self.frames.dom().contains(fid) ==> self.regions.slot_owners[frame_to_index(
                 self.frames[fid].paddr,
-            )].usage
-                == PageUsage::Frame
+            )].usage is Frame
             // Every registered segment has a well-formed range
             // (page-aligned, in-bound, non-empty). Enforced by
             // `op_pre[SegmentFromUnused]`; carried as an invariant so
@@ -713,7 +712,7 @@ impl<'a, 'rcu> VmStore<'rcu> {
                 &&& r.start < r.end
                 &&& r.end <= MAX_PADDR
             }
-            // Every segment-covered slot has `usage == PageUsage::Frame`.
+            // Every segment-covered slot has `usage is Frame`.
             // True by construction: `Op::SegmentFromUnused` sets the
             // covered slots' usage to Frame, and no op transitions a
             // segment-covered slot back to non-Frame (frame_drop is gated
@@ -726,8 +725,9 @@ impl<'a, 'rcu> VmStore<'rcu> {
                     frame_to_index(paddr)]
             self.segments.dom().contains(sid) && self.segments[sid].range.start <= paddr
                 < self.segments[sid].range.end && paddr % PAGE_SIZE == 0
-                ==> self.regions.slot_owners[frame_to_index(paddr)].usage
-                == PageUsage::Frame
+                ==> self.regions.slot_owners[frame_to_index(
+                paddr,
+            )].usage is Frame
             // `unique_frames.dom()` is finite (built by finitely many
             // `insert_unique`), needed wherever the embedding reasons
             // about the unique-handle set as a whole.
@@ -743,7 +743,7 @@ impl<'a, 'rcu> VmStore<'rcu> {
         &&& forall|uid: UniqueId| #[trigger]
             self.unique_frames.dom().contains(uid) ==> {
                 let so = self.regions.slot_owners[frame_to_index(self.unique_frames[uid].paddr)];
-                &&& so.usage == PageUsage::Frame
+                &&& so.usage is Frame
                 &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
                 &&& so.inner_perms.in_list.value() == 0
                 &&& so.paths_in_pt.is_empty()
@@ -843,7 +843,7 @@ impl<'a, 'rcu> VmStore<'rcu> {
             // the segment-cover contribution.
         &&& forall|idx: int|
             #![trigger self.regions.slot_owners[idx]]
-            0 <= idx < max_meta_slots() && self.regions.slot_owners[idx].usage == PageUsage::Frame
+            0 <= idx < max_meta_slots() && self.regions.slot_owners[idx].usage is Frame
                 && self.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
                 && self.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNIQUE
                 ==> handle_count(self.frames, idx) > 0
@@ -861,12 +861,9 @@ impl<'a, 'rcu> VmStore<'rcu> {
             // `cover_count == 0` and the equation reduces to `rc == H + P`.
         &&& forall|idx: int|
             #![trigger self.regions.slot_owners[idx]]
-            0 <= idx < max_meta_slots() && self.regions.slot_owners[idx].usage == PageUsage::Frame
-                && (handle_count(self.frames, idx) > 0
-                || self.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
-                self.segments,
-                index_to_frame(idx),
-            ) > 0) ==> {
+            0 <= idx < max_meta_slots() && self.regions.slot_owners[idx].usage is Frame && (
+            handle_count(self.frames, idx) > 0 || self.regions.slot_owners[idx].paths_in_pt.len()
+                > 0 || segment_cover_count(self.segments, index_to_frame(idx)) > 0) ==> {
                 let so = self.regions.slot_owners[idx];
                 let rc = so.inner_perms.ref_count.value();
                 &&& rc != REF_COUNT_UNUSED
@@ -1348,7 +1345,7 @@ impl<'rcu> VmStore<'rcu> {
             // structural_inv's FrameId⟹Frame-usage clause. Every caller
             // discharges this from the `from_*` / query axioms which
             // commit to Frame-usage at the cloned slot.
-            old(self).regions.slot_owners[frame_to_index(entry.paddr)].usage == PageUsage::Frame,
+            old(self).regions.slot_owners[frame_to_index(entry.paddr)].usage is Frame,
         ensures
             final(self).regions == old(self).regions,
             final(self).tlb_model == old(self).tlb_model,
@@ -1555,7 +1552,7 @@ proof fn lemma_accounting_preserved_by_pt_alloc<'rcu>(s_old: VmStore<'rcu>, s_ne
             s_new.regions.slot_owners[i] != s_old.regions.slot_owners[i] ==> {
                 &&& s_old.regions.slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNUSED
                 &&& s_new.regions.slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-                &&& s_new.regions.slot_owners[i].usage != PageUsage::Frame
+                &&& s_new.regions.slot_owners[i].usage !is Frame
             },
     ensures
         s_new.accounting_inv(),
@@ -1566,7 +1563,7 @@ proof fn lemma_accounting_preserved_by_pt_alloc<'rcu>(s_old: VmStore<'rcu>, s_ne
         forall|fid: FrameId| #[trigger]
             s_new.frames.dom().contains(fid) ==> s_new.regions.slot_owners[frame_to_index(
                 s_new.frames[fid].paddr,
-            )].usage == PageUsage::Frame,
+            )].usage is Frame,
         // Likewise for segment-covered ⟹ Frame-usage.
         forall|sid: SegmentId, paddr: Paddr|
             #![trigger
@@ -1574,7 +1571,7 @@ proof fn lemma_accounting_preserved_by_pt_alloc<'rcu>(s_old: VmStore<'rcu>, s_ne
                 frame_to_index(paddr)]
             s_new.segments.dom().contains(sid) && s_new.segments[sid].range.start <= paddr
                 < s_new.segments[sid].range.end && paddr % PAGE_SIZE == 0
-                ==> s_new.regions.slot_owners[frame_to_index(paddr)].usage == PageUsage::Frame,
+                ==> s_new.regions.slot_owners[frame_to_index(paddr)].usage is Frame,
 {
     // Clause 2 — UNUSED ⟹ no users. An UNUSED slot in `s_new` is
     // unchanged (a transitioned slot is non-UNUSED in `s_new`).
@@ -1592,7 +1589,7 @@ proof fn lemma_accounting_preserved_by_pt_alloc<'rcu>(s_old: VmStore<'rcu>, s_ne
     // in `s_new` is unchanged (a transitioned slot is non-Frame).
     assert forall|idx: int|
         #![trigger s_new.regions.slot_owners[idx]]
-        0 <= idx < max_meta_slots() && s_new.regions.slot_owners[idx].usage == PageUsage::Frame
+        0 <= idx < max_meta_slots() && s_new.regions.slot_owners[idx].usage is Frame
             && s_new.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
             && s_new.regions.slot_owners[idx].inner_perms.ref_count.value()
             != REF_COUNT_UNIQUE implies handle_count(s_new.frames, idx) > 0
@@ -1606,7 +1603,7 @@ proof fn lemma_accounting_preserved_by_pt_alloc<'rcu>(s_old: VmStore<'rcu>, s_ne
     // `s_new` is unchanged, so the old equation carries.
     assert forall|idx: int|
         #![trigger s_new.regions.slot_owners[idx]]
-        0 <= idx < max_meta_slots() && s_new.regions.slot_owners[idx].usage == PageUsage::Frame && (
+        0 <= idx < max_meta_slots() && s_new.regions.slot_owners[idx].usage is Frame && (
         handle_count(s_new.frames, idx) > 0 || s_new.regions.slot_owners[idx].paths_in_pt.len() > 0
             || segment_cover_count(s_new.segments, index_to_frame(idx)) > 0) implies {
         let so = s_new.regions.slot_owners[idx];
@@ -1631,11 +1628,10 @@ proof fn lemma_accounting_preserved_by_pt_alloc<'rcu>(s_old: VmStore<'rcu>, s_ne
             frame_to_index(paddr)]
         s_new.segments.dom().contains(sid) && s_new.segments[sid].range.start <= paddr
             < s_new.segments[sid].range.end && paddr % PAGE_SIZE
-            == 0 implies s_new.regions.slot_owners[frame_to_index(paddr)].usage
-        == PageUsage::Frame by {
+            == 0 implies s_new.regions.slot_owners[frame_to_index(paddr)].usage is Frame by {
         let idx = frame_to_index(paddr);
         // From old structural: covered ⟹ Frame.
-        assert(s_old.regions.slot_owners[idx].usage == PageUsage::Frame);
+        assert(s_old.regions.slot_owners[idx].usage is Frame);
         // From old accounting clause 4: cover >= 1 ⟹ active head ⟹
         // rc ∈ valid SHARED range ⟹ rc != UNUSED.
         lemma_segment_cover_contains(s_old.segments, sid, paddr);
@@ -1651,7 +1647,7 @@ proof fn lemma_accounting_preserved_by_pt_alloc<'rcu>(s_old: VmStore<'rcu>, s_ne
     assert forall|fid: FrameId| #[trigger]
         s_new.frames.dom().contains(fid) implies s_new.regions.slot_owners[frame_to_index(
         s_new.frames[fid].paddr,
-    )].usage == PageUsage::Frame by {
+    )].usage is Frame by {
         let idx = frame_to_index(s_new.frames[fid].paddr);
         // pre H >= 1 since `fid` is in `s_old.frames.dom()`.
         assert(s_old.frames.dom().filter(
@@ -1659,7 +1655,7 @@ proof fn lemma_accounting_preserved_by_pt_alloc<'rcu>(s_old: VmStore<'rcu>, s_ne
         ).contains(fid));
         assert(handle_count(s_old.frames, idx) >= 1);
         // pre accounting_inv clause 4 ⟹ pre rc != UNUSED.
-        assert(s_old.regions.slot_owners[idx].usage == PageUsage::Frame);
+        assert(s_old.regions.slot_owners[idx].usage is Frame);
         assert(s_old.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED);
         // PT-alloc's requires: changed ⟹ pre UNUSED. Contrapositive:
         // pre non-UNUSED ⟹ unchanged.
@@ -1685,13 +1681,13 @@ proof fn lemma_coverage_preserved_slots_eq<'rcu>(s_old: VmStore<'rcu>, s_new: Vm
     ensures
         forall|idx: int|
             0 <= idx < max_meta_slots() ==> #[trigger] s_new.regions.slots.contains_key(idx) || (
-            s_new.regions.slot_owners[idx].usage == PageUsage::PageTable
+            s_new.regions.slot_owners[idx].usage is PageTable
                 && s_new.regions.slot_owners[idx].inner_perms.ref_count.value()
                 != REF_COUNT_UNUSED),
 {
     assert forall|idx: int|
         0 <= idx < max_meta_slots() implies #[trigger] s_new.regions.slots.contains_key(idx) || (
-    s_new.regions.slot_owners[idx].usage == PageUsage::PageTable
+    s_new.regions.slot_owners[idx].usage is PageTable
         && s_new.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED) by {
         if !s_new.regions.slots.contains_key(idx) {
             // `slots == old` ⟹ unparked in `s_old` too ⟹ old coverage's
@@ -1723,7 +1719,7 @@ proof fn step_new_vm_space<'rcu>(tracked s: &mut VmStore<'rcu>)
     let ghost root_idx = vm_space::vm_space_root_idx(owner);
     assert forall|idx: int|
         0 <= idx < max_meta_slots() implies #[trigger] s.regions.slots.contains_key(idx) || (
-    s.regions.slot_owners[idx].usage == PageUsage::PageTable
+    s.regions.slot_owners[idx].usage is PageTable
         && s.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED) by {
         if idx == root_idx {
             // The extracted root is an active PageTable node (axiom).
@@ -1851,7 +1847,7 @@ proof fn step_query<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId)
             // The cursor axiom on Some bumps rc to pre rc + 1 (≤ MAX),
             // preserves usage / paths / storage at target_idx, and
             // preserves all other slots fully.
-            assert(s.regions.slot_owners[target_idx].usage == PageUsage::Frame);
+            assert(s.regions.slot_owners[target_idx].usage is Frame);
             // Discharge accounting_inv on (new regions, new frames).
             assert forall|idx: int|
                 #![trigger s.regions.slot_owners[idx]]
@@ -1877,7 +1873,7 @@ proof fn step_query<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId)
             };
             assert forall|idx: int|
                 #![trigger s.regions.slot_owners[idx]]
-                0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
+                0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
                     && s.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
                     && s.regions.slot_owners[idx].inner_perms.ref_count.value()
                     != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
@@ -1895,12 +1891,9 @@ proof fn step_query<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId)
             };
             assert forall|idx: int|
                 #![trigger s.regions.slot_owners[idx]]
-                0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
-                    && (handle_count(s.frames, idx) > 0
-                    || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
-                    s.segments,
-                    index_to_frame(idx),
-                ) > 0) implies {
+                0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame && (
+                handle_count(s.frames, idx) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0
+                    || segment_cover_count(s.segments, index_to_frame(idx)) > 0) implies {
                 let so = s.regions.slot_owners[idx];
                 let rc = so.inner_perms.ref_count.value();
                 &&& rc != REF_COUNT_UNUSED
@@ -2008,7 +2001,7 @@ proof fn step_map<'rcu>(
 {
     // `usage == Frame` at the mapped slot from `structural_inv`'s
     // FrameId⟹Frame-usage clause.
-    assert(s.regions.slot_owners[frame_to_index(s.frames[fid].paddr)].usage == PageUsage::Frame);
+    assert(s.regions.slot_owners[frame_to_index(s.frames[fid].paddr)].usage is Frame);
     let ghost paddr = s.frames[fid].paddr;
     let ghost target_idx = frame_to_index(paddr);
     let ghost old_frames = s.frames;
@@ -2063,7 +2056,7 @@ proof fn step_map<'rcu>(
     };
     assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
             && s.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
             && s.regions.slot_owners[idx].inner_perms.ref_count.value()
             != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
@@ -2077,7 +2070,7 @@ proof fn step_map<'rcu>(
             assert(s.regions.slot_owners[idx].paths_in_pt.len() == pre_paths_target + 1);
         } else if old_regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNUSED {
             // Newly-non-UNUSED slot ⟹ usage != Frame (changed-slots clause).
-            assert(s.regions.slot_owners[idx].usage != PageUsage::Frame);
+            assert(s.regions.slot_owners[idx].usage !is Frame);
         } else {
             // Non-mapped pre-non-UNUSED slot ⟹ fully preserved; pre
             // clause 3 carries forward.
@@ -2086,9 +2079,13 @@ proof fn step_map<'rcu>(
     };
     assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame && (
-        handle_count(s.frames, idx) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0
-            || segment_cover_count(s.segments, index_to_frame(idx)) > 0) implies {
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame && (handle_count(
+            s.frames,
+            idx,
+        ) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
+            s.segments,
+            index_to_frame(idx),
+        ) > 0) implies {
         let so = s.regions.slot_owners[idx];
         let rc = so.inner_perms.ref_count.value();
         &&& rc != REF_COUNT_UNUSED
@@ -2110,7 +2107,7 @@ proof fn step_map<'rcu>(
             assert(s.regions.slot_owners[idx].paths_in_pt.len() == pre_paths_target + 1);
             assert(handle_count(s.frames, idx) == (handle_count(old_frames, idx) - 1) as nat);
         } else if old_regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNUSED {
-            assert(s.regions.slot_owners[idx].usage != PageUsage::Frame);
+            assert(s.regions.slot_owners[idx].usage !is Frame);
         } else {
             assert(s.regions.slot_owners[idx] == old_regions.slot_owners[idx]);
         }
@@ -2123,10 +2120,10 @@ proof fn step_map<'rcu>(
     assert forall|fid_other: FrameId| #[trigger]
         s.frames.dom().contains(fid_other) implies s.regions.slot_owners[frame_to_index(
         s.frames[fid_other].paddr,
-    )].usage == PageUsage::Frame by {
+    )].usage is Frame by {
         let other_idx = frame_to_index(s.frames[fid_other].paddr);
         // pre: usage == Frame from old structural_inv.
-        assert(old_regions.slot_owners[other_idx].usage == PageUsage::Frame);
+        assert(old_regions.slot_owners[other_idx].usage is Frame);
         if other_idx == target_idx {
             // Cursor preserves usage at target_idx.
             assert(s.regions.slot_owners[target_idx].usage
@@ -2157,12 +2154,11 @@ proof fn step_map<'rcu>(
             frame_to_index(paddr_c)]
         s.segments.dom().contains(sid) && s.segments[sid].range.start <= paddr_c
             < s.segments[sid].range.end && paddr_c % PAGE_SIZE
-            == 0 implies s.regions.slot_owners[frame_to_index(paddr_c)].usage
-        == PageUsage::Frame by {
+            == 0 implies s.regions.slot_owners[frame_to_index(paddr_c)].usage is Frame by {
         let cov_idx = frame_to_index(paddr_c);
         // pre cover >= 1 at cov_idx ⟹ pre slot is Frame + non-UNUSED.
         lemma_segment_cover_contains(old_regions_segments_helper(s), sid, paddr_c);
-        assert(old_regions.slot_owners[cov_idx].usage == PageUsage::Frame);
+        assert(old_regions.slot_owners[cov_idx].usage is Frame);
         assert(old_regions.slot_owners[cov_idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED);
         if cov_idx == target_idx {
             // Map preserves usage at target.
@@ -2239,7 +2235,7 @@ proof fn step_unmap<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId, len: usize
                 assert(pa % PAGE_SIZE == 0);
                 assert(frame_to_index(pa) == idx);
                 // structural `covered ⟹ Frame` at the witness (old state).
-                assert(old_regions.slot_owners[idx].usage == PageUsage::Frame);
+                assert(old_regions.slot_owners[idx].usage is Frame);
                 // active head (cover > 0 ∧ Frame) ⟹ pre rc != UNUSED, <= MAX.
                 assert(old_regions.slot_owners[idx].inner_perms.ref_count.value()
                     != REF_COUNT_UNUSED);
@@ -2249,7 +2245,7 @@ proof fn step_unmap<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId, len: usize
             }
         };
         // Case-split on pre.usage: usage is preserved by the axiom.
-        if old_regions.slot_owners[idx].usage == PageUsage::Frame {
+        if old_regions.slot_owners[idx].usage is Frame {
             // Post.paths empty: Frame ∧ post UNUSED + MetaSlotOwner::inv
             // (UNUSED ∧ non-MMIO ⟹ paths empty).
             assert(s.regions.slot_owners[idx].usage != PageUsage::MMIO);
@@ -2279,7 +2275,7 @@ proof fn step_unmap<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId, len: usize
                     // in the non-Frame branch — contradiction.
                     assert(s.frames.dom().contains(fid));
                     assert(frame_to_index(s.frames[fid].paddr) == idx);
-                    assert(s.regions.slot_owners[idx].usage == PageUsage::Frame);
+                    assert(s.regions.slot_owners[idx].usage is Frame);
                 };
                 assert(filt == Set::empty());
             };
@@ -2287,7 +2283,7 @@ proof fn step_unmap<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId, len: usize
     };
     assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
             && s.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
             && s.regions.slot_owners[idx].inner_perms.ref_count.value()
             != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
@@ -2335,9 +2331,10 @@ proof fn step_unmap<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId, len: usize
     };
     assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame && (
-        handle_count(s.frames, idx) > 0 || s.regions.slot_owners[idx].paths_in_pt.len()
-            > 0) implies {
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame && (handle_count(
+            s.frames,
+            idx,
+        ) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0) implies {
         let so = s.regions.slot_owners[idx];
         let rc = so.inner_perms.ref_count.value();
         &&& rc != REF_COUNT_UNUSED
@@ -2385,7 +2382,7 @@ proof fn step_unmap<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId, len: usize
     assert forall|fid_other: FrameId| #[trigger]
         s.frames.dom().contains(fid_other) implies s.regions.slot_owners[frame_to_index(
         s.frames[fid_other].paddr,
-    )].usage == PageUsage::Frame by {
+    )].usage is Frame by {
         let other_idx = frame_to_index(s.frames[fid_other].paddr);
         assert(s.regions.slot_owners[other_idx].usage == old_regions.slot_owners[other_idx].usage);
     };
@@ -2397,7 +2394,7 @@ proof fn step_unmap<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId, len: usize
     // == UNIQUE`; `usage` / `in_list` are preserved universally.
     assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
         let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
-        &&& so.usage == PageUsage::Frame
+        &&& so.usage is Frame
         &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
         &&& so.inner_perms.in_list.value() == 0
         &&& so.paths_in_pt.is_empty()
@@ -2405,7 +2402,7 @@ proof fn step_unmap<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId, len: usize
         let u_idx = frame_to_index(s.unique_frames[u].paddr);
         assert(old(s).unique_frames.dom().contains(u));
         // Old validity at `u`.
-        assert(old_regions.slot_owners[u_idx].usage == PageUsage::Frame);
+        assert(old_regions.slot_owners[u_idx].usage is Frame);
         assert(old_regions.slot_owners[u_idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
         assert(old_regions.slot_owners[u_idx].paths_in_pt.is_empty());
         assert(old_regions.slot_owners[u_idx].inner_perms.in_list.value() == 0);
@@ -2587,8 +2584,7 @@ proof fn step_frame_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, paddr: Padd
                 // active (H=1).
                 assert forall|idx: int|
                     #![trigger s.regions.slot_owners[idx]]
-                    0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage
-                        == PageUsage::Frame
+                    0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
                         && s.regions.slot_owners[idx].inner_perms.ref_count.value()
                         != REF_COUNT_UNUSED
                         && s.regions.slot_owners[idx].inner_perms.ref_count.value()
@@ -2608,12 +2604,9 @@ proof fn step_frame_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, paddr: Padd
                 // Per-slot accounting (forall covers active heads only).
                 assert forall|idx: int|
                     #![trigger s.regions.slot_owners[idx]]
-                    0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage
-                        == PageUsage::Frame && (handle_count(s.frames, idx) > 0
-                        || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
-                        s.segments,
-                        index_to_frame(idx),
-                    ) > 0) implies {
+                    0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame && (
+                    handle_count(s.frames, idx) > 0 || s.regions.slot_owners[idx].paths_in_pt.len()
+                        > 0 || segment_cover_count(s.segments, index_to_frame(idx)) > 0) implies {
                     let so = s.regions.slot_owners[idx];
                     let rc = so.inner_perms.ref_count.value();
                     &&& rc != REF_COUNT_UNUSED
@@ -2688,8 +2681,7 @@ proof fn step_frame_from_in_use<'rcu>(tracked s: &mut VmStore<'rcu>, paddr: Padd
                 // target post: H = pre + 1 ≥ 1 → active. For other: unchanged.
                 assert forall|idx: int|
                     #![trigger s.regions.slot_owners[idx]]
-                    0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage
-                        == PageUsage::Frame
+                    0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
                         && s.regions.slot_owners[idx].inner_perms.ref_count.value()
                         != REF_COUNT_UNUSED
                         && s.regions.slot_owners[idx].inner_perms.ref_count.value()
@@ -2709,12 +2701,9 @@ proof fn step_frame_from_in_use<'rcu>(tracked s: &mut VmStore<'rcu>, paddr: Padd
                 // Per-slot accounting (forall covers active heads only).
                 assert forall|idx: int|
                     #![trigger s.regions.slot_owners[idx]]
-                    0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage
-                        == PageUsage::Frame && (handle_count(s.frames, idx) > 0
-                        || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
-                        s.segments,
-                        index_to_frame(idx),
-                    ) > 0) implies {
+                    0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame && (
+                    handle_count(s.frames, idx) > 0 || s.regions.slot_owners[idx].paths_in_pt.len()
+                        > 0 || segment_cover_count(s.segments, index_to_frame(idx)) > 0) implies {
                     let so = s.regions.slot_owners[idx];
                     let rc = so.inner_perms.ref_count.value();
                     &&& rc != REF_COUNT_UNUSED
@@ -2728,7 +2717,7 @@ proof fn step_frame_from_in_use<'rcu>(tracked s: &mut VmStore<'rcu>, paddr: Padd
                         // Pre usage(target)==Frame: `get_from_in_use`
                         // preserves `usage`. Pre active-head fires from
                         // pre H >= 1 (or pre paths > 0, or pre cover > 0).
-                        assert(old_regions.slot_owners[idx].usage == PageUsage::Frame);
+                        assert(old_regions.slot_owners[idx].usage is Frame);
                     } else {
                         assert(s.regions.slot_owners[idx] == old_regions.slot_owners[idx]);
                     }
@@ -2810,7 +2799,7 @@ proof fn step_frame_drop<'rcu>(tracked s: &mut VmStore<'rcu>, fid: FrameId)
     // so pre P=pre rc-1 >= 1 (rc>1), post P >= 1, active. ✓
     assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
             && s.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
             && s.regions.slot_owners[idx].inner_perms.ref_count.value()
             != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
@@ -2832,9 +2821,13 @@ proof fn step_frame_drop<'rcu>(tracked s: &mut VmStore<'rcu>, fid: FrameId)
 
     assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame && (
-        handle_count(s.frames, idx) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0
-            || segment_cover_count(s.segments, index_to_frame(idx)) > 0) implies {
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame && (handle_count(
+            s.frames,
+            idx,
+        ) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
+            s.segments,
+            index_to_frame(idx),
+        ) > 0) implies {
         let so = s.regions.slot_owners[idx];
         let rc = so.inner_perms.ref_count.value();
         &&& rc != REF_COUNT_UNUSED
@@ -2850,7 +2843,7 @@ proof fn step_frame_drop<'rcu>(tracked s: &mut VmStore<'rcu>, fid: FrameId)
             // Pre fid contributes ⇒ pre H >= 1 ⇒ pre active head.
             // Pre `usage == Frame`: `drop_step` preserves `usage`,
             // and the clause antecedent gives post `usage == Frame`.
-            assert(old_regions.slot_owners[idx].usage == PageUsage::Frame);
+            assert(old_regions.slot_owners[idx].usage is Frame);
             assert(handle_count(old_frames, idx) > 0);
             let ghost pre_rc = old_regions.slot_owners[idx].inner_perms.ref_count.value();
             let ghost pre_h = handle_count(old_frames, idx);
@@ -2973,8 +2966,7 @@ proof fn step_segment_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, range: Ra
                 };
                 assert forall|idx: int|
                     #![trigger s.regions.slot_owners[idx]]
-                    0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage
-                        == PageUsage::Frame
+                    0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
                         && s.regions.slot_owners[idx].inner_perms.ref_count.value()
                         != REF_COUNT_UNUSED
                         && s.regions.slot_owners[idx].inner_perms.ref_count.value()
@@ -2998,12 +2990,9 @@ proof fn step_segment_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, range: Ra
                 };
                 assert forall|idx: int|
                     #![trigger s.regions.slot_owners[idx]]
-                    0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage
-                        == PageUsage::Frame && (handle_count(s.frames, idx) > 0
-                        || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
-                        s.segments,
-                        index_to_frame(idx),
-                    ) > 0) implies {
+                    0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame && (
+                    handle_count(s.frames, idx) > 0 || s.regions.slot_owners[idx].paths_in_pt.len()
+                        > 0 || segment_cover_count(s.segments, index_to_frame(idx)) > 0) implies {
                     let so = s.regions.slot_owners[idx];
                     let rc = so.inner_perms.ref_count.value();
                     &&& rc != REF_COUNT_UNUSED
@@ -3051,11 +3040,11 @@ proof fn step_segment_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, range: Ra
                 assert forall|fid_other: FrameId| #[trigger]
                     s.frames.dom().contains(fid_other) implies s.regions.slot_owners[frame_to_index(
                     s.frames[fid_other].paddr,
-                )].usage == PageUsage::Frame by {
+                )].usage is Frame by {
                     let other_idx = frame_to_index(s.frames[fid_other].paddr);
                     let other_paddr = index_to_frame(other_idx);
                     // pre fid_other's slot usage == Frame from old structural.
-                    assert(old_regions.slot_owners[other_idx].usage == PageUsage::Frame);
+                    assert(old_regions.slot_owners[other_idx].usage is Frame);
                     // pre rc != UNUSED at fid_other's slot (clause 4 + H>=1).
                     assert(old_frames.dom().filter(
                         |gid: FrameId| frame_to_index(old_frames[gid].paddr) == other_idx,
@@ -3074,7 +3063,7 @@ proof fn step_segment_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, range: Ra
                 // (all-UNUSED) and the axiom preserves it fully.
                 assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
                     let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
-                    &&& so.usage == PageUsage::Frame
+                    &&& so.usage is Frame
                     &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
                     &&& so.inner_perms.in_list.value() == 0
                     &&& so.paths_in_pt.is_empty()
@@ -3121,14 +3110,14 @@ proof fn step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
         let so = old_regions.slot_owners[frame_to_index(paddr)];
         &&& so.inner_perms.ref_count.value() >= 1
         &&& so.inner_perms.ref_count.value() <= REF_COUNT_MAX
-        &&& so.usage == PageUsage::Frame
+        &&& so.usage is Frame
         &&& so.inner_perms.ref_count.value() == 1 ==> so.paths_in_pt.is_empty()
     } by {
         let idx = frame_to_index(paddr);
         // Cover >= 1 at paddr (this segment covers it).
         lemma_segment_cover_contains(old_segments, sid, paddr);
         // Usage == Frame from structural segment-covered ⟹ Frame clause.
-        assert(old_regions.slot_owners[idx].usage == PageUsage::Frame);
+        assert(old_regions.slot_owners[idx].usage is Frame);
         // Accounting clause 4: active head (cover > 0) ⟹ rc != UNUSED,
         // rc != UNIQUE, rc == H + P + cover, storage init.
         let so = old_regions.slot_owners[idx];
@@ -3224,7 +3213,7 @@ proof fn step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
     };
     assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
             && s.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
             && s.regions.slot_owners[idx].inner_perms.ref_count.value()
             != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
@@ -3251,9 +3240,13 @@ proof fn step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
     };
     assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame && (
-        handle_count(s.frames, idx) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0
-            || segment_cover_count(s.segments, index_to_frame(idx)) > 0) implies {
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame && (handle_count(
+            s.frames,
+            idx,
+        ) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
+            s.segments,
+            index_to_frame(idx),
+        ) > 0) implies {
         let so = s.regions.slot_owners[idx];
         let rc = so.inner_perms.ref_count.value();
         &&& rc != REF_COUNT_UNUSED
@@ -3308,11 +3301,11 @@ proof fn step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
     assert forall|fid_other: FrameId| #[trigger]
         s.frames.dom().contains(fid_other) implies s.regions.slot_owners[frame_to_index(
         s.frames[fid_other].paddr,
-    )].usage == PageUsage::Frame by {
+    )].usage is Frame by {
         let other_idx = frame_to_index(s.frames[fid_other].paddr);
         let other_paddr = index_to_frame(other_idx);
         // Pre fid_other's slot: usage == Frame (old structural).
-        assert(old_regions.slot_owners[other_idx].usage == PageUsage::Frame);
+        assert(old_regions.slot_owners[other_idx].usage is Frame);
         // Pre H >= 1 at other_idx (fid_other contributes).
         assert(old_frames.dom().filter(
             |gid: FrameId| frame_to_index(old_frames[gid].paddr) == other_idx,
@@ -3337,8 +3330,7 @@ proof fn step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
             frame_to_index(paddr_c)]
         s.segments.dom().contains(sid_other) && s.segments[sid_other].range.start <= paddr_c
             < s.segments[sid_other].range.end && paddr_c % PAGE_SIZE
-            == 0 implies s.regions.slot_owners[frame_to_index(paddr_c)].usage
-        == PageUsage::Frame by {
+            == 0 implies s.regions.slot_owners[frame_to_index(paddr_c)].usage is Frame by {
         let cov_idx = frame_to_index(paddr_c);
         // sid_other != sid (since sid was removed from s.segments).
         assert(sid_other != sid);
@@ -3346,7 +3338,7 @@ proof fn step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
         assert(old_segments.dom().contains(sid_other));
         assert(old_segments[sid_other] == s.segments[sid_other]);
         // Pre covered ⟹ pre Frame from old structural.
-        assert(old_regions.slot_owners[cov_idx].usage == PageUsage::Frame);
+        assert(old_regions.slot_owners[cov_idx].usage is Frame);
         // Axiom preserves usage universally.
     };
     // Discharge the structural unique-entry validity clause. A UNIQUE
@@ -3355,7 +3347,7 @@ proof fn step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
     // the dropped segment's range, and the teardown axiom preserves it.
     assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
         let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
-        &&& so.usage == PageUsage::Frame
+        &&& so.usage is Frame
         &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
         &&& so.inner_perms.in_list.value() == 0
         &&& so.paths_in_pt.is_empty()
@@ -3367,7 +3359,7 @@ proof fn step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
         s.regions.inv_implies_correct_addr(u_paddr);
         // Old UNIQUE validity at `u`.
         assert(old_regions.slot_owners[u_idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
-        assert(old_regions.slot_owners[u_idx].usage == PageUsage::Frame);
+        assert(old_regions.slot_owners[u_idx].usage is Frame);
         // UNIQUE ⟹ uncovered ⟹ not in the dropped segment's range.
         assert(!(range.start <= u_paddr < range.end)) by {
             if range.start <= u_paddr < range.end {
@@ -3458,8 +3450,7 @@ proof fn step_segment_split<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId,
             frame_to_index(paddr_c)]
         s.segments.dom().contains(sid_other) && s.segments[sid_other].range.start <= paddr_c
             < s.segments[sid_other].range.end && paddr_c % PAGE_SIZE
-            == 0 implies s.regions.slot_owners[frame_to_index(paddr_c)].usage
-        == PageUsage::Frame by {
+            == 0 implies s.regions.slot_owners[frame_to_index(paddr_c)].usage is Frame by {
         if sid_other == id_left {
             assert(old_segments.dom().contains(sid));
             assert(old_segments[sid].range.start <= paddr_c < old_segments[sid].range.end);
@@ -3498,7 +3489,7 @@ proof fn step_segment_split<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId,
     };
     assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
             && s.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
             && s.regions.slot_owners[idx].inner_perms.ref_count.value()
             != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
@@ -3521,9 +3512,13 @@ proof fn step_segment_split<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId,
     };
     assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame && (
-        handle_count(s.frames, idx) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0
-            || segment_cover_count(s.segments, index_to_frame(idx)) > 0) implies {
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame && (handle_count(
+            s.frames,
+            idx,
+        ) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
+            s.segments,
+            index_to_frame(idx),
+        ) > 0) implies {
         let so = s.regions.slot_owners[idx];
         let rc = so.inner_perms.ref_count.value();
         &&& rc != REF_COUNT_UNUSED
@@ -3598,7 +3593,7 @@ proof fn step_segment_next<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
     // Establish facts about the popped slot from `s.inv()`.
     lemma_segment_cover_contains(old_segments, sid, paddr);
     assert(segment_cover_count(old_segments, paddr) >= 1);
-    assert(old_regions.slot_owners[target_idx].usage == PageUsage::Frame);
+    assert(old_regions.slot_owners[target_idx].usage is Frame);
     let ghost so_pre = old_regions.slot_owners[target_idx];
     let ghost pre_rc = so_pre.inner_perms.ref_count.value();
     let ghost pre_H = handle_count(old_frames, target_idx);
@@ -3685,7 +3680,7 @@ proof fn step_segment_next<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
     assert forall|fid_other: FrameId| #[trigger]
         s.frames.dom().contains(fid_other) implies s.regions.slot_owners[frame_to_index(
         s.frames[fid_other].paddr,
-    )].usage == PageUsage::Frame by {
+    )].usage is Frame by {
         let other_idx = frame_to_index(s.frames[fid_other].paddr);
         if fid_other == fid {
             assert(s.frames[fid_other].paddr == paddr);
@@ -3693,7 +3688,7 @@ proof fn step_segment_next<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
         } else {
             assert(old_frames.dom().contains(fid_other));
             assert(s.frames[fid_other] == old_frames[fid_other]);
-            assert(old_regions.slot_owners[other_idx].usage == PageUsage::Frame);
+            assert(old_regions.slot_owners[other_idx].usage is Frame);
         }
     };
     // Structural segment-covered ⟹ Frame-usage.
@@ -3703,18 +3698,17 @@ proof fn step_segment_next<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
             frame_to_index(paddr_c)]
         s.segments.dom().contains(sid_other) && s.segments[sid_other].range.start <= paddr_c
             < s.segments[sid_other].range.end && paddr_c % PAGE_SIZE
-            == 0 implies s.regions.slot_owners[frame_to_index(paddr_c)].usage
-        == PageUsage::Frame by {
+            == 0 implies s.regions.slot_owners[frame_to_index(paddr_c)].usage is Frame by {
         let cov_idx = frame_to_index(paddr_c);
         if !will_become_empty && sid_other == sid {
             // Covered paddr in new_range ⊆ original range.
             assert(old_segments.dom().contains(sid));
-            assert(old_regions.slot_owners[cov_idx].usage == PageUsage::Frame);
+            assert(old_regions.slot_owners[cov_idx].usage is Frame);
         } else {
             assert(sid_other != sid);
             assert(old_segments.dom().contains(sid_other));
             assert(old_segments[sid_other] == s.segments[sid_other]);
-            assert(old_regions.slot_owners[cov_idx].usage == PageUsage::Frame);
+            assert(old_regions.slot_owners[cov_idx].usage is Frame);
         }
     };
     // Segment range well-formedness for the re-inserted entry (if any).
@@ -3745,7 +3739,7 @@ proof fn step_segment_next<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
     };
     assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
             && s.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
             && s.regions.slot_owners[idx].inner_perms.ref_count.value()
             != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
@@ -3766,9 +3760,13 @@ proof fn step_segment_next<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
     };
     assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame && (
-        handle_count(s.frames, idx) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0
-            || segment_cover_count(s.segments, index_to_frame(idx)) > 0) implies {
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame && (handle_count(
+            s.frames,
+            idx,
+        ) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
+            s.segments,
+            index_to_frame(idx),
+        ) > 0) implies {
         let so = s.regions.slot_owners[idx];
         let rc = so.inner_perms.ref_count.value();
         &&& rc != REF_COUNT_UNUSED
@@ -3797,7 +3795,7 @@ proof fn step_segment_next<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
     // (covered) front slot `target_idx`, so the pop axiom preserves it.
     assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
         let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
-        &&& so.usage == PageUsage::Frame
+        &&& so.usage is Frame
         &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
         &&& so.inner_perms.in_list.value() == 0
         &&& so.paths_in_pt.is_empty()
@@ -3808,7 +3806,7 @@ proof fn step_segment_next<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
         assert(has_safe_slot(u_paddr));
         s.regions.inv_implies_correct_addr(u_paddr);
         assert(old_regions.slot_owners[u_idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
-        assert(old_regions.slot_owners[u_idx].usage == PageUsage::Frame);
+        assert(old_regions.slot_owners[u_idx].usage is Frame);
         // The popped front slot is covered ⟹ rc != UNIQUE ⟹ != u_idx.
         assert(u_idx != target_idx) by {
             lemma_segment_cover_contains(old_segments, sid, paddr);
@@ -3861,7 +3859,7 @@ proof fn step_segment_clone_range<'rcu>(
         #![trigger frame_to_index(paddr)]
         (sub_range.start <= paddr < sub_range.end && paddr % PAGE_SIZE == 0) implies {
         let so = old_regions.slot_owners[frame_to_index(paddr)];
-        &&& so.usage == PageUsage::Frame
+        &&& so.usage is Frame
         &&& so.inner_perms.ref_count.value() >= 1
         &&& so.inner_perms.ref_count.value() + 1 <= REF_COUNT_MAX
     } by {
@@ -3937,19 +3935,18 @@ proof fn step_segment_clone_range<'rcu>(
             frame_to_index(paddr_c)]
         s.segments.dom().contains(sid_other) && s.segments[sid_other].range.start <= paddr_c
             < s.segments[sid_other].range.end && paddr_c % PAGE_SIZE
-            == 0 implies s.regions.slot_owners[frame_to_index(paddr_c)].usage
-        == PageUsage::Frame by {
+            == 0 implies s.regions.slot_owners[frame_to_index(paddr_c)].usage is Frame by {
         let cov_idx = frame_to_index(paddr_c);
         if sid_other == sid2 {
             // Covered by the new entry ⟹ in sub_range ⊆ sid's range.
             assert(s.segments[sid2].range == sub_range);
             assert(old_segments.dom().contains(sid));
             assert(sid_range.start <= paddr_c < sid_range.end);
-            assert(old_regions.slot_owners[cov_idx].usage == PageUsage::Frame);
+            assert(old_regions.slot_owners[cov_idx].usage is Frame);
         } else {
             assert(old_segments.dom().contains(sid_other));
             assert(old_segments[sid_other] == s.segments[sid_other]);
-            assert(old_regions.slot_owners[cov_idx].usage == PageUsage::Frame);
+            assert(old_regions.slot_owners[cov_idx].usage is Frame);
         }
         // `cov_0 <= idx < max_meta_slots()` via `inv_implies_correct_addr`
         // (`slot_owners.contains_key`) + `MetaRegionOwners::inv`'s
@@ -3964,10 +3961,10 @@ proof fn step_segment_clone_range<'rcu>(
     assert forall|fid_other: FrameId| #[trigger]
         s.frames.dom().contains(fid_other) implies s.regions.slot_owners[frame_to_index(
         s.frames[fid_other].paddr,
-    )].usage == PageUsage::Frame by {
+    )].usage is Frame by {
         let other_idx = frame_to_index(s.frames[fid_other].paddr);
         assert(old_frames.dom().contains(fid_other));
-        assert(old_regions.slot_owners[other_idx].usage == PageUsage::Frame);
+        assert(old_regions.slot_owners[other_idx].usage is Frame);
         assert(has_safe_slot(s.frames[fid_other].paddr));
         s.regions.inv_implies_correct_addr(s.frames[fid_other].paddr);
         assert(s.regions.slot_owners.contains_key(other_idx));
@@ -3997,7 +3994,7 @@ proof fn step_segment_clone_range<'rcu>(
     // --- accounting clause 2: valid rc ⟹ active head ---
     assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
             && s.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
             && s.regions.slot_owners[idx].inner_perms.ref_count.value()
             != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
@@ -4017,9 +4014,13 @@ proof fn step_segment_clone_range<'rcu>(
     // --- accounting clause 3: the rc equation ---
     assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame && (
-        handle_count(s.frames, idx) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0
-            || segment_cover_count(s.segments, index_to_frame(idx)) > 0) implies {
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame && (handle_count(
+            s.frames,
+            idx,
+        ) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
+            s.segments,
+            index_to_frame(idx),
+        ) > 0) implies {
         let so = s.regions.slot_owners[idx];
         let rc = so.inner_perms.ref_count.value();
         &&& rc != REF_COUNT_UNUSED
@@ -4046,7 +4047,7 @@ proof fn step_segment_clone_range<'rcu>(
     // range), so `segment_clone_embedded` preserves it fully.
     assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
         let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
-        &&& so.usage == PageUsage::Frame
+        &&& so.usage is Frame
         &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
         &&& so.inner_perms.in_list.value() == 0
         &&& so.paths_in_pt.is_empty()
@@ -4057,7 +4058,7 @@ proof fn step_segment_clone_range<'rcu>(
         assert(has_safe_slot(u_paddr));
         s.regions.inv_implies_correct_addr(u_paddr);
         assert(old_regions.slot_owners[u_idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
-        assert(old_regions.slot_owners[u_idx].usage == PageUsage::Frame);
+        assert(old_regions.slot_owners[u_idx].usage is Frame);
         assert(!(sub_range.start <= u_paddr < sub_range.end)) by {
             if sub_range.start <= u_paddr < sub_range.end {
                 // u_paddr ∈ sub_range ⊆ sid_range ⟹ sid covers u_paddr.
@@ -4177,10 +4178,10 @@ proof fn step_unique_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, paddr: Pad
         assert forall|fid: FrameId| #[trigger]
             s.frames.dom().contains(fid) implies s.regions.slot_owners[frame_to_index(
             s.frames[fid].paddr,
-        )].usage == PageUsage::Frame by {
+        )].usage is Frame by {
             let other_idx = frame_to_index(s.frames[fid].paddr);
             assert(old_frames.dom().contains(fid));
-            assert(old_regions.slot_owners[other_idx].usage == PageUsage::Frame);
+            assert(old_regions.slot_owners[other_idx].usage is Frame);
             if other_idx == idx {
                 // Pre `idx` was `Unused`-usage — no `FrameEntry` maps there.
                 assert(false);
@@ -4191,11 +4192,10 @@ proof fn step_unique_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, paddr: Pad
             #![trigger s.segments.dom().contains(sid), frame_to_index(paddr_c)]
             s.segments.dom().contains(sid) && s.segments[sid].range.start <= paddr_c
                 < s.segments[sid].range.end && paddr_c % PAGE_SIZE
-                == 0 implies s.regions.slot_owners[frame_to_index(paddr_c)].usage
-            == PageUsage::Frame by {
+                == 0 implies s.regions.slot_owners[frame_to_index(paddr_c)].usage is Frame by {
             let cov_idx = frame_to_index(paddr_c);
             assert(old_segments.dom().contains(sid));
-            assert(old_regions.slot_owners[cov_idx].usage == PageUsage::Frame);
+            assert(old_regions.slot_owners[cov_idx].usage is Frame);
             if cov_idx == idx {
                 assert(false);
             }
@@ -4203,7 +4203,7 @@ proof fn step_unique_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, paddr: Pad
         // --- structural: unique-entry validity ---
         assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
             let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
-            &&& so.usage == PageUsage::Frame
+            &&& so.usage is Frame
             &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
             &&& so.inner_perms.in_list.value() == 0
             &&& so.paths_in_pt.is_empty()
@@ -4272,7 +4272,7 @@ proof fn step_unique_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, paddr: Pad
         // --- accounting clause 2: valid rc ⟹ active head ---
         assert forall|i: int|
             #![trigger s.regions.slot_owners[i]]
-            0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame
+            0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage is Frame
                 && s.regions.slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
                 && s.regions.slot_owners[i].inner_perms.ref_count.value()
                 != REF_COUNT_UNIQUE implies handle_count(s.frames, i) > 0
@@ -4290,9 +4290,13 @@ proof fn step_unique_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, paddr: Pad
         // --- accounting clause 3: the rc equation ---
         assert forall|i: int|
             #![trigger s.regions.slot_owners[i]]
-            0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame && (
-            handle_count(s.frames, i) > 0 || s.regions.slot_owners[i].paths_in_pt.len() > 0
-                || segment_cover_count(s.segments, index_to_frame(i)) > 0) implies {
+            0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage is Frame && (handle_count(
+                s.frames,
+                i,
+            ) > 0 || s.regions.slot_owners[i].paths_in_pt.len() > 0 || segment_cover_count(
+                s.segments,
+                index_to_frame(i),
+            ) > 0) implies {
             let so = s.regions.slot_owners[i];
             let rc = so.inner_perms.ref_count.value();
             &&& rc != REF_COUNT_UNUSED
@@ -4343,7 +4347,7 @@ proof fn step_unique_drop<'rcu>(tracked s: &mut VmStore<'rcu>, uid: UniqueId)
     s.regions.inv_implies_correct_addr(paddr);
     assert(s.regions.slot_owners.contains_key(idx));
     assert(index_to_frame(idx) == paddr);
-    assert(s.regions.slot_owners[idx].usage == PageUsage::Frame);
+    assert(s.regions.slot_owners[idx].usage is Frame);
     assert(s.regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
     assert(s.regions.slot_owners[idx].inner_perms.in_list.value() == 0);
     assert(s.regions.slot_owners[idx].paths_in_pt.is_empty());
@@ -4385,10 +4389,10 @@ proof fn step_unique_drop<'rcu>(tracked s: &mut VmStore<'rcu>, uid: UniqueId)
     assert forall|fid: FrameId| #[trigger]
         s.frames.dom().contains(fid) implies s.regions.slot_owners[frame_to_index(
         s.frames[fid].paddr,
-    )].usage == PageUsage::Frame by {
+    )].usage is Frame by {
         let other_idx = frame_to_index(s.frames[fid].paddr);
         assert(old_frames.dom().contains(fid));
-        assert(old_regions.slot_owners[other_idx].usage == PageUsage::Frame);
+        assert(old_regions.slot_owners[other_idx].usage is Frame);
         if other_idx != idx {
             assert(s.regions.slot_owners[other_idx] == old_regions.slot_owners[other_idx]);
         }
@@ -4398,11 +4402,10 @@ proof fn step_unique_drop<'rcu>(tracked s: &mut VmStore<'rcu>, uid: UniqueId)
         #![trigger s.segments.dom().contains(sid), frame_to_index(paddr_c)]
         s.segments.dom().contains(sid) && s.segments[sid].range.start <= paddr_c
             < s.segments[sid].range.end && paddr_c % PAGE_SIZE
-            == 0 implies s.regions.slot_owners[frame_to_index(paddr_c)].usage
-        == PageUsage::Frame by {
+            == 0 implies s.regions.slot_owners[frame_to_index(paddr_c)].usage is Frame by {
         let cov_idx = frame_to_index(paddr_c);
         assert(old_segments.dom().contains(sid));
-        assert(old_regions.slot_owners[cov_idx].usage == PageUsage::Frame);
+        assert(old_regions.slot_owners[cov_idx].usage is Frame);
         if cov_idx != idx {
             assert(s.regions.slot_owners[cov_idx] == old_regions.slot_owners[cov_idx]);
         }
@@ -4410,7 +4413,7 @@ proof fn step_unique_drop<'rcu>(tracked s: &mut VmStore<'rcu>, uid: UniqueId)
     // --- structural: unique-entry validity (remaining entries) ---
     assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
         let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
-        &&& so.usage == PageUsage::Frame
+        &&& so.usage is Frame
         &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
         &&& so.inner_perms.in_list.value() == 0
         &&& so.paths_in_pt.is_empty()
@@ -4464,7 +4467,7 @@ proof fn step_unique_drop<'rcu>(tracked s: &mut VmStore<'rcu>, uid: UniqueId)
     // --- accounting clause 2: valid rc ⟹ active head ---
     assert forall|i: int|
         #![trigger s.regions.slot_owners[i]]
-        0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame
+        0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage is Frame
             && s.regions.slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
             && s.regions.slot_owners[i].inner_perms.ref_count.value()
             != REF_COUNT_UNIQUE implies handle_count(s.frames, i) > 0
@@ -4482,9 +4485,13 @@ proof fn step_unique_drop<'rcu>(tracked s: &mut VmStore<'rcu>, uid: UniqueId)
     // --- accounting clause 3: the rc equation ---
     assert forall|i: int|
         #![trigger s.regions.slot_owners[i]]
-        0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame && (
-        handle_count(s.frames, i) > 0 || s.regions.slot_owners[i].paths_in_pt.len() > 0
-            || segment_cover_count(s.segments, index_to_frame(i)) > 0) implies {
+        0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage is Frame && (handle_count(
+            s.frames,
+            i,
+        ) > 0 || s.regions.slot_owners[i].paths_in_pt.len() > 0 || segment_cover_count(
+            s.segments,
+            index_to_frame(i),
+        ) > 0) implies {
         let so = s.regions.slot_owners[i];
         let rc = so.inner_perms.ref_count.value();
         &&& rc != REF_COUNT_UNUSED
@@ -4530,7 +4537,7 @@ proof fn step_from_unique<'rcu>(tracked s: &mut VmStore<'rcu>, uid: UniqueId)
     s.regions.inv_implies_correct_addr(paddr);
     assert(s.regions.slot_owners.contains_key(idx));
     assert(index_to_frame(idx) == paddr);
-    assert(s.regions.slot_owners[idx].usage == PageUsage::Frame);
+    assert(s.regions.slot_owners[idx].usage is Frame);
     assert(s.regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
     assert(s.regions.slot_owners[idx].paths_in_pt.is_empty());
     assert(s.regions.slot_owners[idx].inner_perms.storage.is_init());
@@ -4576,7 +4583,7 @@ proof fn step_from_unique<'rcu>(tracked s: &mut VmStore<'rcu>, uid: UniqueId)
     assert forall|fid_other: FrameId| #[trigger]
         s.frames.dom().contains(fid_other) implies s.regions.slot_owners[frame_to_index(
         s.frames[fid_other].paddr,
-    )].usage == PageUsage::Frame by {
+    )].usage is Frame by {
         let other_idx = frame_to_index(s.frames[fid_other].paddr);
         if fid_other == fid {
             assert(s.frames[fid_other].paddr == paddr);
@@ -4584,7 +4591,7 @@ proof fn step_from_unique<'rcu>(tracked s: &mut VmStore<'rcu>, uid: UniqueId)
         } else {
             assert(old_frames.dom().contains(fid_other));
             assert(s.frames[fid_other] == old_frames[fid_other]);
-            assert(old_regions.slot_owners[other_idx].usage == PageUsage::Frame);
+            assert(old_regions.slot_owners[other_idx].usage is Frame);
             if other_idx != idx {
                 assert(s.regions.slot_owners[other_idx] == old_regions.slot_owners[other_idx]);
             }
@@ -4595,11 +4602,10 @@ proof fn step_from_unique<'rcu>(tracked s: &mut VmStore<'rcu>, uid: UniqueId)
         #![trigger s.segments.dom().contains(sid), frame_to_index(paddr_c)]
         s.segments.dom().contains(sid) && s.segments[sid].range.start <= paddr_c
             < s.segments[sid].range.end && paddr_c % PAGE_SIZE
-            == 0 implies s.regions.slot_owners[frame_to_index(paddr_c)].usage
-        == PageUsage::Frame by {
+            == 0 implies s.regions.slot_owners[frame_to_index(paddr_c)].usage is Frame by {
         let cov_idx = frame_to_index(paddr_c);
         assert(old_segments.dom().contains(sid));
-        assert(old_regions.slot_owners[cov_idx].usage == PageUsage::Frame);
+        assert(old_regions.slot_owners[cov_idx].usage is Frame);
         if cov_idx != idx {
             assert(s.regions.slot_owners[cov_idx] == old_regions.slot_owners[cov_idx]);
         }
@@ -4607,7 +4613,7 @@ proof fn step_from_unique<'rcu>(tracked s: &mut VmStore<'rcu>, uid: UniqueId)
     // --- structural: unique-entry validity (remaining entries) ---
     assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
         let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
-        &&& so.usage == PageUsage::Frame
+        &&& so.usage is Frame
         &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
         &&& so.inner_perms.in_list.value() == 0
         &&& so.paths_in_pt.is_empty()
@@ -4654,7 +4660,7 @@ proof fn step_from_unique<'rcu>(tracked s: &mut VmStore<'rcu>, uid: UniqueId)
     // --- accounting clause 2: valid rc ⟹ active head ---
     assert forall|i: int|
         #![trigger s.regions.slot_owners[i]]
-        0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame
+        0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage is Frame
             && s.regions.slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
             && s.regions.slot_owners[i].inner_perms.ref_count.value()
             != REF_COUNT_UNIQUE implies handle_count(s.frames, i) > 0
@@ -4672,9 +4678,13 @@ proof fn step_from_unique<'rcu>(tracked s: &mut VmStore<'rcu>, uid: UniqueId)
     // --- accounting clause 3: the rc equation ---
     assert forall|i: int|
         #![trigger s.regions.slot_owners[i]]
-        0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame && (
-        handle_count(s.frames, i) > 0 || s.regions.slot_owners[i].paths_in_pt.len() > 0
-            || segment_cover_count(s.segments, index_to_frame(i)) > 0) implies {
+        0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage is Frame && (handle_count(
+            s.frames,
+            i,
+        ) > 0 || s.regions.slot_owners[i].paths_in_pt.len() > 0 || segment_cover_count(
+            s.segments,
+            index_to_frame(i),
+        ) > 0) implies {
         let so = s.regions.slot_owners[i];
         let rc = so.inner_perms.ref_count.value();
         &&& rc != REF_COUNT_UNUSED
@@ -4719,7 +4729,7 @@ proof fn step_try_from_shared<'rcu>(tracked s: &mut VmStore<'rcu>, fid: FrameId)
     s.regions.inv_implies_correct_addr(paddr);
     assert(s.regions.slot_owners.contains_key(idx));
     assert(index_to_frame(idx) == paddr);
-    assert(s.regions.slot_owners[idx].usage == PageUsage::Frame);
+    assert(s.regions.slot_owners[idx].usage is Frame);
     assert(s.frames.dom().filter(
         |gid: FrameId| frame_to_index(s.frames[gid].paddr) == idx,
     ).contains(fid));
@@ -4770,10 +4780,10 @@ proof fn step_try_from_shared<'rcu>(tracked s: &mut VmStore<'rcu>, fid: FrameId)
         assert forall|fid_other: FrameId| #[trigger]
             s.frames.dom().contains(fid_other) implies s.regions.slot_owners[frame_to_index(
             s.frames[fid_other].paddr,
-        )].usage == PageUsage::Frame by {
+        )].usage is Frame by {
             let other_idx = frame_to_index(s.frames[fid_other].paddr);
             assert(old_frames.dom().contains(fid_other));
-            assert(old_regions.slot_owners[other_idx].usage == PageUsage::Frame);
+            assert(old_regions.slot_owners[other_idx].usage is Frame);
             if other_idx != idx {
                 assert(s.regions.slot_owners[other_idx] == old_regions.slot_owners[other_idx]);
             }
@@ -4783,11 +4793,10 @@ proof fn step_try_from_shared<'rcu>(tracked s: &mut VmStore<'rcu>, fid: FrameId)
             #![trigger s.segments.dom().contains(sid), frame_to_index(paddr_c)]
             s.segments.dom().contains(sid) && s.segments[sid].range.start <= paddr_c
                 < s.segments[sid].range.end && paddr_c % PAGE_SIZE
-                == 0 implies s.regions.slot_owners[frame_to_index(paddr_c)].usage
-            == PageUsage::Frame by {
+                == 0 implies s.regions.slot_owners[frame_to_index(paddr_c)].usage is Frame by {
             let cov_idx = frame_to_index(paddr_c);
             assert(old_segments.dom().contains(sid));
-            assert(old_regions.slot_owners[cov_idx].usage == PageUsage::Frame);
+            assert(old_regions.slot_owners[cov_idx].usage is Frame);
             if cov_idx != idx {
                 assert(s.regions.slot_owners[cov_idx] == old_regions.slot_owners[cov_idx]);
             }
@@ -4795,7 +4804,7 @@ proof fn step_try_from_shared<'rcu>(tracked s: &mut VmStore<'rcu>, fid: FrameId)
         // --- structural: unique-entry validity ---
         assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
             let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
-            &&& so.usage == PageUsage::Frame
+            &&& so.usage is Frame
             &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
             &&& so.inner_perms.in_list.value() == 0
             &&& so.paths_in_pt.is_empty()
@@ -4864,7 +4873,7 @@ proof fn step_try_from_shared<'rcu>(tracked s: &mut VmStore<'rcu>, fid: FrameId)
         // --- accounting clause 2: valid rc ⟹ active head ---
         assert forall|i: int|
             #![trigger s.regions.slot_owners[i]]
-            0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame
+            0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage is Frame
                 && s.regions.slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
                 && s.regions.slot_owners[i].inner_perms.ref_count.value()
                 != REF_COUNT_UNIQUE implies handle_count(s.frames, i) > 0
@@ -4883,9 +4892,13 @@ proof fn step_try_from_shared<'rcu>(tracked s: &mut VmStore<'rcu>, fid: FrameId)
         // --- accounting clause 3: the rc equation ---
         assert forall|i: int|
             #![trigger s.regions.slot_owners[i]]
-            0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame && (
-            handle_count(s.frames, i) > 0 || s.regions.slot_owners[i].paths_in_pt.len() > 0
-                || segment_cover_count(s.segments, index_to_frame(i)) > 0) implies {
+            0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage is Frame && (handle_count(
+                s.frames,
+                i,
+            ) > 0 || s.regions.slot_owners[i].paths_in_pt.len() > 0 || segment_cover_count(
+                s.segments,
+                index_to_frame(i),
+            ) > 0) implies {
             let so = s.regions.slot_owners[i];
             let rc = so.inner_perms.ref_count.value();
             &&& rc != REF_COUNT_UNUSED

--- a/ostd/specs/mm/embedding/mod.rs
+++ b/ostd/specs/mm/embedding/mod.rs
@@ -189,9 +189,11 @@ use crate::mm::{
 
 verus! {
 
+broadcast use crate::specs::mm::frame::mapping::lemma_index_to_frame_biinjective;
 // =============================================================================
 // Types
 // =============================================================================
+
 /// Logical identifier for a [`VmSpaceOwner`] in the store.
 pub type VmSpaceId = int;
 
@@ -293,7 +295,7 @@ pub proof fn lemma_segment_cover_witness(
 /// `idx` — i.e. the `#handles(idx)` term of the exact reference-count
 /// accounting `ref_count(idx) == #handles(idx) + paths_in_pt(idx).len()`
 /// (Stage 5 / full #4).
-pub open spec fn handle_count(frames: Map<FrameId, FrameEntry>, idx: usize) -> nat {
+pub open spec fn handle_count(frames: Map<FrameId, FrameEntry>, idx: int) -> nat {
     frames.dom().filter(|fid: FrameId| frame_to_index(frames[fid].paddr) == idx).len()
 }
 
@@ -305,7 +307,7 @@ pub proof fn lemma_handle_count_insert_fresh(
     frames: Map<FrameId, FrameEntry>,
     id: FrameId,
     entry: FrameEntry,
-    idx: usize,
+    idx: int,
 )
     requires
         !frames.dom().contains(id),
@@ -365,7 +367,7 @@ pub proof fn lemma_handle_count_insert_fresh(
 /// Handle-count delta under [`Map::remove`]: -1 at the removed entry's
 /// slot if it was the only one present (or generally `-1` if the entry
 /// at `fid` mapped to `idx`), unchanged elsewhere.
-pub proof fn lemma_handle_count_remove(frames: Map<FrameId, FrameEntry>, fid: FrameId, idx: usize)
+pub proof fn lemma_handle_count_remove(frames: Map<FrameId, FrameEntry>, fid: FrameId, idx: int)
     requires
         frames.dom().contains(fid),
     ensures
@@ -610,7 +612,7 @@ impl<'a, 'rcu> VmStore<'rcu> {
         // Slot-perm coverage (Design B). Every in-region slot keeps its
         // `simple_pptr::PointsTo<MetaSlot>` parked in `regions.slots`.
         // `MetaRegionOwners::inv` only gives the *forward* direction
-        // (`slots.contains_key(i) ==> i < max_meta_slots()`); the reverse
+        // (`slots.contains_key(i) ==> 0 <= i < max_meta_slots()`); the reverse
         // is NOT globally true (`UniqueFrame` / `into_raw` / linked-list
         // permanently extract a slot perm). It IS true here because the
         // embedding's `Op` surface contains *no* perm-extracting
@@ -639,8 +641,8 @@ impl<'a, 'rcu> VmStore<'rcu> {
         // parked; ops on possibly-unparked slots (frame/segment
         // `from_unused`, `from_in_use`) instead guard on
         // `slots.contains_key` directly.
-        &&& forall|idx: usize|
-            idx < max_meta_slots() ==> #[trigger] self.regions.slots.contains_key(idx) || (
+        &&& forall|idx: int|
+            0 <= idx < max_meta_slots() ==> #[trigger] self.regions.slots.contains_key(idx) || (
             self.regions.slot_owners[idx].usage == PageUsage::PageTable
                 && self.regions.slot_owners[idx].inner_perms.ref_count.value()
                 != REF_COUNT_UNUSED)
@@ -648,8 +650,8 @@ impl<'a, 'rcu> VmStore<'rcu> {
             // via `segment_cover_count` (see `accounting_inv`'s rc equation).
             // The per-slot `raw_count` cache that previously mirrored it has
             // been retired.
-        &&& forall|idx: usize|
-            idx < max_meta_slots()
+        &&& forall|idx: int|
+            0 <= idx < max_meta_slots()
                 ==> #[trigger] self.regions.slot_owners[idx].inner_perms.in_list.value() == 0
         &&& self.tlb_model.inv()
         &&& forall|id: VmSpaceId| #[trigger]
@@ -825,10 +827,11 @@ impl<'a, 'rcu> VmStore<'rcu> {
         // (Shape B), reaching UNUSED also requires no segment covers
         // the slot — each segment contributes 1 to rc via its
         // forgotten Frame handle.
-        &&& forall|idx: usize|
+        &&& forall|idx: int|
             #![trigger self.regions.slot_owners[idx]]
-            idx < max_meta_slots() && self.regions.slot_owners[idx].inner_perms.ref_count.value()
-                == REF_COUNT_UNUSED ==> handle_count(self.frames, idx) == 0
+            0 <= idx < max_meta_slots()
+                && self.regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNUSED
+                ==> handle_count(self.frames, idx) == 0
                 && self.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
                 self.segments,
                 index_to_frame(idx),
@@ -838,9 +841,9 @@ impl<'a, 'rcu> VmStore<'rcu> {
             // active-head guard below — absorbs the pre-active-head assume
             // in `step_frame_from_in_use`. With segments, "active" includes
             // the segment-cover contribution.
-        &&& forall|idx: usize|
+        &&& forall|idx: int|
             #![trigger self.regions.slot_owners[idx]]
-            idx < max_meta_slots() && self.regions.slot_owners[idx].usage == PageUsage::Frame
+            0 <= idx < max_meta_slots() && self.regions.slot_owners[idx].usage == PageUsage::Frame
                 && self.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
                 && self.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNIQUE
                 ==> handle_count(self.frames, idx) > 0
@@ -856,11 +859,14 @@ impl<'a, 'rcu> VmStore<'rcu> {
             // handle); user-held handles contribute via `H`; live PTEs
             // contribute via `P`. With `segments` empty (pre-activation),
             // `cover_count == 0` and the equation reduces to `rc == H + P`.
-        &&& forall|idx: usize|
+        &&& forall|idx: int|
             #![trigger self.regions.slot_owners[idx]]
-            idx < max_meta_slots() && self.regions.slot_owners[idx].usage == PageUsage::Frame && (
-            handle_count(self.frames, idx) > 0 || self.regions.slot_owners[idx].paths_in_pt.len()
-                > 0 || segment_cover_count(self.segments, index_to_frame(idx)) > 0) ==> {
+            0 <= idx < max_meta_slots() && self.regions.slot_owners[idx].usage == PageUsage::Frame
+                && (handle_count(self.frames, idx) > 0
+                || self.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
+                self.segments,
+                index_to_frame(idx),
+            ) > 0) ==> {
                 let so = self.regions.slot_owners[idx];
                 let rc = so.inner_perms.ref_count.value();
                 &&& rc != REF_COUNT_UNUSED
@@ -1544,7 +1550,7 @@ proof fn lemma_accounting_preserved_by_pt_alloc<'rcu>(s_old: VmStore<'rcu>, s_ne
         s_new.frames == s_old.frames,
         // Segments unchanged ⟹ `segment_cover_count` unchanged.
         s_new.segments == s_old.segments,
-        forall|i: usize|
+        forall|i: int|
             #![trigger s_new.regions.slot_owners[i]]
             s_new.regions.slot_owners[i] != s_old.regions.slot_owners[i] ==> {
                 &&& s_old.regions.slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNUSED
@@ -1572,9 +1578,9 @@ proof fn lemma_accounting_preserved_by_pt_alloc<'rcu>(s_old: VmStore<'rcu>, s_ne
 {
     // Clause 2 — UNUSED ⟹ no users. An UNUSED slot in `s_new` is
     // unchanged (a transitioned slot is non-UNUSED in `s_new`).
-    assert forall|idx: usize|
+    assert forall|idx: int|
         #![trigger s_new.regions.slot_owners[idx]]
-        idx < max_meta_slots() && s_new.regions.slot_owners[idx].inner_perms.ref_count.value()
+        0 <= idx < max_meta_slots() && s_new.regions.slot_owners[idx].inner_perms.ref_count.value()
             == REF_COUNT_UNUSED implies handle_count(s_new.frames, idx) == 0
         && s_new.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
         s_new.segments,
@@ -1584,9 +1590,9 @@ proof fn lemma_accounting_preserved_by_pt_alloc<'rcu>(s_old: VmStore<'rcu>, s_ne
     };
     // Clause 3 — Frame ∧ non-sentinel ⟹ active head. A Frame-usage slot
     // in `s_new` is unchanged (a transitioned slot is non-Frame).
-    assert forall|idx: usize|
+    assert forall|idx: int|
         #![trigger s_new.regions.slot_owners[idx]]
-        idx < max_meta_slots() && s_new.regions.slot_owners[idx].usage == PageUsage::Frame
+        0 <= idx < max_meta_slots() && s_new.regions.slot_owners[idx].usage == PageUsage::Frame
             && s_new.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
             && s_new.regions.slot_owners[idx].inner_perms.ref_count.value()
             != REF_COUNT_UNIQUE implies handle_count(s_new.frames, idx) > 0
@@ -1598,9 +1604,9 @@ proof fn lemma_accounting_preserved_by_pt_alloc<'rcu>(s_old: VmStore<'rcu>, s_ne
     };
     // Clause 4 — the accounting equation. Same: a Frame-usage slot in
     // `s_new` is unchanged, so the old equation carries.
-    assert forall|idx: usize|
+    assert forall|idx: int|
         #![trigger s_new.regions.slot_owners[idx]]
-        idx < max_meta_slots() && s_new.regions.slot_owners[idx].usage == PageUsage::Frame && (
+        0 <= idx < max_meta_slots() && s_new.regions.slot_owners[idx].usage == PageUsage::Frame && (
         handle_count(s_new.frames, idx) > 0 || s_new.regions.slot_owners[idx].paths_in_pt.len() > 0
             || segment_cover_count(s_new.segments, index_to_frame(idx)) > 0) implies {
         let so = s_new.regions.slot_owners[idx];
@@ -1672,19 +1678,19 @@ proof fn lemma_coverage_preserved_slots_eq<'rcu>(s_old: VmStore<'rcu>, s_new: Vm
     requires
         s_old.structural_inv(),
         s_new.regions.slots == s_old.regions.slots,
-        forall|idx: usize|
+        forall|idx: int|
             #![trigger s_new.regions.slot_owners[idx]]
             !s_old.regions.slots.contains_key(idx) ==> s_new.regions.slot_owners[idx]
                 == s_old.regions.slot_owners[idx],
     ensures
-        forall|idx: usize|
-            idx < max_meta_slots() ==> #[trigger] s_new.regions.slots.contains_key(idx) || (
+        forall|idx: int|
+            0 <= idx < max_meta_slots() ==> #[trigger] s_new.regions.slots.contains_key(idx) || (
             s_new.regions.slot_owners[idx].usage == PageUsage::PageTable
                 && s_new.regions.slot_owners[idx].inner_perms.ref_count.value()
                 != REF_COUNT_UNUSED),
 {
-    assert forall|idx: usize|
-        idx < max_meta_slots() implies #[trigger] s_new.regions.slots.contains_key(idx) || (
+    assert forall|idx: int|
+        0 <= idx < max_meta_slots() implies #[trigger] s_new.regions.slots.contains_key(idx) || (
     s_new.regions.slot_owners[idx].usage == PageUsage::PageTable
         && s_new.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED) by {
         if !s_new.regions.slots.contains_key(idx) {
@@ -1715,8 +1721,8 @@ proof fn step_new_vm_space<'rcu>(tracked s: &mut VmStore<'rcu>)
     // the axiom); every OTHER slot kept its `slots` membership (only the
     // root was removed), so its coverage carries from the old store.
     let ghost root_idx = vm_space::vm_space_root_idx(owner);
-    assert forall|idx: usize|
-        idx < max_meta_slots() implies #[trigger] s.regions.slots.contains_key(idx) || (
+    assert forall|idx: int|
+        0 <= idx < max_meta_slots() implies #[trigger] s.regions.slots.contains_key(idx) || (
     s.regions.slot_owners[idx].usage == PageUsage::PageTable
         && s.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED) by {
         if idx == root_idx {
@@ -1847,9 +1853,10 @@ proof fn step_query<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId)
             // preserves all other slots fully.
             assert(s.regions.slot_owners[target_idx].usage == PageUsage::Frame);
             // Discharge accounting_inv on (new regions, new frames).
-            assert forall|idx: usize|
+            assert forall|idx: int|
                 #![trigger s.regions.slot_owners[idx]]
-                idx < max_meta_slots() && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+                0 <= idx < max_meta_slots()
+                    && s.regions.slot_owners[idx].inner_perms.ref_count.value()
                     == REF_COUNT_UNUSED implies handle_count(s.frames, idx) == 0
                 && s.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
                 s.segments,
@@ -1868,9 +1875,9 @@ proof fn step_query<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId)
                     assert(s.regions.slot_owners[idx] == old_regions.slot_owners[idx]);
                 }
             };
-            assert forall|idx: usize|
+            assert forall|idx: int|
                 #![trigger s.regions.slot_owners[idx]]
-                idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
+                0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
                     && s.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
                     && s.regions.slot_owners[idx].inner_perms.ref_count.value()
                     != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
@@ -1886,11 +1893,14 @@ proof fn step_query<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId)
                     assert(s.regions.slot_owners[idx] == old_regions.slot_owners[idx]);
                 }
             };
-            assert forall|idx: usize|
+            assert forall|idx: int|
                 #![trigger s.regions.slot_owners[idx]]
-                idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame && (
-                handle_count(s.frames, idx) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0
-                    || segment_cover_count(s.segments, index_to_frame(idx)) > 0) implies {
+                0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
+                    && (handle_count(s.frames, idx) > 0
+                    || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
+                    s.segments,
+                    index_to_frame(idx),
+                ) > 0) implies {
                 let so = s.regions.slot_owners[idx];
                 let rc = so.inner_perms.ref_count.value();
                 &&& rc != REF_COUNT_UNUSED
@@ -2033,9 +2043,9 @@ proof fn step_map<'rcu>(
     // target_idx; non-mapped pre-non-UNUSED slots fully preserved;
     // post-UNUSED slots fully preserved; newly-non-UNUSED slots are
     // non-Frame (PT nodes). `s.segments` is unchanged across map.
-    assert forall|idx: usize|
+    assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        idx < max_meta_slots() && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].inner_perms.ref_count.value()
             == REF_COUNT_UNUSED implies handle_count(s.frames, idx) == 0
         && s.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
         s.segments,
@@ -2051,9 +2061,9 @@ proof fn step_map<'rcu>(
             assert(false);
         }
     };
-    assert forall|idx: usize|
+    assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
             && s.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
             && s.regions.slot_owners[idx].inner_perms.ref_count.value()
             != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
@@ -2074,9 +2084,9 @@ proof fn step_map<'rcu>(
             assert(s.regions.slot_owners[idx] == old_regions.slot_owners[idx]);
         }
     };
-    assert forall|idx: usize|
+    assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame && (
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame && (
         handle_count(s.frames, idx) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0
             || segment_cover_count(s.segments, index_to_frame(idx)) > 0) implies {
         let so = s.regions.slot_owners[idx];
@@ -2198,9 +2208,9 @@ proof fn step_unmap<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId, len: usize
     // universally; rc doesn't bump to UNIQUE; storage preserved at
     // post-non-UNUSED; at Frame slots, `rc - paths.len` is invariant
     // with both monotonically non-increasing. `s.frames` is unchanged.
-    assert forall|idx: usize|
+    assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        idx < max_meta_slots() && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].inner_perms.ref_count.value()
             == REF_COUNT_UNUSED implies handle_count(s.frames, idx) == 0
         && s.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
         s.segments,
@@ -2275,9 +2285,9 @@ proof fn step_unmap<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId, len: usize
             };
         }
     };
-    assert forall|idx: usize|
+    assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
             && s.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
             && s.regions.slot_owners[idx].inner_perms.ref_count.value()
             != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
@@ -2323,9 +2333,9 @@ proof fn step_unmap<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId, len: usize
             assert(s.regions.slot_owners[idx].paths_in_pt.len() > 0);
         }
     };
-    assert forall|idx: usize|
+    assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame && (
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame && (
         handle_count(s.frames, idx) > 0 || s.regions.slot_owners[idx].paths_in_pt.len()
             > 0) implies {
         let so = s.regions.slot_owners[idx];
@@ -2557,9 +2567,9 @@ proof fn step_frame_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, paddr: Padd
 
                 // 5.5c new clause: "UNUSED ⟹ no users". Other idx unchanged
                 // (lemma + slot_owner preservation); target_idx is now rc=1.
-                assert forall|idx: usize|
+                assert forall|idx: int|
                     #![trigger s.regions.slot_owners[idx]]
-                    idx < max_meta_slots()
+                    0 <= idx < max_meta_slots()
                         && s.regions.slot_owners[idx].inner_perms.ref_count.value()
                         == REF_COUNT_UNUSED implies handle_count(s.frames, idx) == 0
                     && s.regions.slot_owners[idx].paths_in_pt.is_empty() by {
@@ -2575,9 +2585,10 @@ proof fn step_frame_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, paddr: Padd
                 // 5.5c new clause: "Frame ∧ non-sentinel ⟹ active". Other
                 // idx unchanged (so old clause carries); target post is
                 // active (H=1).
-                assert forall|idx: usize|
+                assert forall|idx: int|
                     #![trigger s.regions.slot_owners[idx]]
-                    idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
+                    0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage
+                        == PageUsage::Frame
                         && s.regions.slot_owners[idx].inner_perms.ref_count.value()
                         != REF_COUNT_UNUSED
                         && s.regions.slot_owners[idx].inner_perms.ref_count.value()
@@ -2595,10 +2606,10 @@ proof fn step_frame_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, paddr: Padd
                 };
 
                 // Per-slot accounting (forall covers active heads only).
-                assert forall|idx: usize|
+                assert forall|idx: int|
                     #![trigger s.regions.slot_owners[idx]]
-                    idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
-                        && (handle_count(s.frames, idx) > 0
+                    0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage
+                        == PageUsage::Frame && (handle_count(s.frames, idx) > 0
                         || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
                         s.segments,
                         index_to_frame(idx),
@@ -2659,9 +2670,9 @@ proof fn step_frame_from_in_use<'rcu>(tracked s: &mut VmStore<'rcu>, paddr: Padd
 
                 // 5.5c new clause: "UNUSED ⟹ no users". For target: post
                 // rc = pre rc + 1 != UNUSED. For other idx: unchanged.
-                assert forall|idx: usize|
+                assert forall|idx: int|
                     #![trigger s.regions.slot_owners[idx]]
-                    idx < max_meta_slots()
+                    0 <= idx < max_meta_slots()
                         && s.regions.slot_owners[idx].inner_perms.ref_count.value()
                         == REF_COUNT_UNUSED implies handle_count(s.frames, idx) == 0
                     && s.regions.slot_owners[idx].paths_in_pt.is_empty() by {
@@ -2675,9 +2686,10 @@ proof fn step_frame_from_in_use<'rcu>(tracked s: &mut VmStore<'rcu>, paddr: Padd
 
                 // 5.5c new clause: "Frame ∧ non-sentinel ⟹ active". For
                 // target post: H = pre + 1 ≥ 1 → active. For other: unchanged.
-                assert forall|idx: usize|
+                assert forall|idx: int|
                     #![trigger s.regions.slot_owners[idx]]
-                    idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
+                    0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage
+                        == PageUsage::Frame
                         && s.regions.slot_owners[idx].inner_perms.ref_count.value()
                         != REF_COUNT_UNUSED
                         && s.regions.slot_owners[idx].inner_perms.ref_count.value()
@@ -2695,10 +2707,10 @@ proof fn step_frame_from_in_use<'rcu>(tracked s: &mut VmStore<'rcu>, paddr: Padd
                 };
 
                 // Per-slot accounting (forall covers active heads only).
-                assert forall|idx: usize|
+                assert forall|idx: int|
                     #![trigger s.regions.slot_owners[idx]]
-                    idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
-                        && (handle_count(s.frames, idx) > 0
+                    0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage
+                        == PageUsage::Frame && (handle_count(s.frames, idx) > 0
                         || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
                         s.segments,
                         index_to_frame(idx),
@@ -2769,9 +2781,9 @@ proof fn step_frame_drop<'rcu>(tracked s: &mut VmStore<'rcu>, fid: FrameId)
     // For target: if drop teardown (rc 1→UNUSED), need post H==0 and
     // paths empty. Both hold: pre eqn 1==H+P with H>=1 ⟹ H==1, P==0
     // ⟹ post H==0 (fid removed) and post paths == pre paths == empty.
-    assert forall|idx: usize|
+    assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        idx < max_meta_slots() && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].inner_perms.ref_count.value()
             == REF_COUNT_UNUSED implies handle_count(s.frames, idx) == 0
         && s.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
         s.segments,
@@ -2796,9 +2808,9 @@ proof fn step_frame_drop<'rcu>(tracked s: &mut VmStore<'rcu>, fid: FrameId)
     // post in rc>1 case: rc-1 in [1,MAX-1] non-sentinel; H-=1 or P
     // preserved. Pre H+P=pre rc; if post H>=1, active; else pre H=1
     // so pre P=pre rc-1 >= 1 (rc>1), post P >= 1, active. ✓
-    assert forall|idx: usize|
+    assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
             && s.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
             && s.regions.slot_owners[idx].inner_perms.ref_count.value()
             != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
@@ -2818,9 +2830,9 @@ proof fn step_frame_drop<'rcu>(tracked s: &mut VmStore<'rcu>, fid: FrameId)
         }
     };
 
-    assert forall|idx: usize|
+    assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame && (
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame && (
         handle_count(s.frames, idx) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0
             || segment_cover_count(s.segments, index_to_frame(idx)) > 0) implies {
         let so = s.regions.slot_owners[idx];
@@ -2933,9 +2945,9 @@ proof fn step_segment_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, range: Ra
                 //   - Slot outside `range`: fully preserved (axiom); segments
                 //     gained one entry whose range doesn't cover this paddr,
                 //     so cover unchanged. Accounting carries from pre.
-                assert forall|idx: usize|
+                assert forall|idx: int|
                     #![trigger s.regions.slot_owners[idx]]
-                    idx < max_meta_slots()
+                    0 <= idx < max_meta_slots()
                         && s.regions.slot_owners[idx].inner_perms.ref_count.value()
                         == REF_COUNT_UNUSED implies handle_count(s.frames, idx) == 0
                     && s.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
@@ -2959,9 +2971,10 @@ proof fn step_segment_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, range: Ra
                         lemma_segment_cover_insert_outside(old_segments, id, entry, paddr);
                     }
                 };
-                assert forall|idx: usize|
+                assert forall|idx: int|
                     #![trigger s.regions.slot_owners[idx]]
-                    idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
+                    0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage
+                        == PageUsage::Frame
                         && s.regions.slot_owners[idx].inner_perms.ref_count.value()
                         != REF_COUNT_UNUSED
                         && s.regions.slot_owners[idx].inner_perms.ref_count.value()
@@ -2983,10 +2996,10 @@ proof fn step_segment_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, range: Ra
                         lemma_segment_cover_insert_outside(old_segments, id, entry, paddr);
                     }
                 };
-                assert forall|idx: usize|
+                assert forall|idx: int|
                     #![trigger s.regions.slot_owners[idx]]
-                    idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
-                        && (handle_count(s.frames, idx) > 0
+                    0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage
+                        == PageUsage::Frame && (handle_count(s.frames, idx) > 0
                         || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
                         s.segments,
                         index_to_frame(idx),
@@ -3016,8 +3029,8 @@ proof fn step_segment_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, range: Ra
                     }
                 };
                 // Discharge structural_inv's `in_list == 0` clause.
-                assert forall|idx: usize|
-                    idx
+                assert forall|idx: int|
+                    0 <= idx
                         < max_meta_slots() implies #[trigger] s.regions.slot_owners[idx].inner_perms.in_list.value()
                     == 0 by {
                     let paddr = index_to_frame(idx);
@@ -3163,8 +3176,8 @@ proof fn step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
     //   - Slot outside `range`: fully preserved (axiom + segment removal
     //     leaves cover unchanged at outside paddrs).
 
-    assert forall|idx: usize|
-        idx
+    assert forall|idx: int|
+        0 <= idx
             < max_meta_slots() implies #[trigger] s.regions.slot_owners[idx].inner_perms.in_list.value()
         == 0 by {
         let paddr = index_to_frame(idx);
@@ -3178,9 +3191,9 @@ proof fn step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
         }
     };
     // Discharge accounting_inv clauses.
-    assert forall|idx: usize|
+    assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        idx < max_meta_slots() && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].inner_perms.ref_count.value()
             == REF_COUNT_UNUSED implies handle_count(s.frames, idx) == 0
         && s.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
         s.segments,
@@ -3209,9 +3222,9 @@ proof fn step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
             lemma_segment_cover_remove_outside(old_segments, sid, paddr);
         }
     };
-    assert forall|idx: usize|
+    assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
             && s.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
             && s.regions.slot_owners[idx].inner_perms.ref_count.value()
             != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
@@ -3236,9 +3249,9 @@ proof fn step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
             lemma_segment_cover_remove_outside(old_segments, sid, paddr);
         }
     };
-    assert forall|idx: usize|
+    assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame && (
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame && (
         handle_count(s.frames, idx) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0
             || segment_cover_count(s.segments, index_to_frame(idx)) > 0) implies {
         let so = s.regions.slot_owners[idx];
@@ -3462,9 +3475,9 @@ proof fn step_segment_split<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId,
     // every per-slot value (rc, paths, usage, etc.) preserved; frames
     // unchanged ⟹ handle_count preserved; cover_count preserved
     // per-paddr via lemma_segment_cover_split.
-    assert forall|idx: usize|
+    assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        idx < max_meta_slots() && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].inner_perms.ref_count.value()
             == REF_COUNT_UNUSED implies handle_count(s.frames, idx) == 0
         && s.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
         s.segments,
@@ -3483,9 +3496,9 @@ proof fn step_segment_split<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId,
             paddr,
         );
     };
-    assert forall|idx: usize|
+    assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
             && s.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
             && s.regions.slot_owners[idx].inner_perms.ref_count.value()
             != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
@@ -3506,9 +3519,9 @@ proof fn step_segment_split<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId,
             paddr,
         );
     };
-    assert forall|idx: usize|
+    assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame && (
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame && (
         handle_count(s.frames, idx) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0
             || segment_cover_count(s.segments, index_to_frame(idx)) > 0) implies {
         let so = s.regions.slot_owners[idx];
@@ -3654,8 +3667,8 @@ proof fn step_segment_next<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
     };
 
     // Structural in_list == 0.
-    assert forall|idx: usize|
-        idx
+    assert forall|idx: int|
+        0 <= idx
             < max_meta_slots() implies #[trigger] s.regions.slot_owners[idx].inner_perms.in_list.value()
         == 0 by {
         let paddr_c = index_to_frame(idx);
@@ -3711,9 +3724,9 @@ proof fn step_segment_next<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
     }
     // Accounting clauses.
 
-    assert forall|idx: usize|
+    assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        idx < max_meta_slots() && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].inner_perms.ref_count.value()
             == REF_COUNT_UNUSED implies handle_count(s.frames, idx) == 0
         && s.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
         s.segments,
@@ -3730,9 +3743,9 @@ proof fn step_segment_next<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
             lemma_handle_count_insert_fresh(old_frames, fid, frame_entry, idx);
         }
     };
-    assert forall|idx: usize|
+    assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
             && s.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
             && s.regions.slot_owners[idx].inner_perms.ref_count.value()
             != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
@@ -3751,9 +3764,9 @@ proof fn step_segment_next<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
             lemma_handle_count_insert_fresh(old_frames, fid, frame_entry, idx);
         }
     };
-    assert forall|idx: usize|
+    assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame && (
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame && (
         handle_count(s.frames, idx) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0
             || segment_cover_count(s.segments, index_to_frame(idx)) > 0) implies {
         let so = s.regions.slot_owners[idx];
@@ -3890,8 +3903,8 @@ proof fn step_segment_clone_range<'rcu>(
     // --- per-slot regions delta: usage / in_list preserved everywhere ---
     // `usage` is preserved at every slot (inside: usage clause of the
     // axiom; outside: full slot preservation).
-    assert forall|idx: usize|
-        idx < max_meta_slots() implies #[trigger] s.regions.slot_owners[idx].usage
+    assert forall|idx: int|
+        0 <= idx < max_meta_slots() implies #[trigger] s.regions.slot_owners[idx].usage
         == old_regions.slot_owners[idx].usage by {
         let aligned = index_to_frame(idx);
         assert(aligned == (idx * PAGE_SIZE) as usize);
@@ -3903,8 +3916,8 @@ proof fn step_segment_clone_range<'rcu>(
         }
     };
     // `in_list == 0` at every slot (preserved by the axiom both ways).
-    assert forall|idx: usize|
-        idx
+    assert forall|idx: int|
+        0 <= idx
             < max_meta_slots() implies #[trigger] s.regions.slot_owners[idx].inner_perms.in_list.value()
         == 0 by {
         let aligned = index_to_frame(idx);
@@ -3938,7 +3951,7 @@ proof fn step_segment_clone_range<'rcu>(
             assert(old_segments[sid_other] == s.segments[sid_other]);
             assert(old_regions.slot_owners[cov_idx].usage == PageUsage::Frame);
         }
-        // `cov_idx < max_meta_slots()` via `inv_implies_correct_addr`
+        // `cov_0 <= idx < max_meta_slots()` via `inv_implies_correct_addr`
         // (`slot_owners.contains_key`) + `MetaRegionOwners::inv`'s
         // biimplication. Then the universal usage-preservation above
         // gives `s.regions` usage == old usage == Frame at cov_idx.
@@ -3958,14 +3971,14 @@ proof fn step_segment_clone_range<'rcu>(
         assert(has_safe_slot(s.frames[fid_other].paddr));
         s.regions.inv_implies_correct_addr(s.frames[fid_other].paddr);
         assert(s.regions.slot_owners.contains_key(other_idx));
-        // `other_idx < max_meta_slots()` (biimplication) ⟹ universal
+        // `other_0 <= idx < max_meta_slots()` (biimplication) ⟹ universal
         // usage-preservation above gives Frame-usage at other_idx.
     };
 
     // --- accounting clause 1: UNUSED ⟹ no users ---
-    assert forall|idx: usize|
+    assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        idx < max_meta_slots() && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].inner_perms.ref_count.value()
             == REF_COUNT_UNUSED implies handle_count(s.frames, idx) == 0
         && s.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
         s.segments,
@@ -3982,9 +3995,9 @@ proof fn step_segment_clone_range<'rcu>(
         }
     };
     // --- accounting clause 2: valid rc ⟹ active head ---
-    assert forall|idx: usize|
+    assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame
             && s.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
             && s.regions.slot_owners[idx].inner_perms.ref_count.value()
             != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
@@ -4002,9 +4015,9 @@ proof fn step_segment_clone_range<'rcu>(
         }
     };
     // --- accounting clause 3: the rc equation ---
-    assert forall|idx: usize|
+    assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame && (
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage == PageUsage::Frame && (
         handle_count(s.frames, idx) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0
             || segment_cover_count(s.segments, index_to_frame(idx)) > 0) implies {
         let so = s.regions.slot_owners[idx];
@@ -4152,8 +4165,8 @@ proof fn step_unique_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, paddr: Pad
         assert(s.segments == old_segments);
 
         // --- structural: in_list == 0 everywhere ---
-        assert forall|i: usize|
-            i
+        assert forall|i: int|
+            0 <= i
                 < max_meta_slots() implies #[trigger] s.regions.slot_owners[i].inner_perms.in_list.value()
             == 0 by {
             if i != idx {
@@ -4241,9 +4254,9 @@ proof fn step_unique_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, paddr: Pad
         };
 
         // --- accounting clause 1: UNUSED ⟹ no users ---
-        assert forall|i: usize|
+        assert forall|i: int|
             #![trigger s.regions.slot_owners[i]]
-            i < max_meta_slots() && s.regions.slot_owners[i].inner_perms.ref_count.value()
+            0 <= i < max_meta_slots() && s.regions.slot_owners[i].inner_perms.ref_count.value()
                 == REF_COUNT_UNUSED implies handle_count(s.frames, i) == 0
             && s.regions.slot_owners[i].paths_in_pt.is_empty() && segment_cover_count(
             s.segments,
@@ -4257,9 +4270,9 @@ proof fn step_unique_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, paddr: Pad
             }
         };
         // --- accounting clause 2: valid rc ⟹ active head ---
-        assert forall|i: usize|
+        assert forall|i: int|
             #![trigger s.regions.slot_owners[i]]
-            i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame
+            0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame
                 && s.regions.slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
                 && s.regions.slot_owners[i].inner_perms.ref_count.value()
                 != REF_COUNT_UNIQUE implies handle_count(s.frames, i) > 0
@@ -4275,9 +4288,9 @@ proof fn step_unique_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, paddr: Pad
             }
         };
         // --- accounting clause 3: the rc equation ---
-        assert forall|i: usize|
+        assert forall|i: int|
             #![trigger s.regions.slot_owners[i]]
-            i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame && (
+            0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame && (
             handle_count(s.frames, i) > 0 || s.regions.slot_owners[i].paths_in_pt.len() > 0
                 || segment_cover_count(s.segments, index_to_frame(i)) > 0) implies {
             let so = s.regions.slot_owners[i];
@@ -4360,8 +4373,9 @@ proof fn step_unique_drop<'rcu>(tracked s: &mut VmStore<'rcu>, uid: UniqueId)
     assert(s.segments == old_segments);
 
     // --- structural: in_list == 0 everywhere ---
-    assert forall|i: usize|
-        i < max_meta_slots() implies #[trigger] s.regions.slot_owners[i].inner_perms.in_list.value()
+    assert forall|i: int|
+        0 <= i
+            < max_meta_slots() implies #[trigger] s.regions.slot_owners[i].inner_perms.in_list.value()
         == 0 by {
         if i != idx {
             assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
@@ -4429,9 +4443,9 @@ proof fn step_unique_drop<'rcu>(tracked s: &mut VmStore<'rcu>, uid: UniqueId)
     };
 
     // --- accounting clause 1: UNUSED ⟹ no users ---
-    assert forall|i: usize|
+    assert forall|i: int|
         #![trigger s.regions.slot_owners[i]]
-        i < max_meta_slots() && s.regions.slot_owners[i].inner_perms.ref_count.value()
+        0 <= i < max_meta_slots() && s.regions.slot_owners[i].inner_perms.ref_count.value()
             == REF_COUNT_UNUSED implies handle_count(s.frames, i) == 0
         && s.regions.slot_owners[i].paths_in_pt.is_empty() && segment_cover_count(
         s.segments,
@@ -4448,9 +4462,9 @@ proof fn step_unique_drop<'rcu>(tracked s: &mut VmStore<'rcu>, uid: UniqueId)
         }
     };
     // --- accounting clause 2: valid rc ⟹ active head ---
-    assert forall|i: usize|
+    assert forall|i: int|
         #![trigger s.regions.slot_owners[i]]
-        i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame
+        0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame
             && s.regions.slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
             && s.regions.slot_owners[i].inner_perms.ref_count.value()
             != REF_COUNT_UNIQUE implies handle_count(s.frames, i) > 0
@@ -4466,15 +4480,11 @@ proof fn step_unique_drop<'rcu>(tracked s: &mut VmStore<'rcu>, uid: UniqueId)
         }
     };
     // --- accounting clause 3: the rc equation ---
-    assert forall|i: usize|
+    assert forall|i: int|
         #![trigger s.regions.slot_owners[i]]
-        i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame && (handle_count(
-            s.frames,
-            i,
-        ) > 0 || s.regions.slot_owners[i].paths_in_pt.len() > 0 || segment_cover_count(
-            s.segments,
-            index_to_frame(i),
-        ) > 0) implies {
+        0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame && (
+        handle_count(s.frames, i) > 0 || s.regions.slot_owners[i].paths_in_pt.len() > 0
+            || segment_cover_count(s.segments, index_to_frame(i)) > 0) implies {
         let so = s.regions.slot_owners[i];
         let rc = so.inner_perms.ref_count.value();
         &&& rc != REF_COUNT_UNUSED
@@ -4554,8 +4564,9 @@ proof fn step_from_unique<'rcu>(tracked s: &mut VmStore<'rcu>, uid: UniqueId)
     assert(s.frames[fid].paddr == paddr);
 
     // --- structural: in_list == 0 everywhere ---
-    assert forall|i: usize|
-        i < max_meta_slots() implies #[trigger] s.regions.slot_owners[i].inner_perms.in_list.value()
+    assert forall|i: int|
+        0 <= i
+            < max_meta_slots() implies #[trigger] s.regions.slot_owners[i].inner_perms.in_list.value()
         == 0 by {
         if i != idx {
             assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
@@ -4625,9 +4636,9 @@ proof fn step_from_unique<'rcu>(tracked s: &mut VmStore<'rcu>, uid: UniqueId)
     };
 
     // --- accounting clause 1: UNUSED ⟹ no users ---
-    assert forall|i: usize|
+    assert forall|i: int|
         #![trigger s.regions.slot_owners[i]]
-        i < max_meta_slots() && s.regions.slot_owners[i].inner_perms.ref_count.value()
+        0 <= i < max_meta_slots() && s.regions.slot_owners[i].inner_perms.ref_count.value()
             == REF_COUNT_UNUSED implies handle_count(s.frames, i) == 0
         && s.regions.slot_owners[i].paths_in_pt.is_empty() && segment_cover_count(
         s.segments,
@@ -4641,9 +4652,9 @@ proof fn step_from_unique<'rcu>(tracked s: &mut VmStore<'rcu>, uid: UniqueId)
         }
     };
     // --- accounting clause 2: valid rc ⟹ active head ---
-    assert forall|i: usize|
+    assert forall|i: int|
         #![trigger s.regions.slot_owners[i]]
-        i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame
+        0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame
             && s.regions.slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
             && s.regions.slot_owners[i].inner_perms.ref_count.value()
             != REF_COUNT_UNIQUE implies handle_count(s.frames, i) > 0
@@ -4659,15 +4670,11 @@ proof fn step_from_unique<'rcu>(tracked s: &mut VmStore<'rcu>, uid: UniqueId)
         }
     };
     // --- accounting clause 3: the rc equation ---
-    assert forall|i: usize|
+    assert forall|i: int|
         #![trigger s.regions.slot_owners[i]]
-        i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame && (handle_count(
-            s.frames,
-            i,
-        ) > 0 || s.regions.slot_owners[i].paths_in_pt.len() > 0 || segment_cover_count(
-            s.segments,
-            index_to_frame(i),
-        ) > 0) implies {
+        0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame && (
+        handle_count(s.frames, i) > 0 || s.regions.slot_owners[i].paths_in_pt.len() > 0
+            || segment_cover_count(s.segments, index_to_frame(i)) > 0) implies {
         let so = s.regions.slot_owners[i];
         let rc = so.inner_perms.ref_count.value();
         &&& rc != REF_COUNT_UNUSED
@@ -4749,8 +4756,8 @@ proof fn step_try_from_shared<'rcu>(tracked s: &mut VmStore<'rcu>, fid: FrameId)
         };
 
         // --- structural: in_list == 0 everywhere ---
-        assert forall|i: usize|
-            i
+        assert forall|i: int|
+            0 <= i
                 < max_meta_slots() implies #[trigger] s.regions.slot_owners[i].inner_perms.in_list.value()
             == 0 by {
             if i != idx {
@@ -4838,9 +4845,9 @@ proof fn step_try_from_shared<'rcu>(tracked s: &mut VmStore<'rcu>, fid: FrameId)
         };
 
         // --- accounting clause 1: UNUSED ⟹ no users ---
-        assert forall|i: usize|
+        assert forall|i: int|
             #![trigger s.regions.slot_owners[i]]
-            i < max_meta_slots() && s.regions.slot_owners[i].inner_perms.ref_count.value()
+            0 <= i < max_meta_slots() && s.regions.slot_owners[i].inner_perms.ref_count.value()
                 == REF_COUNT_UNUSED implies handle_count(s.frames, i) == 0
             && s.regions.slot_owners[i].paths_in_pt.is_empty() && segment_cover_count(
             s.segments,
@@ -4855,9 +4862,9 @@ proof fn step_try_from_shared<'rcu>(tracked s: &mut VmStore<'rcu>, fid: FrameId)
             }
         };
         // --- accounting clause 2: valid rc ⟹ active head ---
-        assert forall|i: usize|
+        assert forall|i: int|
             #![trigger s.regions.slot_owners[i]]
-            i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame
+            0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame
                 && s.regions.slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
                 && s.regions.slot_owners[i].inner_perms.ref_count.value()
                 != REF_COUNT_UNIQUE implies handle_count(s.frames, i) > 0
@@ -4874,9 +4881,9 @@ proof fn step_try_from_shared<'rcu>(tracked s: &mut VmStore<'rcu>, fid: FrameId)
             }
         };
         // --- accounting clause 3: the rc equation ---
-        assert forall|i: usize|
+        assert forall|i: int|
             #![trigger s.regions.slot_owners[i]]
-            i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame && (
+            0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage == PageUsage::Frame && (
             handle_count(s.frames, i) > 0 || s.regions.slot_owners[i].paths_in_pt.len() > 0
                 || segment_cover_count(s.segments, index_to_frame(i)) > 0) implies {
             let so = s.regions.slot_owners[i];

--- a/ostd/specs/mm/embedding/segment.rs
+++ b/ostd/specs/mm/embedding/segment.rs
@@ -112,7 +112,7 @@ pub axiom fn segment_from_unused_embedded(
                     &&& so.inner_perms.storage.is_init()
                 },
         // Slots OUTSIDE the range are fully preserved.
-        res is Some ==> forall|i: usize|
+        res is Some ==> forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             i < crate::specs::mm::frame::mapping::max_meta_slots()
             && !(range.start <= crate::specs::mm::frame::mapping::index_to_frame(i)
@@ -122,7 +122,7 @@ pub axiom fn segment_from_unused_embedded(
         // transitions the (previously UNUSED, parked) covered slots, never
         // a PT root whose perm is not parked in `regions.slots`. Preserves
         // the embedding's slot-perm coverage exception.
-        res is Some ==> forall|i: usize|
+        res is Some ==> forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             !old(regions).slots.contains_key(i) ==> final(regions).slot_owners[i] == old(
                 regions,
@@ -202,7 +202,7 @@ pub proof fn lemma_segment_drop_embedded(
                                 == (so_old.inner_perms.ref_count.value() - 1) as u64
                 },
         // Slots OUTSIDE the range are fully preserved.
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             i < crate::specs::mm::frame::mapping::max_meta_slots()
             && !(range.start <= crate::specs::mm::frame::mapping::index_to_frame(i)
@@ -212,7 +212,7 @@ pub proof fn lemma_segment_drop_embedded(
         // the segment's covered (Frame) slots, never a PT root whose perm
         // is not parked in `regions.slots`. Preserves the embedding's
         // slot-perm coverage exception.
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             !old(regions).slots.contains_key(i) ==> final(regions).slot_owners[i] == old(
                 regions,
@@ -281,7 +281,7 @@ pub proof fn segment_next_embedded(
             &&& so_new.inner_perms.vtable_ptr == so_old.inner_perms.vtable_ptr
         },
         // All other slots fully preserved.
-        forall|i: usize| #![trigger final(regions).slot_owners[i]]
+        forall|i: int| #![trigger final(regions).slot_owners[i]]
             i != frame_to_index(paddr)
                 ==> final(regions).slot_owners[i] == old(regions).slot_owners[i],
         forall|c: CursorOwner<'_, UserPtConfig>| #![auto]
@@ -329,14 +329,14 @@ pub(super) proof fn from_unused_step(
                     &&& so.inner_perms.ref_count.value() == 1
                     &&& so.paths_in_pt.is_empty()
                 },
-        res is Some ==> forall|i: usize|
+        res is Some ==> forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             i < crate::specs::mm::frame::mapping::max_meta_slots()
             && !(range.start <= crate::specs::mm::frame::mapping::index_to_frame(i)
                     < range.end)
                 ==> final(regions).slot_owners[i] == old(regions).slot_owners[i],
         // Unparked (page-table-node) slots untouched (see axiom).
-        res is Some ==> forall|i: usize|
+        res is Some ==> forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             !old(regions).slots.contains_key(i) ==> final(regions).slot_owners[i] == old(
                 regions,
@@ -397,14 +397,14 @@ pub(super) proof fn drop_step(
                     ==> so_new.inner_perms.ref_count.value()
                             == (so_old.inner_perms.ref_count.value() - 1) as u64
             },
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             i < crate::specs::mm::frame::mapping::max_meta_slots()
             && !(entry.range.start <= crate::specs::mm::frame::mapping::index_to_frame(i)
                     < entry.range.end)
                 ==> final(regions).slot_owners[i] == old(regions).slot_owners[i],
         // Unparked (page-table-node) slots untouched (see axiom).
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             !old(regions).slots.contains_key(i) ==> final(regions).slot_owners[i] == old(
                 regions,
@@ -457,7 +457,7 @@ pub axiom fn segment_clone_embedded(
                     &&& so_new.inner_perms.vtable_ptr == so_old.inner_perms.vtable_ptr
                 },
         // Slots OUTSIDE the range are fully preserved.
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             i < crate::specs::mm::frame::mapping::max_meta_slots()
             && !(range.start <= crate::specs::mm::frame::mapping::index_to_frame(i)

--- a/ostd/specs/mm/embedding/segment.rs
+++ b/ostd/specs/mm/embedding/segment.rs
@@ -37,7 +37,9 @@ use crate::specs::{
     arch::*,
     mm::{
         frame::{
-            mapping::frame_to_index, meta_owners::PageUsage, meta_region_owners::MetaRegionOwners,
+            mapping::{frame_to_index, index_to_frame, max_meta_slots},
+            meta_owners::PageUsage,
+            meta_region_owners::MetaRegionOwners,
         },
         page_table::cursor::owners::CursorOwner,
     },
@@ -114,8 +116,8 @@ pub axiom fn segment_from_unused_embedded(
         // Slots OUTSIDE the range are fully preserved.
         res is Some ==> forall|i: int|
             #![trigger final(regions).slot_owners[i]]
-            i < crate::specs::mm::frame::mapping::max_meta_slots()
-            && !(range.start <= crate::specs::mm::frame::mapping::index_to_frame(i)
+            i < max_meta_slots()
+            && !(range.start <= index_to_frame(i)
                     < range.end)
                 ==> final(regions).slot_owners[i] == old(regions).slot_owners[i],
         // Unparked (page-table-node) slots are untouched: allocation only
@@ -204,8 +206,8 @@ pub proof fn lemma_segment_drop_embedded(
         // Slots OUTSIDE the range are fully preserved.
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
-            i < crate::specs::mm::frame::mapping::max_meta_slots()
-            && !(range.start <= crate::specs::mm::frame::mapping::index_to_frame(i)
+            i < max_meta_slots()
+            && !(range.start <= index_to_frame(i)
                     < range.end)
                 ==> final(regions).slot_owners[i] == old(regions).slot_owners[i],
         // Unparked (page-table-node) slots are untouched: drop only frees
@@ -331,8 +333,8 @@ pub(super) proof fn from_unused_step(
                 },
         res is Some ==> forall|i: int|
             #![trigger final(regions).slot_owners[i]]
-            i < crate::specs::mm::frame::mapping::max_meta_slots()
-            && !(range.start <= crate::specs::mm::frame::mapping::index_to_frame(i)
+            i < max_meta_slots()
+            && !(range.start <= index_to_frame(i)
                     < range.end)
                 ==> final(regions).slot_owners[i] == old(regions).slot_owners[i],
         // Unparked (page-table-node) slots untouched (see axiom).
@@ -399,8 +401,8 @@ pub(super) proof fn drop_step(
             },
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
-            i < crate::specs::mm::frame::mapping::max_meta_slots()
-            && !(entry.range.start <= crate::specs::mm::frame::mapping::index_to_frame(i)
+            i < max_meta_slots()
+            && !(entry.range.start <= index_to_frame(i)
                     < entry.range.end)
                 ==> final(regions).slot_owners[i] == old(regions).slot_owners[i],
         // Unparked (page-table-node) slots untouched (see axiom).
@@ -459,8 +461,8 @@ pub axiom fn segment_clone_embedded(
         // Slots OUTSIDE the range are fully preserved.
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
-            i < crate::specs::mm::frame::mapping::max_meta_slots()
-            && !(range.start <= crate::specs::mm::frame::mapping::index_to_frame(i)
+            i < max_meta_slots()
+            && !(range.start <= index_to_frame(i)
                     < range.end)
                 ==> final(regions).slot_owners[i] == old(regions).slot_owners[i],
         forall|c: CursorOwner<'_, UserPtConfig>| #![auto]

--- a/ostd/specs/mm/embedding/segment.rs
+++ b/ostd/specs/mm/embedding/segment.rs
@@ -22,7 +22,7 @@
 //!
 //! - **Generic `M: AnyFrameMeta`** + the `metadata_fn` closure: the
 //!   embedding doesn't carry the per-frame metadata. The axioms commit
-//!   only to `usage == PageUsage::Frame` (matching the exec
+//!   only to `usage is Frame` (matching the exec
 //!   `Segment::from_unused` contract).
 //! - **Split / slice / next / clone / into_raw / from_raw**: deferred
 //!   to follow-up; the base `from_unused` + drop pair is enough to
@@ -107,7 +107,7 @@ pub axiom fn segment_from_unused_embedded(
                 ==> {
                     let idx = frame_to_index(paddr);
                     let so = final(regions).slot_owners[idx];
-                    &&& so.usage == PageUsage::Frame
+                    &&& so.usage is Frame
                     &&& so.inner_perms.ref_count.value() == 1
                     &&& so.paths_in_pt.is_empty()
                     &&& so.inner_perms.in_list.value() == 0
@@ -174,7 +174,7 @@ pub proof fn lemma_segment_drop_embedded(
                     &&& so.inner_perms.ref_count.value() >= 1
                     &&& so.inner_perms.ref_count.value()
                             <= REF_COUNT_MAX
-                    &&& so.usage == PageUsage::Frame
+                    &&& so.usage is Frame
                     // At rc==1 (sole reference being dropped), no PTE
                     // points to this frame — required for the
                     // teardown's `drop_last_in_place_safety_cond`.
@@ -265,7 +265,7 @@ pub proof fn segment_next_embedded(
                 .inner_perms.ref_count.value()
             <= REF_COUNT_MAX,
         old(regions).slot_owners[frame_to_index(paddr)].usage
-            == PageUsage::Frame,
+            is Frame,
     ensures
         final(regions).inv(),
         final(regions).slots == old(regions).slots,
@@ -327,7 +327,7 @@ pub(super) proof fn from_unused_step(
                 ==> {
                     let idx = frame_to_index(paddr);
                     let so = final(regions).slot_owners[idx];
-                    &&& so.usage == PageUsage::Frame
+                    &&& so.usage is Frame
                     &&& so.inner_perms.ref_count.value() == 1
                     &&& so.paths_in_pt.is_empty()
                 },
@@ -375,7 +375,7 @@ pub(super) proof fn drop_step(
                 &&& so.inner_perms.ref_count.value() >= 1
                 &&& so.inner_perms.ref_count.value()
                         <= REF_COUNT_MAX
-                &&& so.usage == PageUsage::Frame
+                &&& so.usage is Frame
                 &&& so.inner_perms.ref_count.value() == 1
                     ==> so.paths_in_pt.is_empty()
             },
@@ -434,7 +434,7 @@ pub axiom fn segment_clone_embedded(
             (range.start <= paddr < range.end && paddr % PAGE_SIZE == 0)
                 ==> {
                     let so = old(regions).slot_owners[frame_to_index(paddr)];
-                    &&& so.usage == PageUsage::Frame
+                    &&& so.usage is Frame
                     &&& so.inner_perms.ref_count.value() >= 1
                     &&& so.inner_perms.ref_count.value() + 1 <= REF_COUNT_MAX
                 },

--- a/ostd/specs/mm/embedding/unique.rs
+++ b/ostd/specs/mm/embedding/unique.rs
@@ -105,7 +105,7 @@ pub axiom fn unique_from_unused_embedded(tracked regions: &mut MetaRegionOwners,
             &&& so_new.slot_vaddr == so_old.slot_vaddr
         },
         // All other slots fully preserved.
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             i != frame_to_index(paddr) ==> final(regions).slot_owners[i] == old(
                 regions,
@@ -150,7 +150,7 @@ pub axiom fn unique_drop_embedded(tracked regions: &mut MetaRegionOwners, paddr:
             &&& so_new.slot_vaddr == so_old.slot_vaddr
         },
         // All other slots fully preserved.
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             i != frame_to_index(paddr) ==> final(regions).slot_owners[i] == old(
                 regions,
@@ -187,7 +187,7 @@ pub axiom fn from_unique_embedded(tracked regions: &mut MetaRegionOwners, paddr:
             &&& so_new.inner_perms.storage == so_old.inner_perms.storage
             &&& so_new.slot_vaddr == so_old.slot_vaddr
         },
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             i != frame_to_index(paddr) ==> final(regions).slot_owners[i] == old(
                 regions,
@@ -224,7 +224,7 @@ pub axiom fn try_from_shared_embedded(tracked regions: &mut MetaRegionOwners, pa
             &&& so_new.inner_perms.storage == so_old.inner_perms.storage
             &&& so_new.slot_vaddr == so_old.slot_vaddr
         },
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             i != frame_to_index(paddr) ==> final(regions).slot_owners[i] == old(
                 regions,

--- a/ostd/specs/mm/embedding/unique.rs
+++ b/ostd/specs/mm/embedding/unique.rs
@@ -97,7 +97,7 @@ pub axiom fn unique_from_unused_embedded(tracked regions: &mut MetaRegionOwners,
             let idx = frame_to_index(paddr);
             let so_old = old(regions).slot_owners[idx];
             let so_new = final(regions).slot_owners[idx];
-            &&& so_new.usage == PageUsage::Frame
+            &&& so_new.usage is Frame
             &&& so_new.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
             &&& so_new.inner_perms.in_list.value() == 0
             &&& so_new.inner_perms.storage.is_init()
@@ -208,7 +208,7 @@ pub axiom fn try_from_shared_embedded(tracked regions: &mut MetaRegionOwners, pa
         old(regions).inv(),
         old(regions).slots.contains_key(frame_to_index(paddr)),
         old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() == 1,
-        old(regions).slot_owners[frame_to_index(paddr)].usage == PageUsage::Frame,
+        old(regions).slot_owners[frame_to_index(paddr)].usage is Frame,
         old(regions).slot_owners[frame_to_index(paddr)].paths_in_pt.is_empty(),
     ensures
         final(regions).inv(),

--- a/ostd/specs/mm/embedding/vm_space.rs
+++ b/ostd/specs/mm/embedding/vm_space.rs
@@ -55,7 +55,7 @@ pub axiom fn vm_space_new_embedded<'a>(tracked regions: &mut MetaRegionOwners) -
         // removes `frame_to_index(root_paddr)` from `regions.slots`.)
         old(regions).slots.contains_key(vm_space_root_idx(res)),
         final(regions).slots == old(regions).slots.remove(vm_space_root_idx(res)),
-        final(regions).slot_owners[vm_space_root_idx(res)].usage == PageUsage::PageTable,
+        final(regions).slot_owners[vm_space_root_idx(res)].usage is PageTable,
         final(regions).slot_owners[vm_space_root_idx(res)].inner_perms.ref_count.value()
             != REF_COUNT_UNUSED,
         forall|i: int|
@@ -73,7 +73,7 @@ pub axiom fn vm_space_new_embedded<'a>(tracked regions: &mut MetaRegionOwners) -
             final(regions).slot_owners[i] != old(regions).slot_owners[i] ==> {
                 &&& old(regions).slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNUSED
                 &&& final(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-                &&& final(regions).slot_owners[i].usage == PageUsage::PageTable
+                &&& final(regions).slot_owners[i].usage is PageTable
             },
         forall|c: CursorOwner<'a, UserPtConfig>|
             #![auto]
@@ -105,7 +105,7 @@ pub(super) proof fn new_vm_space_step<'a>(tracked regions: &mut MetaRegionOwners
         // removes `frame_to_index(root_paddr)` from `regions.slots`.)
         old(regions).slots.contains_key(vm_space_root_idx(res)),
         final(regions).slots == old(regions).slots.remove(vm_space_root_idx(res)),
-        final(regions).slot_owners[vm_space_root_idx(res)].usage == PageUsage::PageTable,
+        final(regions).slot_owners[vm_space_root_idx(res)].usage is PageTable,
         final(regions).slot_owners[vm_space_root_idx(res)].inner_perms.ref_count.value()
             != REF_COUNT_UNUSED,
         forall|i: int|
@@ -123,7 +123,7 @@ pub(super) proof fn new_vm_space_step<'a>(tracked regions: &mut MetaRegionOwners
             final(regions).slot_owners[i] != old(regions).slot_owners[i] ==> {
                 &&& old(regions).slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNUSED
                 &&& final(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-                &&& final(regions).slot_owners[i].usage == PageUsage::PageTable
+                &&& final(regions).slot_owners[i].usage is PageTable
             },
         forall|c: CursorOwner<'a, UserPtConfig>|
             #![auto]

--- a/ostd/specs/mm/embedding/vm_space.rs
+++ b/ostd/specs/mm/embedding/vm_space.rs
@@ -25,7 +25,7 @@ verus! {
 /// is the slot whose perm `VmSpace::new` (`empty_with_owner`) permanently
 /// extracts from `regions.slots` (the root is owned by the page table,
 /// not parked in the free pool).
-pub open spec fn vm_space_root_idx(owner: VmSpaceOwner) -> usize {
+pub open spec fn vm_space_root_idx(owner: VmSpaceOwner) -> int {
     frame_to_index(owner.page_table_owner.value().meta_slot_paddr()->0)
 }
 
@@ -58,7 +58,7 @@ pub axiom fn vm_space_new_embedded<'a>(tracked regions: &mut MetaRegionOwners) -
         final(regions).slot_owners[vm_space_root_idx(res)].usage == PageUsage::PageTable,
         final(regions).slot_owners[vm_space_root_idx(res)].inner_perms.ref_count.value()
             != REF_COUNT_UNUSED,
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners[i].inner_perms.in_list == old(
                 regions,
@@ -68,7 +68,7 @@ pub axiom fn vm_space_new_embedded<'a>(tracked regions: &mut MetaRegionOwners) -
         // non-UNUSED PT node (`usage == PageTable`). `accounting_inv`
         // chains from this; the `usage == PageTable` strengthening also
         // feeds `structural_inv`'s slot-perm coverage exception.
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners[i] != old(regions).slot_owners[i] ==> {
                 &&& old(regions).slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNUSED
@@ -108,7 +108,7 @@ pub(super) proof fn new_vm_space_step<'a>(tracked regions: &mut MetaRegionOwners
         final(regions).slot_owners[vm_space_root_idx(res)].usage == PageUsage::PageTable,
         final(regions).slot_owners[vm_space_root_idx(res)].inner_perms.ref_count.value()
             != REF_COUNT_UNUSED,
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners[i].inner_perms.in_list == old(
                 regions,
@@ -118,7 +118,7 @@ pub(super) proof fn new_vm_space_step<'a>(tracked regions: &mut MetaRegionOwners
         // non-UNUSED PT node (`usage == PageTable`). `accounting_inv`
         // chains from this; the `usage == PageTable` strengthening also
         // feeds `structural_inv`'s slot-perm coverage exception.
-        forall|i: usize|
+        forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners[i] != old(regions).slot_owners[i] ==> {
                 &&& old(regions).slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNUSED

--- a/ostd/specs/mm/frame/frame_specs.rs
+++ b/ostd/specs/mm/frame/frame_specs.rs
@@ -138,7 +138,7 @@ impl<M: ?Sized> Frame<M> {
         {
             &&& pre_owner.inner_perms.ref_count.value() == REF_COUNT_UNUSED
             &&& MetaSlot::get_from_unused_inner_perms_spec(false, post_owner.inner_perms)
-            &&& post_owner.usage == PageUsage::Frame
+            &&& post_owner.usage is Frame
             &&& post_owner.slot_vaddr == pre_owner.slot_vaddr
             &&& post_owner.paths_in_pt == pre_owner.paths_in_pt
             &&& post =~= pre.insert_slot_owner(paddr, post_owner).mint_frame_obligation(idx)

--- a/ostd/specs/mm/frame/frame_specs.rs
+++ b/ostd/specs/mm/frame/frame_specs.rs
@@ -56,10 +56,10 @@ impl<'a, M: ?Sized> Frame<M> {
         &&& new_regions.slot_owners[frame_to_index(paddr)]
             =~= old_regions.slot_owners[frame_to_index(paddr)]
         &&& new_regions.slot_owners[frame_to_index(paddr)].slot_vaddr == r.ptr.addr()
-        &&& forall|i: usize|
+        &&& forall|i: int|
             #![trigger new_regions.slot_owners[i], old_regions.slot_owners[i]]
             i != frame_to_index(paddr) ==> new_regions.slot_owners[i] == old_regions.slot_owners[i]
-        &&& forall|i: usize|
+        &&& forall|i: int|
             i != frame_to_index(paddr) ==> new_regions.slots.contains_key(i)
                 == old_regions.slots.contains_key(i)
         &&& r.ptr.addr() == frame_to_meta(paddr)
@@ -93,12 +93,12 @@ impl<'a, M: ?Sized> Frame<M> {
         old_regions: MetaRegionOwners,
         new_regions: MetaRegionOwners,
     ) -> bool {
-        &&& forall|i: usize|
+        &&& forall|i: int|
             #![trigger new_regions.slots[i], old_regions.slots[i]]
             i != self.index() && old_regions.slots.contains_key(i)
                 ==> new_regions.slots.contains_key(i) && new_regions.slots[i]
                 == old_regions.slots[i]
-        &&& forall|i: usize|
+        &&& forall|i: int|
             #![trigger new_regions.slot_owners[i], old_regions.slot_owners[i]]
             i != self.index() ==> new_regions.slot_owners[i] == old_regions.slot_owners[i]
         &&& new_regions.slot_owners.dom() =~= old_regions.slot_owners.dom()
@@ -118,7 +118,7 @@ impl<M: ?Sized> Frame<M> {
         meta_to_frame(self.ptr.addr())
     }
 
-    pub open spec fn index(self) -> usize {
+    pub open spec fn index(self) -> int {
         frame_to_index(self.paddr())
     }
 
@@ -201,7 +201,7 @@ impl<M: ?Sized> TrackDrop for Frame<M> {
     /// (Full per-instance ledger enforcement is a follow-up; for now
     /// `consume_obligation` is a no-op so the token's identity is
     /// documentary rather than gated against a multiset.)
-    type Obligation = DropObligation<usize>;
+    type Obligation = DropObligation<int>;
 
     open spec fn tracked_redeem_requires(self, s: Self::State) -> bool {
         &&& s.slot_owners.contains_key(self.index())
@@ -216,7 +216,7 @@ impl<M: ?Sized> TrackDrop for Frame<M> {
     ) -> bool {
         let slot_own = s0.slot_owners[self.index()];
         &&& s1.slot_owners[self.index()] == slot_own
-        &&& forall|i: usize|
+        &&& forall|i: int|
             #![trigger s1.slot_owners[i]]
             i != self.index() ==> s1.slot_owners[i] == s0.slot_owners[i]
         &&& s1.slots =~= s0.slots
@@ -290,7 +290,7 @@ impl<M: ?Sized> TrackDrop for Frame<M> {
         let so0 = s0.slot_owners[idx];
         let so1 = s1.slot_owners[idx];
         &&& s1.inv()
-        &&& forall|i: usize|
+        &&& forall|i: int|
             #![trigger s1.slot_owners[i]]
             i != idx ==> s1.slot_owners[i] == s0.slot_owners[i]
         &&& s1.slots =~= s0.slots

--- a/ostd/specs/mm/frame/frame_specs.rs
+++ b/ostd/specs/mm/frame/frame_specs.rs
@@ -114,7 +114,7 @@ impl<M: ?Sized> Inv for Frame<M> {
 }
 
 impl<M: ?Sized> Frame<M> {
-    pub open spec fn paddr(self) -> usize {
+    pub open spec fn paddr(self) -> Paddr {
         meta_to_frame(self.ptr.addr())
     }
 
@@ -246,7 +246,7 @@ impl<M: ?Sized> TrackDrop for Frame<M> {
     // via `from_raw` after the slot has been torn down. Hence the drop is
     // only permitted when `raw_count == 0`.
     open spec fn drop_requires(self, s: Self::State, obl: Self::Obligation) -> bool {
-        let idx = frame_to_index(meta_to_frame(self.ptr.addr()));
+        let idx = self.index();
         let slot_own = s.slot_owners[idx];
         // Cross-object validity: this Frame is consistent with `s` and
         // the slot is in the SHARED rc range. `wf_with_region` carries the
@@ -286,7 +286,7 @@ impl<M: ?Sized> TrackDrop for Frame<M> {
         s1: Self::State,
         obl: Self::Obligation,
     ) -> bool {
-        let idx = frame_to_index(meta_to_frame(self.ptr.addr()));
+        let idx = self.index();
         let so0 = s0.slot_owners[idx];
         let so1 = s1.slot_owners[idx];
         &&& s1.inv()

--- a/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
+++ b/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
@@ -298,7 +298,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
         &&& perm.addr() == self.list[i].paddr
         &&& perm.points_to.addr() == self.list[i].paddr
         &&& perm.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
-        &&& regions.slot_owners[idx].usage == PageUsage::Frame
+        &&& regions.slot_owners[idx].usage is Frame
         &&& perm.wf(&perm.inner_perms)
         &&& perm.addr() % META_SLOT_SIZE == 0
         &&& FRAME_METADATA_RANGE.start <= perm.addr() < FRAME_METADATA_RANGE.start + MAX_NR_PAGES
@@ -403,7 +403,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
                 &&& perm.addr() == self.list[i].paddr
                 &&& perm.points_to.addr() == self.list[i].paddr
                 &&& perm.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
-                &&& regions.slot_owners[idx].usage == PageUsage::Frame
+                &&& regions.slot_owners[idx].usage is Frame
                 &&& perm.wf(&perm.inner_perms)
                 &&& perm.addr() % META_SLOT_SIZE == 0
                 &&& FRAME_METADATA_RANGE.start <= perm.addr() < FRAME_METADATA_RANGE.start
@@ -455,7 +455,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
                 &&& perm.addr() == self.list[i].paddr
                 &&& perm.points_to.addr() == self.list[i].paddr
                 &&& perm.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
-                &&& regions.slot_owners[idx].usage == PageUsage::Frame
+                &&& regions.slot_owners[idx].usage is Frame
                 &&& perm.wf(&perm.inner_perms)
                 &&& perm.addr() % META_SLOT_SIZE == 0
                 &&& FRAME_METADATA_RANGE.start <= perm.addr() < FRAME_METADATA_RANGE.start
@@ -567,7 +567,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
                     &&& fp.points_to.addr() == old.list[p].paddr
                     &&& fp.points_to.pptr() == r0.slots[i].pptr()
                     &&& fp.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
-                    &&& fr.slot_owners[i].usage == PageUsage::Frame
+                    &&& fr.slot_owners[i].usage is Frame
                     &&& fp.wf(&fp.inner_perms)
                     &&& fp.addr() % META_SLOT_SIZE == 0
                     &&& FRAME_METADATA_RANGE.start <= fp.addr() < FRAME_METADATA_RANGE.start
@@ -715,7 +715,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
                 &&& fpn.addr() == link.paddr
                 &&& fpn.points_to.addr() == link.paddr
                 &&& fpn.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
-                &&& fr.slot_owners[ins].usage == PageUsage::Frame
+                &&& fr.slot_owners[ins].usage is Frame
                 &&& fpn.wf(&fpn.inner_perms)
                 &&& fpn.addr() % META_SLOT_SIZE == 0
                 &&& FRAME_METADATA_RANGE.start <= fpn.addr() < FRAME_METADATA_RANGE.start
@@ -751,7 +751,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
                     &&& fp.points_to.addr() == old.list[p].paddr
                     &&& fp.points_to.pptr() == r0.slots[i].pptr()
                     &&& fp.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
-                    &&& fr.slot_owners[i].usage == PageUsage::Frame
+                    &&& fr.slot_owners[i].usage is Frame
                     &&& fp.wf(&fp.inner_perms)
                     &&& fp.addr() % META_SLOT_SIZE == 0
                     &&& FRAME_METADATA_RANGE.start <= fp.addr() < FRAME_METADATA_RANGE.start

--- a/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
+++ b/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
@@ -264,7 +264,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
     }
 
     /// The region slot index keyed by the `i`-th link's meta-slot address.
-    pub open spec fn slot_index_at(self, i: int) -> usize {
+    pub open spec fn slot_index_at(self, i: int) -> int {
         frame_to_index(meta_to_frame(self.list[i].paddr))
     }
 
@@ -355,7 +355,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
         ensures
             self.list.len() <= max_meta_slots(),
     {
-        let idxs = Seq::new(self.list.len(), |i: int| self.slot_index_at(i) as int);
+        let idxs = Seq::new(self.list.len(), |i: int| self.slot_index_at(i));
 
         idxs.unique_seq_to_set();
 

--- a/ostd/specs/mm/frame/mapping.rs
+++ b/ostd/specs/mm/frame/mapping.rs
@@ -28,20 +28,6 @@ pub open spec fn index_to_meta(i: usize) -> (res: Vaddr)
     (FRAME_METADATA_RANGE.start + i * META_SLOT_SIZE) as usize
 }
 
-pub broadcast proof fn lemma_FRAME_METADATA_RANGE_is_page_aligned()
-    ensures
-        #[trigger] FRAME_METADATA_RANGE.start % PAGE_SIZE == 0,
-        FRAME_METADATA_RANGE.end % PAGE_SIZE == 0,
-{
-}
-
-pub broadcast proof fn lemma_FRAME_METADATA_RANGE_is_large_enough()
-    ensures
-        #[trigger] FRAME_METADATA_RANGE.end >= FRAME_METADATA_RANGE.start + MAX_NR_PAGES
-            * META_SLOT_SIZE,
-{
-}
-
 #[verifier::inline]
 pub open spec fn frame_to_index(paddr: Paddr) -> usize
     recommends
@@ -121,8 +107,6 @@ pub broadcast proof fn lemma_meta_to_frame_alignment(meta: Vaddr)
 }
 
 pub broadcast group group_page_meta {
-    lemma_FRAME_METADATA_RANGE_is_page_aligned,
-    lemma_FRAME_METADATA_RANGE_is_large_enough,
     lemma_paddr_to_meta_biinjective,
     lemma_meta_to_paddr_biinjective,
     lemma_meta_to_frame_soundness,

--- a/ostd/specs/mm/frame/mapping.rs
+++ b/ostd/specs/mm/frame/mapping.rs
@@ -21,27 +21,38 @@ pub open spec fn max_meta_slots() -> int {
     (FRAME_METADATA_RANGE.end - FRAME_METADATA_RANGE.start) / META_SLOT_SIZE as int
 }
 
-pub open spec fn index_to_meta(i: usize) -> (res: Vaddr)
+pub open spec fn index_to_meta(i: int) -> (res: Vaddr)
     recommends
-        0 <= i < max_meta_slots() as usize,
+        0 <= i < max_meta_slots(),
 {
-    (FRAME_METADATA_RANGE.start + i * META_SLOT_SIZE) as usize
+    (FRAME_METADATA_RANGE.start + i * META_SLOT_SIZE) as Vaddr
 }
 
 #[verifier::inline]
-pub open spec fn frame_to_index(paddr: Paddr) -> usize
+pub open spec fn frame_to_index(paddr: Paddr) -> int
     recommends
         paddr % PAGE_SIZE == 0,
 {
-    paddr / PAGE_SIZE
+    (paddr / PAGE_SIZE) as int
 }
 
 #[verifier::inline]
-pub open spec fn index_to_frame(index: usize) -> Paddr
+pub open spec fn index_to_frame(index: int) -> Paddr
     recommends
-        index < max_meta_slots(),
+        0 <= index < max_meta_slots(),
 {
-    (index * PAGE_SIZE) as usize
+    (index * PAGE_SIZE) as Paddr
+}
+
+/// Converting an in-range metadata-slot index to its frame address and back
+/// preserves the index, and the resulting address is page aligned.
+pub broadcast proof fn lemma_index_to_frame_biinjective(index: int)
+    requires
+        0 <= index < max_meta_slots(),
+    ensures
+        #[trigger] index_to_frame(index) % PAGE_SIZE == 0,
+        frame_to_index(index_to_frame(index)) == index,
+{
 }
 
 /// `frame_to_index` is injective on page-aligned paddrs.
@@ -107,6 +118,7 @@ pub broadcast proof fn lemma_meta_to_frame_alignment(meta: Vaddr)
 }
 
 pub broadcast group group_page_meta {
+    lemma_index_to_frame_biinjective,
     lemma_paddr_to_meta_biinjective,
     lemma_meta_to_paddr_biinjective,
     lemma_meta_to_frame_soundness,

--- a/ostd/specs/mm/frame/mapping.rs
+++ b/ostd/specs/mm/frame/mapping.rs
@@ -21,7 +21,7 @@ pub open spec fn max_meta_slots() -> int {
     (FRAME_METADATA_RANGE.end - FRAME_METADATA_RANGE.start) / META_SLOT_SIZE as int
 }
 
-pub open spec fn meta_addr(i: usize) -> (res: usize)
+pub open spec fn index_to_meta(i: usize) -> (res: Vaddr)
     recommends
         0 <= i < max_meta_slots() as usize,
 {

--- a/ostd/specs/mm/frame/meta_region_owners.rs
+++ b/ostd/specs/mm/frame/meta_region_owners.rs
@@ -15,7 +15,7 @@ use vstd_extra::{
 use crate::specs::{
     arch::{MAX_PADDR, PAGE_SIZE},
     mm::frame::{
-        mapping::{frame_to_index, max_meta_slots, meta_addr},
+        mapping::{frame_to_index, max_meta_slots, index_to_meta},
         meta_owners::Metadata,
     },
 };
@@ -86,7 +86,7 @@ impl Inv for MetaRegionOwners {
                 self.slots.contains_key(i) ==> {
                     &&& self.slot_owners[i].inv()
                     &&& self.slots[i].is_init()
-                    &&& self.slots[i].addr() == meta_addr(i)
+                    &&& self.slots[i].addr() == index_to_meta(i)
                     &&& self.slots[i].value().wf(self.slot_owners[i])
                     &&& self.slot_owners[i].slot_vaddr == self.slots[i].addr()
                 }

--- a/ostd/specs/mm/frame/meta_region_owners.rs
+++ b/ostd/specs/mm/frame/meta_region_owners.rs
@@ -15,7 +15,7 @@ use vstd_extra::{
 use crate::specs::{
     arch::{MAX_PADDR, PAGE_SIZE},
     mm::frame::{
-        mapping::{frame_to_index, max_meta_slots, index_to_meta},
+        mapping::{frame_to_index, index_to_meta, max_meta_slots},
         meta_owners::Metadata,
     },
 };
@@ -53,8 +53,8 @@ verus! {
 /// the verified code that call `from_raw` have a precondition that the frame's index is not a key in `slots`.
 #[verifier::ext_equal]
 pub tracked struct MetaRegionOwners {
-    pub slots: Map<usize, simple_pptr::PointsTo<MetaSlot>>,
-    pub slot_owners: Map<usize, MetaSlotOwner>,
+    pub slots: Map<int, simple_pptr::PointsTo<MetaSlot>>,
+    pub slot_owners: Map<int, MetaSlotOwner>,
     /// Outstanding per-instance obligations for both `Frame<M>` and
     /// `Segment<M>`, as a multiset of slot indices. `ManuallyDrop::new(frame,
     /// ..)` adds one entry at `frame.key()` (mint paired with the `raw_count++`
@@ -63,26 +63,27 @@ pub tracked struct MetaRegionOwners {
     /// [`crate::specs::mm::frame::segment::tracked_mint_seg_obligations`]).
     /// Multiset semantics — multiple outstanding obligations at the same slot
     /// are counted individually.
-    pub frame_obligations: vstd::multiset::Multiset<usize>,
+    pub frame_obligations: vstd::multiset::Multiset<int>,
 }
 
 pub ghost struct MetaRegionModel {
-    pub slots: Map<usize, MetaSlotModel>,
+    pub slots: Map<int, MetaSlotModel>,
 }
 
 impl Inv for MetaRegionOwners {
     open spec fn inv(self) -> bool {
         &&& {
             // All accessible slots are within the valid address range.
-            forall|i: usize| i < max_meta_slots() <==> #[trigger] self.slot_owners.contains_key(i)
+            forall|i: int|
+                0 <= i < max_meta_slots() <==> #[trigger] self.slot_owners.contains_key(i)
         }
         &&& {
-            forall|i: usize| #[trigger]
+            forall|i: int| #[trigger]
                 self.slot_owners.contains_key(i) ==> self.slots.contains_key(i)
         }
-        &&& { forall|i: usize| #[trigger] self.slots.contains_key(i) ==> i < max_meta_slots() }
+        &&& { forall|i: int| #[trigger] self.slots.contains_key(i) ==> 0 <= i < max_meta_slots() }
         &&& {
-            forall|i: usize| #[trigger]
+            forall|i: int| #[trigger]
                 self.slots.contains_key(i) ==> {
                     &&& self.slot_owners[i].inv()
                     &&& self.slots[i].is_init()
@@ -96,8 +97,8 @@ impl Inv for MetaRegionOwners {
 
 impl Inv for MetaRegionModel {
     open spec fn inv(self) -> bool {
-        &&& forall|i: usize| i < max_meta_slots() <==> #[trigger] self.slots.contains_key(i)
-        &&& forall|i: usize| #[trigger] self.slots.contains_key(i) ==> self.slots[i].inv()
+        &&& forall|i: int| 0 <= i < max_meta_slots() <==> #[trigger] self.slots.contains_key(i)
+        &&& forall|i: int| #[trigger] self.slots.contains_key(i) ==> self.slots[i].inv()
     }
 }
 
@@ -121,25 +122,25 @@ impl MetaRegionOwners {
         Self { slot_owners: self.slot_owners.insert(index, owner), ..self }
     }
 
-    pub open spec fn ref_count(self, i: usize) -> (res: u64)
+    pub open spec fn ref_count(self, i: int) -> (res: u64)
         recommends
             self.inv(),
-            i < max_meta_slots() as usize,
+            0 <= i < max_meta_slots(),
     {
         self.slot_owners[i].inner_perms.ref_count.value()
     }
 
     /// `other` agrees with `self` on every slot owner except the one at index
     /// `idx`: a single-slot operation leaves all other slots' owners untouched.
-    pub open spec fn slot_owners_agree_except(self, other: MetaRegionOwners, idx: usize) -> bool {
-        forall|i: usize|
+    pub open spec fn slot_owners_agree_except(self, other: MetaRegionOwners, idx: int) -> bool {
+        forall|i: int|
             #![trigger other.slot_owners[i]]
             i != idx ==> other.slot_owners[i] == self.slot_owners[i]
     }
 
     pub axiom fn borrow_typed_perm<M: AnyFrameMeta + Repr<MetaSlotStorage>>(
         &self,
-        i: usize,
+        i: int,
     ) -> (tracked res: &vstd_extra::cast_ptr::PointsTo<MetaSlot, Metadata<M>>)
         requires
             self.slots.contains_key(i),
@@ -163,7 +164,7 @@ impl MetaRegionOwners {
     /// `slot_owners[i]` (raw_count/usage/slot_vaddr/paths_in_pt) are unchanged.
     pub axiom fn borrow_mut_typed_perm<M: AnyFrameMeta + Repr<MetaSlotStorage>>(
         &mut self,
-        i: usize,
+        i: int,
     ) -> (tracked res: &mut vstd_extra::cast_ptr::PointsTo<MetaSlot, Metadata<M>>)
         requires
             old(self).slots.contains_key(i),
@@ -180,8 +181,8 @@ impl MetaRegionOwners {
             final(self).slot_owners.dom() == old(self).slot_owners.dom(),
             final(self).slots[i] == final(res).points_to,
             final(self).slot_owners[i].inner_perms == final(res).inner_perms,
-            forall|k: usize| k != i ==> #[trigger] final(self).slots[k] == old(self).slots[k],
-            forall|k: usize|
+            forall|k: int| k != i ==> #[trigger] final(self).slots[k] == old(self).slots[k],
+            forall|k: int|
                 k != i ==> #[trigger] final(self).slot_owners[k] == old(self).slot_owners[k],
             final(self).slot_owners[i].usage == old(self).slot_owners[i].usage,
             final(self).slot_owners[i].slot_vaddr == old(self).slot_owners[i].slot_vaddr,
@@ -242,7 +243,7 @@ impl MetaRegionOwners {
             paddr % PAGE_SIZE == 0,
             self.inv(),
         ensures
-            self.slot_owners.contains_key(frame_to_index(paddr) as usize),
+            self.slot_owners.contains_key(frame_to_index(paddr)),
     {
     }
 
@@ -269,11 +270,11 @@ impl MetaRegionOwners {
     // ----------------------------------------------------------------------
     // Frame-side per-instance ledger.
     // ----------------------------------------------------------------------
-    pub open spec fn mint_frame_obligation(self, slot_idx: usize) -> Self {
+    pub open spec fn mint_frame_obligation(self, slot_idx: int) -> Self {
         Self { frame_obligations: self.frame_obligations.insert(slot_idx), ..self }
     }
 
-    pub open spec fn redeem_frame_obligation(self, slot_idx: usize) -> Self
+    pub open spec fn redeem_frame_obligation(self, slot_idx: int) -> Self
         recommends
             self.frame_obligations.count(slot_idx) > 0,
     {
@@ -284,8 +285,8 @@ impl MetaRegionOwners {
     /// Pairs the production of a per-Frame [`DropObligation`] with a
     /// `+1` on the `frame_obligations[slot_idx]` count. Called by Frame's
     /// `constructor_spec` (i.e. `ManuallyDrop::new(frame, ..)`).
-    pub axiom fn tracked_mint_frame_obligation(tracked &mut self, slot_idx: usize) -> (tracked obl:
-        DropObligation<usize>)
+    pub axiom fn tracked_mint_frame_obligation(tracked &mut self, slot_idx: int) -> (tracked obl:
+        DropObligation<int>)
         ensures
             obl.value() == slot_idx,
             *final(self) == old(self).mint_frame_obligation(slot_idx),
@@ -296,7 +297,7 @@ impl MetaRegionOwners {
     /// by `Drop::drop` or `ManuallyDrop::new`).
     pub axiom fn tracked_redeem_frame_obligation(
         tracked &mut self,
-        tracked obl: DropObligation<usize>,
+        tracked obl: DropObligation<int>,
     )
         requires
             old(self).frame_obligations.count(obl.value()) > 0,

--- a/ostd/specs/mm/frame/meta_specs.rs
+++ b/ostd/specs/mm/frame/meta_specs.rs
@@ -11,7 +11,7 @@ use vstd_extra::{cast_ptr::*, ownership::*};
 use crate::specs::{
     arch::*,
     mm::frame::{
-        mapping::{frame_to_index, index_to_frame, lemma_paddr_to_meta_biinjective, index_to_meta},
+        mapping::{frame_to_index, index_to_frame, index_to_meta, lemma_paddr_to_meta_biinjective},
         meta_owners::MetadataInnerPerms,
         meta_region_owners::MetaRegionOwners,
     },
@@ -128,7 +128,7 @@ impl MetaSlot {
             &&& post.slot_owners[idx].usage == PageUsage::PageTable
             &&& post.slot_owners[idx].slot_vaddr == pre.slot_owners[idx].slot_vaddr
             &&& post.slot_owners[idx].paths_in_pt == pre.slot_owners[idx].paths_in_pt
-            &&& forall|i: usize| i != idx ==> (#[trigger] post.slot_owners[i] == pre.slot_owners[i])
+            &&& forall|i: int| i != idx ==> (#[trigger] post.slot_owners[i] == pre.slot_owners[i])
             &&& pre.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNUSED
         }
     }
@@ -146,7 +146,7 @@ impl MetaSlot {
     ) -> bool {
         let idx = frame_to_index(paddr);
         &&& post.slots.dom() =~= pre.slots.dom()
-        &&& forall|k: usize|
+        &&& forall|k: int|
             #![trigger post.slots[k]]
             k != idx && pre.slots.contains_key(k) ==> post.slots[k] == pre.slots[k]
     }
@@ -220,7 +220,7 @@ impl MetaSlot {
             &&& post.slot_owners[idx].slot_vaddr == pre.slot_owners[idx].slot_vaddr
             &&& post.slot_owners[idx].usage == pre.slot_owners[idx].usage
             &&& post.slot_owners[idx].paths_in_pt == pre.slot_owners[idx].paths_in_pt
-            &&& forall|i: usize| i != idx ==> (#[trigger] post.slot_owners[i] == pre.slot_owners[i])
+            &&& forall|i: int| i != idx ==> (#[trigger] post.slot_owners[i] == pre.slot_owners[i])
         }
     }
 
@@ -264,9 +264,9 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Frame<M> {
 /// region facts phrased over `frame_to_index(meta_to_frame(ptr.addr))` at
 /// `slot_index` (e.g. recovering `ref_count == REF_COUNT_UNIQUE` from
 /// `global_inv`).
-pub broadcast proof fn lemma_index_to_meta_to_index(i: usize)
+pub broadcast proof fn lemma_index_to_meta_to_index(i: int)
     requires
-        i < MAX_NR_PAGES,
+        0 <= i < MAX_NR_PAGES,
     ensures
         #[trigger] frame_to_index(meta_to_frame(index_to_meta(i))) == i,
 {

--- a/ostd/specs/mm/frame/meta_specs.rs
+++ b/ostd/specs/mm/frame/meta_specs.rs
@@ -11,7 +11,7 @@ use vstd_extra::{cast_ptr::*, ownership::*};
 use crate::specs::{
     arch::*,
     mm::frame::{
-        mapping::{frame_to_index, index_to_frame, index_to_meta, lemma_paddr_to_meta_biinjective},
+        mapping::{frame_to_index, index_to_meta},
         meta_owners::MetadataInnerPerms,
         meta_region_owners::MetaRegionOwners,
     },
@@ -256,25 +256,6 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Frame<M> {
             _marker: PhantomData,
         }
     }
-}
-
-/// Index round-trip: the slot index recovered from a slot's metadata address
-/// is the original index. Callers holding `ptr.addr() == index_to_meta(slot_index)`
-/// (via [`crate::mm::frame::unique::UniqueFrame::wf`]) use this to re-derive
-/// region facts phrased over `frame_to_index(meta_to_frame(ptr.addr))` at
-/// `slot_index` (e.g. recovering `ref_count == REF_COUNT_UNIQUE` from
-/// `global_inv`).
-pub broadcast proof fn lemma_index_to_meta_to_index(i: int)
-    requires
-        0 <= i < MAX_NR_PAGES,
-    ensures
-        #[trigger] frame_to_index(meta_to_frame(index_to_meta(i))) == i,
-{
-    let p = index_to_frame(i);
-
-    // `index_to_meta(i)` is exactly the metadata address of physical page `p`.
-    // Existing biinjectivity closes `meta_to_frame(frame_to_meta(p)) == p`.
-    lemma_paddr_to_meta_biinjective(p);
 }
 
 } // verus!

--- a/ostd/specs/mm/frame/meta_specs.rs
+++ b/ostd/specs/mm/frame/meta_specs.rs
@@ -11,7 +11,7 @@ use vstd_extra::{cast_ptr::*, ownership::*};
 use crate::specs::{
     arch::*,
     mm::frame::{
-        mapping::{frame_to_index, index_to_frame, lemma_paddr_to_meta_biinjective, meta_addr},
+        mapping::{frame_to_index, index_to_frame, lemma_paddr_to_meta_biinjective, index_to_meta},
         meta_owners::MetadataInnerPerms,
         meta_region_owners::MetaRegionOwners,
     },
@@ -259,20 +259,20 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Frame<M> {
 }
 
 /// Index round-trip: the slot index recovered from a slot's metadata address
-/// is the original index. Callers holding `ptr.addr() == meta_addr(slot_index)`
+/// is the original index. Callers holding `ptr.addr() == index_to_meta(slot_index)`
 /// (via [`crate::mm::frame::unique::UniqueFrame::wf`]) use this to re-derive
 /// region facts phrased over `frame_to_index(meta_to_frame(ptr.addr))` at
 /// `slot_index` (e.g. recovering `ref_count == REF_COUNT_UNIQUE` from
 /// `global_inv`).
-pub broadcast proof fn lemma_meta_addr_to_index(i: usize)
+pub broadcast proof fn lemma_index_to_meta_to_index(i: usize)
     requires
         i < MAX_NR_PAGES,
     ensures
-        #[trigger] frame_to_index(meta_to_frame(meta_addr(i))) == i,
+        #[trigger] frame_to_index(meta_to_frame(index_to_meta(i))) == i,
 {
     let p = index_to_frame(i);
 
-    // `meta_addr(i)` is exactly the metadata address of physical page `p`.
+    // `index_to_meta(i)` is exactly the metadata address of physical page `p`.
     // Existing biinjectivity closes `meta_to_frame(frame_to_meta(p)) == p`.
     lemma_paddr_to_meta_biinjective(p);
 }

--- a/ostd/specs/mm/frame/meta_specs.rs
+++ b/ostd/specs/mm/frame/meta_specs.rs
@@ -97,7 +97,7 @@ impl MetaSlot {
         {
             &&& pre_owner.inner_perms.ref_count.value() == REF_COUNT_UNUSED
             &&& MetaSlot::get_from_unused_inner_perms_spec(as_unique, post_owner.inner_perms)
-            &&& post_owner.usage == PageUsage::Frame
+            &&& post_owner.usage is Frame
             &&& post_owner.slot_vaddr == pre_owner.slot_vaddr
             &&& post_owner.paths_in_pt == pre_owner.paths_in_pt
             &&& post =~= pre.insert_slot_owner(paddr, post_owner)
@@ -125,7 +125,7 @@ impl MetaSlot {
         {
             &&& post.slot_owners.dom() =~= pre.slot_owners.dom()
             &&& MetaSlot::get_from_unused_inner_perms_spec(false, post.slot_owners[idx].inner_perms)
-            &&& post.slot_owners[idx].usage == PageUsage::PageTable
+            &&& post.slot_owners[idx].usage is PageTable
             &&& post.slot_owners[idx].slot_vaddr == pre.slot_owners[idx].slot_vaddr
             &&& post.slot_owners[idx].paths_in_pt == pre.slot_owners[idx].paths_in_pt
             &&& forall|i: int| i != idx ==> (#[trigger] post.slot_owners[i] == pre.slot_owners[i])

--- a/ostd/specs/mm/frame/segment.rs
+++ b/ostd/specs/mm/frame/segment.rs
@@ -10,7 +10,7 @@ use crate::specs::{
     arch::PAGE_SIZE,
     mm::{
         frame::{
-            mapping::{frame_to_index, meta_addr},
+            mapping::{frame_to_index, index_to_meta},
             meta_region_owners::MetaRegionOwners,
         },
         virt_mem::MemView,
@@ -109,7 +109,7 @@ impl<M: AnyFrameMeta + ?Sized> Segment<M> {
                 &&& regions.frame_obligations.count(idx) >= 1
                 &&& regions.slot_owners.contains_key(idx)
                 &&& regions.slots.contains_key(idx)
-                &&& regions.slot_owners[idx].slot_vaddr == meta_addr(idx)
+                &&& regions.slot_owners[idx].slot_vaddr == index_to_meta(idx)
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value()
                     > 0
                 // Segment frames are shared (never `UNIQUE`).
@@ -146,7 +146,7 @@ impl<M: AnyFrameMeta + ?Sized> Segment<M> {
                     idx,
                 )
                 // Borrow-protocol transition: `raw_count` is dormant.
-                &&& regions.slot_owners[idx].slot_vaddr == meta_addr(idx)
+                &&& regions.slot_owners[idx].slot_vaddr == index_to_meta(idx)
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value() > 0
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value()
                     <= crate::mm::frame::meta::REF_COUNT_MAX

--- a/ostd/specs/mm/frame/segment.rs
+++ b/ostd/specs/mm/frame/segment.rs
@@ -230,7 +230,7 @@ impl<M: AnyFrameMeta + ?Sized> Segment<M> {
 /// treats opaquely under SMT), a `spec fn` is auto-unfolded so equalities
 /// between `frame_idx_at(...)` and `frame_to_index(...)` are derivable.
 #[verifier::inline]
-pub open spec fn frame_idx_at(range_start: usize, j: int) -> usize {
+pub open spec fn frame_idx_at(range_start: usize, j: int) -> int {
     frame_to_index((range_start + j * PAGE_SIZE) as usize)
 }
 
@@ -261,7 +261,7 @@ pub open spec fn seg_obligations_minted(
         ) >= pre.frame_obligations.count(frame_to_index((range_start + i * PAGE_SIZE) as usize))
             + 1
         // Frame condition: every slot that is NOT a segment frame is untouched.
-    &&& forall|jdx: usize|
+    &&& forall|jdx: int|
         #![trigger post.frame_obligations.count(jdx)]
         (forall|i: int|
             #![trigger frame_to_index((range_start + i * PAGE_SIZE) as usize)]
@@ -299,7 +299,7 @@ pub proof fn tracked_mint_seg_obligations(
         final(regions).slots == old(regions).slots,
         final(regions).slot_owners == old(regions).slot_owners,
         // Counts only grow.
-        forall|idx: usize|
+        forall|idx: int|
             #![trigger final(regions).frame_obligations.count(idx)]
             final(regions).frame_obligations.count(idx) >= old(regions).frame_obligations.count(
                 idx,
@@ -319,7 +319,7 @@ pub proof fn tracked_mint_seg_obligations(
         // first `n-1` frames against `g0`. Bridge each ensures to `n`.
         // Frame condition: a non-segment slot is untouched by the recursion
         // (it omits the slot from `[0, n-1)`) and is not the mint target.
-        assert forall|jdx: usize|
+        assert forall|jdx: int|
             #![trigger regions.frame_obligations.count(jdx)]
             (forall|i: int|
                 #![trigger frame_to_index((range_start + i * PAGE_SIZE) as usize)]

--- a/ostd/specs/mm/frame/unique.rs
+++ b/ostd/specs/mm/frame/unique.rs
@@ -7,7 +7,7 @@ use crate::specs::{
     mm::{
         Paddr,
         frame::{
-            mapping::{frame_to_index, max_meta_slots, index_to_meta},
+            mapping::{frame_to_index, index_to_meta, max_meta_slots},
             meta_region_owners::MetaRegionOwners,
         },
     },
@@ -31,7 +31,7 @@ verus! {
 //FIXME: why do we need a index here?
 pub tracked struct UniqueFrameOwner<M: AnyFrameMeta + ?Sized + Repr<MetaSlotStorage> + OwnerOf> {
     pub meta_own: M::Owner,
-    pub ghost slot_index: usize,
+    pub ghost slot_index: int,
 }
 
 pub ghost struct UniqueFrameModel<M: AnyFrameMeta + ?Sized + Repr<MetaSlotStorage> + OwnerOf> {
@@ -40,7 +40,7 @@ pub ghost struct UniqueFrameModel<M: AnyFrameMeta + ?Sized + Repr<MetaSlotStorag
 
 impl<M: AnyFrameMeta + ?Sized + Repr<MetaSlotStorage> + OwnerOf> Inv for UniqueFrameOwner<M> {
     open spec fn inv(self) -> bool {
-        &&& self.slot_index < MAX_NR_PAGES
+        &&& 0 <= self.slot_index < MAX_NR_PAGES
         &&& self.slot_index < max_meta_slots()
     }
 }
@@ -149,7 +149,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrameOwner<M> {
         &&& regions.frame_obligations.count(self.slot_index) > 0
     }
 
-    pub proof fn from_raw_owner(owner: M::Owner, index: Ghost<usize>) -> Self {
+    pub proof fn from_raw_owner(owner: M::Owner, index: Ghost<int>) -> Self {
         UniqueFrameOwner::<M> { meta_own: owner, slot_index: index@ }
     }
 
@@ -171,7 +171,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrameOwner<M> {
             == old_regions.slot_owners[frame_to_index(paddr)].usage
         &&& regions.slot_owners[frame_to_index(paddr)].paths_in_pt
             == old_regions.slot_owners[frame_to_index(paddr)].paths_in_pt
-        &&& forall|i: usize|
+        &&& forall|i: int|
             i != frame_to_index(paddr) ==> regions.slot_owners[i]
                 == old_regions.slot_owners[i]
         // Setting up the owner does not touch the per-frame ledger; the
@@ -203,7 +203,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> TrackDrop for UniqueFram
     /// at any moment a slot is in either Frame-SHARED mode (ref_count in
     /// [1, MAX]) or UniqueFrame-UNIQUE mode (ref_count == UNIQUE), never
     /// both, so the multiset semantics are unambiguous.
-    type Obligation = DropObligation<usize>;
+    type Obligation = DropObligation<int>;
 
     open spec fn tracked_redeem_requires(self, s: Self::State) -> bool {
         &&& s.slot_owners.contains_key(frame_to_index(meta_to_frame(self.ptr.addr())))
@@ -227,7 +227,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> TrackDrop for UniqueFram
             == s0.slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].usage
         &&& s1.slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].paths_in_pt
             == s0.slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].paths_in_pt
-        &&& forall|i: usize|
+        &&& forall|i: int|
             #![trigger s1.slot_owners[i]]
             i != frame_to_index(meta_to_frame(self.ptr.addr())) ==> s1.slot_owners[i]
                 == s0.slot_owners[i]
@@ -266,7 +266,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> TrackDrop for UniqueFram
         s1: Self::State,
         obl: Self::Obligation,
     ) -> bool {
-        &&& forall|i: usize|
+        &&& forall|i: int|
             #![trigger s1.slot_owners[i]]
             i != frame_to_index(meta_to_frame(self.ptr.addr())) ==> s1.slot_owners[i]
                 == s0.slot_owners[i]

--- a/ostd/specs/mm/frame/unique.rs
+++ b/ostd/specs/mm/frame/unique.rs
@@ -7,7 +7,7 @@ use crate::specs::{
     mm::{
         Paddr,
         frame::{
-            mapping::{frame_to_index, max_meta_slots, meta_addr},
+            mapping::{frame_to_index, max_meta_slots, index_to_meta},
             meta_region_owners::MetaRegionOwners,
         },
     },
@@ -68,7 +68,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> OwnerOf for UniqueFrame<
     type Owner = UniqueFrameOwner<M>;
 
     open spec fn wf(self, owner: Self::Owner) -> bool {
-        &&& self.ptr.addr() == meta_addr(owner.slot_index)
+        &&& self.ptr.addr() == index_to_meta(owner.slot_index)
     }
 }
 
@@ -80,7 +80,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrame<M> {
     /// [`UniqueFrame::drop`]) can state a single invariant instead of re-listing
     /// each conjunct.
     ///
-    /// The slot's `slot_owners.contains_key(idx)`, `slot_vaddr == meta_addr(idx)`,
+    /// The slot's `slot_owners.contains_key(idx)`, `slot_vaddr == index_to_meta(idx)`,
     /// `storage.is_init()`, and `vtable_ptr.is_init()` are **derived**, not
     /// required: `regions.inv()` (with `owner.inv()`'s `idx < max_meta_slots`)
     /// delivers the first two and `slot_owners[idx].inv()`; the latter's UNIQUE
@@ -117,7 +117,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrameOwner<M> {
 
     pub open spec fn perm_inv(self, perm: vstd::simple_pptr::PointsTo<MetaSlot>) -> bool {
         &&& perm.is_init()
-        &&& perm.addr() == meta_addr(self.slot_index)
+        &&& perm.addr() == index_to_meta(self.slot_index)
     }
 
     /// Borrow-model global invariant: the frame's permission is parked in
@@ -135,10 +135,10 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrameOwner<M> {
         &&& regions.slot_owners.contains_key(self.slot_index)
         &&& perm.is_init()
         &&& perm.wf(&perm.inner_perms)
-        &&& perm.addr() == meta_addr(self.slot_index)
+        &&& perm.addr() == index_to_meta(self.slot_index)
         &&& perm.addr() == perm.points_to.addr()
         &&& perm.value().metadata.wf(self.meta_own)
-        &&& regions.slot_owners[self.slot_index].slot_vaddr == meta_addr(self.slot_index)
+        &&& regions.slot_owners[self.slot_index].slot_vaddr == index_to_meta(self.slot_index)
         &&& regions.slot_owners[self.slot_index].inner_perms.ref_count.value()
             == REF_COUNT_UNIQUE
         // Data-frame node-repark discriminator (our change): a unique frame's

--- a/ostd/specs/mm/frame/unique.rs
+++ b/ostd/specs/mm/frame/unique.rs
@@ -155,7 +155,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrameOwner<M> {
         // slot is tracked with `Frame` usage, distinguishing it from page-table
         // node slots (`PageTable`) and letting linked-list/list-store consumers
         // derive `usage == Frame` (e.g. for the empty-`paths_in_pt` argument).
-        &&& regions.slot_owners[self.slot_index].usage == PageUsage::Frame
+        &&& regions.slot_owners[self.slot_index].usage is Frame
         &&& regions.frame_obligations.count(self.slot_index) > 0
     }
 

--- a/ostd/specs/mm/frame/unique.rs
+++ b/ostd/specs/mm/frame/unique.rs
@@ -28,6 +28,16 @@ use super::meta_owners::*;
 
 verus! {
 
+impl<M: AnyFrameMeta + ?Sized + Repr<MetaSlotStorage> + OwnerOf> UniqueFrame<M> {
+    pub open spec fn paddr(self) -> Paddr {
+        meta_to_frame(self.ptr.addr())
+    }
+
+    pub open spec fn index(self) -> int {
+        frame_to_index(self.paddr())
+    }
+}
+
 //FIXME: why do we need a index here?
 pub tracked struct UniqueFrameOwner<M: AnyFrameMeta + ?Sized + Repr<MetaSlotStorage> + OwnerOf> {
     pub meta_own: M::Owner,
@@ -206,7 +216,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> TrackDrop for UniqueFram
     type Obligation = DropObligation<int>;
 
     open spec fn tracked_redeem_requires(self, s: Self::State) -> bool {
-        &&& s.slot_owners.contains_key(frame_to_index(meta_to_frame(self.ptr.addr())))
+        &&& s.slot_owners.contains_key(self.index())
         &&& s.slot_owners[frame_to_index(
             meta_to_frame(self.ptr.addr()),
         )].inner_perms.ref_count.value() != REF_COUNT_UNUSED
@@ -219,32 +229,25 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> TrackDrop for UniqueFram
         s1: Self::State,
         obl: Self::Obligation,
     ) -> bool {
-        &&& s1.slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].inner_perms
-            == s0.slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].inner_perms
-        &&& s1.slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].slot_vaddr
-            == s0.slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].slot_vaddr
-        &&& s1.slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].usage
-            == s0.slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].usage
-        &&& s1.slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].paths_in_pt
-            == s0.slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].paths_in_pt
+        &&& s1.slot_owners[self.index()].inner_perms == s0.slot_owners[self.index()].inner_perms
+        &&& s1.slot_owners[self.index()].slot_vaddr == s0.slot_owners[self.index()].slot_vaddr
+        &&& s1.slot_owners[self.index()].usage == s0.slot_owners[self.index()].usage
+        &&& s1.slot_owners[self.index()].paths_in_pt == s0.slot_owners[self.index()].paths_in_pt
         &&& forall|i: int|
             #![trigger s1.slot_owners[i]]
-            i != frame_to_index(meta_to_frame(self.ptr.addr())) ==> s1.slot_owners[i]
-                == s0.slot_owners[i]
+            i != self.index() ==> s1.slot_owners[i] == s0.slot_owners[i]
         &&& s1.slots
             =~= s0.slots
         // Linear-drop discipline: minting a UniqueFrame (`MD::new`) adds
         // one entry at the slot index via the paired mint axiom — same
         // ledger Frame uses.
-        &&& s1.frame_obligations =~= s0.frame_obligations.insert(
-            frame_to_index(meta_to_frame(self.ptr.addr())),
-        )
-        &&& obl.value() == frame_to_index(meta_to_frame(self.ptr.addr()))
+        &&& s1.frame_obligations =~= s0.frame_obligations.insert(self.index())
+        &&& obl.value() == self.index()
         &&& s1.inv()
     }
 
     proof fn tracked_redeem(self, tracked s: &mut Self::State) -> (tracked obl: Self::Obligation) {
-        let index = frame_to_index(meta_to_frame(self.ptr.addr()));
+        let index = self.index();
         let tracked mut slot_own = s.slot_owners.tracked_remove(index);
         s.slot_owners.tracked_insert(index, slot_own);
         // Paired mint axiom: produces the token AND adds its Loc to
@@ -254,10 +257,10 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> TrackDrop for UniqueFram
     }
 
     open spec fn drop_requires(self, s: Self::State, obl: Self::Obligation) -> bool {
-        &&& s.slot_owners.contains_key(frame_to_index(meta_to_frame(self.ptr.addr())))
+        &&& s.slot_owners.contains_key(self.index())
         &&& s.inv()
-        &&& s.frame_obligations.count(frame_to_index(meta_to_frame(self.ptr.addr()))) > 0
-        &&& obl.value() == frame_to_index(meta_to_frame(self.ptr.addr()))
+        &&& s.frame_obligations.count(self.index()) > 0
+        &&& obl.value() == self.index()
     }
 
     open spec fn drop_ensures(
@@ -268,17 +271,14 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> TrackDrop for UniqueFram
     ) -> bool {
         &&& forall|i: int|
             #![trigger s1.slot_owners[i]]
-            i != frame_to_index(meta_to_frame(self.ptr.addr())) ==> s1.slot_owners[i]
-                == s0.slot_owners[i]
+            i != self.index() ==> s1.slot_owners[i] == s0.slot_owners[i]
         &&& s1.slots
             =~= s0.slots
         // The trait-level `drop_ensures` records the per-instance
         // ledger contribution: one entry at `obl_key` is removed via
         // `consume_obligation`. (`UniqueFrame`'s inherent `drop` exec
         // function is responsible for arranging this in the body.)
-        &&& s1.frame_obligations =~= s0.frame_obligations.remove(
-            frame_to_index(meta_to_frame(self.ptr.addr())),
-        )
+        &&& s1.frame_obligations =~= s0.frame_obligations.remove(self.index())
         &&& s1.inv()
     }
 }

--- a/ostd/specs/mm/page_table/cursor/cursor_fn_specs.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_fn_specs.rs
@@ -169,7 +169,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         let (pa, level, prop) = C::item_into_raw(item);
         let idx = frame_to_index(pa);
         &&& regions.slots.contains_key(idx)
-        &&& regions.slot_owners[idx].usage != PageUsage::PageTable
+        &&& regions.slot_owners[idx].usage !is PageTable
         &&& regions.slot_owners[idx].inner_perms.ref_count.value()
             != REF_COUNT_UNUSED
         // Tracked items hold a refcount; untracked (MMIO) don't.

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -109,7 +109,7 @@ pub proof fn subtree_unlock_upgrade<'rcu, C: PageTableConfig>(
     let h = CursorOwner::<'rcu, C>::node_unlocked(guards);
 
     if subtree.value().is_node() {
-        if subtree.value().node().meta_addr_self() == excepted_addr {
+        if subtree.value().node().meta_vaddr() == excepted_addr {
             // addr == excepted_addr contradicts path != excepted_path
             // via metaregion_sound's singleton paths_in_pt.
             let idx = frame_to_index(meta_to_frame(excepted_addr));
@@ -447,7 +447,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         );
 
         let cur_entry = self.cur_entry_owner();
-        let cur_entry_addr = cur_entry.node().meta_addr_self();
+        let cur_entry_addr = cur_entry.node().meta_vaddr();
         let cur_entry_path = old_cont.path().push_tail(old_cont.idx as int);
 
         assert forall|i: int|
@@ -458,8 +458,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             let cont_i = self.continuations[i];
 
             if cont_i.guard.inner.inner@.ptr.addr() == guard.inner.inner@.ptr.addr() {
-                let addr = cont_i.entry_own.node().meta_addr_self();
-                assert(addr == cur_entry.node().meta_addr_self());
+                let addr = cont_i.entry_own.node().meta_vaddr();
+                assert(addr == cur_entry.node().meta_vaddr());
                 let idx = frame_to_index(meta_to_frame(addr));
                 assert(regions.slot_owners[idx].paths_in_pt == set![cont_i.path()]);
                 assert(regions.slot_owners[idx].paths_in_pt == set![cur_entry_path]);
@@ -640,7 +640,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.pop_level_owner().0.metaregion_sound(regions),
     {
         let child = self.continuations[self.level - 1];
-        let child_addr = child.entry_own.node().meta_addr_self();
+        let child_addr = child.entry_own.node().meta_vaddr();
 
         self.map_children_implies(
             CursorOwner::<'rcu, C>::node_unlocked(guards),

--- a/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
@@ -119,7 +119,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             regions.inv(),
             self.metaregion_sound(regions),
             regions.slots.contains_key(changed_idx),
-            regions.slot_owners[changed_idx].usage != PageUsage::PageTable,
+            regions.slot_owners[changed_idx].usage !is PageTable,
         ensures
             self.no_node_at_idx(changed_idx),
     {
@@ -463,7 +463,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             regions0.inv(),
             regions0.slot_owners.contains_key(removed_idx),
             regions0.slots.contains_key(removed_idx),
-            regions0.slot_owners[removed_idx].usage != PageUsage::PageTable,
+            regions0.slot_owners[removed_idx].usage !is PageTable,
             self@.mappings == owner_before_replace@.mappings - PageTableOwner(
                 owner_before_replace.cur_subtree(),
             )@.mappings,

--- a/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
@@ -43,7 +43,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
     /// frame. Callers satisfy it by observing that page-table node metadata
     /// lives in `FRAME_METADATA_RANGE`, which is disjoint from any data-frame
     /// paddr (where `paths_in_pt` inserts happen).
-    pub open spec fn no_node_at_idx(self, idx: usize) -> bool {
+    pub open spec fn no_node_at_idx(self, idx: int) -> bool {
         &&& self.map_full_tree(
             |e: EntryOwner<C>, _p: TreePath<NR_ENTRIES>|
                 e.is_node() && e.meta_slot_paddr() is Some ==> frame_to_index(
@@ -113,7 +113,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
     /// (e.g., `map` and the huge-page split) use this helper to
     /// satisfy the precondition of
     /// [`Self::metaregion_preserved_under_path_insert`].
-    pub proof fn no_node_at_idx_from_slot_key(self, regions: MetaRegionOwners, changed_idx: usize)
+    pub proof fn no_node_at_idx_from_slot_key(self, regions: MetaRegionOwners, changed_idx: int)
         requires
             self.inv(),
             regions.inv(),
@@ -156,7 +156,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         self,
         regions0: MetaRegionOwners,
         regions1: MetaRegionOwners,
-        changed_idx: usize,
+        changed_idx: int,
         new_path: TreePath<NR_ENTRIES>,
     )
         requires
@@ -166,7 +166,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             regions0.slot_owners.contains_key(changed_idx),
             regions1.slots == regions0.slots,
             regions1.slot_owners.dom() =~= regions0.slot_owners.dom(),
-            forall|i: usize|
+            forall|i: int|
                 #![trigger regions1.slot_owners[i]]
                 i != changed_idx ==> regions0.slot_owners[i] == regions1.slot_owners[i],
             regions1.slot_owners[changed_idx].inner_perms
@@ -215,7 +215,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
     /// being removed has just left the cursor tree.
     pub open spec fn path_removable_at_idx(
         self,
-        idx: usize,
+        idx: int,
         removed_path: TreePath<NR_ENTRIES>,
     ) -> bool {
         &&& self.map_full_tree(
@@ -337,7 +337,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
     /// `path_removable_at_idx` conjunction.
     pub proof fn path_removable_from_no_node_and_no_frame_path(
         self,
-        idx: usize,
+        idx: int,
         removed_path: TreePath<NR_ENTRIES>,
     )
         requires
@@ -390,7 +390,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         self,
         regions0: MetaRegionOwners,
         regions1: MetaRegionOwners,
-        changed_idx: usize,
+        changed_idx: int,
         removed_path: TreePath<NR_ENTRIES>,
     )
         requires
@@ -400,7 +400,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             regions0.slot_owners.contains_key(changed_idx),
             regions1.slots == regions0.slots,
             regions1.slot_owners.dom() =~= regions0.slot_owners.dom(),
-            forall|i: usize|
+            forall|i: int|
                 #![trigger regions1.slot_owners[i]]
                 i != changed_idx ==> regions0.slot_owners[i] == regions1.slot_owners[i],
             regions1.slot_owners[changed_idx].inner_perms
@@ -451,7 +451,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         owner_before_replace: Self,
         regions0: MetaRegionOwners,
         regions1: MetaRegionOwners,
-        removed_idx: usize,
+        removed_idx: int,
         removed_path: TreePath<NR_ENTRIES>,
         target: Mapping,
     )
@@ -471,7 +471,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             owner_before_replace.cur_subtree().value().path == removed_path,
             regions1.slots == regions0.slots,
             regions1.slot_owners.dom() =~= regions0.slot_owners.dom(),
-            forall|i: usize|
+            forall|i: int|
                 #![trigger regions1.slot_owners[i]]
                 i != removed_idx ==> regions0.slot_owners[i] == regions1.slot_owners[i],
             regions1.slot_owners[removed_idx].inner_perms

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -16,7 +16,7 @@ use crate::specs::{
     arch::*,
     mm::{
         frame::{
-            mapping::{frame_to_index, meta_addr},
+            mapping::{frame_to_index, index_to_meta},
             meta_region_owners::MetaRegionOwners,
         },
         page_table::{

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -806,7 +806,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         TreePath<NR_ENTRIES>,
     ) -> bool) {
         |owner: EntryOwner<C>, path: TreePath<NR_ENTRIES>|
-            owner.is_node() ==> guards.unlocked(owner.node().meta_addr_self())
+            owner.is_node() ==> guards.unlocked(owner.node().meta_vaddr())
     }
 
     pub open spec fn node_unlocked_except(guards: Guards<'rcu>, addr: usize) -> (spec_fn(
@@ -814,8 +814,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         TreePath<NR_ENTRIES>,
     ) -> bool) {
         |owner: EntryOwner<C>, path: TreePath<NR_ENTRIES>|
-            owner.is_node() ==> owner.node().meta_addr_self() != addr ==> guards.unlocked(
-                owner.node().meta_addr_self(),
+            owner.is_node() ==> owner.node().meta_vaddr() != addr ==> guards.unlocked(
+                owner.node().meta_vaddr(),
             )
     }
 
@@ -843,7 +843,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
     pub open spec fn only_current_locked(self, guards: Guards<'rcu>) -> bool {
         self.map_only_children(
-            Self::node_unlocked_except(guards, self.cur_entry_owner().node().meta_addr_self()),
+            Self::node_unlocked_except(guards, self.cur_entry_owner().node().meta_vaddr()),
         )
     }
 
@@ -860,11 +860,11 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             guards1.guards == guards0.guards.remove(guard.inner.inner@.ptr.addr()),
             // The dropped guard is for the current entry's node (from pop_level).
             self.cur_entry_owner().is_node(),
-            guard.inner.inner@.ptr.addr() == self.cur_entry_owner().node().meta_addr_self(),
+            guard.inner.inner@.ptr.addr() == self.cur_entry_owner().node().meta_vaddr(),
         ensures
             self.children_not_locked(guards1),
     {
-        let current_addr = self.cur_entry_owner().node().meta_addr_self();
+        let current_addr = self.cur_entry_owner().node().meta_vaddr();
         let f = Self::node_unlocked_except(guards0, current_addr);
         let g = Self::node_unlocked(guards1);
 

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -1121,7 +1121,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         self,
         old_regions: MetaRegionOwners,
         new_regions: MetaRegionOwners,
-        idx: usize,
+        idx: int,
     )
         requires
             self.inv(),
@@ -1149,7 +1149,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             new_regions.slot_owners[idx].usage == old_regions.slot_owners[idx].usage,
             // All other slot_owners unchanged
             new_regions.slot_owners.dom() == old_regions.slot_owners.dom(),
-            forall|i: usize|
+            forall|i: int|
                 #![trigger new_regions.slot_owners[i]]
                 i != idx && old_regions.slot_owners.contains_key(i) ==> new_regions.slot_owners[i]
                     == old_regions.slot_owners[i],
@@ -2089,9 +2089,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.inv(),
             self.metaregion_sound(regions0),
             regions0.slot_owners =~= regions1.slot_owners,
-            forall|k: usize|
+            forall|k: int|
                 regions0.slots.contains_key(k) ==> #[trigger] regions1.slots.contains_key(k),
-            forall|k: usize|
+            forall|k: int|
                 regions0.slots.contains_key(k) ==> regions0.slots[k]
                     == #[trigger] regions1.slots[k],
         ensures
@@ -2106,7 +2106,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         self,
         regions0: MetaRegionOwners,
         regions1: MetaRegionOwners,
-        idx: usize,
+        idx: int,
     )
         requires
             self.inv(),
@@ -2130,7 +2130,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             regions1.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED,
             // Bumped rc stays in the SHARED range (needed for the node branch).
             regions1.slot_owners[idx].inner_perms.ref_count.value() <= REF_COUNT_MAX,
-            forall|i: usize|
+            forall|i: int|
                 #![trigger regions1.slot_owners[i]]
                 i != idx && regions0.slot_owners.contains_key(i) ==> regions1.slot_owners[i]
                     == regions0.slot_owners[i],
@@ -2148,13 +2148,13 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         self,
         regions0: MetaRegionOwners,
         regions1: MetaRegionOwners,
-        changed_idx: usize,
+        changed_idx: int,
     )
         requires
             self.inv(),
             self.metaregion_sound(regions0),
             regions1.inv(),
-            forall|k: usize|
+            forall|k: int|
                 regions0.slots.contains_key(k) ==> #[trigger] regions1.slots.contains_key(k),
             // Borrow-protocol transition: `raw_count` is dormant, so the
             // borrow is net-zero on `regions` — the slot perm at
@@ -2162,7 +2162,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             // `Frame::borrow`, which leaves `slots` unchanged). With
             // `raw_count` no longer in `metaregion_sound`, full slot
             // preservation is what carries soundness across the borrow.
-            forall|k: usize|
+            forall|k: int|
                 regions0.slots.contains_key(k) ==> regions0.slots[k]
                     == #[trigger] regions1.slots[k],
             // All other fields at changed_idx preserved
@@ -2174,7 +2174,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             regions1.slot_owners[changed_idx].paths_in_pt
                 == regions0.slot_owners[changed_idx].paths_in_pt,
             // All other slots unchanged
-            forall|i: usize|
+            forall|i: int|
                 #![trigger regions1.slot_owners[i]]
                 i != changed_idx ==> regions0.slot_owners[i] == regions1.slot_owners[i],
             regions0.slot_owners.dom() =~= regions1.slot_owners.dom(),

--- a/ostd/specs/mm/page_table/node/child.rs
+++ b/ostd/specs/mm/page_table/node/child.rs
@@ -21,7 +21,7 @@ impl<C: PageTableConfig> OwnerOf for Child<C> {
         match self {
             Self::PageTable(node) => {
                 &&& owner.is_node()
-                &&& node.ptr.addr() == owner.node().meta_addr_self()
+                &&& node.ptr.addr() == owner.node().meta_vaddr()
                 &&& node.index() == frame_to_index(meta_to_frame(node.ptr.addr()))
             },
             Self::Frame(paddr, level, prop) => {
@@ -42,7 +42,7 @@ impl<'a, C: PageTableConfig> OwnerOf for ChildRef<'a, C> {
         match self {
             Self::PageTable(node) => {
                 &&& owner.is_node()
-                &&& node.inner@.ptr.addr() == owner.node().meta_addr_self()
+                &&& node.inner@.ptr.addr() == owner.node().meta_vaddr()
             },
             Self::Frame(paddr, level, prop) => {
                 &&& owner.is_frame()

--- a/ostd/specs/mm/page_table/node/entry.rs
+++ b/ostd/specs/mm/page_table/node/entry.rs
@@ -30,7 +30,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
     ) -> bool {
         &&& parent_owner.level == owner.parent_level
         &&& parent_owner.inv()
-        &&& guard.inner.inner@.ptr.addr() == parent_owner.meta_addr_self()
+        &&& guard.inner.inner@.ptr.addr() == parent_owner.meta_vaddr()
         &&& guard.inner.inner@.wf(parent_owner)
         &&& owner.match_pte(parent_owner.children_perm.value()[self.idx as int], owner.parent_level)
     }

--- a/ostd/specs/mm/page_table/node/entry_owners.rs
+++ b/ostd/specs/mm/page_table/node/entry_owners.rs
@@ -514,8 +514,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
             &&& regions.slots[idx].addr() == index_to_meta(idx)
             &&& regions.slots[idx].is_init()
             &&& regions.slots[idx].value().wf(regions.slot_owners[idx])
-            &&& regions.slot_owners[idx].usage
-                != PageUsage::PageTable
+            &&& regions.slot_owners[idx].usage !is PageTable
             // Tracked vs MMIO discriminator is the slot's `usage`. MMIO slots
             // stay in the free pool with `rc == UNUSED`; tracked slots have
             // `rc > 0`. The slot's `usage == MMIO` is pinned by the paddr's

--- a/ostd/specs/mm/page_table/node/entry_owners.rs
+++ b/ostd/specs/mm/page_table/node/entry_owners.rs
@@ -417,7 +417,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
             self.frame_sub_pages_valid(r0),
             r0.slots == r1.slots,
             r0.slot_owners.dom() =~= r1.slot_owners.dom(),
-            forall|i: usize|
+            forall|i: int|
                 #![trigger r1.slot_owners[i]]
                 i != frame_to_index(self.meta_slot_paddr()->0) && r0.slot_owners.contains_key(i)
                     ==> r0.slot_owners[i] == r1.slot_owners[i],
@@ -542,7 +542,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
     pub proof fn lemma_active_entry_not_in_free_pool(
         entry: Self,
         regions: MetaRegionOwners,
-        free_idx: usize,
+        free_idx: int,
     )
         requires
             regions.inv(),
@@ -583,8 +583,8 @@ impl<C: PageTableConfig> EntryOwner<C> {
             self.inv(),
             self.metaregion_sound(r0),
             r0.slot_owners == r1.slot_owners,
-            forall|k: usize| r0.slots.contains_key(k) ==> #[trigger] r1.slots.contains_key(k),
-            forall|k: usize| r0.slots.contains_key(k) ==> r0.slots[k] == #[trigger] r1.slots[k],
+            forall|k: int| r0.slots.contains_key(k) ==> #[trigger] r1.slots.contains_key(k),
+            forall|k: int| r0.slots.contains_key(k) ==> r0.slots[k] == #[trigger] r1.slots[k],
         ensures
             self.metaregion_sound(r1),
     {
@@ -596,18 +596,18 @@ impl<C: PageTableConfig> EntryOwner<C> {
         self,
         r0: MetaRegionOwners,
         r1: MetaRegionOwners,
-        changed_idx: usize,
+        changed_idx: int,
     )
         requires
             self.inv(),
             self.metaregion_sound(r0),
-            forall|i: usize|
+            forall|i: int|
                 #![trigger r1.slot_owners[i]]
                 i != changed_idx ==> r0.slot_owners[i] == r1.slot_owners[i],
             r0.slot_owners.dom() =~= r1.slot_owners.dom(),
             // slots preserved at the entry's index (frames read from slots)
-            forall|k: usize| r0.slots.contains_key(k) ==> #[trigger] r1.slots.contains_key(k),
-            forall|k: usize| r0.slots.contains_key(k) ==> r0.slots[k] == #[trigger] r1.slots[k],
+            forall|k: int| r0.slots.contains_key(k) ==> #[trigger] r1.slots.contains_key(k),
+            forall|k: int| r0.slots.contains_key(k) ==> r0.slots[k] == #[trigger] r1.slots[k],
             self.meta_slot_paddr() is Some ==> frame_to_index(self.meta_slot_paddr()->0)
                 != changed_idx,
             // Huge frames: if changed_idx is one of this frame's 4KB sub-page slots and
@@ -639,7 +639,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
         self,
         r0: MetaRegionOwners,
         r1: MetaRegionOwners,
-        changed_idx: usize,
+        changed_idx: int,
     )
         requires
             self.inv(),
@@ -648,7 +648,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
             r0.slots == r1.slots,
             r0.slot_owners.dom() =~= r1.slot_owners.dom(),
             // All slots other than changed_idx are entirely unchanged.
-            forall|i: usize|
+            forall|i: int|
                 #![trigger r1.slot_owners[i]]
                 i != changed_idx ==> r0.slot_owners[i] == r1.slot_owners[i],
             // At changed_idx, only paths_in_pt differs.
@@ -668,7 +668,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
             self.is_frame() && self.parent_level > 1 ==> {
                 let pa = self.frame().mapped_pa;
                 let sub_level = (self.parent_level - 1) as PagingLevel;
-                forall|j: usize|
+                forall|j: int|
                     0 < j < NR_ENTRIES ==> {
                         let sub_idx = #[trigger] frame_to_index(
                             (pa + j * page_size(sub_level)) as usize,
@@ -759,7 +759,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
                 &&& r1.slot_owners[idx].usage == r0.slot_owners[idx].usage
             }),
             // All other slot_owners unchanged: preserves sub-page validity for huge frames.
-            forall|i: usize|
+            forall|i: int|
                 #![trigger r1.slot_owners[i]]
                 i != frame_to_index(self.meta_slot_paddr()->0) && r0.slot_owners.contains_key(i)
                     ==> r0.slot_owners[i] == r1.slot_owners[i],

--- a/ostd/specs/mm/page_table/node/entry_owners.rs
+++ b/ostd/specs/mm/page_table/node/entry_owners.rs
@@ -310,7 +310,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
         }
         &&& pte.is_present() && !pte.is_last(parent_level) ==> {
             &&& self.is_node()
-            &&& meta_to_frame(self.node().meta_addr_self()) == pte.paddr()
+            &&& meta_to_frame(self.node().meta_vaddr()) == pte.paddr()
         }
         &&& pte.is_present() && pte.is_last(parent_level) ==> {
             &&& self.is_frame()
@@ -504,7 +504,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
             let idx = frame_to_index(self.meta_slot_paddr()->0);
             &&& regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
             &&& 0 < regions.slot_owners[idx].inner_perms.ref_count.value() <= REF_COUNT_MAX
-            &&& regions.slot_owners[idx].slot_vaddr == self.node().meta_addr_self()
+            &&& regions.slot_owners[idx].slot_vaddr == self.node().meta_vaddr()
             &&& regions.slots[idx].value().wf(regions.slot_owners[idx])
             &&& regions.slot_owners[idx].paths_in_pt == set![self.path]
             &&& self.node().metaregion_sound_node(regions)
@@ -562,7 +562,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
 
     pub open spec fn meta_slot_paddr(self) -> Option<Paddr> {
         if self.is_node() {
-            Some(meta_to_frame(self.node().meta_addr_self()))
+            Some(meta_to_frame(self.node().meta_vaddr()))
         } else if self.is_frame() {
             Some(self.frame().mapped_pa)
         } else {
@@ -811,10 +811,10 @@ impl<C: PageTableConfig> EntryOwner<C> {
             )].paths_in_pt == set![other.path],
             self.path != other.path,
         ensures
-            self.node().meta_addr_self() != other.node().meta_addr_self(),
+            self.node().meta_vaddr() != other.node().meta_vaddr(),
     {
-        let slot_vaddr = self.node().meta_addr_self();
-        let other_addr = other.node().meta_addr_self();
+        let slot_vaddr = self.node().meta_vaddr();
+        let other_addr = other.node().meta_vaddr();
         let self_idx = frame_to_index(meta_to_frame(slot_vaddr));
         let other_idx = frame_to_index(meta_to_frame(other_addr));
 
@@ -908,7 +908,7 @@ impl<C: PageTableConfig> View for EntryOwner<C> {
                     map_va: vaddr(self.path) as int,
                     //                    frame_pa: self.base_addr as int,
                     //                    in_frame_index: self.index as int,
-                    map_to_pa: meta_to_frame(node.meta_addr_self()) as int,
+                    map_to_pa: meta_to_frame(node.meta_vaddr()) as int,
                     level: self.path.len() as u8,
                     phantom: PhantomData,
                 },

--- a/ostd/specs/mm/page_table/node/entry_owners.rs
+++ b/ostd/specs/mm/page_table/node/entry_owners.rs
@@ -9,7 +9,7 @@ use crate::specs::{
     arch::*,
     mm::{
         frame::{
-            mapping::{frame_to_index, meta_addr},
+            mapping::{frame_to_index, index_to_meta},
             meta_owners::PageUsage,
             meta_region_owners::MetaRegionOwners,
         },
@@ -511,7 +511,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
         } else if self.is_frame() {
             let idx = frame_to_index(self.meta_slot_paddr()->0);
             &&& regions.slots.contains_key(idx)
-            &&& regions.slots[idx].addr() == meta_addr(idx)
+            &&& regions.slots[idx].addr() == index_to_meta(idx)
             &&& regions.slots[idx].is_init()
             &&& regions.slots[idx].value().wf(regions.slot_owners[idx])
             &&& regions.slot_owners[idx].usage

--- a/ostd/specs/mm/page_table/node/owners.rs
+++ b/ostd/specs/mm/page_table/node/owners.rs
@@ -290,8 +290,7 @@ impl<C: PageTableConfig> NodeOwner<C> {
         // freshly-allocated node (whose slot was `UNUSED`) can't collide with an
         // existing live node — giving `alloc_if_none`/`split` the parent≠child
         // slot distinctness without a PointsTo-linearity axiom.
-        &&& regions.slot_owners[self.slot_index].usage
-            == PageUsage::PageTable
+        &&& regions.slot_owners[self.slot_index].usage is PageTable
         // `nr_children` counts the present PTEs in `children_perm`. A settled-node
         // invariant (it is momentarily broken mid-`replace`/`alloc_if_none`, between
         // the PTE write and the counter update, which is why it lives here rather

--- a/ostd/specs/mm/page_table/node/owners.rs
+++ b/ostd/specs/mm/page_table/node/owners.rs
@@ -10,7 +10,7 @@ use crate::specs::{
     arch::{MAX_PADDR, NR_ENTRIES, NR_LEVELS},
     mm::{
         frame::{
-            mapping::{frame_to_index, max_meta_slots, index_to_meta},
+            mapping::{frame_to_index, index_to_meta, max_meta_slots},
             meta_owners::*,
             meta_region_owners::MetaRegionOwners,
         },
@@ -228,7 +228,7 @@ pub tracked struct NodeOwner<C: PageTableConfig> {
     pub children_perm: array_ptr::PointsTo<C::E, NR_ENTRIES>,
     pub ghost level: PagingLevel,
     pub ghost tree_level: int,
-    pub ghost slot_index: usize,
+    pub ghost slot_index: int,
 }
 
 impl<C: PageTableConfig> Inv for NodeOwner<C> {
@@ -237,9 +237,11 @@ impl<C: PageTableConfig> Inv for NodeOwner<C> {
         &&& 0 <= self.meta_own.nr_children.value() <= NR_ENTRIES
         &&& 1 <= self.level <= NR_LEVELS
         &&& self.children_perm.is_init_all()
-        &&& self.children_perm.addr() == paddr_to_vaddr(meta_to_frame(index_to_meta(self.slot_index)))
+        &&& self.children_perm.addr() == paddr_to_vaddr(
+            meta_to_frame(index_to_meta(self.slot_index)),
+        )
         &&& self.tree_level == INC_LEVELS - self.level - 1
-        &&& self.slot_index < max_meta_slots() as usize
+        &&& 0 <= self.slot_index < max_meta_slots()
         &&& FRAME_METADATA_RANGE.start <= index_to_meta(self.slot_index) < FRAME_METADATA_RANGE.end
         &&& index_to_meta(self.slot_index) % META_SLOT_SIZE == 0
         &&& meta_to_frame(index_to_meta(self.slot_index)) < VMALLOC_BASE_VADDR

--- a/ostd/specs/mm/page_table/node/owners.rs
+++ b/ostd/specs/mm/page_table/node/owners.rs
@@ -10,7 +10,7 @@ use crate::specs::{
     arch::{MAX_PADDR, NR_ENTRIES, NR_LEVELS},
     mm::{
         frame::{
-            mapping::{frame_to_index, max_meta_slots, meta_addr},
+            mapping::{frame_to_index, max_meta_slots, index_to_meta},
             meta_owners::*,
             meta_region_owners::MetaRegionOwners,
         },
@@ -237,16 +237,16 @@ impl<C: PageTableConfig> Inv for NodeOwner<C> {
         &&& 0 <= self.meta_own.nr_children.value() <= NR_ENTRIES
         &&& 1 <= self.level <= NR_LEVELS
         &&& self.children_perm.is_init_all()
-        &&& self.children_perm.addr() == paddr_to_vaddr(meta_to_frame(meta_addr(self.slot_index)))
+        &&& self.children_perm.addr() == paddr_to_vaddr(meta_to_frame(index_to_meta(self.slot_index)))
         &&& self.tree_level == INC_LEVELS - self.level - 1
         &&& self.slot_index < max_meta_slots() as usize
-        &&& FRAME_METADATA_RANGE.start <= meta_addr(self.slot_index) < FRAME_METADATA_RANGE.end
-        &&& meta_addr(self.slot_index) % META_SLOT_SIZE == 0
-        &&& meta_to_frame(meta_addr(self.slot_index)) < VMALLOC_BASE_VADDR
+        &&& FRAME_METADATA_RANGE.start <= index_to_meta(self.slot_index) < FRAME_METADATA_RANGE.end
+        &&& index_to_meta(self.slot_index) % META_SLOT_SIZE == 0
+        &&& meta_to_frame(index_to_meta(self.slot_index)) < VMALLOC_BASE_VADDR
             - LINEAR_MAPPING_BASE_VADDR
-        &&& meta_to_frame(meta_addr(self.slot_index)) < MAX_PADDR
-        &&& meta_to_frame(meta_addr(self.slot_index)) == self.children_perm.addr()
-        &&& self.slot_index == frame_to_index(meta_to_frame(meta_addr(self.slot_index)))
+        &&& meta_to_frame(index_to_meta(self.slot_index)) < MAX_PADDR
+        &&& meta_to_frame(index_to_meta(self.slot_index)) == self.children_perm.addr()
+        &&& self.slot_index == frame_to_index(meta_to_frame(index_to_meta(self.slot_index)))
     }
 }
 
@@ -254,7 +254,7 @@ impl<C: PageTableConfig> NodeOwner<C> {
     /// The meta address of this node's slot, computed from `slot_index`.
     /// Always equals `self.meta_perm.addr()` under `inv()`.
     pub open spec fn meta_vaddr(self) -> Vaddr {
-        meta_addr(self.slot_index)
+        index_to_meta(self.slot_index)
     }
 
     /// Reconstructs a metadata cast_ptr from `regions` at `self.slot_index`.

--- a/ostd/specs/mm/page_table/node/owners.rs
+++ b/ostd/specs/mm/page_table/node/owners.rs
@@ -226,9 +226,9 @@ impl<C: PageTableConfig> OwnerOf for PageTablePageMeta<C> {
 pub tracked struct NodeOwner<C: PageTableConfig> {
     pub meta_own: PageMetaOwner,
     pub children_perm: array_ptr::PointsTo<C::E, NR_ENTRIES>,
-    pub level: PagingLevel,
-    pub tree_level: int,
-    pub slot_index: usize,
+    pub ghost level: PagingLevel,
+    pub ghost tree_level: int,
+    pub ghost slot_index: usize,
 }
 
 impl<C: PageTableConfig> Inv for NodeOwner<C> {
@@ -253,7 +253,7 @@ impl<C: PageTableConfig> Inv for NodeOwner<C> {
 impl<C: PageTableConfig> NodeOwner<C> {
     /// The meta address of this node's slot, computed from `slot_index`.
     /// Always equals `self.meta_perm.addr()` under `inv()`.
-    pub open spec fn meta_addr_self(self) -> Vaddr {
+    pub open spec fn meta_vaddr(self) -> Vaddr {
         meta_addr(self.slot_index)
     }
 
@@ -341,7 +341,7 @@ impl<C: PageTableConfig> NodeOwner<C> {
 
 impl<'rcu, C: PageTableConfig> NodeOwner<C> {
     pub open spec fn relate_guard(self, guard: PageTableGuard<'rcu, C>) -> bool {
-        &&& guard.inner.inner@.ptr.addr() == self.meta_addr_self()
+        &&& guard.inner.inner@.ptr.addr() == self.meta_vaddr()
         &&& guard.inner.inner@.wf(self)
     }
 }
@@ -374,7 +374,7 @@ impl<C: PageTableConfig> OwnerOf for PageTableNode<C> {
     type Owner = NodeOwner<C>;
 
     open spec fn wf(self, owner: Self::Owner) -> bool {
-        &&& self.ptr.addr() == owner.meta_addr_self()
+        &&& self.ptr.addr() == owner.meta_vaddr()
     }
 }
 

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -1450,8 +1450,8 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             self.inv(),
             self.metaregion_sound(r0),
             r0.slot_owners == r1.slot_owners,
-            forall|k: usize| r0.slots.contains_key(k) ==> #[trigger] r1.slots.contains_key(k),
-            forall|k: usize| r0.slots.contains_key(k) ==> r0.slots[k] == #[trigger] r1.slots[k],
+            forall|k: int| r0.slots.contains_key(k) ==> #[trigger] r1.slots.contains_key(k),
+            forall|k: int| r0.slots.contains_key(k) ==> r0.slots[k] == #[trigger] r1.slots[k],
         ensures
             self.metaregion_sound(r1),
     {
@@ -1474,8 +1474,8 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             subtree.inv(),
             subtree.subtree_satisfies(path, Self::metaregion_sound_pred(r0)),
             r0.slot_owners == r1.slot_owners,
-            forall|k: usize| r0.slots.contains_key(k) ==> #[trigger] r1.slots.contains_key(k),
-            forall|k: usize| r0.slots.contains_key(k) ==> r0.slots[k] == #[trigger] r1.slots[k],
+            forall|k: int| r0.slots.contains_key(k) ==> #[trigger] r1.slots.contains_key(k),
+            forall|k: int| r0.slots.contains_key(k) ==> r0.slots[k] == #[trigger] r1.slots[k],
         ensures
             subtree.subtree_satisfies(path, Self::metaregion_sound_pred(r1)),
         decreases INC_LEVELS - subtree.level(),
@@ -1506,17 +1506,17 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         self,
         r0: MetaRegionOwners,
         r1: MetaRegionOwners,
-        changed_idx: usize,
+        changed_idx: int,
     )
         requires
             self.inv(),
             self.metaregion_sound(r0),
-            forall|i: usize|
+            forall|i: int|
                 #![trigger r1.slot_owners[i]]
                 i != changed_idx ==> r0.slot_owners[i] == r1.slot_owners[i],
             r0.slot_owners.dom() == r1.slot_owners.dom(),
-            forall|k: usize| r0.slots.contains_key(k) ==> #[trigger] r1.slots.contains_key(k),
-            forall|k: usize| r0.slots.contains_key(k) ==> r0.slots[k] == #[trigger] r1.slots[k],
+            forall|k: int| r0.slots.contains_key(k) ==> #[trigger] r1.slots.contains_key(k),
+            forall|k: int| r0.slots.contains_key(k) ==> r0.slots[k] == #[trigger] r1.slots[k],
             // No tree entry's primary slot is at changed_idx.
             self.0.subtree_satisfies(
                 self.0.value().path,
@@ -1564,17 +1564,17 @@ impl<C: PageTableConfig> PageTableOwner<C> {
         path: TreePath<NR_ENTRIES>,
         r0: MetaRegionOwners,
         r1: MetaRegionOwners,
-        changed_idx: usize,
+        changed_idx: int,
     )
         requires
             subtree.inv(),
             subtree.subtree_satisfies(path, Self::metaregion_sound_pred(r0)),
-            forall|i: usize|
+            forall|i: int|
                 #![trigger r1.slot_owners[i]]
                 i != changed_idx ==> r0.slot_owners[i] == r1.slot_owners[i],
             r0.slot_owners.dom() == r1.slot_owners.dom(),
-            forall|k: usize| r0.slots.contains_key(k) ==> #[trigger] r1.slots.contains_key(k),
-            forall|k: usize| r0.slots.contains_key(k) ==> r0.slots[k] == #[trigger] r1.slots[k],
+            forall|k: int| r0.slots.contains_key(k) ==> #[trigger] r1.slots.contains_key(k),
+            forall|k: int| r0.slots.contains_key(k) ==> r0.slots[k] == #[trigger] r1.slots[k],
             subtree.subtree_satisfies(
                 path,
                 |e: EntryOwner<C>, p: TreePath<NR_ENTRIES>|

--- a/ostd/src/mm/frame/frame_ref.rs
+++ b/ostd/src/mm/frame/frame_ref.rs
@@ -61,7 +61,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage>> FrameRef<'_, M> {
         }
 
         proof_decl! {
-            let tracked from_raw_obl: vstd_extra::drop_tracking::DropObligation<usize>;
+            let tracked from_raw_obl: vstd_extra::drop_tracking::DropObligation<int>;
         }
         // `from_raw` mints one `frame_obligations` entry at the slot and
         // hands back the token; the token is dropped affinely (the ledger

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -20,7 +20,7 @@ use crate::mm::kspace::FRAME_METADATA_RANGE;
 use crate::specs::arch::*;
 use crate::specs::mm::frame::{
     linked_list::linked_list_owners::*,
-    mapping::{frame_to_index, group_page_meta, max_meta_slots, meta_addr},
+    mapping::{frame_to_index, group_page_meta, max_meta_slots, index_to_meta},
     meta_owners::{MetaSlotOwner, Metadata},
     meta_region_owners::MetaRegionOwners,
     unique::UniqueFrameOwner,
@@ -857,7 +857,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                 &&& final(regions).slot_owners[idx].inner_perms.in_list.value() == 0
                 &&& final(regions).slot_owners[idx].inner_perms.storage.is_init()
                 &&& final(regions).slot_owners[idx].inner_perms.vtable_ptr.is_init()
-                &&& final(regions).slot_owners[idx].slot_vaddr == meta_addr(idx)
+                &&& final(regions).slot_owners[idx].slot_vaddr == index_to_meta(idx)
                 &&& final(regions).slot_owners[idx].paths_in_pt == old(
                     regions,
                 ).slot_owners[idx].paths_in_pt

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -20,7 +20,7 @@ use crate::mm::kspace::FRAME_METADATA_RANGE;
 use crate::specs::arch::*;
 use crate::specs::mm::frame::{
     linked_list::linked_list_owners::*,
-    mapping::{frame_to_index, group_page_meta, max_meta_slots, index_to_meta},
+    mapping::{frame_to_index, group_page_meta, index_to_meta, max_meta_slots},
     meta_owners::{MetaSlotOwner, Metadata},
     meta_region_owners::MetaRegionOwners,
     unique::UniqueFrameOwner,
@@ -862,7 +862,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                     regions,
                 ).slot_owners[idx].paths_in_pt
             },
-            res.is_some() ==> forall|j: usize|
+            res.is_some() ==> forall|j: int|
                 #![trigger final(regions).slot_owners[j]]
                 j != frame_to_index(meta_to_frame(old(self).current->0.addr())) ==> {
                     &&& final(regions).slot_owners[j].usage == old(regions).slot_owners[j].usage
@@ -919,7 +919,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
 
         proof {
             assert(regions.slots.dom() == regions0.slots.dom());
-            assert forall|j: usize| #![trigger regions0.slot_owners[j]] j != idx implies {
+            assert forall|j: int| #![trigger regions0.slot_owners[j]] j != idx implies {
                 &&& regions.slot_owners[j].usage == regions0.slot_owners[j].usage
                 &&& regions.slot_owners[j].slot_vaddr == regions0.slot_owners[j].slot_vaddr
                 &&& regions.slot_owners[j].paths_in_pt == regions0.slot_owners[j].paths_in_pt
@@ -953,7 +953,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
             proof {
                 assert(regions.inv());
                 assert(regions.slots.dom() == regions0.slots.dom());
-                assert forall|j: usize| #![trigger regions0.slot_owners[j]] j != idx implies {
+                assert forall|j: int| #![trigger regions0.slot_owners[j]] j != idx implies {
                     &&& regions.slot_owners[j].usage == regions0.slot_owners[j].usage
                     &&& regions.slot_owners[j].slot_vaddr == regions0.slot_owners[j].slot_vaddr
                     &&& regions.slot_owners[j].paths_in_pt == regions0.slot_owners[j].paths_in_pt
@@ -967,7 +967,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
             self.list.front = next_ptr;
             proof {
                 assert(regions.slots.dom() == regions0.slots.dom());
-                assert forall|j: usize| #![trigger regions0.slot_owners[j]] j != idx implies {
+                assert forall|j: int| #![trigger regions0.slot_owners[j]] j != idx implies {
                     &&& regions.slot_owners[j].usage == regions0.slot_owners[j].usage
                     &&& regions.slot_owners[j].slot_vaddr == regions0.slot_owners[j].slot_vaddr
                     &&& regions.slot_owners[j].paths_in_pt == regions0.slot_owners[j].paths_in_pt
@@ -995,7 +995,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
             proof {
                 assert(regions.inv());
                 assert(regions.slots.dom() == regions0.slots.dom());
-                assert forall|j: usize| #![trigger regions0.slot_owners[j]] j != idx implies {
+                assert forall|j: int| #![trigger regions0.slot_owners[j]] j != idx implies {
                     &&& regions.slot_owners[j].usage == regions0.slot_owners[j].usage
                     &&& regions.slot_owners[j].slot_vaddr == regions0.slot_owners[j].slot_vaddr
                     &&& regions.slot_owners[j].paths_in_pt == regions0.slot_owners[j].paths_in_pt
@@ -1012,7 +1012,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
             self.current = None;
             proof {
                 assert(regions.slots.dom() == regions0.slots.dom());
-                assert forall|j: usize| #![trigger regions0.slot_owners[j]] j != idx implies {
+                assert forall|j: int| #![trigger regions0.slot_owners[j]] j != idx implies {
                     &&& regions.slot_owners[j].usage == regions0.slot_owners[j].usage
                     &&& regions.slot_owners[j].slot_vaddr == regions0.slot_owners[j].slot_vaddr
                     &&& regions.slot_owners[j].paths_in_pt == regions0.slot_owners[j].paths_in_pt
@@ -1038,7 +1038,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
             assert(regions.inv());
             assert(regions.slots.dom() == regions0.slots.dom());
             assert(regions.slot_owners[idx].paths_in_pt == regions0.slot_owners[idx].paths_in_pt);
-            assert forall|j: usize| #![trigger regions0.slot_owners[j]] j != idx implies {
+            assert forall|j: int| #![trigger regions0.slot_owners[j]] j != idx implies {
                 &&& regions.slot_owners[j].usage == regions0.slot_owners[j].usage
                 &&& regions.slot_owners[j].slot_vaddr == regions0.slot_owners[j].slot_vaddr
                 &&& regions.slot_owners[j].paths_in_pt == regions0.slot_owners[j].paths_in_pt
@@ -1169,7 +1169,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
         let frame_ptr = ReprPtr::<MetaSlot, Metadata<Link<M>>>::from_pptr(frame.ptr);
         let frame_ptr_as_link = MetadataAsLink::cast_from_metadata(frame_ptr);
 
-        let ghost frame_idx_g: usize = frame_own.slot_index;
+        let ghost frame_idx_g: int = frame_own.slot_index;
 
         if let Some(current) = self.current {
             let current_md = MetadataAsLink::cast_to_metadata(current);
@@ -1438,7 +1438,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> TrackDrop for LinkedList<M> {
                 let idx = frame_to_index(meta_to_frame(s0.0.list[i].paddr));
                 s1.1.frame_obligations.count(idx) == s0.1.frame_obligations.count(idx)
             }
-        &&& forall|idx: usize|
+        &&& forall|idx: int|
             #![trigger s1.1.slot_owners[idx]]
             (forall|i: int|
                 #![trigger s0.0.list[i]]
@@ -1511,7 +1511,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> Drop for LinkedList<M> {
                         regions.frame_obligations.count(idx) == 0
                     },
                 // slots values inside the original_list.
-                forall|idx: usize|
+                forall|idx: int|
                     #![trigger regions.slot_owners[idx]]
                     (forall|j: int|
                         #![trigger original_list[j]]

--- a/ostd/src/mm/frame/meta.rs
+++ b/ostd/src/mm/frame/meta.rs
@@ -104,7 +104,7 @@ use self::mapping::{frame_to_meta, meta_to_frame};
 use crate::mm::io::{Infallible, VmReader};
 use crate::specs::arch::*;
 use crate::specs::mm::frame::{
-    mapping::{frame_to_index, meta_addr},
+    mapping::{frame_to_index, index_to_meta},
     meta_owners::*,
     meta_region_owners::MetaRegionOwners,
 };

--- a/ostd/src/mm/frame/mod.rs
+++ b/ostd/src/mm/frame/mod.rs
@@ -86,7 +86,7 @@ use crate::specs::mm::frame::meta_owners::*;
 use crate::specs::mm::frame::meta_region_owners::MetaRegionOwners;
 use crate::specs::mm::frame::{
     frame_specs::*,
-    mapping::{frame_to_index, group_page_meta, max_meta_slots, index_to_meta},
+    mapping::{frame_to_index, group_page_meta, index_to_meta, max_meta_slots},
 };
 
 verus! {
@@ -563,7 +563,7 @@ impl<M> Frame<M> {
     #[verus_spec(r =>
         with
             Tracked(regions): Tracked<&mut MetaRegionOwners>,
-            -> obl: Tracked<vstd_extra::drop_tracking::DropObligation<usize>>,
+            -> obl: Tracked<vstd_extra::drop_tracking::DropObligation<int>>,
         requires
             Self::from_raw_requires_safety(*old(regions), paddr),
             old(regions).slots.contains_key(frame_to_index(paddr)),
@@ -587,7 +587,7 @@ impl<M> Frame<M> {
         let ghost idx = frame_to_index(paddr);
 
         proof_decl! {
-            let tracked obl_minted: vstd_extra::drop_tracking::DropObligation<usize>;
+            let tracked obl_minted: vstd_extra::drop_tracking::DropObligation<int>;
         }
         proof {
             // Mint the obligation that will be consumed by either
@@ -642,7 +642,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage>> RCClone for Frame<M> {
             == old_perm.slot_owners[idx].usage
         // Other slot_owners unchanged
         &&& new_perm.slots == old_perm.slots
-        &&& forall|i: usize|
+        &&& forall|i: int|
             i != idx ==> (#[trigger] new_perm.slot_owners[i] == old_perm.slot_owners[i])
         &&& new_perm.slot_owners.dom() == old_perm.slot_owners.dom()
         &&& new_perm.frame_obligations == old_perm.frame_obligations.insert(idx)
@@ -675,7 +675,7 @@ impl<M: ?Sized> Drop for Frame<M> {
     fn drop(
         self,
         Tracked(regions): Tracked<&mut MetaRegionOwners>,
-        Tracked(obl): Tracked<DropObligation<usize>>,
+        Tracked(obl): Tracked<DropObligation<int>>,
     ) {
         proof {
             regions.tracked_redeem_frame_obligation(obl);
@@ -714,7 +714,7 @@ impl<M: ?Sized> Drop for Frame<M> {
         proof {
             regions.slot_owners.tracked_insert(idx, slot_own);
 
-            assert forall|i: usize| i != idx implies #[trigger] regions.slot_owners[i]
+            assert forall|i: int| i != idx implies #[trigger] regions.slot_owners[i]
                 == old_regions.slot_owners[i] by {}
             assert(regions.slots == old_regions.slots);
             assert(regions.slot_owners.dom() == old_regions.slot_owners.dom());
@@ -724,17 +724,17 @@ impl<M: ?Sized> Drop for Frame<M> {
             // indices, the invariant carries over from `old_regions.inv()`.
             // For `idx`, `slot_own.inv()` and the perm/slot agreement at
             // `idx` are already asserted above.
-            assert forall|i: usize|
-                i < max_meta_slots() <==> #[trigger] regions.slot_owners.contains_key(i) by {}
+            assert forall|i: int|
+                0 <= i < max_meta_slots() <==> #[trigger] regions.slot_owners.contains_key(i) by {}
 
-            assert forall|i: usize| #[trigger] regions.slots.contains_key(i) implies i
+            assert forall|i: int| #[trigger] regions.slots.contains_key(i) implies i
                 < max_meta_slots() by {
                 if i == idx {
                     assert(regions.slot_owners.contains_key(idx));
                 }
             }
 
-            assert forall|i: usize| #[trigger] regions.slots.contains_key(i) implies ({
+            assert forall|i: int| #[trigger] regions.slots.contains_key(i) implies ({
                 &&& regions.slot_owners.contains_key(i)
                 &&& regions.slot_owners[i].inv()
                 &&& regions.slots[i].is_init()
@@ -750,7 +750,7 @@ impl<M: ?Sized> Drop for Frame<M> {
                 }
             }
 
-            assert forall|i: usize| #[trigger]
+            assert forall|i: int| #[trigger]
                 regions.slot_owners.contains_key(i) implies regions.slot_owners[i].inv() by {
                 if i == idx {
                     assert(slot_own.inv());
@@ -879,7 +879,7 @@ impl TryFrom<Frame<dyn AnyFrameMeta>> for UFrame {
             regions,
         ).slot_owners[frame_to_index(paddr)].usage,
         final(regions).slots == old(regions).slots,
-        forall|i: usize|
+        forall|i: int|
             i != frame_to_index(paddr) ==> (#[trigger] final(regions).slot_owners[i] == old(
                 regions,
             ).slot_owners[i]),

--- a/ostd/src/mm/frame/mod.rs
+++ b/ostd/src/mm/frame/mod.rs
@@ -86,7 +86,7 @@ use crate::specs::mm::frame::meta_owners::*;
 use crate::specs::mm::frame::meta_region_owners::MetaRegionOwners;
 use crate::specs::mm::frame::{
     frame_specs::*,
-    mapping::{frame_to_index, group_page_meta, max_meta_slots, meta_addr},
+    mapping::{frame_to_index, group_page_meta, max_meta_slots, index_to_meta},
 };
 
 verus! {
@@ -738,13 +738,13 @@ impl<M: ?Sized> Drop for Frame<M> {
                 &&& regions.slot_owners.contains_key(i)
                 &&& regions.slot_owners[i].inv()
                 &&& regions.slots[i].is_init()
-                &&& regions.slots[i].addr() == meta_addr(i)
+                &&& regions.slots[i].addr() == index_to_meta(i)
                 &&& regions.slots[i].value().wf(regions.slot_owners[i])
                 &&& regions.slot_owners[i].slot_vaddr == regions.slots[i].addr()
             }) by {
                 if i == idx {
                     assert(regions.slots[i].is_init());
-                    assert(regions.slots[i].addr() == meta_addr(i));
+                    assert(regions.slots[i].addr() == index_to_meta(i));
                     assert(regions.slots[i].value().wf(regions.slot_owners[i]));
                     assert(regions.slot_owners[i].slot_vaddr == regions.slots[i].addr());
                 }

--- a/ostd/src/mm/frame/mod.rs
+++ b/ostd/src/mm/frame/mod.rs
@@ -622,7 +622,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage>> RCClone for Frame<M> {
         new_perm: MetaRegionOwners,
         res: Self,
     ) -> bool {
-        let idx = frame_to_index(meta_to_frame(self.ptr.addr()));
+        let idx = self.index();
         &&& new_perm.inv()
         // ref_count incremented
         &&& new_perm.slot_owners[idx].inner_perms.ref_count.value()
@@ -654,7 +654,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage>> RCClone for Frame<M> {
         }
 
         let paddr = meta_to_frame(self.ptr.addr());
-        let ghost idx = frame_to_index(meta_to_frame(self.ptr.addr()));
+        let ghost idx = self.index();
 
         unsafe {
             #[verus_spec(with Tracked(perm))]
@@ -680,7 +680,7 @@ impl<M: ?Sized> Drop for Frame<M> {
         proof {
             regions.tracked_redeem_frame_obligation(obl);
         }
-        let ghost idx = frame_to_index(meta_to_frame(self.ptr.addr()));
+        let ghost idx = self.index();
         let ghost old_regions = *regions;
 
         let tracked mut slot_own = regions.slot_owners.tracked_remove(idx);

--- a/ostd/src/mm/frame/obligation_demo.rs
+++ b/ostd/src/mm/frame/obligation_demo.rs
@@ -43,7 +43,7 @@ verus! {
 )]
 pub fn demo_honored(slot_idx: usize) {
     proof {
-        let tracked obl = regions.tracked_mint_frame_obligation(slot_idx);
+        let tracked obl = regions.tracked_mint_frame_obligation(slot_idx as int);
         // ... here a real caller would construct a Frame/Segment, hand it
         // around, etc. — for the demo we just immediately redeem.
         regions.tracked_redeem_frame_obligation(obl);
@@ -84,7 +84,7 @@ pub fn demo_leaked_when_enabled(slot_idx: usize) {
         // or a single segment frame. No matching `Drop::drop` /
         // `ManuallyDrop::new` follows, so the multiset entry persists and
         // `clean_inv` fails on `frame_obligations.len() == 0` at function exit.
-        let tracked _obl = regions.tracked_mint_frame_obligation(slot_idx);
+        let tracked _obl = regions.tracked_mint_frame_obligation(slot_idx as int);
     }
 }
 

--- a/ostd/src/mm/frame/segment.rs
+++ b/ostd/src/mm/frame/segment.rs
@@ -16,7 +16,7 @@ use crate::mm::page_table::RCClone;
 use crate::mm::{PagingLevel, Vaddr, frame::MetaSlot, paddr_to_vaddr};
 use crate::specs::arch::*;
 use crate::specs::mm::frame::{
-    mapping::{frame_to_index, group_page_meta, meta_addr},
+    mapping::{frame_to_index, group_page_meta, index_to_meta},
     meta_owners::*,
     meta_region_owners::MetaRegionOwners,
     segment::*,
@@ -290,7 +290,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                         let idx = frame_to_index(addrs[j]);
                         &&& regions.slots.contains_key(idx)
                         &&& regions.slot_owners.contains_key(idx)
-                        &&& regions.slot_owners[idx].slot_vaddr == meta_addr(idx)
+                        &&& regions.slot_owners[idx].slot_vaddr == index_to_meta(idx)
                         &&& regions.slot_owners[idx].inner_perms.ref_count.value() > 0
                         &&& regions.slot_owners[idx].inner_perms.ref_count.value()
                             <= crate::mm::frame::meta::REF_COUNT_MAX
@@ -339,7 +339,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                                     let idx = frame_to_index(addrs[j]);
                                     &&& regions.slots.contains_key(idx)
                                     &&& regions.slot_owners.contains_key(idx)
-                                    &&& regions.slot_owners[idx].slot_vaddr == meta_addr(idx)
+                                    &&& regions.slot_owners[idx].slot_vaddr == index_to_meta(idx)
                                     &&& regions.slot_owners[idx].inner_perms.ref_count.value() > 0
                                     &&& regions.slot_owners[idx].inner_perms.ref_count.value()
                                         <= crate::mm::frame::meta::REF_COUNT_MAX
@@ -357,7 +357,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                             broadcast use group_page_meta;
 
                             assert(addrs[k] == p);
-                            assert(meta_addr(idx_k) == frame_to_meta(p));
+                            assert(index_to_meta(idx_k) == frame_to_meta(p));
                             assert(regions.slots.contains_key(idx_k));
                         }
                         proof_decl! {
@@ -455,7 +455,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                 &&& regions.frame_obligations.count(idx) >= 1
                 &&& regions.slot_owners.contains_key(idx)
                 &&& regions.slots.contains_key(idx)
-                &&& regions.slot_owners[idx].slot_vaddr == meta_addr(idx)
+                &&& regions.slot_owners[idx].slot_vaddr == index_to_meta(idx)
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value() > 0
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value()
                     <= crate::mm::frame::meta::REF_COUNT_MAX
@@ -619,7 +619,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                 &&& regions.frame_obligations.count(idx) >= 1
                 &&& regions.slot_owners.contains_key(idx)
                 &&& regions.slots.contains_key(idx)
-                &&& regions.slot_owners[idx].slot_vaddr == meta_addr(idx)
+                &&& regions.slot_owners[idx].slot_vaddr == index_to_meta(idx)
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value() > 0
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value()
                     <= crate::mm::frame::meta::REF_COUNT_MAX
@@ -635,7 +635,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                 &&& regions.frame_obligations.count(idx) >= 1
                 &&& regions.slot_owners.contains_key(idx)
                 &&& regions.slots.contains_key(idx)
-                &&& regions.slot_owners[idx].slot_vaddr == meta_addr(idx)
+                &&& regions.slot_owners[idx].slot_vaddr == index_to_meta(idx)
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value() > 0
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value()
                     <= crate::mm::frame::meta::REF_COUNT_MAX
@@ -1094,7 +1094,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> SegmentIterator<'a, 
                     &&& (**regions_ref).frame_obligations.count(idx) >= 1
                     &&& (**regions_ref).slot_owners.contains_key(idx)
                     &&& (**regions_ref).slots.contains_key(idx)
-                    &&& (**regions_ref).slot_owners[idx].slot_vaddr == meta_addr(idx)
+                    &&& (**regions_ref).slot_owners[idx].slot_vaddr == index_to_meta(idx)
                     &&& (**regions_ref).slot_owners[idx].inner_perms.ref_count.value() > 0
                     &&& (**regions_ref).slot_owners[idx].inner_perms.ref_count.value()
                         <= crate::mm::frame::meta::REF_COUNT_MAX

--- a/ostd/src/mm/frame/segment.rs
+++ b/ostd/src/mm/frame/segment.rs
@@ -361,9 +361,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                             assert(regions.slots.contains_key(idx_k));
                         }
                         proof_decl! {
-                            let tracked from_raw_obl: vstd_extra::drop_tracking::DropObligation<
-                                usize,
-                            >;
+                            let tracked from_raw_obl: vstd_extra::drop_tracking::DropObligation<int>;
                         }
                         let frame = unsafe {
                             #[verus_spec(with Tracked(regions) => Tracked(from_raw_obl))]
@@ -869,7 +867,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
 }
 
 /// A frame yielded from a [`SegmentIterator`] together with its drop obligation.
-pub type SegmentIteratorItem<M> = (Frame<M>, Tracked<DropObligation<usize>>);
+pub type SegmentIteratorItem<M> = (Frame<M>, Tracked<DropObligation<int>>);
 
 /// Prophetic sequence state used to specify the frames that a segment iterator will yield.
 /// FIXME: Do we need another iterator struct?
@@ -1068,7 +1066,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> SegmentIterator<'a, 
             }
 
             proof_decl! {
-                let tracked from_raw_obl: DropObligation<usize>;
+                let tracked from_raw_obl: DropObligation<int>;
             }
             let frame = unsafe {
                 #[verus_spec(with Tracked(*regions_ref) => Tracked(from_raw_obl))]
@@ -1341,7 +1339,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage>> Segment<M> {
             }
 
             proof_decl! {
-                let tracked from_raw_obl: vstd_extra::drop_tracking::DropObligation<usize>;
+                let tracked from_raw_obl: vstd_extra::drop_tracking::DropObligation<int>;
             }
 
             // SAFETY: each segment frame holds a forgotten reference;

--- a/ostd/src/mm/frame/unique.rs
+++ b/ostd/src/mm/frame/unique.rs
@@ -12,7 +12,6 @@ use crate::specs::mm::frame::{
     mapping::{frame_to_index, group_page_meta, index_to_meta, max_meta_slots},
     meta_owners::{MetaSlotStorage, Metadata},
     meta_region_owners::MetaRegionOwners,
-    meta_specs::lemma_index_to_meta_to_index,
     unique::UniqueFrameOwner,
 };
 
@@ -154,7 +153,9 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrame<M> {
     ) -> UniqueFrame<M1> {
         let ghost idx = frame_to_index(meta_to_frame(self.ptr.addr()));
         proof {
-            lemma_index_to_meta_to_index(owner.slot_index);
+            broadcast use group_page_meta;
+
+            assert(idx == owner.slot_index);
         }
         let tracked mut slot_own = regions.slot_owners.tracked_remove(idx);
         let tracked perm_ref = regions.slots.tracked_borrow(idx);
@@ -600,7 +601,6 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Frame<M> {
         proof {
             broadcast use group_page_meta;
 
-            lemma_index_to_meta_to_index(owner.slot_index);
             regions.inv_implies_correct_addr(meta_to_frame(unique.ptr.addr()));
             assert(idx == owner.slot_index);
             assert(regions.slots[idx].addr() == unique.ptr.addr());

--- a/ostd/src/mm/frame/unique.rs
+++ b/ostd/src/mm/frame/unique.rs
@@ -9,10 +9,10 @@ use vstd_extra::ownership::*;
 
 use crate::specs::arch::*;
 use crate::specs::mm::frame::{
-    mapping::{frame_to_index, group_page_meta, max_meta_slots, meta_addr},
+    mapping::{frame_to_index, group_page_meta, max_meta_slots, index_to_meta},
     meta_owners::{MetaSlotStorage, Metadata},
     meta_region_owners::MetaRegionOwners,
-    meta_specs::lemma_meta_addr_to_index,
+    meta_specs::lemma_index_to_meta_to_index,
     unique::UniqueFrameOwner,
 };
 
@@ -154,7 +154,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrame<M> {
     ) -> UniqueFrame<M1> {
         let ghost idx = frame_to_index(meta_to_frame(self.ptr.addr()));
         proof {
-            lemma_meta_addr_to_index(owner.slot_index);
+            lemma_index_to_meta_to_index(owner.slot_index);
         }
         let tracked mut slot_own = regions.slot_owners.tracked_remove(idx);
         let tracked perm_ref = regions.slots.tracked_borrow(idx);
@@ -547,7 +547,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> 
             // `slot_owners[idx].inv()`; the latter's UNIQUE branch (under
             // `rc == REF_COUNT_UNIQUE`) gives the storage/vtable init.
             assert(regions.slot_owners.contains_key(idx));
-            assert(regions.slot_owners[idx].slot_vaddr == meta_addr(idx));
+            assert(regions.slot_owners[idx].slot_vaddr == index_to_meta(idx));
             assert(regions.slot_owners[idx].inner_perms.storage.is_init());
             assert(regions.slot_owners[idx].inner_perms.vtable_ptr.is_init());
 
@@ -600,7 +600,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Frame<M> {
         proof {
             broadcast use group_page_meta;
 
-            lemma_meta_addr_to_index(owner.slot_index);
+            lemma_index_to_meta_to_index(owner.slot_index);
             regions.inv_implies_correct_addr(meta_to_frame(unique.ptr.addr()));
             assert(idx == owner.slot_index);
             assert(regions.slots[idx].addr() == unique.ptr.addr());

--- a/ostd/src/mm/frame/unique.rs
+++ b/ostd/src/mm/frame/unique.rs
@@ -9,7 +9,7 @@ use vstd_extra::ownership::*;
 
 use crate::specs::arch::*;
 use crate::specs::mm::frame::{
-    mapping::{frame_to_index, group_page_meta, max_meta_slots, index_to_meta},
+    mapping::{frame_to_index, group_page_meta, index_to_meta, max_meta_slots},
     meta_owners::{MetaSlotStorage, Metadata},
     meta_region_owners::MetaRegionOwners,
     meta_specs::lemma_index_to_meta_to_index,
@@ -530,7 +530,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> 
         ensures
             final(regions).inv(),
             final(regions).slots == old(regions).slots,
-            forall|i: usize| #![trigger final(regions).slot_owners[i]]
+            forall|i: int| #![trigger final(regions).slot_owners[i]]
                 i != owner.slot_index ==> final(regions).slot_owners[i]
                     == old(regions).slot_owners[i],
             final(regions).frame_obligations == old(regions).frame_obligations.remove(

--- a/ostd/src/mm/frame/unique.rs
+++ b/ostd/src/mm/frame/unique.rs
@@ -140,7 +140,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrame<M> {
             self.wf(owner),
             owner.inv(),
             owner.global_inv(*old(regions)),
-            old(regions).slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].inner_perms.in_list.value() == 0,
+            old(regions).slot_owners[self.index()].inner_perms.in_list.value() == 0,
             old(regions).inv(),
         ensures
             res.wf(new_owner@),
@@ -151,7 +151,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrame<M> {
         self,
         metadata: M1,
     ) -> UniqueFrame<M1> {
-        let ghost idx = frame_to_index(meta_to_frame(self.ptr.addr()));
+        let ghost idx = self.index();
         proof {
             broadcast use group_page_meta;
 
@@ -394,11 +394,11 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> 
 
     pub open spec fn into_raw_requires(self, regions: MetaRegionOwners) -> bool {
         &&& regions.slot_owners.contains_key(
-            frame_to_index(meta_to_frame(self.ptr.addr())),
+            self.index(),
         )
         // `self` is a live value with a pending Drop; forgetting it (`MD::new`)
         // discharges that obligation.
-        &&& regions.frame_obligations.count(frame_to_index(meta_to_frame(self.ptr.addr()))) > 0
+        &&& regions.frame_obligations.count(self.index()) > 0
         &&& regions.inv()
     }
 
@@ -412,9 +412,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> 
         &&& regions.inv()
         &&& regions.slots == old_regions.slots
         &&& regions.slot_owners == old_regions.slot_owners
-        &&& regions.frame_obligations == old_regions.frame_obligations.remove(
-            frame_to_index(meta_to_frame(self.ptr.addr())),
-        )
+        &&& regions.frame_obligations == old_regions.frame_obligations.remove(self.index())
     }
 
     /// Converts this frame into a raw physical address.
@@ -427,7 +425,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> 
             self.wf(*owner),
             owner.inv(),
             old(regions).inv(),
-            old(regions).slot_owners[frame_to_index(meta_to_frame(self.ptr.addr()))].inner_perms.ref_count.value() != REF_COUNT_UNUSED,
+            old(regions).slot_owners[self.index()].inner_perms.ref_count.value() != REF_COUNT_UNUSED,
         ensures
             Self::into_raw_ensures(self, *old(regions), *final(regions), r),
             final(regions).inv(),
@@ -437,7 +435,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> 
         let paddr = self.start_paddr();
 
         proof_decl! {
-            let ghost idx = frame_to_index(meta_to_frame(self.ptr.addr()));
+            let ghost idx = self.index();
             let tracked redeem_obl = DropObligation::tracked_mint(idx);
             regions.tracked_redeem_frame_obligation(redeem_obl);
             let tracked md_obl = DropObligation::tracked_mint(idx);

--- a/ostd/src/mm/kspace/kvirt_area.rs
+++ b/ostd/src/mm/kspace/kvirt_area.rs
@@ -205,14 +205,14 @@ fn collect_largest_pages(va: Vaddr, pa: Paddr, len: usize) -> alloc::vec::Vec<(P
         final(kernel_owner)@ is Some,
         final(kernel_owner)@->0.inv(),
         (final(kernel_owner)@->0).0.value().is_node(),
-        res.root.ptr.addr() == (final(kernel_owner)@->0).0.value().node().meta_addr_self(),
+        res.root.ptr.addr() == (final(kernel_owner)@->0).0.value().node().meta_vaddr(),
         old(kernel_owner)@ is Some ==> final(kernel_owner)@ == old(kernel_owner)@,
         !PageTable::<KernelPtConfig>::create_user_pt_panic_condition(
             (final(kernel_owner)@->0).0.value().node(),
         ),
         (final(kernel_owner)@->0).0.value().metaregion_sound(*regions),
         final(kernel_owner)@->0.metaregion_sound(*regions),
-        guards.unlocked((final(kernel_owner)@->0).0.value().node().meta_addr_self()),
+        guards.unlocked((final(kernel_owner)@->0).0.value().node().meta_vaddr()),
 )]
 pub(crate) fn get_kernel_page_table<'rcu>() -> &'static PageTable<KernelPtConfig> {
     KERNEL_PAGE_TABLE.get().unwrap()

--- a/ostd/src/mm/page_table/cursor/locking.rs
+++ b/ostd/src/mm/page_table/cursor/locking.rs
@@ -165,7 +165,7 @@ pub fn lock_range<'rcu, C: PageTableConfig, A: InAtomicMode>(
                 )
                 &&& guards.lock_held(
                     cursor_own.continuations[cursor_own.level - 1]
-                        .entry_own.node().meta_addr_self(),
+                        .entry_own.node().meta_vaddr(),
                 )
             },
     )]
@@ -304,7 +304,7 @@ pub fn unlock_range<C: PageTableConfig, A: InAtomicMode>(cursor: &mut Cursor<'_,
         // The subtree root is lock_held in guards.
         r is Some ==> final(guards).lock_held(
             final(cursor_own).continuations[final(cursor_own).level - 1]
-                .entry_own.node().meta_addr_self()),
+                .entry_own.node().meta_vaddr()),
         // regions invariant preserved
         final(regions).inv(),
         // Locking only allocates fresh page-table nodes from UNUSED slots;
@@ -523,16 +523,16 @@ fn try_traverse_and_lock_subtree_root<'rcu, C: PageTableConfig, A: InAtomicMode>
         entry_own.is_node(),
         entry_own.inv(),
         entry_own.node().relate_guard(*cur_node),
-        old(guards).lock_held(entry_own.node().meta_addr_self()),
+        old(guards).lock_held(entry_own.node().meta_vaddr()),
         cur_node_va <= va_range.start,
         va_range.start < va_range.end,
         old(regions).inv(),
     ensures
         // The root node is still lock_held (not ManuallyDrop'd by this fn).
-        final(guards).lock_held(entry_own.node().meta_addr_self()),
+        final(guards).lock_held(entry_own.node().meta_vaddr()),
         // All other locks are preserved: addresses not in this subtree are unchanged.
         forall |addr: usize|
-            addr != entry_own.node().meta_addr_self()
+            addr != entry_own.node().meta_vaddr()
             && old(guards).guards.contains(addr) ==>
             #[trigger] final(guards).guards.contains(addr),
         // Addresses not in old guards don't appear in final guards

--- a/ostd/src/mm/page_table/cursor/locking.rs
+++ b/ostd/src/mm/page_table/cursor/locking.rs
@@ -67,14 +67,14 @@ pub assume_specification<Idx: Clone>[ Range::<Idx>::clone ](range: &Range<Idx>) 
         // locking, the same bound holds after. Locking may allocate new PT
         // nodes (bumping some parent ref counts), but ref counts stay within
         // safe bounds during a single lock_range call.
-        (forall |i: usize| #![trigger old(regions).slot_owners[i]]
+        (forall |i: int| #![trigger old(regions).slot_owners[i]]
             old(regions).slot_owners.contains_key(i)
             && old(regions).slot_owners[i].inner_perms.ref_count.value()
                 != REF_COUNT_UNUSED
             ==> old(regions).slot_owners[i].inner_perms.ref_count.value() + 1
                 < REF_COUNT_MAX)
         ==>
-        (forall |i: usize| #![trigger final(regions).slot_owners[i]]
+        (forall |i: int| #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners.contains_key(i)
             && final(regions).slot_owners[i].inner_perms.ref_count.value()
                 != REF_COUNT_UNUSED
@@ -82,7 +82,7 @@ pub assume_specification<Idx: Clone>[ Range::<Idx>::clone ](range: &Range<Idx>) 
                 < REF_COUNT_MAX),
         // Locking only allocates page-table nodes from UNUSED slots, so any
         // slot that was already in use keeps its paths_in_pt intact.
-        forall|idx: usize| #![trigger final(regions).slot_owners[idx].paths_in_pt]
+        forall|idx: int| #![trigger final(regions).slot_owners[idx].paths_in_pt]
             old(regions).slot_owners[idx].inner_perms.ref_count.value()
                 != REF_COUNT_UNUSED
             ==> final(regions).slot_owners[idx].paths_in_pt
@@ -91,7 +91,7 @@ pub assume_specification<Idx: Clone>[ Range::<Idx>::clone ](range: &Range<Idx>) 
         // preserved across `lock_range` — composes
         // `try_traverse_and_lock_subtree_root`'s in-use preservation with
         // `dfs_acquire_lock`'s `slot_owners ==` preservation.
-        forall|idx: usize| #![trigger final(regions).slot_owners[idx]]
+        forall|idx: int| #![trigger final(regions).slot_owners[idx]]
             old(regions).slot_owners.contains_key(idx)
             && old(regions).slot_owners[idx].inner_perms.ref_count.value()
                 != REF_COUNT_UNUSED
@@ -102,12 +102,12 @@ pub assume_specification<Idx: Clone>[ Range::<Idx>::clone ](range: &Range<Idx>) 
         // Saturated-slot bridge (bidirectional): a slot is at
         // `>= REF_COUNT_MAX` before iff after, with the same value.
         // Composes helpers' clauses (see their ensures).
-        forall|idx: usize| #![trigger final(regions).slot_owners[idx].inner_perms.ref_count.value()]
+        forall|idx: int| #![trigger final(regions).slot_owners[idx].inner_perms.ref_count.value()]
             final(regions).slot_owners[idx].inner_perms.ref_count.value()
                 >= REF_COUNT_MAX
             ==> old(regions).slot_owners[idx].inner_perms.ref_count.value()
                     == final(regions).slot_owners[idx].inner_perms.ref_count.value(),
-        forall|idx: usize| #![trigger old(regions).slot_owners[idx].inner_perms.ref_count.value()]
+        forall|idx: int| #![trigger old(regions).slot_owners[idx].inner_perms.ref_count.value()]
             old(regions).slot_owners[idx].inner_perms.ref_count.value()
                 >= REF_COUNT_MAX
             ==> final(regions).slot_owners[idx].inner_perms.ref_count.value()
@@ -222,15 +222,13 @@ pub fn lock_range<'rcu, C: PageTableConfig, A: InAtomicMode>(
             && res.0.level == res.0.guard_level && res.0.va < res.0.barrier_va.end && (
         *res.1).as_page_table_owner() == pt_own && (*res.1).continuations[3].path()
             == pt_own.0.value().path);
-        assume((forall|i: usize|
+        assume((forall|i: int|
             #![trigger old(regions).slot_owners[i]]
             old(regions).slot_owners.contains_key(i) && old(
                 regions,
             ).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED ==> old(
                 regions,
-            ).slot_owners[i].inner_perms.ref_count.value() + 1 < REF_COUNT_MAX) ==> (forall|
-            i: usize,
-        |
+            ).slot_owners[i].inner_perms.ref_count.value() + 1 < REF_COUNT_MAX) ==> (forall|i: int|
             #![trigger regions.slot_owners[i]]
             regions.slot_owners.contains_key(i)
                 && regions.slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
@@ -309,7 +307,7 @@ pub fn unlock_range<C: PageTableConfig, A: InAtomicMode>(cursor: &mut Cursor<'_,
         final(regions).inv(),
         // Locking only allocates fresh page-table nodes from UNUSED slots;
         // it does not mutate any slot that was already in use.
-        forall|idx: usize| #![trigger final(regions).slot_owners[idx].paths_in_pt]
+        forall|idx: int| #![trigger final(regions).slot_owners[idx].paths_in_pt]
             old(regions).slot_owners[idx].inner_perms.ref_count.value()
                 != REF_COUNT_UNUSED
             ==> final(regions).slot_owners[idx].paths_in_pt
@@ -317,7 +315,7 @@ pub fn unlock_range<C: PageTableConfig, A: InAtomicMode>(cursor: &mut Cursor<'_,
         // For *in-use* slots (non-UNUSED refcount), the refcount value and
         // usage are exactly preserved — locking only allocates fresh PT
         // nodes from UNUSED slots; it never mutates a slot already in use.
-        forall|idx: usize| #![trigger final(regions).slot_owners[idx]]
+        forall|idx: int| #![trigger final(regions).slot_owners[idx]]
             old(regions).slot_owners.contains_key(idx)
             && old(regions).slot_owners[idx].inner_perms.ref_count.value()
                 != REF_COUNT_UNUSED
@@ -332,12 +330,12 @@ pub fn unlock_range<C: PageTableConfig, A: InAtomicMode>(cursor: &mut Cursor<'_,
         // already-saturated slots. Used by `KVirtArea::query` to bridge
         // the inner `Cursor::query`'s per-specific-slot saturation
         // condition back to the caller's `*old(regions)` snapshot.
-        forall|idx: usize| #![trigger final(regions).slot_owners[idx].inner_perms.ref_count.value()]
+        forall|idx: int| #![trigger final(regions).slot_owners[idx].inner_perms.ref_count.value()]
             final(regions).slot_owners[idx].inner_perms.ref_count.value()
                 >= REF_COUNT_MAX
             ==> old(regions).slot_owners[idx].inner_perms.ref_count.value()
                     == final(regions).slot_owners[idx].inner_perms.ref_count.value(),
-        forall|idx: usize| #![trigger old(regions).slot_owners[idx].inner_perms.ref_count.value()]
+        forall|idx: int| #![trigger old(regions).slot_owners[idx].inner_perms.ref_count.value()]
             old(regions).slot_owners[idx].inner_perms.ref_count.value()
                 >= REF_COUNT_MAX
             ==> final(regions).slot_owners[idx].inner_perms.ref_count.value()

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -3215,8 +3215,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             assert(regions_before_new_child.slots.contains_key(pa_idx_install)) by {
                 assert(Self::item_slot_in_regions(item, regions_before_new_child));
             };
-            assert(regions_before_new_child.slot_owners[pa_idx_install].usage
-                != PageUsage::PageTable) by {
+            assert(regions_before_new_child.slot_owners[pa_idx_install].usage !is PageTable) by {
                 assert(Self::item_slot_in_regions(item, regions_before_new_child));
             };
             owner1.no_node_at_idx_from_slot_key(regions_before_new_child, pa_idx_install);

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -47,7 +47,7 @@ use crate::mm::frame::meta::{
 use crate::mm::frame::{AnyFrameMeta, Frame};
 use crate::mm::page_table::*;
 use crate::mm::{MAX_PADDR, Paddr, Vaddr, page_size};
-use crate::specs::mm::frame::mapping::{frame_to_index, max_meta_slots, index_to_meta};
+use crate::specs::mm::frame::mapping::{frame_to_index, index_to_meta, max_meta_slots};
 use crate::specs::mm::frame::meta_owners::{MetaSlotOwner, PageUsage, is_mmio_paddr};
 use crate::specs::mm::frame::meta_region_owners::MetaRegionOwners;
 use crate::specs::mm::page_table::cursor::page_size_lemmas::*;
@@ -211,7 +211,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
             final(regions).inv(),
             final(regions).slots == old(regions).slots,
             final(regions).slot_owners.dom() == old(regions).slot_owners.dom(),
-            forall|i: usize|
+            forall|i: int|
                 i != frame_to_index(pa) ==> (#[trigger] final(regions).slot_owners[i] == old(
                     regions,
                 ).slot_owners[i]),
@@ -300,14 +300,14 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
             // Cursor::new inherits lock_range's weakened preservation: only
             // slots that were non-UNUSED before the call keep their
             // paths_in_pt (new PT allocations come from UNUSED slots).
-            forall|idx: usize| #![trigger final(regions).slot_owners[idx].paths_in_pt]
+            forall|idx: int| #![trigger final(regions).slot_owners[idx].paths_in_pt]
                 old(regions).slot_owners[idx].inner_perms.ref_count.value()
                     != REF_COUNT_UNUSED
                 ==> final(regions).slot_owners[idx].paths_in_pt
                         == old(regions).slot_owners[idx].paths_in_pt,
             // For *in-use* slots, refcount value and usage are exactly
             // preserved across `Cursor::new` (= `lock_range`).
-            forall|idx: usize| #![trigger final(regions).slot_owners[idx]]
+            forall|idx: int| #![trigger final(regions).slot_owners[idx]]
                 old(regions).slot_owners.contains_key(idx)
                 && old(regions).slot_owners[idx].inner_perms.ref_count.value()
                     != REF_COUNT_UNUSED
@@ -321,12 +321,12 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
             // saturation condition back to the caller's snapshot — both
             // for the `requires P ==> may_panic()` discharge (forward
             // direction) and the `ensures !P` discharge (backward).
-            forall|idx: usize| #![trigger final(regions).slot_owners[idx].inner_perms.ref_count.value()]
+            forall|idx: int| #![trigger final(regions).slot_owners[idx].inner_perms.ref_count.value()]
                 final(regions).slot_owners[idx].inner_perms.ref_count.value()
                     >= REF_COUNT_MAX
                 ==> old(regions).slot_owners[idx].inner_perms.ref_count.value()
                         == final(regions).slot_owners[idx].inner_perms.ref_count.value(),
-            forall|idx: usize| #![trigger old(regions).slot_owners[idx].inner_perms.ref_count.value()]
+            forall|idx: int| #![trigger old(regions).slot_owners[idx].inner_perms.ref_count.value()]
                 old(regions).slot_owners[idx].inner_perms.ref_count.value()
                     >= REF_COUNT_MAX
                 ==> final(regions).slot_owners[idx].inner_perms.ref_count.value()
@@ -335,14 +335,14 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                 CursorMut::<C, A>::item_not_mapped(item, *old(regions)) ==>
                 CursorMut::<C, A>::item_not_mapped(item, *final(regions)),
             // Non-saturation preservation.
-            (forall |i: usize| #![trigger old(regions).slot_owners[i]]
+            (forall |i: int| #![trigger old(regions).slot_owners[i]]
                 old(regions).slot_owners.contains_key(i)
                 && old(regions).slot_owners[i].inner_perms.ref_count.value()
                     != REF_COUNT_UNUSED
                 ==> old(regions).slot_owners[i].inner_perms.ref_count.value() + 1
                     < REF_COUNT_MAX)
             ==>
-            (forall |i: usize| #![trigger final(regions).slot_owners[i]]
+            (forall |i: int| #![trigger final(regions).slot_owners[i]]
                 final(regions).slot_owners.contains_key(i)
                 && final(regions).slot_owners[i].inner_perms.ref_count.value()
                     != REF_COUNT_UNUSED
@@ -488,14 +488,14 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                 // The descent itself never clones, so every slot's refcount
                 // is *exactly* its precondition value at each loop head (the
                 // single `clone_item` is the last action before `return`).
-                forall|i: usize|
+                forall|i: int|
                     #![trigger regions.slot_owners[i]]
                     old(regions).slot_owners.contains_key(i)
                         ==> regions.slot_owners[i].inner_perms.ref_count.value() == old(
                         regions,
                     ).slot_owners[i].inner_perms.ref_count.value(),
                 regions.slot_owners.dom() == old(regions).slot_owners.dom(),
-                forall|idx: usize|
+                forall|idx: int|
                     #![trigger regions.slot_owners[idx]]
                     old(regions).slot_owners.contains_key(idx) ==> {
                         &&& regions.slot_owners[idx].paths_in_pt == old(
@@ -525,9 +525,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                             regions,
                         ).slot_owners[idx].inner_perms.in_list.id()
                     },
-                forall|k: usize|
+                forall|k: int|
                     old(regions).slots.contains_key(k) ==> #[trigger] regions.slots.contains_key(k),
-                forall|k: usize|
+                forall|k: int|
                     old(regions).slots.contains_key(k) ==> old(regions).slots[k]
                         == #[trigger] regions.slots[k],
             decreases self.level,
@@ -1668,14 +1668,14 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
             final(owner).va == old(owner).va.align_up(old(self).level as int),
             final(self).va <= old(self).va + page_size(old(self).level),
             // move_forward only calls pop_level, which does not touch regions.
-            forall|idx: usize|
+            forall|idx: int|
                 #![trigger final(regions).slot_owners[idx].paths_in_pt]
                 final(regions).slot_owners[idx].paths_in_pt == old(
                     regions,
                 ).slot_owners[idx].paths_in_pt,
             // Slots and slot_owners fully unchanged (pop_level is purely cursor manipulation).
             final(regions).slots == old(regions).slots,
-            forall|idx: usize|
+            forall|idx: int|
                 #![trigger final(regions).slot_owners[idx]]
                 final(regions).slot_owners[idx] == old(regions).slot_owners[idx],
     )]
@@ -2266,12 +2266,12 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             // CursorMut::new inherits the weakened Cursor::new preservation:
             // PT-node allocations come from UNUSED slots, so any slot that
             // was already in use keeps its paths_in_pt.
-            forall |idx: usize| #![trigger final(regions).slot_owners[idx].paths_in_pt]
+            forall |idx: int| #![trigger final(regions).slot_owners[idx].paths_in_pt]
                 old(regions).slot_owners[idx].inner_perms.ref_count.value()
                     != REF_COUNT_UNUSED
                 ==> final(regions).slot_owners[idx].paths_in_pt
                         == old(regions).slot_owners[idx].paths_in_pt,
-            forall|idx: usize| #![trigger final(regions).slot_owners[idx]]
+            forall|idx: int| #![trigger final(regions).slot_owners[idx]]
                 old(regions).slot_owners.contains_key(idx)
                 && old(regions).slot_owners[idx].inner_perms.ref_count.value()
                     != REF_COUNT_UNUSED
@@ -2552,12 +2552,12 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 Self::item_slot_in_regions(item, *old(regions)) ==>
                 Self::item_slot_in_regions(item, *final(regions)),
             (level <= old(self).0.level && old(owner).cur_entry_owner().is_absent()) ==> final(owner).cur_entry_owner().is_absent(),
-            forall|idx: usize|
+            forall|idx: int|
                 old(regions).slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED ==>
                 (#[trigger] final(regions).slot_owners[idx]) == old(regions).slot_owners[idx],
             // `regions.slots` is monotonic — PT-node allocation removes-and-re-inserts
             // each slot it touches, so all old keys are preserved.
-            forall|idx: usize| #![trigger final(regions).slots.contains_key(idx)]
+            forall|idx: int| #![trigger final(regions).slots.contains_key(idx)]
                 old(regions).slots.contains_key(idx) ==> final(regions).slots.contains_key(idx),
     )]
     #[verifier::spinoff_prover]
@@ -2600,10 +2600,10 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 self.0.level <= owner0.level || self.0.level <= level,
                 self.0.level < level ==> self.0.level >= owner0.level,
                 self.0.level < level ==> owner@ == owner0@,
-                forall|idx: usize|
+                forall|idx: int|
                     old(regions).slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
                         ==> (#[trigger] regions.slot_owners[idx]) == old(regions).slot_owners[idx],
-                forall|idx: usize|
+                forall|idx: int|
                     #![trigger regions.slots.contains_key(idx)]
                     old(regions).slots.contains_key(idx) ==> regions.slots.contains_key(idx),
             decreases abs(level - self.0.level),
@@ -2986,7 +2986,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         assert(regions_after_ref.slots.contains_key(idx));
                         assert(Self::item_slot_in_regions(item, regions_after_ref));
                     };
-                    assert forall|idx: usize|
+                    assert forall|idx: int|
                         old(regions).slot_owners[idx].inner_perms.ref_count.value()
                             != REF_COUNT_UNUSED implies (#[trigger] regions.slot_owners[idx])
                         == old(regions).slot_owners[idx] by {
@@ -3073,7 +3073,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 && old(owner).cur_entry_owner().is_absent()) ==> res.is_ok(),
             res is Err && res.unwrap_err() is StrayPageTable ==> C::item_into_raw(item).1 > 1,
             // For non-UNUSED indices other than the mapped frame, paths_in_pt is preserved.
-            forall|idx: usize| #![trigger final(regions).slot_owners[idx].paths_in_pt]
+            forall|idx: int| #![trigger final(regions).slot_owners[idx].paths_in_pt]
                 old(regions).slot_owners.contains_key(idx) &&
                 idx != frame_to_index(C::item_into_raw(item).0) &&
                 old(regions).slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED ==>
@@ -3082,7 +3082,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             // (map_loop only allocates new PT nodes from previously-UNUSED slots, so
             // any slot already in use stays in use; replace_cur_entry replaces the
             // current entry without dropping refcounts of unrelated slots.)
-            forall|idx: usize| #![trigger final(regions).slot_owners[idx].inner_perms.ref_count.value()]
+            forall|idx: int| #![trigger final(regions).slot_owners[idx].inner_perms.ref_count.value()]
                 old(regions).slot_owners.contains_key(idx) &&
                 old(regions).slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED ==>
                 final(regions).slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED,
@@ -3092,7 +3092,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             // preserves ref_count for all slots (per its own postcondition at
             // [mod.rs:3380]). Lets callers re-derive `item_slot_in_regions`
             // for unrelated paddrs.
-            forall|idx: usize| #![trigger final(regions).slot_owners[idx].inner_perms.ref_count.value()]
+            forall|idx: int| #![trigger final(regions).slot_owners[idx].inner_perms.ref_count.value()]
                 old(regions).slot_owners.contains_key(idx) &&
                 idx != frame_to_index(C::item_into_raw(item).0) &&
                 old(regions).slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED ==>
@@ -3121,7 +3121,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                     frame_to_index(C::item_into_raw(item).0)].inner_perms.ref_count.value()
                     <= REF_COUNT_MAX,
             // `regions.slots` is monotonic — slot existence is preserved through map.
-            forall|idx: usize| #![trigger final(regions).slots.contains_key(idx)]
+            forall|idx: int| #![trigger final(regions).slots.contains_key(idx)]
                 old(regions).slots.contains_key(idx) ==> final(regions).slots.contains_key(idx),
             final(self).0.guard_level == old(self).0.guard_level,
             final(self).0.barrier_va == old(self).0.barrier_va,
@@ -3257,7 +3257,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
 
             assert(regions.inv()) by {
                 assert(regions.slots == regions_before_new_child.slots);
-                assert forall|i: usize| #[trigger] regions.slots.contains_key(i) implies {
+                assert forall|i: int| #[trigger] regions.slots.contains_key(i) implies {
                     &&& regions.slot_owners.contains_key(i)
                     &&& regions.slot_owners[i].inv()
                     &&& regions.slots[i].is_init()
@@ -3270,16 +3270,18 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         assert(regions_before_new_child.slot_owners[pa_idx_install].inv());
                     }
                 };
-                assert forall|i: usize| #[trigger]
+                assert forall|i: int| #[trigger]
                     regions.slot_owners.contains_key(i) implies regions.slot_owners[i].inv() by {
                     if i != pa_idx_install {
                     } else {
                         assert(regions_before_new_child.slot_owners[pa_idx_install].inv());
                     }
                 };
-                assert forall|i: usize|
-                    i < max_meta_slots() <==> #[trigger] regions.slot_owners.contains_key(i) by {};
-                assert forall|i: usize| #[trigger] regions.slots.contains_key(i) implies i
+                assert forall|i: int|
+                    0 <= i < max_meta_slots() <==> #[trigger] regions.slot_owners.contains_key(
+                        i,
+                    ) by {};
+                assert forall|i: int| #[trigger] regions.slots.contains_key(i) implies i
                     < max_meta_slots() by {
                     assert(regions_before_new_child.slots.contains_key(i));
                 };
@@ -3342,7 +3344,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 }
             };
             let ghost pa_idx2 = frame_to_index(C::item_into_raw(item).0);
-            assert forall|idx: usize|
+            assert forall|idx: int|
                 old(regions).slot_owners.contains_key(idx) && idx != pa_idx2 && old(
                     regions,
                 ).slot_owners[idx].inner_perms.ref_count.value()
@@ -3368,14 +3370,14 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             };
 
             assert(regions_before_new_child.slots == regions_after_new_child.slots);
-            assert(forall|k: usize|
+            assert(forall|k: int|
                 #![trigger regions_after_replace.slots.contains_key(k)]
                 regions_after_new_child.slots.contains_key(k)
                     ==> regions_after_replace.slots.contains_key(k));
-            assert(forall|k: usize|
+            assert(forall|k: int|
                 #![trigger regions.slots.contains_key(k)]
                 regions_after_replace.slots.contains_key(k) ==> regions.slots.contains_key(k));
-            assert forall|idx: usize|
+            assert forall|idx: int|
                 old(regions).slots.contains_key(idx) implies #[trigger] regions.slots.contains_key(
                 idx,
             ) by {
@@ -3949,7 +3951,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 == PageTableOwner(old(owner).cur_subtree())@.mappings.len(),
             // paths_in_pt is changed only for new_owner's slot; all others are preserved.
             // (new_owner.value here is the post-into_pte state; meta_slot_paddr() is unchanged.)
-            forall|idx: usize|
+            forall|idx: int|
                 #![trigger final(regions).slot_owners[idx].paths_in_pt]
                 (new_owner.value().is_absent() || idx != frame_to_index(
                     new_owner.value().meta_slot_paddr()->0,
@@ -3957,14 +3959,14 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                     regions,
                 ).slot_owners[idx].paths_in_pt,
             // `regions.slots` keys are monotonic across the entry replacement.
-            forall|idx: usize|
+            forall|idx: int|
                 #![trigger final(regions).slots.contains_key(idx)]
                 old(regions).slots.contains_key(idx) ==> final(regions).slots.contains_key(idx),
             // ref_count is preserved per-slot across the whole replace_cur_entry call.
             // The body only touches regions via `Entry::replace` (which preserves
             // ref_count by spec); `dfs_mark_stray_and_unlock` doesn't take regions at
             // all, so the StrayPageTable branch can't perturb refcounts either.
-            forall|idx: usize|
+            forall|idx: int|
                 #![trigger final(regions).slot_owners[idx].inner_perms.ref_count.value()]
                 final(regions).slot_owners[idx].inner_perms.ref_count.value() == old(
                     regions,
@@ -3972,7 +3974,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             // When `res is None` (⇔ pre-replace cur_entry was absent), `Entry::replace`
             // fully preserves `regions.slots`.
             res is None ==> final(regions).slots == old(regions).slots,
-            res is Some && res->0 is Mapped && new_owner.value().is_absent() ==> forall|idx: usize|
+            res is Some && res->0 is Mapped && new_owner.value().is_absent() ==> forall|idx: int|
                 #![trigger final(regions).slot_owners[idx]]
                 final(regions).slot_owners[idx] == old(regions).slot_owners[idx],
     )]
@@ -4560,13 +4562,13 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             },
         };
 
-        assert(forall|idx: usize|
+        assert(forall|idx: int|
             #![trigger regions.slot_owners[idx].paths_in_pt]
             (new_owner.value().is_absent() || idx != frame_to_index(
                 new_owner.value().meta_slot_paddr().unwrap(),
             )) ==> regions.slot_owners[idx].paths_in_pt == regions0.slot_owners[idx].paths_in_pt)
             by {
-            assert(forall|i: usize|
+            assert(forall|i: int|
                 #![trigger regions.slot_owners[i].paths_in_pt]
                 regions.slot_owners[i].paths_in_pt
                     == regions_after_replace.slot_owners[i].paths_in_pt);

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -601,7 +601,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
 
                         owner.map_children_implies(
                             CursorOwner::node_unlocked(guards0),
-                            CursorOwner::node_unlocked_except(*guards, child_node.meta_addr_self()),
+                            CursorOwner::node_unlocked_except(*guards, child_node.meta_vaddr()),
                         );
                         owner.cur_entry_node_implies_level_gt_1();
                     }
@@ -1130,7 +1130,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                             CursorOwner::node_unlocked(guards0),
                             CursorOwner::node_unlocked_except(
                                 *guards,
-                                child_node_owner.meta_addr_self(),
+                                child_node_owner.meta_vaddr(),
                             ),
                         );
                     }
@@ -1146,7 +1146,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                         self.push_level(pt_guard);
                     } else {
                         let ghost guards_before_drop = *guards;
-                        let ghost locked_addr = child_node_owner.meta_addr_self();
+                        let ghost locked_addr = child_node_owner.meta_vaddr();
 
                         proof_decl! {
                             let tracked guard_obl = pt_guard.tracked_redeem(guards);
@@ -2026,7 +2026,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
         let tracked child = parent_continuation.tracked_take_child();
         let tracked parent_own = parent_continuation.entry_own.tracked_take_node();
 
-        let ghost index = frame_to_index(meta_to_frame(parent_own.meta_addr_self()));
+        let ghost index = frame_to_index(meta_to_frame(parent_own.meta_vaddr()));
 
         let ghost ptei = AbstractVaddr::from_vaddr(self.va).index[owner.level - 1];
 
@@ -2517,7 +2517,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
 
             owner.map_children_implies(
                 CursorOwner::node_unlocked(guards0),
-                CursorOwner::node_unlocked_except(*guards, child_node.meta_addr_self()),
+                CursorOwner::node_unlocked_except(*guards, child_node.meta_vaddr()),
             );
 
             owner.cur_entry_node_implies_level_gt_1();
@@ -2733,7 +2733,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         node.alloc_absent_child(entry_idx, rcu_guard)
                     };
 
-                    let ghost new_node_addr = child_owner.value().node().meta_addr_self();
+                    let ghost new_node_addr = child_owner.value().node().meta_vaddr();
                     let ghost new_child_value = child_owner.value();
 
                     let ghost new_pt_idx = frame_to_index(
@@ -2766,7 +2766,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         continuation.tracked_put_child(child_owner);
                         owner.continuations.tracked_insert(owner.level - 1, continuation);
 
-                        assert(owner.cur_entry_owner().node().meta_addr_self() == new_node_addr);
+                        assert(owner.cur_entry_owner().node().meta_vaddr() == new_node_addr);
 
                         assert forall|i: int|
                             owner_pre_none.level <= i
@@ -4397,12 +4397,12 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 proof {
                     owner.map_children_implies(
                         CursorOwner::node_unlocked(guards0),
-                        CursorOwner::node_unlocked_except(*guards, old_node_owner.meta_addr_self()),
+                        CursorOwner::node_unlocked_except(*guards, old_node_owner.meta_vaddr()),
                     );
                 }
 
                 let ghost guards1 = *guards;
-                let ghost locked_addr = old_node_owner.meta_addr_self();
+                let ghost locked_addr = old_node_owner.meta_vaddr();
                 let ghost owner_before_dfs = *owner;
 
                 // SAFETY:

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -47,7 +47,7 @@ use crate::mm::frame::meta::{
 use crate::mm::frame::{AnyFrameMeta, Frame};
 use crate::mm::page_table::*;
 use crate::mm::{MAX_PADDR, Paddr, Vaddr, page_size};
-use crate::specs::mm::frame::mapping::{frame_to_index, max_meta_slots, meta_addr};
+use crate::specs::mm::frame::mapping::{frame_to_index, max_meta_slots, index_to_meta};
 use crate::specs::mm::frame::meta_owners::{MetaSlotOwner, PageUsage, is_mmio_paddr};
 use crate::specs::mm::frame::meta_region_owners::MetaRegionOwners;
 use crate::specs::mm::page_table::cursor::page_size_lemmas::*;
@@ -3261,7 +3261,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                     &&& regions.slot_owners.contains_key(i)
                     &&& regions.slot_owners[i].inv()
                     &&& regions.slots[i].is_init()
-                    &&& regions.slots[i].addr() == meta_addr(i)
+                    &&& regions.slots[i].addr() == index_to_meta(i)
                     &&& regions.slots[i].value().wf(regions.slot_owners[i])
                     &&& regions.slot_owners[i].slot_vaddr == regions.slots[i].addr()
                 } by {

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -364,7 +364,7 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
         ensures
     // Other slots always unchanged.
 
-            forall|i: usize|
+            forall|i: int|
                 i != frame_to_index(pa) ==> (#[trigger] new_regions.slot_owners[i]
                     == old_regions.slot_owners[i]),
             // The frame's slot: bumped if the item is ref-counted, otherwise unchanged.
@@ -966,7 +966,7 @@ impl PageTable<KernelPtConfig> {
         PageTable::empty_with_owner());
         let new_root = new_pt.root;
         // Capture new_idx as a ghost BEFORE the tracked_take below empties new_pt_owner.
-        let ghost new_idx_g: usize = crate::specs::mm::frame::mapping::frame_to_index(
+        let ghost new_idx_g: int = crate::specs::mm::frame::mapping::frame_to_index(
             new_pt_owner@.unwrap().0.value().meta_slot_paddr().unwrap(),
         );
         let ghost new_pt_owner_snap = new_pt_owner@.unwrap();
@@ -1026,7 +1026,7 @@ impl PageTable<KernelPtConfig> {
             );
             assert(regions_before_self_borrow.slot_owners
                 == regions_after_kroot_borrow.slot_owners);
-            assert forall|k: usize|
+            assert forall|k: int|
                 regions_before_self_borrow.slots.contains_key(
                     k,
                 ) implies regions_before_self_borrow.slots[k]
@@ -1060,7 +1060,7 @@ impl PageTable<KernelPtConfig> {
 
             assert(!regions_before_self_borrow.slots.contains_key(new_idx));
             assert(!regions_after_kroot_borrow.slots.contains_key(new_idx));
-            assert forall|k: usize|
+            assert forall|k: int|
                 regions_after_kroot_borrow.slots.contains_key(
                     k,
                 ) implies regions_after_kroot_borrow.slots[k] == #[trigger] regions.slots[k] by {
@@ -1318,12 +1318,12 @@ impl<C: PageTableConfig> PageTable<C> {
                 crate::specs::mm::frame::mapping::frame_to_index(
                     (final(owner)@->0).0.value().meta_slot_paddr()->0)),
             // Other slots and lock state are preserved.
-            forall |i: usize| #![trigger final(regions).slot_owners[i]]
+            forall |i: int| #![trigger final(regions).slot_owners[i]]
                 i != crate::specs::mm::frame::mapping::frame_to_index(
                     (final(owner)@->0).0.value().meta_slot_paddr()->0)
                 ==> final(regions).slot_owners[i] == old(regions).slot_owners[i],
             forall |a: usize| old(guards).lock_held(a) ==> final(guards).lock_held(a),
-            forall |idx: usize| #![trigger final(regions).slot_owners[idx].paths_in_pt]
+            forall |idx: int| #![trigger final(regions).slot_owners[idx].paths_in_pt]
                 final(regions).slot_owners[idx].paths_in_pt
                     == old(regions).slot_owners[idx].paths_in_pt,
             // Allocation preserves the soundness of the kernel page-table tree:
@@ -1449,12 +1449,12 @@ impl<C: PageTableConfig> PageTable<C> {
             // CursorMut::new inherits Cursor::new's weakened preservation:
             // PT-node allocations come from UNUSED slots, so any slot that
             // was already in use keeps its paths_in_pt.
-            forall |idx: usize| #![trigger final(regions).slot_owners[idx].paths_in_pt]
+            forall |idx: int| #![trigger final(regions).slot_owners[idx].paths_in_pt]
                 old(regions).slot_owners[idx].inner_perms.ref_count.value()
                     != REF_COUNT_UNUSED
                 ==> final(regions).slot_owners[idx].paths_in_pt
                         == old(regions).slot_owners[idx].paths_in_pt,
-            forall|idx: usize| #![trigger final(regions).slot_owners[idx]]
+            forall|idx: int| #![trigger final(regions).slot_owners[idx]]
                 old(regions).slot_owners.contains_key(idx)
                 && old(regions).slot_owners[idx].inner_perms.ref_count.value()
                     != REF_COUNT_UNUSED
@@ -1500,20 +1500,20 @@ impl<C: PageTableConfig> PageTable<C> {
                 &&& r.unwrap().1@.continuations[3].path() == owner.0.value().path
             },
             !Cursor::<C, G>::cursor_new_success_conditions(*va) ==> r is Err,
-            forall|idx: usize| #![trigger final(regions).slot_owners[idx].paths_in_pt]
+            forall|idx: int| #![trigger final(regions).slot_owners[idx].paths_in_pt]
                 old(regions).slot_owners[idx].inner_perms.ref_count.value()
                     != REF_COUNT_UNUSED
                 ==> final(regions).slot_owners[idx].paths_in_pt
                         == old(regions).slot_owners[idx].paths_in_pt,
             // Non-saturation preservation.
-            (forall |i: usize| #![trigger old(regions).slot_owners[i]]
+            (forall |i: int| #![trigger old(regions).slot_owners[i]]
                 old(regions).slot_owners.contains_key(i)
                 && old(regions).slot_owners[i].inner_perms.ref_count.value()
                     != REF_COUNT_UNUSED
                 ==> old(regions).slot_owners[i].inner_perms.ref_count.value() + 1
                     < REF_COUNT_MAX)
             ==>
-            (forall |i: usize| #![trigger final(regions).slot_owners[i]]
+            (forall |i: int| #![trigger final(regions).slot_owners[i]]
                 final(regions).slot_owners.contains_key(i)
                 && final(regions).slot_owners[i].inner_perms.ref_count.value()
                     != REF_COUNT_UNUSED
@@ -1523,12 +1523,12 @@ impl<C: PageTableConfig> PageTable<C> {
             // a slot at `>= REF_COUNT_MAX` before iff after, with the same
             // value. Used by `KVirtArea::query` to bridge inner-cursor
             // saturation back to the caller's snapshot.
-            forall|idx: usize| #![trigger final(regions).slot_owners[idx].inner_perms.ref_count.value()]
+            forall|idx: int| #![trigger final(regions).slot_owners[idx].inner_perms.ref_count.value()]
                 final(regions).slot_owners[idx].inner_perms.ref_count.value()
                     >= REF_COUNT_MAX
                 ==> old(regions).slot_owners[idx].inner_perms.ref_count.value()
                         == final(regions).slot_owners[idx].inner_perms.ref_count.value(),
-            forall|idx: usize| #![trigger old(regions).slot_owners[idx].inner_perms.ref_count.value()]
+            forall|idx: int| #![trigger old(regions).slot_owners[idx].inner_perms.ref_count.value()]
                 old(regions).slot_owners[idx].inner_perms.ref_count.value()
                     >= REF_COUNT_MAX
                 ==> final(regions).slot_owners[idx].inner_perms.ref_count.value()

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -940,7 +940,7 @@ impl PageTable<KernelPtConfig> {
             kernel_owner.0.value().is_node(),
             !Self::create_user_pt_panic_condition(kernel_owner.0.value().node()),
             // The kernel page table's root frame matches the tracked owner.
-            self.root.ptr.addr() == kernel_owner.0.value().node().meta_addr_self(),
+            self.root.ptr.addr() == kernel_owner.0.value().node().meta_vaddr(),
             // The kernel root entry is sound with respect to the meta regions.
             kernel_owner.0.value().metaregion_sound(*old(regions)),
             // The whole kernel page-table tree is sound: every entry's metaregion
@@ -948,7 +948,7 @@ impl PageTable<KernelPtConfig> {
             // soundness inside the loop body.
             kernel_owner.metaregion_sound(*old(regions)),
             // The kernel root is not currently locked.
-            old(guards).unlocked(kernel_owner.0.value().node().meta_addr_self()),
+            old(guards).unlocked(kernel_owner.0.value().node().meta_vaddr()),
         ensures
             final(regions).inv(),
     )]
@@ -1276,7 +1276,7 @@ impl<C: PageTableConfig> PageTable<C> {
         regions: MetaRegionOwners,
     ) -> bool {
         &&& owner.inv()
-        &&& self.root.ptr.addr() == owner.0.value().node().meta_addr_self()
+        &&& self.root.ptr.addr() == owner.0.value().node().meta_vaddr()
         &&& owner.metaregion_sound(regions)
     }
 
@@ -1301,10 +1301,10 @@ impl<C: PageTableConfig> PageTable<C> {
             final(owner)@->0.inv(),
             (final(owner)@->0).0.value().is_node(),
             (final(owner)@->0).0.value().is_node(),
-            r.root.ptr.addr() == (final(owner)@->0).0.value().node().meta_addr_self(),
+            r.root.ptr.addr() == (final(owner)@->0).0.value().node().meta_vaddr(),
             (final(owner)@->0).0.value().metaregion_sound(*final(regions)),
             final(regions).inv(),
-            final(guards).unlocked((final(owner)@->0).0.value().node().meta_addr_self()),
+            final(guards).unlocked((final(owner)@->0).0.value().node().meta_vaddr()),
             // Allocating a fresh node does not change the lock set, so any node
             // that was (un)locked before remains so.
             final(guards).guards == old(guards).guards,

--- a/ostd/src/mm/page_table/node/child.rs
+++ b/ostd/src/mm/page_table/node/child.rs
@@ -74,7 +74,7 @@ impl<C: PageTableConfig> Child<C> {
             *final(regions) == old(owner).into_pte_regions_spec(*old(regions)),
             *final(owner) == old(owner).into_pte_owner_spec(),
             old(owner).is_node() ==> res == C::E::new_pt_spec(
-                meta_to_frame(old(owner).node().meta_addr_self()),
+                meta_to_frame(old(owner).node().meta_vaddr()),
             ),
     )]
     pub fn into_pte(self) -> C::E {

--- a/ostd/src/mm/page_table/node/child.rs
+++ b/ostd/src/mm/page_table/node/child.rs
@@ -154,7 +154,7 @@ impl<C: PageTableConfig> Child<C> {
             }
 
             proof_decl! {
-                let tracked from_raw_obl: vstd_extra::drop_tracking::DropObligation<usize>;
+                let tracked from_raw_obl: vstd_extra::drop_tracking::DropObligation<int>;
             }
 
             let node = unsafe {
@@ -221,11 +221,11 @@ impl<C: PageTableConfig> ChildRef<'_, C> {
         ensures
             res.invariants(*entry_owner, *final(regions)),
             final(regions).slot_owners == old(regions).slot_owners,
-            forall|k: usize|
+            forall|k: int|
                 old(regions).slots.contains_key(k) ==> #[trigger] final(regions).slots.contains_key(
                     k,
                 ),
-            forall|k: usize|
+            forall|k: int|
                 old(regions).slots.contains_key(k) ==> old(regions).slots[k]
                     == #[trigger] final(regions).slots[k],
     )]
@@ -250,7 +250,7 @@ impl<C: PageTableConfig> ChildRef<'_, C> {
             proof {
                 // `borrow_paddr` preserves the region maps, so every old slot key keeps
                 // the same permission value.
-                assert forall|k: usize| old(regions).slots.contains_key(k) implies old(
+                assert forall|k: int| old(regions).slots.contains_key(k) implies old(
                     regions,
                 ).slots[k] == #[trigger] regions.slots[k] by {};
             }

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -153,11 +153,11 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         ensures
             res.invariants(*owner, *final(regions)),
             final(regions).slot_owners == old(regions).slot_owners,
-            forall|k: usize|
+            forall|k: int|
                 old(regions).slots.contains_key(k) ==> #[trigger] final(regions).slots.contains_key(
                     k,
                 ),
-            forall|k: usize|
+            forall|k: int|
                 old(regions).slots.contains_key(k) ==> old(regions).slots[k]
                     == #[trigger] final(regions).slots[k],
             final(regions).inv(),
@@ -318,7 +318,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             final(self).parent_perms_preserved(*old(parent_owner), *final(parent_owner)),
             final(parent_owner).metaregion_sound_node(*final(regions)),
             // paths_in_pt changes when new owner is a node; preserved otherwise.
-            forall|idx: usize|
+            forall|idx: int|
                 #![trigger final(regions).slot_owners[idx].paths_in_pt]
                 (!final(new_owner).is_node() || final(new_owner).is_absent() || idx
                     != frame_to_index(final(new_owner).meta_slot_paddr()->0))
@@ -326,7 +326,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                     regions,
                 ).slot_owners[idx].paths_in_pt,
             // slots: monotonic (from_pte may add; into_pte doesn't remove for non-nodes).
-            forall|k: usize|
+            forall|k: int|
                 old(regions).slots.contains_key(k) ==> #[trigger] final(regions).slots.contains_key(
                     k,
                 ),
@@ -335,12 +335,12 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             // ghost `paths_in_pt` is touched by the surrounding body, never
             // `inner_perms`); both use the `..old_slot` struct-update form
             // so `inner_perms.ref_count` is preserved across the rewrite.
-            forall|idx: usize|
+            forall|idx: int|
                 #![trigger final(regions).slot_owners[idx].inner_perms.ref_count.value()]
                 final(regions).slot_owners[idx].inner_perms.ref_count.value() == old(
                     regions,
                 ).slot_owners[idx].inner_perms.ref_count.value(),
-            forall|idx: usize|
+            forall|idx: int|
                 #![trigger final(regions).slot_owners[idx].inner_perms]
                 final(regions).slot_owners[idx].inner_perms == old(
                     regions,
@@ -349,7 +349,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             // When both old and new are not nodes: from_pte/into_pte are identity.
             (!old(owner).is_node() && !final(new_owner).is_node()) ==> {
                 &&& final(regions).slots == old(regions).slots
-                &&& forall|i: usize|
+                &&& forall|i: int|
                     #![trigger final(regions).slot_owners[i]]
                     final(regions).slot_owners[i] == old(
                         regions,
@@ -362,7 +362,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 &&& final(regions).frame_obligations == old(regions).frame_obligations
             },
             // When old child is absent and new child is not a node: slots values unchanged.
-            (old(owner).is_absent() && !final(new_owner).is_node()) ==> forall|k: usize|
+            (old(owner).is_absent() && !final(new_owner).is_node()) ==> forall|k: int|
                 old(regions).slots.contains_key(k) ==> old(regions).slots[k]
                     == #[trigger] final(regions).slots[k],
             Self::replace_nonpanic_condition(*old(parent_owner), *old(new_owner)),
@@ -560,12 +560,12 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                         final(owner).value().node().children_perm.value()[i],
                         final(owner).child(i).value().parent_level)
                 // slot_owners unchanged for all indices except the new PT node's index.
-                &&& forall|i: usize| i != frame_to_index(final(owner).value().meta_slot_paddr()->0) ==>
+                &&& forall|i: int| i != frame_to_index(final(owner).value().meta_slot_paddr()->0) ==>
                     (#[trigger] final(regions).slot_owners[i]) == old(regions).slot_owners[i]
                 // slots keys: the new PT node was removed then re-inserted, so all old keys preserved.
-                &&& forall|i: usize| old(regions).slots.contains_key(i)
+                &&& forall|i: int| old(regions).slots.contains_key(i)
                     ==> (#[trigger] final(regions).slots.contains_key(i))
-                &&& forall|i: usize| #![trigger final(regions).slots[i]]
+                &&& forall|i: int| #![trigger final(regions).slots[i]]
                     i != frame_to_index(final(owner).value().meta_slot_paddr()->0)
                         && old(regions).slots.contains_key(i)
                     ==> final(regions).slots[i] == old(regions).slots[i]
@@ -857,10 +857,10 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             forall |i: usize| old(guards).unlocked(i) ==> final(guards).unlocked(i),
             // slot_owners unchanged for all indices except the new PT node's index.
             old(owner).value().is_frame() && old(parent_owner).level > 1 ==> {
-                &&& forall|i: usize| i != frame_to_index(meta_to_frame(final(owner).value().node().meta_vaddr())) ==>
+                &&& forall|i: int| i != frame_to_index(meta_to_frame(final(owner).value().node().meta_vaddr())) ==>
                     (#[trigger] final(regions).slot_owners[i]) == old(regions).slot_owners[i]
                 // slots keys preserved (alloc removes then borrow re-inserts).
-                &&& forall|i: usize| old(regions).slots.contains_key(i)
+                &&& forall|i: int| old(regions).slots.contains_key(i)
                     ==> (#[trigger] final(regions).slots.contains_key(i))
                 // The new PT node's ref_count is not UNUSED.
                 &&& final(regions).slot_owners[frame_to_index(meta_to_frame(final(owner).value().node().meta_vaddr()))]
@@ -1592,23 +1592,23 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
             forall|j: int| 0 <= j < NR_ENTRIES && j != idx ==>
                 #[trigger] final(parent_owner).children_perm.value()[j]
                     == old(parent_owner).children_perm.value()[j],
-            forall|slot: usize|
+            forall|slot: int|
                 #![trigger final(regions).slot_owners[slot].paths_in_pt]
                 (!final(new_owner).is_node() || final(new_owner).is_absent() || slot
                     != frame_to_index(final(new_owner).meta_slot_paddr()->0))
                     ==> final(regions).slot_owners[slot].paths_in_pt == old(
                     regions,
                 ).slot_owners[slot].paths_in_pt,
-            forall|k: usize|
+            forall|k: int|
                 old(regions).slots.contains_key(k) ==> #[trigger] final(regions).slots.contains_key(
                     k,
                 ),
-            forall|slot: usize|
+            forall|slot: int|
                 #![trigger final(regions).slot_owners[slot].inner_perms.ref_count.value()]
                 final(regions).slot_owners[slot].inner_perms.ref_count.value() == old(
                     regions,
                 ).slot_owners[slot].inner_perms.ref_count.value(),
-            forall|slot: usize|
+            forall|slot: int|
                 #![trigger final(regions).slot_owners[slot].inner_perms]
                 final(regions).slot_owners[slot].inner_perms == old(
                     regions,
@@ -1616,14 +1616,14 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
             final(regions).slots == old(regions).slots,
             (!old(owner).is_node() && !final(new_owner).is_node()) ==> {
                 &&& final(regions).slots == old(regions).slots
-                &&& forall|i: usize|
+                &&& forall|i: int|
                     #![trigger final(regions).slot_owners[i]]
                     final(regions).slot_owners[i] == old(
                         regions,
                     ).slot_owners[i]
                 &&& final(regions).frame_obligations == old(regions).frame_obligations
             },
-            (old(owner).is_absent() && !final(new_owner).is_node()) ==> forall|k: usize|
+            (old(owner).is_absent() && !final(new_owner).is_node()) ==> forall|k: int|
                 old(regions).slots.contains_key(k) ==> old(regions).slots[k]
                     == #[trigger] final(regions).slots[k],
             Entry::<C>::replace_nonpanic_condition(*old(parent_owner), *old(new_owner)),
@@ -1796,11 +1796,11 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
                 (#[trigger] final(owner).children()[i])->0.value().match_pte(
                     final(owner).value().node().children_perm.value()[i],
                     final(owner).children()[i]->0.value().parent_level),
-            forall|i: usize| i != frame_to_index(final(owner).value().meta_slot_paddr()->0) ==>
+            forall|i: int| i != frame_to_index(final(owner).value().meta_slot_paddr()->0) ==>
                 (#[trigger] final(regions).slot_owners[i]) == old(regions).slot_owners[i],
-            forall|i: usize| old(regions).slots.contains_key(i)
+            forall|i: int| old(regions).slots.contains_key(i)
                 ==> (#[trigger] final(regions).slots.contains_key(i)),
-            forall|i: usize| #![trigger final(regions).slots[i]]
+            forall|i: int| #![trigger final(regions).slots[i]]
                 i != frame_to_index(final(owner).value().meta_slot_paddr()->0)
                     && old(regions).slots.contains_key(i)
                 ==> final(regions).slots[i] == old(regions).slots[i],
@@ -1870,9 +1870,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
         }
 
         proof {
-            let pte = C::E::new_pt_spec(
-                meta_to_frame(new_node_owner.value().node().meta_vaddr()),
-            );
+            let pte = C::E::new_pt_spec(meta_to_frame(new_node_owner.value().node().meta_vaddr()));
             C::E::lemma_page_table_entry_properties();
         }
 

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -520,18 +520,18 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 &&& final(owner).value().is_node()
                 &&& final(owner).level() == old(owner).level()
                 &&& final(owner).value().parent_level == old(owner).value().parent_level
-                &&& final(guards).lock_held(final(owner).value().node().meta_addr_self())
+                &&& final(guards).lock_held(final(owner).value().node().meta_vaddr())
                 &&& final(owner).value().node().relate_guard(res->0)
                 &&& final(owner).value().path == old(owner).value().path
                 &&& final(owner).value().metaregion_sound(*final(regions))
                 &&& OwnerSubtree::implies(
                     CursorOwner::<'rcu, C>::node_unlocked(*old(guards)),
-                    CursorOwner::<'rcu, C>::node_unlocked_except(*final(guards), final(owner).value().node().meta_addr_self()))
+                    CursorOwner::<'rcu, C>::node_unlocked_except(*final(guards), final(owner).value().node().meta_vaddr()))
                 &&& Self::metaregion_sound_neq_preserved(old(owner).value(), final(owner).value(), *old(regions), *final(regions))
                 &&& Self::path_tracked_pred_preserved(*old(regions), *final(regions))
                 &&& old(regions).slots.contains_key(frame_to_index(final(owner).value().meta_slot_paddr()->0))
                 &&& final(owner).subtree_satisfies(final(owner).value().path,
-                    CursorOwner::<'rcu, C>::node_unlocked_except(*final(guards), final(owner).value().node().meta_addr_self()))
+                    CursorOwner::<'rcu, C>::node_unlocked_except(*final(guards), final(owner).value().node().meta_vaddr()))
                 &&& final(owner).subtree_satisfies(final(owner).value().path, PageTableOwner::<C>::metaregion_sound_pred(*final(regions)))
                 &&& final(owner).subtree_satisfies(final(owner).value().path, PageTableOwner::<C>::path_tracked_pred(*final(regions)))
                 &&& PageTableOwner(*final(owner)).view_rec(final(owner).value().path) == set![]
@@ -584,7 +584,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 &&& *final(owner) == *old(owner)
             },
             forall |i: usize| old(guards).lock_held(i) ==> final(guards).lock_held(i),
-            forall |i: usize| old(guards).unlocked(i) && i != final(owner).value().node().meta_addr_self() ==> final(guards).unlocked(i),
+            forall |i: usize| old(guards).unlocked(i) && i != final(owner).value().node().meta_vaddr() ==> final(guards).unlocked(i),
     )]
     #[verifier::spinoff_prover]
     pub(in crate::mm) fn alloc_if_none<A: InAtomicMode>(&mut self, guard: &'rcu A) -> Option<
@@ -639,7 +639,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
 
             proof {
                 let pte = C::E::new_pt_spec(
-                    meta_to_frame(new_node_owner.value().node().meta_addr_self()),
+                    meta_to_frame(new_node_owner.value().node().meta_vaddr()),
                 );
                 C::E::lemma_page_table_entry_properties();
             }
@@ -732,7 +732,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 // (which have `None` grandchildren), via
                 // `fresh_node_subtree_satisfies`.
 
-                let ghost new_node_addr = owner.value().node().meta_addr_self();
+                let ghost new_node_addr = owner.value().node().meta_vaddr();
                 let f_nu = CursorOwner::<'rcu, C>::node_unlocked_except(*guards, new_node_addr);
                 let f_ms = PageTableOwner::<C>::metaregion_sound_pred(*regions);
                 let f_pt = PageTableOwner::<C>::path_tracked_pred(*regions);
@@ -819,7 +819,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 &&& final(owner).level() == old(owner).level()
                 &&& final(parent_owner).relate_guard(*final(self).node)
                 &&& final(owner).value().node().relate_guard(res->0)
-                &&& final(owner).value().node().meta_addr_self() == res->0.inner.inner@.ptr.addr()
+                &&& final(owner).value().node().meta_vaddr() == res->0.inner.inner@.ptr.addr()
                 &&& final(guards).lock_held(res->0.inner.inner@.ptr.addr())
                 // All children of the new node subtree are frames with the same prop (from the split loop).
                 &&& forall |j: int| 0 <= j < NR_ENTRIES ==>
@@ -857,16 +857,16 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             forall |i: usize| old(guards).unlocked(i) ==> final(guards).unlocked(i),
             // slot_owners unchanged for all indices except the new PT node's index.
             old(owner).value().is_frame() && old(parent_owner).level > 1 ==> {
-                &&& forall|i: usize| i != frame_to_index(meta_to_frame(final(owner).value().node().meta_addr_self())) ==>
+                &&& forall|i: usize| i != frame_to_index(meta_to_frame(final(owner).value().node().meta_vaddr())) ==>
                     (#[trigger] final(regions).slot_owners[i]) == old(regions).slot_owners[i]
                 // slots keys preserved (alloc removes then borrow re-inserts).
                 &&& forall|i: usize| old(regions).slots.contains_key(i)
                     ==> (#[trigger] final(regions).slots.contains_key(i))
                 // The new PT node's ref_count is not UNUSED.
-                &&& final(regions).slot_owners[frame_to_index(meta_to_frame(final(owner).value().node().meta_addr_self()))]
+                &&& final(regions).slot_owners[frame_to_index(meta_to_frame(final(owner).value().node().meta_vaddr()))]
                     .inner_perms.ref_count.value() != REF_COUNT_UNUSED
                 // The allocated slot had ref_count == UNUSED before allocation.
-                &&& old(regions).slot_owners[frame_to_index(meta_to_frame(final(owner).value().node().meta_addr_self()))]
+                &&& old(regions).slot_owners[frame_to_index(meta_to_frame(final(owner).value().node().meta_vaddr()))]
                     .inner_perms.ref_count.value() == REF_COUNT_UNUSED
             },
             // Parent's other PTEs are preserved: only the entry at self.idx
@@ -940,7 +940,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
 
         let ghost children_perm = new_owner.value().node().children_perm;
         let ghost new_owner_path = new_owner.value().path;
-        let ghost new_owner_meta_addr = new_owner.value().node().meta_addr_self();
+        let ghost new_owner_meta_addr = new_owner.value().node().meta_vaddr();
 
         proof {
             // Carry the huge frame's slot facts (the precondition's
@@ -1032,7 +1032,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 new_owner.value().is_node(),
                 new_owner.inv(),
                 new_owner.value().path == new_owner_path,
-                new_owner.value().node().meta_addr_self() == new_owner_meta_addr,
+                new_owner.value().node().meta_vaddr() == new_owner_meta_addr,
                 new_owner.value().node().relate_guard(pt_lock_guard),
                 guards.lock_held(new_owner_meta_addr),
                 new_owner.value().node().level == (level - 1) as PagingLevel,
@@ -1761,15 +1761,15 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
             final(owner).value().path == old(owner).value().path,
             final(owner).value().metaregion_sound(*final(regions)),
             final(owner).value().node().relate_guard(res),
-            final(owner).value().node().meta_addr_self() == res.inner.inner@.ptr.addr(),
+            final(owner).value().node().meta_vaddr() == res.inner.inner@.ptr.addr(),
             final(owner).value().match_pte(
                 final(parent_owner).children_perm.value()[idx as int],
                 final(parent_owner).level,
             ),
-            final(guards).lock_held(final(owner).value().node().meta_addr_self()),
+            final(guards).lock_held(final(owner).value().node().meta_vaddr()),
             OwnerSubtree::implies(
                 CursorOwner::<'rcu, C>::node_unlocked(*old(guards)),
-                CursorOwner::<'rcu, C>::node_unlocked_except(*final(guards), final(owner).value().node().meta_addr_self())),
+                CursorOwner::<'rcu, C>::node_unlocked_except(*final(guards), final(owner).value().node().meta_vaddr())),
             Entry::<C>::metaregion_sound_neq_preserved(
                 old(owner).value(),
                 final(owner).value(),
@@ -1779,7 +1779,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
             Entry::<C>::path_tracked_pred_preserved(*old(regions), *final(regions)),
             old(regions).slots.contains_key(frame_to_index(final(owner).value().meta_slot_paddr()->0)),
             final(owner).subtree_satisfies(final(owner).value().path,
-                CursorOwner::<'rcu, C>::node_unlocked_except(*final(guards), final(owner).value().node().meta_addr_self())),
+                CursorOwner::<'rcu, C>::node_unlocked_except(*final(guards), final(owner).value().node().meta_vaddr())),
             final(owner).subtree_satisfies(final(owner).value().path, PageTableOwner::<C>::metaregion_sound_pred(*final(regions))),
             final(owner).subtree_satisfies(final(owner).value().path, PageTableOwner::<C>::path_tracked_pred(*final(regions))),
             PageTableOwner(*final(owner)).view_rec(final(owner).value().path) == set![],
@@ -1820,7 +1820,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
                     == old(parent_owner).children_perm.value()[j],
             *final(self) == *old(self),
             forall |i: usize| old(guards).lock_held(i) ==> final(guards).lock_held(i),
-            forall |i: usize| old(guards).unlocked(i) && i != final(owner).value().node().meta_addr_self() ==> final(guards).unlocked(i),
+            forall |i: usize| old(guards).unlocked(i) && i != final(owner).value().node().meta_vaddr() ==> final(guards).unlocked(i),
     )]
     pub(in crate::mm) fn alloc_absent_child<A: InAtomicMode>(
         &mut self,
@@ -1871,7 +1871,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
 
         proof {
             let pte = C::E::new_pt_spec(
-                meta_to_frame(new_node_owner.value().node().meta_addr_self()),
+                meta_to_frame(new_node_owner.value().node().meta_vaddr()),
             );
             C::E::lemma_page_table_entry_properties();
         }
@@ -1966,7 +1966,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
             // (which have `None` grandchildren), via
             // `fresh_node_subtree_satisfies`.
 
-            let ghost new_node_addr = owner.value().node().meta_addr_self();
+            let ghost new_node_addr = owner.value().node().meta_vaddr();
             let f_nu = CursorOwner::<'rcu, C>::node_unlocked_except(*guards, new_node_addr);
             let f_ms = PageTableOwner::<C>::metaregion_sound_pred(*regions);
             let f_pt = PageTableOwner::<C>::path_tracked_pred(*regions);

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -529,22 +529,22 @@ impl<C: PageTableConfig> PageTableNode<C> {
             final(parent_owner).inv(),
             allocated_empty_node_owner(owner@, level),
             allocated_empty_node_grandchildren_none(owner@),
-            res.ptr.addr() == owner@.value().node().meta_addr_self(),
-            guards.unlocked(owner@.value().node().meta_addr_self()),
-            MetaSlot::get_node_from_unused_spec(meta_to_frame(owner@.value().node().meta_addr_self()), *old(regions), *final(regions)),
-            MetaSlot::slot_perm_reparked_spec(meta_to_frame(owner@.value().node().meta_addr_self()), *old(regions), *final(regions)),
+            res.ptr.addr() == owner@.value().node().meta_vaddr(),
+            guards.unlocked(owner@.value().node().meta_vaddr()),
+            MetaSlot::get_node_from_unused_spec(meta_to_frame(owner@.value().node().meta_vaddr()), *old(regions), *final(regions)),
+            MetaSlot::slot_perm_reparked_spec(meta_to_frame(owner@.value().node().meta_vaddr()), *old(regions), *final(regions)),
 
             final(regions).frame_obligations == old(regions).frame_obligations.insert(
-                frame_to_index(meta_to_frame(owner@.value().node().meta_addr_self()))),
-            old(regions).slots.contains_key(frame_to_index(meta_to_frame(owner@.value().node().meta_addr_self()))),
+                frame_to_index(meta_to_frame(owner@.value().node().meta_vaddr()))),
+            old(regions).slots.contains_key(frame_to_index(meta_to_frame(owner@.value().node().meta_vaddr()))),
 
             !crate::specs::mm::frame::meta_owners::is_mmio_paddr(
-                meta_to_frame(owner@.value().node().meta_addr_self())),
+                meta_to_frame(owner@.value().node().meta_vaddr())),
             owner@.value().metaregion_sound(*final(regions)),
             forall|i: usize|
                 #[trigger] old(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-                ==> i != frame_to_index(meta_to_frame(owner@.value().node().meta_addr_self())),
-            owner@.value().match_pte(C::E::new_pt_spec(meta_to_frame(owner@.value().node().meta_addr_self())), level as PagingLevel),
+                ==> i != frame_to_index(meta_to_frame(owner@.value().node().meta_vaddr())),
+            owner@.value().match_pte(C::E::new_pt_spec(meta_to_frame(owner@.value().node().meta_vaddr())), level as PagingLevel),
             final(parent_owner).meta_own == old(parent_owner).meta_own,
             final(parent_owner).slot_index == old(parent_owner).slot_index,
             final(parent_owner).level == old(parent_owner).level,
@@ -552,7 +552,7 @@ impl<C: PageTableConfig> PageTableNode<C> {
             final(parent_owner).children_perm.addr() == old(parent_owner).children_perm.addr(),
             final(parent_owner).children_perm.value() == old(parent_owner).children_perm.value().update(
                 idx as int,
-                C::E::new_pt_spec(meta_to_frame(owner@.value().node().meta_addr_self())),
+                C::E::new_pt_spec(meta_to_frame(owner@.value().node().meta_vaddr())),
             ),
             final(regions).slots.contains_key(owner@.value().node().slot_index),
             owner@.value().node().metaregion_sound_node(*final(regions)),
@@ -658,10 +658,10 @@ impl<'a, C: PageTableConfig> PageTableNodeRef<'a, C> {
             Tracked(guards): Tracked<&mut Guards<'rcu>>
         requires
             self.inner@.invariants(*owner),
-            old(guards).unlocked(owner.meta_addr_self()),
+            old(guards).unlocked(owner.meta_vaddr()),
         ensures
-            final(guards).lock_held(owner.meta_addr_self()),
-            Self::locks_preserved_except(owner.meta_addr_self(), *old(guards), *final(guards)),
+            final(guards).lock_held(owner.meta_vaddr()),
+            Self::locks_preserved_except(owner.meta_vaddr(), *old(guards), *final(guards)),
             owner.relate_guard(res),
     )]
     pub fn lock<'rcu, A: InAtomicMode>(self, _guard: &'rcu A) -> PageTableGuard<'rcu, C> where
@@ -683,10 +683,10 @@ impl<'a, C: PageTableConfig> PageTableNodeRef<'a, C> {
              Tracked(guards): Tracked<&mut Guards<'rcu>>,
         requires
             self.inner@.invariants(*owner),
-            old(guards).unlocked(owner.meta_addr_self()),
+            old(guards).unlocked(owner.meta_vaddr()),
         ensures
-            final(guards).lock_held(owner.meta_addr_self()),
-            Self::locks_preserved_except(owner.meta_addr_self(), *old(guards), *final(guards)),
+            final(guards).lock_held(owner.meta_vaddr()),
+            Self::locks_preserved_except(owner.meta_vaddr(), *old(guards), *final(guards)),
             owner.relate_guard(res),
     )]
     pub unsafe fn make_guard_unchecked<'rcu, A: InAtomicMode>(
@@ -697,7 +697,7 @@ impl<'a, C: PageTableConfig> PageTableNodeRef<'a, C> {
 
         proof {
             let ghost guards0 = *guards;
-            guards.guards = guards.guards.insert(owner.meta_addr_self());
+            guards.guards = guards.guards.insert(owner.meta_vaddr());
 
         }
 

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -185,7 +185,7 @@ unsafe impl<C: PageTableConfig> AnyFrameMeta for PageTablePageMeta<C> {
         let ghost pre_skip_cursor: int = reader.cursor.vaddr as int;
 
         let ghost initial_view: crate::specs::mm::virt_mem::MemView = vm_io_owner.read_view_of();
-        let ghost initial_dom: vstd::set::Set<usize> = regions.slots.dom();
+        let ghost initial_dom: vstd::set::Set<int> = regions.slots.dom();
         let ghost initial_reader: crate::mm::VmReader<'_, crate::mm::Infallible> = *reader;
 
         #[verus_spec(with Tracked(vm_io_owner))]
@@ -210,7 +210,7 @@ unsafe impl<C: PageTableConfig> AnyFrameMeta for PageTablePageMeta<C> {
         let ghost range_end: int = range.end as int;
         let n_iters: usize = range.end - range.start;
         let mut iter_count: usize = 0;
-        let ghost mut removed_indices: vstd::set::Set<usize> = vstd::set::Set::empty();
+        let ghost mut removed_indices: vstd::set::Set<int> = vstd::set::Set::empty();
 
         proof {
             C::lemma_page_table_config_constant_properties();
@@ -280,7 +280,7 @@ unsafe impl<C: PageTableConfig> AnyFrameMeta for PageTablePageMeta<C> {
                 // Witness past iter for each removed idx — the discharge
                 // proof picks it up via `choose|j|` and invokes
                 // `walk_uniqueness` at (current_cursor, witness_cursor).
-                forall|idx: usize| #[trigger]
+                forall|idx: int| #[trigger]
                     removed_indices.contains(idx) ==> exists|j: int|
                         #![trigger Self::walk_pte_at_view(
                             initial_view,
@@ -350,10 +350,8 @@ unsafe impl<C: PageTableConfig> AnyFrameMeta for PageTablePageMeta<C> {
                         );
                         broadcast use lemma_frame_to_index_injective;
 
-                        assert forall|idx: usize| #[trigger]
-                            removed_indices.contains(idx) implies idx != frame_to_index(
-                            pte.paddr(),
-                        ) by {
+                        assert forall|idx: int| #[trigger] removed_indices.contains(idx) implies idx
+                            != frame_to_index(pte.paddr()) by {
                             let j = choose|j: int|
                                 #![trigger Self::walk_pte_at_view(
                                     initial_view,
@@ -426,7 +424,7 @@ unsafe impl<C: PageTableConfig> AnyFrameMeta for PageTablePageMeta<C> {
                         });
                     }
                     proof_decl! {
-                        let tracked from_raw_obl: vstd_extra::drop_tracking::DropObligation<usize>;
+                        let tracked from_raw_obl: vstd_extra::drop_tracking::DropObligation<int>;
                     }
                     let frame = unsafe {
                         #[verus_spec(with Tracked(regions) => Tracked(from_raw_obl))]
@@ -541,7 +539,7 @@ impl<C: PageTableConfig> PageTableNode<C> {
             !crate::specs::mm::frame::meta_owners::is_mmio_paddr(
                 meta_to_frame(owner@.value().node().meta_vaddr())),
             owner@.value().metaregion_sound(*final(regions)),
-            forall|i: usize|
+            forall|i: int|
                 #[trigger] old(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
                 ==> i != frame_to_index(meta_to_frame(owner@.value().node().meta_vaddr())),
             owner@.value().match_pte(C::E::new_pt_spec(meta_to_frame(owner@.value().node().meta_vaddr())), level as PagingLevel),
@@ -937,7 +935,7 @@ impl<C: PageTableConfig> PageTablePageMeta<C> {
     pub open spec fn walk_coverage_at(
         self,
         view: crate::specs::mm::virt_mem::MemView,
-        dom: vstd::set::Set<usize>,
+        dom: vstd::set::Set<int>,
         c: usize,
     ) -> bool {
         let pte = Self::walk_pte_at_view(view, c);
@@ -949,7 +947,7 @@ impl<C: PageTableConfig> PageTablePageMeta<C> {
         self,
         reader: crate::mm::VmReader<'_, crate::mm::Infallible>,
         view: crate::specs::mm::virt_mem::MemView,
-        dom: vstd::set::Set<usize>,
+        dom: vstd::set::Set<int>,
         c: usize,
     )
         requires
@@ -1021,7 +1019,7 @@ impl<C: PageTableConfig> PageTablePageMeta<C> {
         self,
         reader: crate::mm::VmReader<'_, crate::mm::Infallible>,
         view: crate::specs::mm::virt_mem::MemView,
-        dom: vstd::set::Set<usize>,
+        dom: vstd::set::Set<int>,
     ) -> bool {
         forall|c: usize|
             #![trigger Self::walk_pte_at_view(view, c)]
@@ -1086,7 +1084,7 @@ impl<C: PageTableConfig> PageTablePageMeta<C> {
     /// shape when refcount == 1).
     pub open spec fn child_perms_embedding(
         regions: crate::specs::mm::frame::meta_region_owners::MetaRegionOwners,
-        excluded: vstd::set::Set<usize>,
+        excluded: vstd::set::Set<int>,
     ) -> bool {
         forall|paddr: crate::mm::Paddr|
             #![trigger regions.slot_owners[frame_to_index(paddr)]]


### PR DESCRIPTION
- Change the index type of `MetaRegionOwners` from `usize` to `int`.
- Rename `NodeOwner::meta_addr_self` to `meta_vaddr`.
- Rename `specs::mm::frame::mapping::meta_addr` to `index_to_meta`.
- Use the idiomatic `is` syntax for `PageUsage`.
- Remove other redundancy.