### PR TITLE
chore: Minor improvement in spec

### DIFF
--- a/ostd/specs/mm/embedding/frame.rs
+++ b/ostd/specs/mm/embedding/frame.rs
@@ -79,7 +79,7 @@ pub axiom fn frame_from_unused_embedded(
         // `Frame::from_unused` `requires`: an out-of-bound / misaligned
         // `paddr` is not a precondition violation — it returns `Err`
         // (here `None`) without touching `regions`.
-        valid_frame_paddr(paddr) ==> old(regions).slots.contains_key(frame_to_index(paddr)),
+        valid_frame_paddr(paddr) ==> old(regions).contains(frame_to_index(paddr)),
     ensures
         final(regions).inv(),
         // Liveness, mirroring exec `!valid_frame_paddr(paddr) ==> r is Err`:
@@ -117,7 +117,7 @@ pub axiom fn frame_from_in_use_embedded(
         // `valid_frame_paddr`-guarded, mirroring the relaxed exec
         // `Frame::from_in_use` `requires`: a bad `paddr` returns `Err`
         // (here `None`) without touching `regions`.
-        valid_frame_paddr(paddr) ==> old(regions).slots.contains_key(
+        valid_frame_paddr(paddr) ==> old(regions).contains(
             frame_to_index(paddr),
         ),
 // Refcount saturation is NOT required: exec
@@ -186,7 +186,7 @@ pub axiom fn frame_from_in_use_embedded(
 pub axiom fn frame_drop_embedded(tracked regions: &mut MetaRegionOwners, paddr: Paddr)
     requires
         old(regions).inv(),
-        old(regions).slots.contains_key(frame_to_index(paddr)),
+        old(regions).contains(frame_to_index(paddr)),
         old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() > 0,
         old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
             != REF_COUNT_UNUSED,
@@ -280,7 +280,7 @@ pub(super) proof fn from_unused_step(
 ) -> (tracked res: Option<FrameEntry>)
     requires
         old(regions).inv(),
-        valid_frame_paddr(paddr) ==> old(regions).slots.contains_key(frame_to_index(paddr)),
+        valid_frame_paddr(paddr) ==> old(regions).contains(frame_to_index(paddr)),
     ensures
         final(regions).inv(),
         !valid_frame_paddr(paddr) ==> res is None,
@@ -313,7 +313,7 @@ pub(super) proof fn from_in_use_step(
 ) -> (tracked res: Option<FrameEntry>)
     requires
         old(regions).inv(),
-        valid_frame_paddr(paddr) ==> old(regions).slots.contains_key(
+        valid_frame_paddr(paddr) ==> old(regions).contains(
             frame_to_index(paddr),
         ),
 // Saturation `panic_diverge`s in exec — not a precondition.
@@ -352,7 +352,7 @@ pub(super) proof fn from_in_use_step(
 /// axiom covers both via one postcondition keyed on the live refcount.
 pub open spec fn drop_pre(regions: MetaRegionOwners, paddr: Paddr) -> bool {
     let so = regions.slot_owners[frame_to_index(paddr)];
-    &&& regions.slots.contains_key(frame_to_index(paddr))
+    &&& regions.contains(frame_to_index(paddr))
     &&& so.inner_perms.ref_count.value() > 0
     &&& so.inner_perms.ref_count.value() != REF_COUNT_UNUSED
     &&& so.inner_perms.ref_count.value() <= REF_COUNT_MAX

--- a/ostd/specs/mm/embedding/list_store.rs
+++ b/ostd/specs/mm/embedding/list_store.rs
@@ -63,7 +63,7 @@ use crate::specs::{
         linked_list::linked_list_owners::{
             CursorOwner, LinkInnerPerms, LinkOwner, LinkedListOwner, MetaSlotSmall,
         },
-        mapping::frame_to_index,
+        mapping::{frame_to_index, meta_to_index},
         meta_owners::PageUsage,
         meta_region_owners::MetaRegionOwners,
         unique::UniqueFrameOwner,
@@ -109,16 +109,16 @@ pub open spec fn list_registry_ok<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
     lo: LinkedListOwner<M>,
 ) -> bool {
     &&& forall|i: int|
-        #![trigger lo.slot_index_at(i)]
-        0 <= i < lo.list.len() ==> regions.slot_owners[lo.slot_index_at(
-            i,
+        #![trigger meta_to_index(lo.list[i].paddr)]
+        0 <= i < lo.list.len() ==> regions.slot_owners[meta_to_index(
+            lo.list[i].paddr,
         )].inner_perms.in_list.value() == lo.list_id
     &&& lo.list_id != 0 ==> forall|idx: int|
         #![trigger regions.slot_owners[idx]]
         regions.slot_owners.contains_key(idx)
             && regions.slot_owners[idx].inner_perms.in_list.value() == lo.list_id ==> exists|i: int|
 
-            0 <= i < lo.list.len() && lo.slot_index_at(i) == idx
+            0 <= i < lo.list.len() && #[trigger] meta_to_index(lo.list[i].paddr) == idx
 }
 
 /// One-step-soundness store for the frame `LinkedList`. Holds the shared
@@ -323,10 +323,10 @@ pub proof fn push_front_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
         forall|k: int|
             #![trigger final(regions).slots[k]]
             #![trigger final(regions).slot_owners[k]]
-            k != old(frame_own).slot_index && (old(owner).list.len() > 0 ==> k != old(
-                owner,
-            ).slot_index_at(0)) ==> final(regions).slots[k] == old(regions).slots[k]
-                && final(regions).slot_owners[k] == old(regions).slot_owners[k],
+            k != old(frame_own).slot_index && (old(owner).list.len() > 0 ==> k != meta_to_index(
+                old(owner).list[0].paddr,
+            )) ==> final(regions).slots[k] == old(regions).slots[k] && final(regions).slot_owners[k]
+                == old(regions).slot_owners[k],
         forall|l: LinkedListOwner<M>|
             #![trigger l.relate_region(*old(regions))]
             l.inv() && l.relate_region(*old(regions)) && l.list_id != final(owner).list_id
@@ -410,21 +410,21 @@ pub proof fn tracked_pop_front_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
         frame_own.inv(),
         frame_own.global_inv(*final(regions)),
         frame_own.frame_link_inv(*final(regions)),
-        frame_own.slot_index == old(owner).slot_index_at(0),
+        frame_own.slot_index == meta_to_index(old(owner).list[0].paddr),
         final(regions).slot_owners[frame_own.slot_index].inner_perms.in_list.value() == 0,
         // `from_raw` re-mints the drop-obligation.
         final(regions).frame_obligations =~= old(regions).frame_obligations.insert(
-            old(owner).slot_index_at(0),
+            meta_to_index(old(owner).list[0].paddr),
         ),
         // Outside-the-list slot preservation (front specialisation:
-        // popped slot + the new front at `slot_index_at(1)`).
+        // popped slot + the new front's metadata index).
         forall|j: int|
             #![trigger final(regions).slots[j]]
             #![trigger final(regions).slot_owners[j]]
-            j != old(owner).slot_index_at(0) && (old(owner).list.len() > 1 ==> j != old(
-                owner,
-            ).slot_index_at(1)) ==> final(regions).slots[j] == old(regions).slots[j]
-                && final(regions).slot_owners[j] == old(regions).slot_owners[j],
+            j != meta_to_index(old(owner).list[0].paddr) && (old(owner).list.len() > 1 ==> j
+                != meta_to_index(old(owner).list[1].paddr)) ==> final(regions).slots[j] == old(
+                regions,
+            ).slots[j] && final(regions).slot_owners[j] == old(regions).slot_owners[j],
         // Other lists preserved.
         forall|l: LinkedListOwner<M>|
             #![trigger l.relate_region(*old(regions))]
@@ -452,7 +452,7 @@ pub proof fn tracked_pop_front_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
                 *final(regions),
             ) && fo.frame_link_inv(*final(regions))
                 && final(regions).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0
-                && fo.slot_index != old(owner).slot_index_at(0),
+                && fo.slot_index != meta_to_index(old(owner).list[0].paddr),
 {
     let tracked frame_own = take_at_embedded(regions, owner, 0);
     frame_own
@@ -499,13 +499,12 @@ pub proof fn lemma_push_back_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
         forall|k: int|
             #![trigger final(regions).slots[k]]
             #![trigger final(regions).slot_owners[k]]
-            k != old(frame_own).slot_index && (old(owner).list.len() > 1 ==> k != old(
-                owner,
-            ).slot_index_at(old(owner).list.len() - 2)) && (old(owner).list.len() > 0 ==> k != old(
-                owner,
-            ).slot_index_at(old(owner).list.len() - 1)) ==> final(regions).slots[k] == old(
-                regions,
-            ).slots[k] && final(regions).slot_owners[k] == old(regions).slot_owners[k],
+            k != old(frame_own).slot_index && (old(owner).list.len() > 1 ==> k != meta_to_index(
+                old(owner).list[old(owner).list.len() - 2].paddr,
+            )) && (old(owner).list.len() > 0 ==> k != meta_to_index(
+                old(owner).list[old(owner).list.len() - 1].paddr,
+            )) ==> final(regions).slots[k] == old(regions).slots[k] && final(regions).slot_owners[k]
+                == old(regions).slot_owners[k],
         forall|l: LinkedListOwner<M>|
             #![trigger l.relate_region(*old(regions))]
             l.inv() && l.relate_region(*old(regions)) && l.list_id != final(owner).list_id
@@ -542,7 +541,7 @@ pub proof fn lemma_push_back_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
 /// Checked back specialization of [`take_at_embedded`], reflecting the
 /// (verified) [`crate::mm::frame::LinkedList::pop_back`]. Identical to
 /// [`tracked_pop_front_embedded`] except the *last* link is popped (touching the
-/// back neighbour at `slot_index_at(len - 2)`).
+/// back neighbour's metadata index).
 pub proof fn tracked_pop_back_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
     tracked regions: &mut MetaRegionOwners,
     tracked owner: &mut LinkedListOwner<M>,
@@ -561,18 +560,20 @@ pub proof fn tracked_pop_back_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
         frame_own.inv(),
         frame_own.global_inv(*final(regions)),
         frame_own.frame_link_inv(*final(regions)),
-        frame_own.slot_index == old(owner).slot_index_at(old(owner).list.len() - 1),
+        frame_own.slot_index == meta_to_index(old(owner).list[old(owner).list.len() - 1].paddr),
         final(regions).slot_owners[frame_own.slot_index].inner_perms.in_list.value() == 0,
         final(regions).frame_obligations =~= old(regions).frame_obligations.insert(
-            old(owner).slot_index_at(old(owner).list.len() - 1),
+            meta_to_index(old(owner).list[old(owner).list.len() - 1].paddr),
         ),
         forall|j: int|
             #![trigger final(regions).slots[j]]
             #![trigger final(regions).slot_owners[j]]
-            j != old(owner).slot_index_at(old(owner).list.len() - 1) && (old(owner).list.len() > 1
-                ==> j != old(owner).slot_index_at(old(owner).list.len() - 2))
-                ==> final(regions).slots[j] == old(regions).slots[j]
-                && final(regions).slot_owners[j] == old(regions).slot_owners[j],
+            j != meta_to_index(old(owner).list[old(owner).list.len() - 1].paddr) && (old(
+                owner,
+            ).list.len() > 1 ==> j != meta_to_index(
+                old(owner).list[old(owner).list.len() - 2].paddr,
+            )) ==> final(regions).slots[j] == old(regions).slots[j] && final(regions).slot_owners[j]
+                == old(regions).slot_owners[j],
         forall|l: LinkedListOwner<M>|
             #![trigger l.relate_region(*old(regions))]
             l.inv() && l.relate_region(*old(regions)) && l.list_id != final(owner).list_id
@@ -597,7 +598,7 @@ pub proof fn tracked_pop_back_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
                 *final(regions),
             ) && fo.frame_link_inv(*final(regions))
                 && final(regions).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0
-                && fo.slot_index != old(owner).slot_index_at(old(owner).list.len() - 1),
+                && fo.slot_index != meta_to_index(old(owner).list[old(owner).list.len() - 1].paddr),
 {
     let ghost n = owner.list.len() - 1;
     let tracked frame_own = take_at_embedded(regions, owner, n);
@@ -641,8 +642,9 @@ pub axiom fn insert_before_at_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
         forall|k: int|
             #![trigger final(regions).slots[k]]
             #![trigger final(regions).slot_owners[k]]
-            k != old(frame_own).slot_index && (n > 0 ==> k != old(owner).slot_index_at(n - 1)) && (n
-                < old(owner).list.len() ==> k != old(owner).slot_index_at(n))
+            k != old(frame_own).slot_index && (n > 0 ==> k != meta_to_index(
+                old(owner).list[n - 1].paddr,
+            )) && (n < old(owner).list.len() ==> k != meta_to_index(old(owner).list[n].paddr))
                 ==> final(regions).slots[k] == old(regions).slots[k]
                 && final(regions).slot_owners[k] == old(regions).slot_owners[k],
         forall|l: LinkedListOwner<M>|
@@ -695,18 +697,20 @@ pub axiom fn take_at_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
         frame_own.inv(),
         frame_own.global_inv(*final(regions)),
         frame_own.frame_link_inv(*final(regions)),
-        frame_own.slot_index == old(owner).slot_index_at(n),
+        frame_own.slot_index == meta_to_index(old(owner).list[n].paddr),
         final(regions).slot_owners[frame_own.slot_index].inner_perms.in_list.value() == 0,
         final(regions).frame_obligations =~= old(regions).frame_obligations.insert(
-            old(owner).slot_index_at(n),
+            meta_to_index(old(owner).list[n].paddr),
         ),
         forall|j: int|
             #![trigger final(regions).slots[j]]
             #![trigger final(regions).slot_owners[j]]
-            j != old(owner).slot_index_at(n) && (n > 0 ==> j != old(owner).slot_index_at(n - 1))
-                && (n < old(owner).list.len() - 1 ==> j != old(owner).slot_index_at(n + 1))
-                ==> final(regions).slots[j] == old(regions).slots[j]
-                && final(regions).slot_owners[j] == old(regions).slot_owners[j],
+            j != meta_to_index(old(owner).list[n].paddr) && (n > 0 ==> j != meta_to_index(
+                old(owner).list[n - 1].paddr,
+            )) && (n < old(owner).list.len() - 1 ==> j != meta_to_index(
+                old(owner).list[n + 1].paddr,
+            )) ==> final(regions).slots[j] == old(regions).slots[j] && final(regions).slot_owners[j]
+                == old(regions).slot_owners[j],
         forall|l: LinkedListOwner<M>|
             #![trigger l.relate_region(*old(regions))]
             l.inv() && l.relate_region(*old(regions)) && l.list_id != final(owner).list_id
@@ -731,7 +735,7 @@ pub axiom fn take_at_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
                 *final(regions),
             ) && fo.frame_link_inv(*final(regions))
                 && final(regions).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0
-                && fo.slot_index != old(owner).slot_index_at(n),
+                && fo.slot_index != meta_to_index(old(owner).list[n].paddr),
 ;
 
 /// Trusted reflection of the (now-strengthened, verified) whole-list
@@ -759,9 +763,9 @@ pub axiom fn list_drop_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
         owner.inv(),
         owner.relate_region(*old(regions)),
         forall|i: int|
-            #![trigger owner.slot_index_at(i)]
+            #![trigger meta_to_index(owner.list[i].paddr)]
             0 <= i < owner.list.len() ==> old(regions).frame_obligations.count(
-                owner.slot_index_at(i),
+                meta_to_index(owner.list[i].paddr),
             ) == 0,
         // Mirrors the exec `TrackDrop for LinkedList::drop_requires`
         // conjunct (`linked_list.rs`): each link's slot has no live PTE
@@ -771,9 +775,9 @@ pub axiom fn list_drop_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
         // from `MetaSlotOwner::inv`'s UNIQUE branch (a UNIQUE slot — which
         // every link is, via `relate_region`) has empty `paths_in_pt`).
         forall|i: int|
-            #![trigger owner.slot_index_at(i)]
-            0 <= i < owner.list.len() ==> old(regions).slot_owners[owner.slot_index_at(
-                i,
+            #![trigger meta_to_index(owner.list[i].paddr)]
+            0 <= i < owner.list.len() ==> old(regions).slot_owners[meta_to_index(
+                owner.list[i].paddr,
             )].paths_in_pt.is_empty(),
     ensures
         final(regions).inv(),
@@ -782,9 +786,9 @@ pub axiom fn list_drop_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
         owner.list.len() == 0 ==> *final(regions) == *old(regions),
         // Each former link is freed: its slot is UNUSED with `in_list` 0.
         forall|i: int|
-            #![trigger owner.slot_index_at(i)]
+            #![trigger meta_to_index(owner.list[i].paddr)]
             0 <= i < owner.list.len() ==> {
-                let idx = owner.slot_index_at(i);
+                let idx = meta_to_index(owner.list[i].paddr);
                 &&& final(regions).slot_owners[idx].inner_perms.ref_count.value()
                     == REF_COUNT_UNUSED
                 &&& final(regions).slot_owners[idx].inner_perms.in_list.value() == 0
@@ -792,7 +796,8 @@ pub axiom fn list_drop_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
         // Every slot outside the dropped list is fully preserved.
         forall|idx: int|
             #![trigger final(regions).slot_owners[idx]]
-            (forall|i: int| 0 <= i < owner.list.len() ==> idx != owner.slot_index_at(i))
+            (forall|i: int|
+                0 <= i < owner.list.len() ==> idx != #[trigger] meta_to_index(owner.list[i].paddr))
                 ==> final(regions).slot_owners[idx] == old(regions).slot_owners[idx]
                 && final(regions).slots[idx] == old(regions).slots[idx]
                 && final(regions).frame_obligations.count(idx) == old(
@@ -861,8 +866,9 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
             self.lists.dom().contains(id),
         ensures
             res <==> (valid_frame_paddr(frame) && exists|i: int|
-                0 <= i < self.lists[id].list.len() && self.lists[id].slot_index_at(i)
-                    == frame_to_index(frame)),
+                0 <= i < self.lists[id].list.len() && #[trigger] meta_to_index(
+                    self.lists[id].list[i].paddr,
+                ) == frame_to_index(frame)),
     {
         let idx = frame_to_index(frame);
         if valid_frame_paddr(frame) {
@@ -877,16 +883,18 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
                 if res {
                     // reverse: a slot tagged with the id is one of the links.
                     assert(exists|i: int|
-                        0 <= i < self.lists[id].list.len() && self.lists[id].slot_index_at(i)
-                            == idx);
+                        0 <= i < self.lists[id].list.len() && #[trigger] meta_to_index(
+                            self.lists[id].list[i].paddr,
+                        ) == idx);
                 } else {
                     // forward: every link's slot is tagged, so an untagged
                     // slot is no link.
                     assert forall|i: int|
-                        0 <= i < self.lists[id].list.len() implies self.lists[id].slot_index_at(i)
-                        != idx by {
-                        assert(self.regions.slot_owners[self.lists[id].slot_index_at(
-                            i,
+                        0 <= i < self.lists[id].list.len() implies #[trigger] meta_to_index(
+                        self.lists[id].list[i].paddr,
+                    ) != idx by {
+                        assert(self.regions.slot_owners[meta_to_index(
+                            self.lists[id].list[i].paddr,
                         )].inner_perms.in_list.value() == self.lists[id].list_id);
                     };
                 }
@@ -955,8 +963,9 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
             forall|i: int|
                 0 <= i < old(self).lists[id].list.len() ==> old(
                     self,
-                ).regions.frame_obligations.count(#[trigger] old(self).lists[id].slot_index_at(i))
-                    == 0,
+                ).regions.frame_obligations.count(
+                    #[trigger] meta_to_index(old(self).lists[id].list[i].paddr),
+                ) == 0,
         ensures
             final(self).inv(),
             !final(self).lists.dom().contains(id),
@@ -975,11 +984,11 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
         // `regions.inv()`'s UNIQUE branch (`usage != MMIO ==> empty`) then
         // gives it an empty `paths_in_pt`.
         assert forall|i: int|
-            #![trigger self.lists[id].slot_index_at(i)]
-            0 <= i
-                < self.lists[id].list.len() implies self.regions.slot_owners[self.lists[id].slot_index_at(
-        i)].paths_in_pt.is_empty() by {
-            let idx = self.lists[id].slot_index_at(i);
+            #![trigger meta_to_index(self.lists[id].list[i].paddr)]
+            0 <= i < self.lists[id].list.len() implies self.regions.slot_owners[meta_to_index(
+            self.lists[id].list[i].paddr,
+        )].paths_in_pt.is_empty() by {
+            let idx = meta_to_index(self.lists[id].list[i].paddr);
             // Instantiate `relate_region`'s per-link forall (trigger
             // `self.list[i]`) to get `relate_region_at(regions, i)`.
             let _ = self.lists[id].list[i];
@@ -1283,7 +1292,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
         } else {
             let ghost old_self = *self;
             let ghost old_regions = self.regions;
-            let ghost popped_idx = self.lists[id].slot_index_at(0);
+            let ghost popped_idx = meta_to_index(self.lists[id].list[0].paddr);
             let ghost old_list_id = self.lists[id].list_id;
             // Pop preconditions from `inv`.
             assert(self.lists[id].relate_region(self.regions));
@@ -1567,7 +1576,9 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
         } else {
             let ghost old_self = *self;
             let ghost old_regions = self.regions;
-            let ghost popped_idx = self.lists[id].slot_index_at(self.lists[id].list.len() - 1);
+            let ghost popped_idx = meta_to_index(
+                self.lists[id].list[self.lists[id].list.len() - 1].paddr,
+            );
             let ghost old_list_id = self.lists[id].list_id;
             assert(self.lists[id].relate_region(self.regions));
 
@@ -1849,7 +1860,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
         } else {
             let ghost old_self = *self;
             let ghost old_regions = self.regions;
-            let ghost popped_idx = self.lists[id].slot_index_at(n);
+            let ghost popped_idx = meta_to_index(self.lists[id].list[n].paddr);
             let ghost old_list_id = self.lists[id].list_id;
             assert(self.lists[id].relate_region(self.regions));
 
@@ -2306,25 +2317,28 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
             final(self).inv(),
             // `res` is exactly list membership of `frame`.
             res == (exists|i: int|
-                0 <= i < old(self).lists[id].list.len() && old(self).lists[id].slot_index_at(i)
-                    == frame_to_index(frame)),
+                0 <= i < old(self).lists[id].list.len() && #[trigger] meta_to_index(
+                    old(self).lists[id].list[i].paddr,
+                ) == frame_to_index(frame)),
             // On a hit: the list is checked out into a cursor positioned
             // at the matching link.
             res ==> !final(self).lists.dom().contains(id) && final(self).cursors.dom().contains(id)
                 && exists|i: int|
-                0 <= i < old(self).lists[id].list.len() && old(self).lists[id].slot_index_at(i)
-                    == frame_to_index(frame) && final(self).cursors[id]
+                0 <= i < old(self).lists[id].list.len() && #[trigger] meta_to_index(
+                    old(self).lists[id].list[i].paddr,
+                ) == #[trigger] frame_to_index(frame) && final(self).cursors[id]
                     == CursorOwner::cursor_mut_at_owner(old(self).lists[id], i),
             // On a miss: no checkout, the store is unchanged.
             !res ==> *final(self) == *old(self),
     {
         if exists|i: int|
-            0 <= i < self.lists[id].list.len() && self.lists[id].slot_index_at(i) == frame_to_index(
-                frame,
-            ) {
+            0 <= i < self.lists[id].list.len() && #[trigger] meta_to_index(
+                self.lists[id].list[i].paddr,
+            ) == frame_to_index(frame) {
             let ghost index = choose|i: int|
-                0 <= i < self.lists[id].list.len() && self.lists[id].slot_index_at(i)
-                    == frame_to_index(frame);
+                0 <= i < self.lists[id].list.len() && #[trigger] meta_to_index(
+                    self.lists[id].list[i].paddr,
+                ) == frame_to_index(frame);
             let ghost old_self = *self;
             let tracked owner = self.lists.tracked_remove(id);
             let tracked cur = CursorOwner::tracked_cursor_mut_at_owner(owner, index);
@@ -2623,7 +2637,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
             let ghost old_regions = self.regions;
             let ghost n = self.cursors[id].index;
             let ghost old_list_id = self.cursors[id].list_own.list_id;
-            let ghost popped_idx = self.cursors[id].list_own.slot_index_at(n);
+            let ghost popped_idx = meta_to_index(self.cursors[id].list_own.list[n].paddr);
             assert(self.cursors[id].list_own.relate_region(self.regions));
             // A non-empty list carries a nonzero id (`LinkedListOwner::inv`).
             assert(old_list_id != 0);

--- a/ostd/specs/mm/embedding/list_store.rs
+++ b/ostd/specs/mm/embedding/list_store.rs
@@ -115,9 +115,8 @@ pub open spec fn list_registry_ok<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
         )].inner_perms.in_list.value() == lo.list_id
     &&& lo.list_id != 0 ==> forall|idx: int|
         #![trigger regions.slot_owners[idx]]
-        regions.slot_owners.contains_key(idx)
-            && regions.slot_owners[idx].inner_perms.in_list.value() == lo.list_id ==> exists|i: int|
-
+        regions.contains(idx) && regions.slot_owners[idx].inner_perms.in_list.value() == lo.list_id
+            ==> exists|i: int|
             0 <= i < lo.list.len() && #[trigger] meta_to_index(lo.list[i].paddr) == idx
 }
 
@@ -874,7 +873,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
         if valid_frame_paddr(frame) {
             // A safe slot is a managed region key.
             self.regions.inv_implies_correct_addr(frame);
-            assert(self.regions.slot_owners.contains_key(idx));
+            assert(self.regions.contains(idx));
             if self.lists[id].list_id != 0 {
                 // The registry for list `id` (forward + reverse) from `inv`.
                 assert(list_registry_ok(self.regions, self.lists[id]));
@@ -993,7 +992,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
             // `self.list[i]`) to get `relate_region_at(regions, i)`.
             let _ = self.lists[id].list[i];
             self.lists[id].relate_region_at_facts(self.regions, i);
-            assert(self.regions.slot_owners.contains_key(idx));
+            assert(self.regions.contains(idx));
             assert(self.regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
             assert(self.regions.slot_owners[idx].usage is Frame);
         };

--- a/ostd/specs/mm/embedding/mod.rs
+++ b/ostd/specs/mm/embedding/mod.rs
@@ -2215,7 +2215,7 @@ proof fn step_unmap<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId, len: usize
         // From `regions.inv()`: idx < max_meta_slots ⟹ slot_owners[idx]
         // satisfies MetaSlotOwner::inv (so UNUSED ∧ non-MMIO ⟹ paths
         // empty fires).
-        assert(s.regions.slot_owners.contains_key(idx));
+        assert(s.regions.contains(idx));
         // Post cover == 0. Unmap leaves `s.segments` untouched, so post
         // cover == pre cover. If pre cover >= 1: a witnessing segment +
         // structural `covered ⟹ Frame` gives pre usage == Frame, and pre
@@ -2299,11 +2299,11 @@ proof fn step_unmap<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId, len: usize
         // becomes post rc == pre rc + post paths but post rc ≤ pre rc
         // ⟹ post paths == 0 ⟹ post rc == pre rc == UNUSED). So at
         // post non-UNUSED Frame slot, pre rc != UNUSED.
-        assert(s.regions.slot_owners.contains_key(idx));
+        assert(s.regions.contains(idx));
         assert(old_regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED) by {
             if old_regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNUSED {
                 // Trigger MetaSlotOwner::inv on pre at this idx.
-                assert(old_regions.slot_owners.contains_key(idx));
+                assert(old_regions.contains(idx));
                 assert(old_regions.slot_owners[idx].paths_in_pt == Set::empty());
                 // rc-paths invariant: post rc + 0 == UNUSED + post paths
                 //                  ⟹ post rc == UNUSED + post paths.
@@ -2409,7 +2409,7 @@ proof fn step_unmap<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId, len: usize
         // `u_idx` is a managed slot.
         assert(valid_frame_paddr(s.unique_frames[u].paddr));
         s.regions.inv_implies_correct_addr(s.unique_frames[u].paddr);
-        assert(s.regions.slot_owners.contains_key(u_idx));
+        assert(s.regions.contains(u_idx));
         // usage / in_list preserved universally by the unmap axiom.
         assert(s.regions.slot_owners[u_idx].usage == old_regions.slot_owners[u_idx].usage);
         assert(s.regions.slot_owners[u_idx].inner_perms.in_list
@@ -2915,8 +2915,9 @@ proof fn step_segment_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, range: Ra
         // is parked (`slots.contains_key`).
         assert forall|paddr: Paddr|
             #![trigger frame_to_index(paddr)]
-            (range.start <= paddr < range.end && paddr % PAGE_SIZE
-                == 0) implies s.regions.slots.contains_key(frame_to_index(paddr)) by {
+            (range.start <= paddr < range.end && paddr % PAGE_SIZE == 0) implies s.regions.contains(
+            frame_to_index(paddr),
+        ) by {
             s.regions.inv_implies_correct_addr(paddr);
         };
         let tracked res = segment::from_unused_step(&mut s.regions, range);
@@ -3131,7 +3132,7 @@ proof fn step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
         // rc >= 1 since cover >= 1 ⟹ H + P + cover >= 1.
         // Triggers MetaSlotOwner::inv's SHARED branch (Item 1): rc in
         // [1, MAX] ⟹ storage init, in_list == 0.
-        assert(old_regions.slot_owners.contains_key(idx));
+        assert(old_regions.contains(idx));
         // rc == 1 case: rc = H + P + cover = 1, cover >= 1 ⟹ cover == 1
         // and H == 0 and P == 0 ⟹ paths empty.
         if rc == 1 {
@@ -3286,7 +3287,7 @@ proof fn step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
             // post rc <= MAX (pre rc was, post = pre - 1, still in range).
             // storage.is_init at post: post rc ∈ SHARED (1 <= post rc <= MAX)
             // ⟹ MetaSlotOwner::inv SHARED branch ⟹ storage.is_init.
-            assert(s.regions.slot_owners.contains_key(idx));
+            assert(s.regions.contains(idx));
             assert(s.regions.slot_owners[idx].inner_perms.storage.is_init());
         } else {
             assert(s.regions.slot_owners[idx] == old_regions.slot_owners[idx]);
@@ -3602,10 +3603,10 @@ proof fn step_segment_next<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
     assert(pre_rc == pre_H + pre_P + pre_cover);
     assert(pre_rc != REF_COUNT_UNUSED);
     assert(pre_rc != REF_COUNT_UNIQUE);
-    assert(old_regions.slot_owners.contains_key(target_idx));
+    assert(old_regions.contains(target_idx));
     assert(valid_frame_paddr(paddr));
     s.regions.inv_implies_correct_addr(paddr);
-    assert(s.regions.slots.contains_key(target_idx));
+    assert(s.regions.contains(target_idx));
     // page-alignment + bound for shrink_front lemma.
     assert(range.start % PAGE_SIZE == 0);
     assert(range.end <= MAX_PADDR);
@@ -3954,7 +3955,7 @@ proof fn step_segment_clone_range<'rcu>(
         // gives `s.regions` usage == old usage == Frame at cov_idx.
         assert(valid_frame_paddr(paddr_c));
         s.regions.inv_implies_correct_addr(paddr_c);
-        assert(s.regions.slot_owners.contains_key(cov_idx));
+        assert(s.regions.contains(cov_idx));
     };
 
     // --- structural: FrameId ⟹ Frame-usage (frames unchanged) ---
@@ -3967,7 +3968,7 @@ proof fn step_segment_clone_range<'rcu>(
         assert(old_regions.slot_owners[other_idx].usage is Frame);
         assert(valid_frame_paddr(s.frames[fid_other].paddr));
         s.regions.inv_implies_correct_addr(s.frames[fid_other].paddr);
-        assert(s.regions.slot_owners.contains_key(other_idx));
+        assert(s.regions.contains(other_idx));
         // `other_0 <= idx < max_meta_slots()` (biimplication) ⟹ universal
         // usage-preservation above gives Frame-usage at other_idx.
     };
@@ -4145,7 +4146,7 @@ proof fn step_unique_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, paddr: Pad
 
         // `idx` in range; `paddr` is its page base.
         s.regions.inv_implies_correct_addr(paddr);
-        assert(s.regions.slot_owners.contains_key(idx));
+        assert(s.regions.contains(idx));
         assert(index_to_frame(idx) == paddr);
 
         // Pre "no users" facts at the UNUSED slot (accounting clause 1).
@@ -4347,7 +4348,7 @@ proof fn step_unique_drop<'rcu>(tracked s: &mut VmStore<'rcu>, uid: UniqueId)
     // branch of `MetaSlotOwner::inv`.
     assert(valid_frame_paddr(paddr));
     s.regions.inv_implies_correct_addr(paddr);
-    assert(s.regions.slot_owners.contains_key(idx));
+    assert(s.regions.contains(idx));
     assert(index_to_frame(idx) == paddr);
     assert(s.regions.slot_owners[idx].usage is Frame);
     assert(s.regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
@@ -4536,7 +4537,7 @@ proof fn step_from_unique<'rcu>(tracked s: &mut VmStore<'rcu>, uid: UniqueId)
     // Slot facts from the structural unique-entry clause + UNIQUE branch.
     assert(valid_frame_paddr(paddr));
     s.regions.inv_implies_correct_addr(paddr);
-    assert(s.regions.slot_owners.contains_key(idx));
+    assert(s.regions.contains(idx));
     assert(index_to_frame(idx) == paddr);
     assert(s.regions.slot_owners[idx].usage is Frame);
     assert(s.regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
@@ -4727,7 +4728,7 @@ proof fn step_try_from_shared<'rcu>(tracked s: &mut VmStore<'rcu>, fid: FrameId)
     // to `handle_count` (so the slot is an active head).
     assert(valid_frame_paddr(paddr));
     s.regions.inv_implies_correct_addr(paddr);
-    assert(s.regions.slot_owners.contains_key(idx));
+    assert(s.regions.contains(idx));
     assert(index_to_frame(idx) == paddr);
     assert(s.regions.slot_owners[idx].usage is Frame);
     assert(s.frames.dom().filter(

--- a/ostd/specs/mm/embedding/segment.rs
+++ b/ostd/specs/mm/embedding/segment.rs
@@ -94,7 +94,7 @@ pub axiom fn segment_from_unused_embedded(
         forall|paddr: Paddr|
             #![trigger frame_to_index(paddr)]
             (range.start <= paddr < range.end && paddr % PAGE_SIZE == 0)
-                ==> old(regions).slots.contains_key(frame_to_index(paddr)),
+                ==> old(regions).contains(frame_to_index(paddr)),
     ensures
         final(regions).inv(),
         // `slots` domain preserved (Design B re-parking).
@@ -257,7 +257,7 @@ pub proof fn segment_next_embedded(
     requires
         old(regions).inv(),
         valid_frame_paddr(paddr),
-        old(regions).slots.contains_key(frame_to_index(paddr)),
+        old(regions).contains(frame_to_index(paddr)),
         old(regions).slot_owners[frame_to_index(paddr)]
                 .inner_perms.ref_count.value() >= 1,
         old(regions).slot_owners[frame_to_index(paddr)]
@@ -315,7 +315,7 @@ pub(super) proof fn from_unused_step(
         forall|paddr: Paddr|
             #![trigger frame_to_index(paddr)]
             (range.start <= paddr < range.end && paddr % PAGE_SIZE == 0)
-                ==> old(regions).slots.contains_key(frame_to_index(paddr)),
+                ==> old(regions).contains(frame_to_index(paddr)),
     ensures
         final(regions).inv(),
         final(regions).slots == old(regions).slots,

--- a/ostd/specs/mm/embedding/unique.rs
+++ b/ostd/specs/mm/embedding/unique.rs
@@ -84,7 +84,7 @@ pub axiom fn unique_from_unused_embedded(tracked regions: &mut MetaRegionOwners,
     requires
         old(regions).inv(),
         valid_frame_paddr(paddr),
-        old(regions).slots.contains_key(frame_to_index(paddr)),
+        old(regions).contains(frame_to_index(paddr)),
         old(regions).slot_owners[frame_to_index(paddr)].usage is Unused,
         old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
             == REF_COUNT_UNUSED,
@@ -128,7 +128,7 @@ pub axiom fn unique_from_unused_embedded(tracked regions: &mut MetaRegionOwners,
 pub axiom fn unique_drop_embedded(tracked regions: &mut MetaRegionOwners, paddr: Paddr)
     requires
         old(regions).inv(),
-        old(regions).slots.contains_key(frame_to_index(paddr)),
+        old(regions).contains(frame_to_index(paddr)),
         old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
             == REF_COUNT_UNIQUE,
         old(regions).slot_owners[frame_to_index(paddr)].inner_perms.in_list.value() == 0,
@@ -170,7 +170,7 @@ pub axiom fn unique_drop_embedded(tracked regions: &mut MetaRegionOwners, paddr:
 pub axiom fn from_unique_embedded(tracked regions: &mut MetaRegionOwners, paddr: Paddr)
     requires
         old(regions).inv(),
-        old(regions).slots.contains_key(frame_to_index(paddr)),
+        old(regions).contains(frame_to_index(paddr)),
         old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
             == REF_COUNT_UNIQUE,
     ensures
@@ -206,7 +206,7 @@ pub axiom fn from_unique_embedded(tracked regions: &mut MetaRegionOwners, paddr:
 pub axiom fn try_from_shared_embedded(tracked regions: &mut MetaRegionOwners, paddr: Paddr)
     requires
         old(regions).inv(),
-        old(regions).slots.contains_key(frame_to_index(paddr)),
+        old(regions).contains(frame_to_index(paddr)),
         old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() == 1,
         old(regions).slot_owners[frame_to_index(paddr)].usage is Frame,
         old(regions).slot_owners[frame_to_index(paddr)].paths_in_pt.is_empty(),

--- a/ostd/specs/mm/embedding/vm_space.rs
+++ b/ostd/specs/mm/embedding/vm_space.rs
@@ -53,7 +53,7 @@ pub axiom fn vm_space_new_embedded<'a>(tracked regions: &mut MetaRegionOwners) -
         // `structural_inv` slot-perm coverage exception, so coverage
         // stays chainable. (Mirrors `empty_with_owner`'s ensures, which
         // removes `frame_to_index(root_paddr)` from `regions.slots`.)
-        old(regions).slots.contains_key(vm_space_root_idx(res)),
+        old(regions).contains(vm_space_root_idx(res)),
         final(regions).slots == old(regions).slots.remove(vm_space_root_idx(res)),
         final(regions).slot_owners[vm_space_root_idx(res)].usage is PageTable,
         final(regions).slot_owners[vm_space_root_idx(res)].inner_perms.ref_count.value()
@@ -103,7 +103,7 @@ pub(super) proof fn new_vm_space_step<'a>(tracked regions: &mut MetaRegionOwners
         // `structural_inv` slot-perm coverage exception, so coverage
         // stays chainable. (Mirrors `empty_with_owner`'s ensures, which
         // removes `frame_to_index(root_paddr)` from `regions.slots`.)
-        old(regions).slots.contains_key(vm_space_root_idx(res)),
+        old(regions).contains(vm_space_root_idx(res)),
         final(regions).slots == old(regions).slots.remove(vm_space_root_idx(res)),
         final(regions).slot_owners[vm_space_root_idx(res)].usage is PageTable,
         final(regions).slot_owners[vm_space_root_idx(res)].inner_perms.ref_count.value()

--- a/ostd/specs/mm/frame/frame_specs.rs
+++ b/ostd/specs/mm/frame/frame_specs.rs
@@ -177,9 +177,8 @@ impl<M: ?Sized> Frame<M> {
         let slot_own = s.slot_owners[idx];
         &&& self.inv()
         &&& s.inv()
-        &&& s.slots.contains_key(idx)
+        &&& s.contains(idx)
         &&& s.slots[idx].pptr() == self.ptr
-        &&& s.slot_owners.contains_key(idx)
         &&& slot_own.inner_perms.ref_count.value() != REF_COUNT_UNUSED
         &&& slot_own.inner_perms.ref_count.value() != REF_COUNT_UNIQUE
         &&& slot_own.inner_perms.ref_count.value() > 0

--- a/ostd/specs/mm/frame/frame_specs.rs
+++ b/ostd/specs/mm/frame/frame_specs.rs
@@ -39,7 +39,7 @@ impl<'a, M: ?Sized> Frame<M> {
     /// gate, since the `UNUSED` sentinel `u64::MAX` also satisfies it; and
     /// the PT-node ownership model only exposes `!= UNUSED`.)
     pub open spec fn from_raw_requires_safety(regions: MetaRegionOwners, paddr: Paddr) -> bool {
-        &&& regions.slot_owners.contains_key(frame_to_index(paddr))
+        &&& regions.contains(frame_to_index(paddr))
         &&& regions.slot_owners[frame_to_index(paddr)].slot_vaddr == frame_to_meta(paddr)
         &&& valid_frame_paddr(paddr)
         &&& regions.inv()
@@ -54,7 +54,7 @@ impl<'a, M: ?Sized> Frame<M> {
         r: Self,
     ) -> bool {
         &&& new_regions.inv()
-        &&& new_regions.slots.contains_key(frame_to_index(paddr))
+        &&& new_regions.contains(frame_to_index(paddr))
         &&& new_regions.slot_owners[frame_to_index(paddr)]
             =~= old_regions.slot_owners[frame_to_index(paddr)]
         &&& new_regions.slot_owners[frame_to_index(paddr)].slot_vaddr == r.ptr.addr()
@@ -62,8 +62,7 @@ impl<'a, M: ?Sized> Frame<M> {
             #![trigger new_regions.slot_owners[i], old_regions.slot_owners[i]]
             i != frame_to_index(paddr) ==> new_regions.slot_owners[i] == old_regions.slot_owners[i]
         &&& forall|i: int|
-            i != frame_to_index(paddr) ==> new_regions.slots.contains_key(i)
-                == old_regions.slots.contains_key(i)
+            i != frame_to_index(paddr) ==> new_regions.contains(i) == old_regions.contains(i)
         &&& r.ptr.addr() == frame_to_meta(paddr)
         &&& r.paddr() == paddr
         &&& r.inv()
@@ -97,9 +96,8 @@ impl<'a, M: ?Sized> Frame<M> {
     ) -> bool {
         &&& forall|i: int|
             #![trigger new_regions.slots[i], old_regions.slots[i]]
-            i != self.index() && old_regions.slots.contains_key(i)
-                ==> new_regions.slots.contains_key(i) && new_regions.slots[i]
-                == old_regions.slots[i]
+            i != self.index() && old_regions.contains(i) ==> new_regions.contains(i)
+                && new_regions.slots[i] == old_regions.slots[i]
         &&& forall|i: int|
             #![trigger new_regions.slot_owners[i], old_regions.slot_owners[i]]
             i != self.index() ==> new_regions.slot_owners[i] == old_regions.slot_owners[i]
@@ -204,7 +202,7 @@ impl<M: ?Sized> TrackDrop for Frame<M> {
     type Obligation = DropObligation<int>;
 
     open spec fn tracked_redeem_requires(self, s: Self::State) -> bool {
-        &&& s.slot_owners.contains_key(self.index())
+        &&& s.contains(self.index())
         &&& s.inv()
     }
 

--- a/ostd/specs/mm/frame/frame_specs.rs
+++ b/ostd/specs/mm/frame/frame_specs.rs
@@ -6,7 +6,9 @@ use vstd_extra::{cast_ptr::*, drop_tracking::*, ownership::*};
 use crate::specs::{
     arch::*,
     mm::frame::{
-        mapping::frame_to_index, meta_owners::PageUsage, meta_region_owners::MetaRegionOwners,
+        mapping::{frame_to_index, meta_to_index},
+        meta_owners::PageUsage,
+        meta_region_owners::MetaRegionOwners,
     },
 };
 
@@ -231,7 +233,7 @@ impl<M: ?Sized> TrackDrop for Frame<M> {
 
     proof fn tracked_redeem(self, tracked s: &mut Self::State) -> (tracked obl: Self::Obligation) {
         let meta_addr = self.ptr.addr();
-        let index = frame_to_index(meta_to_frame(meta_addr));
+        let index = meta_to_index(meta_addr);
         let tracked mut slot_own = s.slot_owners.tracked_remove(index);
         s.slot_owners.tracked_insert(index, slot_own);
         // Paired mint axiom: produces the token AND adds its Loc to

--- a/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
+++ b/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
@@ -480,7 +480,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
                 #![trigger self.list[i]]
                 0 <= i < self.list.len() ==> {
                     let idx = meta_to_index(self.list[i].paddr);
-                    &&& regions2.slot_owners.contains_key(idx)
+                    &&& regions2.contains(idx)
                     &&& regions2.slot_owners[idx] == regions1.slot_owners[idx]
                 },
         ensures

--- a/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
+++ b/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
@@ -298,8 +298,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
     pub open spec fn relate_region_at(self, regions: MetaRegionOwners, i: int) -> bool {
         let idx = meta_to_index(self.list[i].paddr);
         let value = self.meta_value_at(regions, i);
-        &&& regions.slots.contains_key(idx)
-        &&& regions.slot_owners.contains_key(idx)
+        &&& regions.contains(idx)
         &&& regions.slots[idx].addr() == self.list[i].paddr
         &&& regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE
         &&& regions.slot_owners[idx].usage is Frame
@@ -396,8 +395,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
             ({
                 let idx = meta_to_index(self.list[i].paddr);
                 let value = self.meta_value_at(regions, i);
-                &&& regions.slots.contains_key(idx)
-                &&& regions.slot_owners.contains_key(idx)
+                &&& regions.contains(idx)
                 &&& regions.slots[idx].addr() == self.list[i].paddr
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE
                 &&& regions.slot_owners[idx].usage is Frame
@@ -433,8 +431,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
             ({
                 let idx = meta_to_index(self.list[i].paddr);
                 let value = self.meta_value_at(regions, i);
-                &&& regions.slots.contains_key(idx)
-                &&& regions.slot_owners.contains_key(idx)
+                &&& regions.contains(idx)
                 &&& self.repr_perms.len() == self.list.len()
                 &&& regions.slots[idx].addr() == self.list[i].paddr
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE
@@ -537,8 +534,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
                         fr.slot_owners[i].inner_perms.storage,
                         new.repr_perms[np],
                     );
-                    &&& fr.slots.contains_key(i)
-                    &&& fr.slot_owners.contains_key(i)
+                    &&& fr.contains(i)
                     &&& fr.slots[i].addr() == old.list[p].paddr
                     &&& fr.slots[i].pptr() == r0.slots[i].pptr()
                     &&& fr.slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNIQUE
@@ -675,8 +671,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
             ({
                 let ins = meta_to_index(new.list[n].paddr);
                 let fpn = new.meta_value_at(fr, n);
-                &&& fr.slots.contains_key(ins)
-                &&& fr.slot_owners.contains_key(ins)
+                &&& fr.contains(ins)
                 &&& fr.slots[ins].addr() == link.paddr
                 &&& fr.slot_owners[ins].inner_perms.ref_count.value() == REF_COUNT_UNIQUE
                 &&& fr.slot_owners[ins].usage is Frame
@@ -713,8 +708,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
                         p + 1
                     };
                     let fp = new.meta_value_at(fr, np);
-                    &&& fr.slots.contains_key(i)
-                    &&& fr.slot_owners.contains_key(i)
+                    &&& fr.contains(i)
                     &&& fr.slots[i].addr() == old.list[p].paddr
                     &&& fr.slots[i].pptr() == r0.slots[i].pptr()
                     &&& fr.slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNIQUE

--- a/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
+++ b/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
@@ -11,7 +11,7 @@ use vstd_extra::{
 use crate::specs::{
     arch::MAX_NR_PAGES,
     mm::frame::{
-        mapping::{frame_to_index, max_meta_slots},
+        mapping::{max_meta_slots, meta_to_index},
         meta_owners::*,
         meta_region_owners::MetaRegionOwners,
         unique::UniqueFrameOwner,
@@ -22,10 +22,7 @@ use crate::mm::{
     Paddr,
     frame::{
         AnyFrameMeta, CursorMut, Link, LinkedList, MetaSlot,
-        meta::{
-            META_SLOT_SIZE, REF_COUNT_UNIQUE,
-            mapping::{frame_to_meta, meta_to_frame},
-        },
+        meta::{META_SLOT_SIZE, REF_COUNT_UNIQUE},
     },
     kspace::FRAME_METADATA_RANGE,
 };
@@ -259,11 +256,11 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> Inv for LinkedListOwner<M> {
 
 impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
     pub open spec fn meta_addr_at(self, regions: MetaRegionOwners, i: int) -> usize {
-        regions.slots[self.slot_index_at(i)].addr()
+        regions.slots[meta_to_index(self.list[i].paddr)].addr()
     }
 
     pub open spec fn meta_pptr_at(self, regions: MetaRegionOwners, i: int) -> PPtr<MetaSlot> {
-        regions.slots[self.slot_index_at(i)].pptr()
+        regions.slots[meta_to_index(self.list[i].paddr)].pptr()
     }
 
     /// Per-link structural invariant: the link's own `inv()` holds and its
@@ -275,13 +272,8 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
         &&& self.list[i].in_list == self.list_id
     }
 
-    /// The region slot index keyed by the `i`-th link's meta-slot address.
-    pub open spec fn slot_index_at(self, i: int) -> int {
-        frame_to_index(meta_to_frame(self.list[i].paddr))
-    }
-
     pub open spec fn meta_wf_at(self, regions: MetaRegionOwners, i: int) -> bool {
-        let idx = self.slot_index_at(i);
+        let idx = meta_to_index(self.list[i].paddr);
         typed_meta_wf::<Link<M>>(
             regions.slots[idx],
             regions.slot_owners[idx].inner_perms.storage,
@@ -293,7 +285,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
         recommends
             self.meta_wf_at(regions, i),
     {
-        let idx = self.slot_index_at(i);
+        let idx = meta_to_index(self.list[i].paddr);
         typed_meta_value::<Link<M>>(
             regions.slot_owners[idx].inner_perms.storage,
             self.repr_perms[i],
@@ -304,7 +296,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
     /// storage permissions plus the list-owned representation permission.
     #[verifier::opaque]
     pub open spec fn relate_region_at(self, regions: MetaRegionOwners, i: int) -> bool {
-        let idx = self.slot_index_at(i);
+        let idx = meta_to_index(self.list[i].paddr);
         let value = self.meta_value_at(regions, i);
         &&& regions.slots.contains_key(idx)
         &&& regions.slot_owners.contains_key(idx)
@@ -334,23 +326,24 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
     /// The list-wide region relation: every link satisfies `relate_region_at`,
     /// and distinct list positions map to distinct region slot indices (so a
     /// frame appears at most once — required by the borrow model, where link
-    /// edits mutate `regions.slots[slot_index_at(i)]` and must not alias).
+    /// edits mutate `regions.slots[meta_to_index(self.list[i].paddr)]` and must not alias).
     pub open spec fn relate_region(self, regions: MetaRegionOwners) -> bool {
         &&& self.repr_perms.len() == self.list.len()
         &&& forall|i: int|
             #![trigger self.list[i]]
             0 <= i < self.list.len() ==> self.relate_region_at(regions, i)
         &&& forall|i: int, j: int|
-            #![trigger self.slot_index_at(i), self.slot_index_at(j)]
-            0 <= i < self.list.len() && 0 <= j < self.list.len() && i != j ==> self.slot_index_at(i)
-                != self.slot_index_at(j)
+            #![trigger meta_to_index(self.list[i].paddr), meta_to_index(self.list[j].paddr)]
+            0 <= i < self.list.len() && 0 <= j < self.list.len() && i != j ==> meta_to_index(
+                self.list[i].paddr,
+            ) != meta_to_index(self.list[j].paddr)
         &&& self.list.len() > 0 ==> self.list_id != 0
     }
 
     /// Pigeonhole bound: the list is no longer than the number of meta slots.
     /// Each link occupies a region slot (`relate_region_at` ⟹
-    /// `slots.contains_key(slot_index_at(i))`, and `regions.inv()` ⟹
-    /// `slot_index_at(i) < max_meta_slots()`), and distinct positions occupy
+    /// `slots.contains_key(meta_to_index(self.list[i].paddr))`, and `regions.inv()` ⟹
+    /// `meta_to_index(self.list[i].paddr) < max_meta_slots()`), and distinct positions occupy
     /// distinct slots (`relate_region`'s injectivity). So the positions inject
     /// into `[0, max_meta_slots())` and the length is capped by it.
     pub proof fn length_le_max_meta_slots(self, regions: MetaRegionOwners)
@@ -360,7 +353,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
         ensures
             self.list.len() <= max_meta_slots(),
     {
-        let idxs = Seq::new(self.list.len(), |i: int| self.slot_index_at(i));
+        let idxs = Seq::new(self.list.len(), |i: int| meta_to_index(self.list[i].paddr));
 
         idxs.unique_seq_to_set();
 
@@ -371,7 +364,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
                 idxs.to_set().contains(x) implies bound.contains(x) by {
                 let i = choose|i: int| 0 <= i < idxs.len() && idxs[i] == x;
                 self.relate_region_at_facts(regions, i);
-                // `regions.inv()`: `contains_key(slot_index_at(i)) ⟹ < max_meta_slots()`.
+                // `regions.inv()`: the contained slot index is `< max_meta_slots()`.
             }
         }
         lemma_int_range(0, max_meta_slots());
@@ -401,7 +394,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
             self.relate_region_at(regions, i),
         ensures
             ({
-                let idx = self.slot_index_at(i);
+                let idx = meta_to_index(self.list[i].paddr);
                 let value = self.meta_value_at(regions, i);
                 &&& regions.slots.contains_key(idx)
                 &&& regions.slot_owners.contains_key(idx)
@@ -438,7 +431,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
     pub proof fn relate_region_at_from_clauses(self, regions: MetaRegionOwners, i: int)
         requires
             ({
-                let idx = self.slot_index_at(i);
+                let idx = meta_to_index(self.list[i].paddr);
                 let value = self.meta_value_at(regions, i);
                 &&& regions.slots.contains_key(idx)
                 &&& regions.slot_owners.contains_key(idx)
@@ -489,7 +482,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
             forall|i: int|
                 #![trigger self.list[i]]
                 0 <= i < self.list.len() ==> {
-                    let idx = self.slot_index_at(i);
+                    let idx = meta_to_index(self.list[i].paddr);
                     &&& regions2.slot_owners.contains_key(idx)
                     &&& regions2.slot_owners[idx] == regions1.slot_owners[idx]
                 },
@@ -532,9 +525,9 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
             new.repr_perms.len() == new.list.len(),
             new.list_id == old.list_id,
             forall|p: int|
-                #![trigger old.slot_index_at(p)]
+                #![trigger meta_to_index(old.list[p].paddr)]
                 (0 <= p < old.list.len() && p != n) ==> ({
-                    let i = old.slot_index_at(p);
+                    let i = meta_to_index(old.list[p].paddr);
                     let np = if p < n {
                         p
                     } else {
@@ -569,20 +562,20 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
     {
         let nlen = new.list.len() as int;
 
-        assert forall|k: int| #![trigger new.slot_index_at(k)] 0 <= k < nlen implies {
+        assert forall|k: int| #![trigger meta_to_index(new.list[k].paddr)] 0 <= k < nlen implies {
             let p = if k < n {
                 k
             } else {
                 k + 1
             };
             &&& new.list[k] == old.list[p]
-            &&& new.slot_index_at(k) == old.slot_index_at(p)
+            &&& meta_to_index(new.list[k].paddr) == meta_to_index(old.list[p].paddr)
         } by {}
 
         assert forall|a: int, b: int|
-            #![trigger new.slot_index_at(a), new.slot_index_at(b)]
-            0 <= a < nlen && 0 <= b < nlen && a != b implies new.slot_index_at(a)
-            != new.slot_index_at(b) by {
+            #![trigger meta_to_index(new.list[a].paddr), meta_to_index(new.list[b].paddr)]
+            0 <= a < nlen && 0 <= b < nlen && a != b implies meta_to_index(new.list[a].paddr)
+            != meta_to_index(new.list[b].paddr) by {
             let pa = if a < n {
                 a
             } else {
@@ -652,7 +645,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
     ///
     /// New position `k` maps to old position `k` (k<n), is the inserted link
     /// (k==n), or maps to old `k-1` (k>n). The inserted link sits at slot
-    /// `ins = new.slot_index_at(n)`; its `prev`/`next` point to old `n-1`/`n`
+    /// `ins = meta_to_index(new.list[n].paddr)`; its `prev`/`next` point to old `n-1`/`n`
     /// (or `None` at the ends), and old `n-1`'s `next` / old `n`'s `prev` are
     /// rewired to point at the inserted link. Mirror of
     /// [`pop_preserves_relate_region`].
@@ -675,10 +668,12 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
             old.list.len() > 0 ==> new.list_id == old.list_id,
             link.in_list == new.list_id,
             forall|p: int|
-                #![trigger old.slot_index_at(p)]
-                (0 <= p < old.list.len()) ==> old.slot_index_at(p) != new.slot_index_at(n),
+                #![trigger meta_to_index(old.list[p].paddr)]
+                (0 <= p < old.list.len()) ==> meta_to_index(old.list[p].paddr) != meta_to_index(
+                    new.list[n].paddr,
+                ),
             ({
-                let ins = new.slot_index_at(n);
+                let ins = meta_to_index(new.list[n].paddr);
                 let fpn = new.meta_value_at(fr, n);
                 &&& fr.slots.contains_key(ins)
                 &&& fr.slot_owners.contains_key(ins)
@@ -695,19 +690,23 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
                 &&& (n > 0 ==> {
                     &&& fpn.prev is Some
                     &&& fpn.prev->0.addr() == old.list[n - 1].paddr
-                    &&& fpn.prev->0.ptr.addr() == r0.slots[old.slot_index_at(n - 1)].pptr().addr()
+                    &&& fpn.prev->0.ptr.addr() == r0.slots[meta_to_index(
+                        old.list[n - 1].paddr,
+                    )].pptr().addr()
                 })
                 &&& (n < old.list.len() ==> {
                     &&& fpn.next is Some
                     &&& fpn.next->0.addr() == old.list[n].paddr
-                    &&& fpn.next->0.ptr.addr() == r0.slots[old.slot_index_at(n)].pptr().addr()
+                    &&& fpn.next->0.ptr.addr() == r0.slots[meta_to_index(
+                        old.list[n].paddr,
+                    )].pptr().addr()
                 })
             }),
             forall|p: int|
-                #![trigger old.slot_index_at(p)]
+                #![trigger meta_to_index(old.list[p].paddr)]
                 (0 <= p < old.list.len()) ==> ({
-                    let i = old.slot_index_at(p);
-                    let ins = new.slot_index_at(n);
+                    let i = meta_to_index(old.list[p].paddr);
+                    let ins = meta_to_index(new.list[n].paddr);
                     let np = if p < n {
                         p
                     } else {
@@ -742,21 +741,20 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
             new.relate_region(fr),
     {
         let nlen = new.list.len() as int;
-        let ins = new.slot_index_at(n);
+        let ins = meta_to_index(new.list[n].paddr);
 
-        assert forall|k: int| #![trigger new.slot_index_at(k)] 0 <= k < nlen implies ({
-            &&& (k < n ==> new.list[k] == old.list[k] && new.slot_index_at(k) == old.slot_index_at(
-                k,
-            ))
-            &&& (k == n ==> new.list[k] == link && new.slot_index_at(k) == ins)
-            &&& (k > n ==> new.list[k] == old.list[k - 1] && new.slot_index_at(k)
-                == old.slot_index_at(k - 1))
+        assert forall|k: int| #![trigger meta_to_index(new.list[k].paddr)] 0 <= k < nlen implies ({
+            &&& (k < n ==> new.list[k] == old.list[k] && meta_to_index(new.list[k].paddr)
+                == meta_to_index(old.list[k].paddr))
+            &&& (k == n ==> new.list[k] == link && meta_to_index(new.list[k].paddr) == ins)
+            &&& (k > n ==> new.list[k] == old.list[k - 1] && meta_to_index(new.list[k].paddr)
+                == meta_to_index(old.list[k - 1].paddr))
         }) by {}
 
         assert forall|a: int, b: int|
-            #![trigger new.slot_index_at(a), new.slot_index_at(b)]
-            0 <= a < nlen && 0 <= b < nlen && a != b implies new.slot_index_at(a)
-            != new.slot_index_at(b) by {}
+            #![trigger meta_to_index(new.list[a].paddr), meta_to_index(new.list[b].paddr)]
+            0 <= a < nlen && 0 <= b < nlen && a != b implies meta_to_index(new.list[a].paddr)
+            != meta_to_index(new.list[b].paddr) by {}
 
         assert forall|m: int| #![trigger new.meta_addr_at(fr, m)] 0 <= m < nlen implies ({
             &&& (m < n ==> new.meta_addr_at(fr, m) == old.meta_addr_at(r0, m) && new.meta_pptr_at(

--- a/ostd/specs/mm/frame/mapping.rs
+++ b/ostd/specs/mm/frame/mapping.rs
@@ -21,6 +21,14 @@ pub open spec fn max_meta_slots() -> int {
     (FRAME_METADATA_RANGE.end - FRAME_METADATA_RANGE.start) / META_SLOT_SIZE as int
 }
 
+#[verifier::inline]
+pub open spec fn frame_to_index(paddr: Paddr) -> int
+    recommends
+        paddr % PAGE_SIZE == 0,
+{
+    (paddr / PAGE_SIZE) as int
+}
+
 pub open spec fn index_to_meta(i: int) -> (res: Vaddr)
     recommends
         0 <= i < max_meta_slots(),
@@ -28,12 +36,9 @@ pub open spec fn index_to_meta(i: int) -> (res: Vaddr)
     (FRAME_METADATA_RANGE.start + i * META_SLOT_SIZE) as Vaddr
 }
 
-#[verifier::inline]
-pub open spec fn frame_to_index(paddr: Paddr) -> int
-    recommends
-        paddr % PAGE_SIZE == 0,
-{
-    (paddr / PAGE_SIZE) as int
+/// Converts a frame metadata-slot virtual address to its frame index.
+pub open spec fn meta_to_index(vaddr: Vaddr) -> int {
+    frame_to_index(meta_to_frame(vaddr))
 }
 
 #[verifier::inline]

--- a/ostd/specs/mm/frame/meta_region_owners.rs
+++ b/ostd/specs/mm/frame/meta_region_owners.rs
@@ -111,6 +111,12 @@ impl InvView for MetaRegionOwners {
 }
 
 impl MetaRegionOwners {
+    /// Returns whether the slot permission and its corresponding owner are both present.
+    pub open spec fn contains(self, index: int) -> bool {
+        &&& self.slots.contains_key(index)
+        &&& self.slot_owners.contains_key(index)
+    }
+
     pub open spec fn insert_slot_owner(self, paddr: Paddr, owner: MetaSlotOwner) -> Self {
         let index = frame_to_index(paddr);
         Self { slot_owners: self.slot_owners.insert(index, owner), ..self }

--- a/ostd/specs/mm/frame/meta_region_owners.rs
+++ b/ostd/specs/mm/frame/meta_region_owners.rs
@@ -67,7 +67,8 @@ pub ghost struct MetaRegionModel {
 impl Inv for MetaRegionOwners {
     open spec fn inv(self) -> bool {
         &&& {
-            // All accessible slots are within the valid address range.
+            // Keep the map-membership trigger: callers frequently expose a
+            // slot-owner lookup without mentioning the `contains` wrapper.
             forall|i: int|
                 0 <= i < max_meta_slots() <==> #[trigger] self.slot_owners.contains_key(i)
         }
@@ -86,6 +87,12 @@ impl Inv for MetaRegionOwners {
                     &&& self.slot_owners[i].slot_vaddr == self.slots[i].addr()
                 }
         }
+    }
+}
+
+impl MetaRegionModel {
+    pub open spec fn contains(self, index: int) -> bool {
+        self.slots.contains_key(index)
     }
 }
 
@@ -113,8 +120,8 @@ impl InvView for MetaRegionOwners {
 impl MetaRegionOwners {
     /// Returns whether the slot permission and its corresponding owner are both present.
     pub open spec fn contains(self, index: int) -> bool {
-        &&& self.slots.contains_key(index)
         &&& self.slot_owners.contains_key(index)
+        &&& self.slots.contains_key(index)
     }
 
     pub open spec fn insert_slot_owner(self, paddr: Paddr, owner: MetaSlotOwner) -> Self {
@@ -145,8 +152,9 @@ impl MetaRegionOwners {
     {
         forall|paddr: Paddr|
             #![trigger frame_to_index(paddr)]
-            (range.start <= paddr < range.end && paddr % PAGE_SIZE == 0)
-                ==> self.slots.contains_key(frame_to_index(paddr))
+            (range.start <= paddr < range.end && paddr % PAGE_SIZE == 0) ==> self.contains(
+                frame_to_index(paddr),
+            )
     }
 
     pub open spec fn paddr_range_not_mapped(self, range: Range<Paddr>) -> bool
@@ -167,8 +175,9 @@ impl MetaRegionOwners {
     {
         forall|paddr: Paddr|
             #![trigger frame_to_index(paddr)]
-            (range.start <= paddr < range.end && paddr % PAGE_SIZE == 0)
-                ==> !self.slots.contains_key(frame_to_index(paddr))
+            (range.start <= paddr < range.end && paddr % PAGE_SIZE == 0) ==> !self.contains(
+                frame_to_index(paddr),
+            )
     }
 
     /// Instantiates `paddr_range_not_mapped` at a specific paddr in the range.
@@ -190,7 +199,7 @@ impl MetaRegionOwners {
             valid_frame_paddr(paddr),
             self.inv(),
         ensures
-            self.slot_owners.contains_key(frame_to_index(paddr)),
+            self.contains(frame_to_index(paddr)),
     {
     }
 

--- a/ostd/specs/mm/frame/meta_specs.rs
+++ b/ostd/specs/mm/frame/meta_specs.rs
@@ -128,7 +128,7 @@ impl MetaSlot {
         &&& post.slots.dom() =~= pre.slots.dom()
         &&& forall|k: int|
             #![trigger post.slots[k]]
-            k != idx && pre.slots.contains_key(k) ==> post.slots[k] == pre.slots[k]
+            k != idx && pre.contains(k) ==> post.slots[k] == pre.slots[k]
     }
 
     /// Obligation-ledger effect of producing a fresh live `Frame` handle on

--- a/ostd/specs/mm/frame/segment.rs
+++ b/ostd/specs/mm/frame/segment.rs
@@ -107,8 +107,7 @@ impl<M: AnyFrameMeta + ?Sized> Segment<M> {
                 // Per-frame linear-drop: the segment holds one (forgotten)
                 // reference per frame, recorded as a `frame_obligations` count.
                 &&& regions.frame_obligations.count(idx) >= 1
-                &&& regions.slot_owners.contains_key(idx)
-                &&& regions.slots.contains_key(idx)
+                &&& regions.contains(idx)
                 &&& regions.slot_owners[idx].slot_vaddr == index_to_meta(idx)
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value()
                     > 0
@@ -141,10 +140,7 @@ impl<M: AnyFrameMeta + ?Sized> Segment<M> {
             ({
                 let idx = frame_to_index((self.range.start + i * PAGE_SIZE) as usize);
                 &&& regions.frame_obligations.count(idx) >= 1
-                &&& regions.slot_owners.contains_key(idx)
-                &&& regions.slots.contains_key(
-                    idx,
-                )
+                &&& regions.contains(idx)
                 // Borrow-protocol transition: `raw_count` is dormant.
                 &&& regions.slot_owners[idx].slot_vaddr == index_to_meta(idx)
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value() > 0

--- a/ostd/specs/mm/frame/segment.rs
+++ b/ostd/specs/mm/frame/segment.rs
@@ -140,7 +140,9 @@ impl<M: AnyFrameMeta + ?Sized> Segment<M> {
             ({
                 let idx = frame_to_index((self.range.start + i * PAGE_SIZE) as usize);
                 &&& regions.frame_obligations.count(idx) >= 1
-                &&& regions.contains(idx)
+                &&& regions.contains(
+                    idx,
+                )
                 // Borrow-protocol transition: `raw_count` is dormant.
                 &&& regions.slot_owners[idx].slot_vaddr == index_to_meta(idx)
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value() > 0

--- a/ostd/specs/mm/frame/unique.rs
+++ b/ostd/specs/mm/frame/unique.rs
@@ -146,8 +146,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrameOwner<M> {
     /// obligation in `frame_obligations` (minted at `from_unused`/`from_raw`,
     /// consumed by `drop`/`into_raw`).
     pub open spec fn global_inv(self, regions: MetaRegionOwners) -> bool {
-        &&& regions.slots.contains_key(self.slot_index)
-        &&& regions.slot_owners.contains_key(self.slot_index)
+        &&& regions.contains(self.slot_index)
         &&& self.meta_wf(regions)
         &&& regions.slots[self.slot_index].addr() == index_to_meta(self.slot_index)
         &&& self.meta_value(regions).wf(self.meta_own)

--- a/ostd/specs/mm/frame/unique.rs
+++ b/ostd/specs/mm/frame/unique.rs
@@ -218,7 +218,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> TrackDrop for UniqueFram
     type Obligation = DropObligation<int>;
 
     open spec fn tracked_redeem_requires(self, s: Self::State) -> bool {
-        &&& s.slot_owners.contains_key(self.index())
+        &&& s.contains(self.index())
         &&& s.slot_owners[meta_to_index(self.ptr.addr())].inner_perms.ref_count.value()
             != REF_COUNT_UNUSED
         &&& s.inv()
@@ -258,7 +258,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> TrackDrop for UniqueFram
     }
 
     open spec fn drop_requires(self, s: Self::State, obl: Self::Obligation) -> bool {
-        &&& s.slot_owners.contains_key(self.index())
+        &&& s.contains(self.index())
         &&& s.inv()
         &&& s.frame_obligations.count(self.index()) > 0
         &&& obl.value() == self.index()

--- a/ostd/specs/mm/frame/unique.rs
+++ b/ostd/specs/mm/frame/unique.rs
@@ -7,7 +7,7 @@ use crate::specs::{
     mm::{
         Paddr,
         frame::{
-            mapping::{frame_to_index, index_to_meta, max_meta_slots},
+            mapping::{frame_to_index, index_to_meta, max_meta_slots, meta_to_index},
             meta_region_owners::MetaRegionOwners,
         },
     },
@@ -220,9 +220,8 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> TrackDrop for UniqueFram
 
     open spec fn tracked_redeem_requires(self, s: Self::State) -> bool {
         &&& s.slot_owners.contains_key(self.index())
-        &&& s.slot_owners[frame_to_index(
-            meta_to_frame(self.ptr.addr()),
-        )].inner_perms.ref_count.value() != REF_COUNT_UNUSED
+        &&& s.slot_owners[meta_to_index(self.ptr.addr())].inner_perms.ref_count.value()
+            != REF_COUNT_UNUSED
         &&& s.inv()
     }
 

--- a/ostd/specs/mm/page_table/cursor/cursor_fn_specs.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_fn_specs.rs
@@ -168,7 +168,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
     pub open spec fn item_slot_in_regions(item: C::Item, regions: MetaRegionOwners) -> bool {
         let (pa, level, prop) = C::item_into_raw(item);
         let idx = frame_to_index(pa);
-        &&& regions.slots.contains_key(idx)
+        &&& regions.contains(idx)
         &&& regions.slot_owners[idx].usage !is PageTable
         &&& regions.slot_owners[idx].inner_perms.ref_count.value()
             != REF_COUNT_UNUSED
@@ -187,7 +187,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 #![trigger frame_to_index((pa + j * PAGE_SIZE) as usize)]
                 0 < j < page_size(level) / PAGE_SIZE ==> {
                     let sub_idx = frame_to_index((pa + j * PAGE_SIZE) as usize);
-                    &&& regions.slots.contains_key(sub_idx)
+                    &&& regions.contains(sub_idx)
                     &&& C::tracked(item)
                         ==> regions.slot_owners[sub_idx].inner_perms.ref_count.value()
                         != REF_COUNT_UNUSED

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -12,7 +12,7 @@ use crate::specs::{
     arch::{NR_ENTRIES, NR_LEVELS},
     mm::{
         Guards, Mapping, MetaRegionOwners,
-        frame::mapping::frame_to_index,
+        frame::mapping::meta_to_index,
         page_table::{
             AbstractVaddr,
             cursor::{owners::*, page_size_lemmas::lemma_page_size_ge_page_size},
@@ -22,10 +22,7 @@ use crate::specs::{
     },
 };
 
-use crate::mm::{
-    Paddr, PagingConstsTrait, PagingLevel, Vaddr, frame::meta::mapping::meta_to_frame, page_size,
-    page_table::*,
-};
+use crate::mm::{Paddr, PagingConstsTrait, PagingLevel, Vaddr, page_size, page_table::*};
 
 use crate::arch::mm::PagingConsts;
 
@@ -88,8 +85,7 @@ pub proof fn subtree_unlock_upgrade<'rcu, C: PageTableConfig>(
             path,
             CursorOwner::<'rcu, C>::node_unlocked_except(guards, excepted_addr),
         ),
-        regions.slot_owners[frame_to_index(meta_to_frame(excepted_addr))].paths_in_pt
-            == set![excepted_path],
+        regions.slot_owners[meta_to_index(excepted_addr)].paths_in_pt == set![excepted_path],
         // Structural path == value path
         path == subtree.value().path,
         path.inv(),
@@ -112,7 +108,7 @@ pub proof fn subtree_unlock_upgrade<'rcu, C: PageTableConfig>(
         if subtree.value().node().meta_vaddr() == excepted_addr {
             // addr == excepted_addr contradicts path != excepted_path
             // via metaregion_sound's singleton paths_in_pt.
-            let idx = frame_to_index(meta_to_frame(excepted_addr));
+            let idx = meta_to_index(excepted_addr);
 
             assert(set![subtree.value().path].contains(excepted_path));
             assert(false);
@@ -460,7 +456,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             if cont_i.guard.inner.inner@.ptr.addr() == guard.inner.inner@.ptr.addr() {
                 let addr = cont_i.entry_own.node().meta_vaddr();
                 assert(addr == cur_entry.node().meta_vaddr());
-                let idx = frame_to_index(meta_to_frame(addr));
+                let idx = meta_to_index(addr);
                 assert(regions.slot_owners[idx].paths_in_pt == set![cont_i.path()]);
                 assert(regions.slot_owners[idx].paths_in_pt == set![cur_entry_path]);
                 assert(set![cont_i.path()].contains(cur_entry_path));

--- a/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
@@ -118,7 +118,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.inv(),
             regions.inv(),
             self.metaregion_sound(regions),
-            regions.slots.contains_key(changed_idx),
+            regions.contains(changed_idx),
             regions.slot_owners[changed_idx].usage !is PageTable,
         ensures
             self.no_node_at_idx(changed_idx),
@@ -163,7 +163,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.inv(),
             self.metaregion_sound(regions0),
             regions0.inv(),
-            regions0.slot_owners.contains_key(changed_idx),
+            regions0.contains(changed_idx),
             regions1.slots == regions0.slots,
             regions1.slot_owners.dom() =~= regions0.slot_owners.dom(),
             forall|i: int|
@@ -397,7 +397,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             self.inv(),
             self.metaregion_sound(regions0),
             regions0.inv(),
-            regions0.slot_owners.contains_key(changed_idx),
+            regions0.contains(changed_idx),
             regions1.slots == regions0.slots,
             regions1.slot_owners.dom() =~= regions0.slot_owners.dom(),
             forall|i: int|

--- a/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
@@ -461,8 +461,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             owner_before_replace.in_locked_range(),
             self.metaregion_sound(regions0),
             regions0.inv(),
-            regions0.slot_owners.contains_key(removed_idx),
-            regions0.slots.contains_key(removed_idx),
+            regions0.contains(removed_idx),
             regions0.slot_owners[removed_idx].usage !is PageTable,
             self@.mappings == owner_before_replace@.mappings - PageTableOwner(
                 owner_before_replace.cur_subtree(),

--- a/ostd/specs/mm/page_table/cursor/split_while_huge_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/split_while_huge_lemmas.rs
@@ -141,6 +141,8 @@ impl<C: PageTableConfig> CursorView<C> {
     /// Requires: `v.inv()`, `v.present()`, the mapping at `cur_va` has
     /// `page_size > new_size`, `page_size % new_size == 0`, and `new_size`
     /// is itself a valid page size.
+    #[verifier::rlimit(80)]
+    #[verifier::spinoff_prover]
     pub proof fn split_if_mapped_huge_spec_preserves_inv(v: Self, new_size: usize)
         requires
             v.inv(),

--- a/ostd/specs/mm/page_table/node/child.rs
+++ b/ostd/specs/mm/page_table/node/child.rs
@@ -2,14 +2,11 @@ use vstd::prelude::*;
 
 use vstd_extra::ownership::*;
 
-use crate::specs::mm::frame::meta_region_owners::MetaRegionOwners;
+use crate::specs::mm::frame::{mapping::meta_to_index, meta_region_owners::MetaRegionOwners};
 
 use crate::arch::mm::PagingConsts;
 use crate::mm::{
-    Paddr, PagingConstsTrait, PagingLevel, Vaddr,
-    frame::{meta::mapping::meta_to_frame, *},
-    page_prop::PageProperty,
-    page_table::*,
+    Paddr, PagingConstsTrait, PagingLevel, Vaddr, frame::*, page_prop::PageProperty, page_table::*,
 };
 
 verus! {
@@ -22,7 +19,7 @@ impl<C: PageTableConfig> OwnerOf for Child<C> {
             Self::PageTable(node) => {
                 &&& owner.is_node()
                 &&& node.ptr.addr() == owner.node().meta_vaddr()
-                &&& node.index() == frame_to_index(meta_to_frame(node.ptr.addr()))
+                &&& node.index() == meta_to_index(node.ptr.addr())
             },
             Self::Frame(paddr, level, prop) => {
                 &&& owner.is_frame()

--- a/ostd/specs/mm/page_table/node/entry.rs
+++ b/ostd/specs/mm/page_table/node/entry.rs
@@ -105,7 +105,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             old_child.inv(),
             new_child.is_node(),
             regions0.inv(),
-            regions0.slots.contains_key(frame_to_index(new_child.meta_slot_paddr()->0)),
+            regions0.contains(frame_to_index(new_child.meta_slot_paddr()->0)),
             regions0.slot_owners[frame_to_index(
                 new_child.meta_slot_paddr()->0,
             )].inner_perms.ref_count.value() == REF_COUNT_UNUSED,
@@ -159,7 +159,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         &&& old_owner.path == new_owner.path
         &&& old_owner.parent_level == new_owner.parent_level
         &&& new_owner.is_node() ==> {
-            &&& regions.slots.contains_key(frame_to_index(new_owner.meta_slot_paddr()->0))
+            &&& regions.contains(frame_to_index(new_owner.meta_slot_paddr()->0))
             &&& regions.slot_owners[frame_to_index(
                 new_owner.meta_slot_paddr()->0,
             )].inner_perms.ref_count.value() != REF_COUNT_UNUSED

--- a/ostd/specs/mm/page_table/node/entry_owners.rs
+++ b/ostd/specs/mm/page_table/node/entry_owners.rs
@@ -9,7 +9,7 @@ use crate::specs::{
     arch::*,
     mm::{
         frame::{
-            mapping::{frame_to_index, index_to_meta},
+            mapping::{frame_to_index, index_to_meta, meta_to_index},
             meta_owners::PageUsage,
             meta_region_owners::MetaRegionOwners,
         },
@@ -812,8 +812,8 @@ impl<C: PageTableConfig> EntryOwner<C> {
     {
         let slot_vaddr = self.node().meta_vaddr();
         let other_addr = other.node().meta_vaddr();
-        let self_idx = frame_to_index(meta_to_frame(slot_vaddr));
-        let other_idx = frame_to_index(meta_to_frame(other_addr));
+        let self_idx = meta_to_index(slot_vaddr);
+        let other_idx = meta_to_index(other_addr);
 
         if slot_vaddr == other_addr {
             assert(set![self.path].contains(other.path));

--- a/ostd/specs/mm/page_table/node/owners.rs
+++ b/ostd/specs/mm/page_table/node/owners.rs
@@ -281,8 +281,7 @@ impl<C: PageTableConfig> NodeOwner<C> {
     /// the NodeOwner and the slot perm parked in regions.
     pub open spec fn metaregion_sound_node(self, regions: MetaRegionOwners) -> bool {
         let idx = self.slot_index;
-        &&& regions.slots.contains_key(idx)
-        &&& regions.slot_owners.contains_key(idx)
+        &&& regions.contains(idx)
         &&& self.meta_wf(regions)
         &&& self.meta_value(regions).wf(self.meta_own)
         &&& self.level == self.meta_value(regions).level

--- a/ostd/specs/mm/page_table/node/owners.rs
+++ b/ostd/specs/mm/page_table/node/owners.rs
@@ -10,7 +10,7 @@ use crate::specs::{
     arch::{MAX_PADDR, NR_ENTRIES, NR_LEVELS},
     mm::{
         frame::{
-            mapping::{frame_to_index, index_to_meta, max_meta_slots},
+            mapping::{index_to_meta, max_meta_slots, meta_to_index},
             meta_owners::*,
             meta_region_owners::MetaRegionOwners,
         },
@@ -248,7 +248,7 @@ impl<C: PageTableConfig> Inv for NodeOwner<C> {
             - LINEAR_MAPPING_BASE_VADDR
         &&& meta_to_frame(index_to_meta(self.slot_index)) < MAX_PADDR
         &&& meta_to_frame(index_to_meta(self.slot_index)) == self.children_perm.addr()
-        &&& self.slot_index == frame_to_index(meta_to_frame(index_to_meta(self.slot_index)))
+        &&& self.slot_index == meta_to_index(index_to_meta(self.slot_index))
     }
 }
 

--- a/ostd/src/mm/frame/frame_ref.rs
+++ b/ostd/src/mm/frame/frame_ref.rs
@@ -7,10 +7,10 @@ use vstd_extra::cast_ptr::Repr;
 use vstd_extra::drop_tracking::*;
 use vstd_extra::prelude::*;
 
-use crate::mm::frame::meta::mapping::{frame_to_meta, meta_to_frame};
+use crate::mm::frame::meta::mapping::frame_to_meta;
 
 use crate::specs::mm::frame::{
-    mapping::frame_to_index, meta_owners::MetaSlotStorage, meta_region_owners::MetaRegionOwners,
+    mapping::meta_to_index, meta_owners::MetaSlotStorage, meta_region_owners::MetaRegionOwners,
 };
 
 use super::{
@@ -155,7 +155,7 @@ pub unsafe trait NonNullPtr: 'static + Sized + TrackDrop<State = MetaRegionOwner
     ) -> Self::Ref<'a>
         requires
             old(regions).inv(),
-            old(regions).slot_owners.contains_key(frame_to_index(meta_to_frame(raw.addr()))),
+            old(regions).slot_owners.contains_key(meta_to_index(raw.addr())),
     ;
 
     /// Converts a shared reference to a raw pointer.

--- a/ostd/src/mm/frame/frame_ref.rs
+++ b/ostd/src/mm/frame/frame_ref.rs
@@ -155,7 +155,7 @@ pub unsafe trait NonNullPtr: 'static + Sized + TrackDrop<State = MetaRegionOwner
     ) -> Self::Ref<'a>
         requires
             old(regions).inv(),
-            old(regions).slot_owners.contains_key(meta_to_index(raw.addr())),
+            old(regions).contains(meta_to_index(raw.addr())),
     ;
 
     /// Converts a shared reference to a raw pointer.

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -822,7 +822,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
             Tracked(owner) : Tracked<&mut CursorOwner<M>>
     )]
     #[verifier::spinoff_prover]
-    #[verifier::rlimit(120)]
+    #[verifier::rlimit(240)]
     pub fn take_current(&mut self) -> (res: Option<
         (UniqueFrame<Link<M>>, Tracked<UniqueFrameOwner<Link<M>>>),
     >)
@@ -889,6 +889,12 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
 
         proof {
             owner.list_own.relate_region_at_facts(*regions, owner.index);
+            if owner.index > 0 {
+                owner.list_own.relate_region_at_facts(*regions, owner.index - 1);
+            }
+            if owner.index < owner.list_own.list.len() - 1 {
+                owner.list_own.relate_region_at_facts(*regions, owner.index + 1);
+            }
         }
 
         let meta_ptr = current.addr();
@@ -919,9 +925,6 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
         frame.meta()).prev;
 
         if let Some(prev) = prev_ptr {
-            proof {
-                owner0.list_own.relate_region_at_facts(regions0, owner0.index - 1);
-            }
             let ghost prev_idx = meta_to_index(owner.list_own.list[owner.index - 1].paddr);
             let tracked prev_points_to = regions.slots.tracked_borrow(prev_idx);
             let tracked prev_slot_owner = regions.slot_owners.tracked_borrow_mut(prev_idx);
@@ -962,9 +965,6 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
         }
 
         if let Some(next) = next_ptr {
-            proof {
-                owner0.list_own.relate_region_at_facts(regions0, owner0.index + 1);
-            }
             let ghost next_idx = meta_to_index(owner.list_own.list[owner.index].paddr);
             let tracked next_points_to = regions.slots.tracked_borrow(next_idx);
             let tracked next_slot_owner = regions.slot_owners.tracked_borrow_mut(next_idx);

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -648,8 +648,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                     let tracked repr_perm = owner.list_own.repr_perms.tracked_borrow(owner.index);
                 }
                 proof {
-                    assert(regions.slots.contains_key(idx));
-                    assert(regions.slot_owners.contains_key(idx));
+                    assert(regions.contains(idx));
                 }
                 let link = borrow_meta(
                     current,
@@ -707,8 +706,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                     let tracked repr_perm = owner.list_own.repr_perms.tracked_borrow(owner.index);
                 }
                 proof {
-                    assert(regions.slots.contains_key(idx));
-                    assert(regions.slot_owners.contains_key(idx));
+                    assert(regions.contains(idx));
                 }
 
                 let link = borrow_meta(
@@ -784,8 +782,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                 }
                 let ghost idx = meta_to_index(current.addr());
                 proof {
-                    assert(regions.slots.contains_key(idx));
-                    assert(regions.slot_owners.contains_key(idx));
+                    assert(regions.contains(idx));
                 }
                 let tracked points_to = regions.slots.tracked_borrow(idx);
                 let tracked slot_owner = regions.slot_owners.tracked_borrow_mut(idx);
@@ -1046,8 +1043,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                     p - 1
                 };
                 let fp = owner.list_own.meta_value_at(*regions, np);
-                &&& regions.slots.contains_key(i)
-                &&& regions.slot_owners.contains_key(i)
+                &&& regions.contains(i)
                 &&& regions.slots[i].addr() == oldl.list[p].paddr
                 &&& regions.slots[i].pptr() == regions0.slots[i].pptr()
                 &&& regions.slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNIQUE
@@ -1071,8 +1067,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                 let fp = owner.list_own.meta_value_at(*regions, np);
                 oldl.relate_region_at_facts(regions0, p);
                 oldl.relate_region_at_facts(regions0, nn);
-                assert(regions.slots.contains_key(i));
-                assert(regions.slot_owners.contains_key(i));
+                assert(regions.contains(i));
             }
             LinkedListOwner::pop_preserves_relate_region(
                 oldl,
@@ -1319,8 +1314,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                     p + 1
                 };
                 let fp = owner.list_own.meta_value_at(*regions, np);
-                &&& regions.slots.contains_key(i)
-                &&& regions.slot_owners.contains_key(i)
+                &&& regions.contains(i)
                 &&& regions.slots[i].addr() == oldl.list[p].paddr
                 &&& regions.slots[i].pptr() == regions0.slots[i].pptr()
                 &&& regions.slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNIQUE
@@ -1357,12 +1351,10 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                 if nn >= 0 && nn < oldl.list.len() {
                     oldl.relate_region_at_facts(regions0, nn);
                 }
-                assert(regions.slots.contains_key(i));
-                assert(regions.slot_owners.contains_key(i));
+                assert(regions.contains(i));
             }
 
-            assert(regions.slots.contains_key(ins));
-            assert(regions.slot_owners.contains_key(ins));
+            assert(regions.contains(ins));
 
             LinkedListOwner::insert_preserves_relate_region(
                 oldl,
@@ -1580,8 +1572,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> Drop for LinkedList<M> {
                     #![trigger original_list[j]]
                     0 <= j < n ==> {
                         let idx = meta_to_index(original_list[j].paddr);
-                        &&& original_regions.slot_owners.contains_key(idx)
-                        &&& original_regions.slots.contains_key(idx)
+                        &&& original_regions.contains(idx)
                         &&& original_regions.frame_obligations.count(idx) == 0
                         &&& original_regions.slot_owners[idx].paths_in_pt.is_empty()
                         &&& original_regions.slot_owners[idx].inner_perms.ref_count.value()

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -20,7 +20,7 @@ use crate::mm::kspace::FRAME_METADATA_RANGE;
 use crate::specs::arch::*;
 use crate::specs::mm::frame::{
     linked_list::linked_list_owners::*,
-    mapping::{frame_to_index, group_page_meta, index_to_meta, max_meta_slots},
+    mapping::{frame_to_index, group_page_meta, index_to_meta, max_meta_slots, meta_to_index},
     meta_owners::{
         MetaSlotOwner, MetaSlotStorage, borrow_meta, borrow_meta_mut, typed_meta_value,
         typed_meta_wf,
@@ -642,7 +642,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
             // SAFETY: The cursor is pointing to a valid element.
             Some(current) => {
                 proof_decl!{
-                    let ghost idx = frame_to_index(meta_to_frame(current.addr()));
+                    let ghost idx = meta_to_index(current.addr());
                     let tracked points_to = regions.slots.tracked_borrow(idx);
                     let tracked slot_owner = regions.slot_owners.tracked_borrow(idx);
                     let tracked repr_perm = owner.list_own.repr_perms.tracked_borrow(owner.index);
@@ -701,7 +701,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
             // SAFETY: The cursor is pointing to a valid element.
             Some(current) => {
                 proof_decl!{
-                    let ghost idx = frame_to_index(meta_to_frame(current.addr()));
+                    let ghost idx = meta_to_index(current.addr());
                     let tracked points_to = regions.slots.tracked_borrow(idx);
                     let tracked slot_owner = regions.slot_owners.tracked_borrow(idx);
                     let tracked repr_perm = owner.list_own.repr_perms.tracked_borrow(owner.index);
@@ -782,7 +782,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                 proof {
                     owner.list_own.relate_region_at_facts(*regions, owner.index);
                 }
-                let ghost idx = frame_to_index(meta_to_frame(current.addr()));
+                let ghost idx = meta_to_index(current.addr());
                 proof {
                     assert(regions.slots.contains_key(idx));
                     assert(regions.slot_owners.contains_key(idx));
@@ -852,7 +852,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
             final(owner).list_own.list_id == old(owner).list_own.list_id,
             res.is_some() ==> {
                 let paddr = old(self).current->0.addr();
-                let idx = frame_to_index(meta_to_frame(paddr));
+                let idx = meta_to_index(paddr);
                 &&& final(regions).slots.dom() == old(regions).slots.dom()
                 &&& final(regions).slot_owners[idx].inner_perms.ref_count.value()
                     == REF_COUNT_UNIQUE
@@ -866,7 +866,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
             },
             res.is_some() ==> forall|j: int|
                 #![trigger final(regions).slot_owners[j]]
-                j != frame_to_index(meta_to_frame(old(self).current->0.addr())) ==> {
+                j != meta_to_index(old(self).current->0.addr()) ==> {
                     &&& final(regions).slot_owners[j].usage == old(regions).slot_owners[j].usage
                     &&& final(regions).slot_owners[j].slot_vaddr == old(
                         regions,
@@ -879,13 +879,11 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
             // Properties of the returned frame needed for UniqueFrame::drop
             res.is_some() ==> (res->0).0.wf((res->0).1@),
             res.is_some() ==> (res->0).1@.inv(),
-            res.is_some() ==> (res->0).1@.slot_index == frame_to_index(
-                meta_to_frame(old(self).current->0.addr()),
-            ),
+            res.is_some() ==> (res->0).1@.slot_index == meta_to_index(old(self).current->0.addr()),
             res.is_some() ==> (res->0).0.ptr.addr() == old(self).current->0.addr(),
             res.is_some() ==> final(regions).frame_obligations == old(
                 regions,
-            ).frame_obligations.insert(frame_to_index(meta_to_frame(old(self).current->0.addr()))),
+            ).frame_obligations.insert(meta_to_index(old(self).current->0.addr())),
     {
         let ghost owner0 = *owner;
         let ghost regions0 = *regions;
@@ -930,7 +928,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
         frame.meta()).prev;
 
         if let Some(prev) = prev_ptr {
-            let ghost prev_idx = owner.list_own.slot_index_at(owner.index - 1);
+            let ghost prev_idx = meta_to_index(owner.list_own.list[owner.index - 1].paddr);
             let tracked prev_points_to = regions.slots.tracked_borrow(prev_idx);
             let tracked prev_slot_owner = regions.slot_owners.tracked_borrow_mut(prev_idx);
             let tracked prev_repr_perm = owner.list_own.repr_perms.tracked_borrow_mut(
@@ -952,7 +950,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                     &&& regions.slot_owners[j].slot_vaddr == regions0.slot_owners[j].slot_vaddr
                     &&& regions.slot_owners[j].paths_in_pt == regions0.slot_owners[j].paths_in_pt
                 } by {
-                    if j == frame_to_index(meta_to_frame(prev.addr())) {
+                    if j == meta_to_index(prev.addr()) {
                     }
                 }
             }
@@ -970,7 +968,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
         }
 
         if let Some(next) = next_ptr {
-            let ghost next_idx = owner.list_own.slot_index_at(owner.index);
+            let ghost next_idx = meta_to_index(owner.list_own.list[owner.index].paddr);
             let tracked next_points_to = regions.slots.tracked_borrow(next_idx);
             let tracked next_slot_owner = regions.slot_owners.tracked_borrow_mut(next_idx);
             let tracked next_repr_perm = owner.list_own.repr_perms.tracked_borrow_mut(owner.index);
@@ -990,7 +988,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                     &&& regions.slot_owners[j].slot_vaddr == regions0.slot_owners[j].slot_vaddr
                     &&& regions.slot_owners[j].paths_in_pt == regions0.slot_owners[j].paths_in_pt
                 } by {
-                    if j == frame_to_index(meta_to_frame(next.addr())) {
+                    if j == meta_to_index(next.addr()) {
                     }
                 }
             }
@@ -1039,9 +1037,9 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
             let ghost oldl = owner0.list_own;
             let ghost nn = owner0.index as int;
             assert forall|p: int|
-                #![trigger oldl.slot_index_at(p)]
+                #![trigger meta_to_index(oldl.list[p].paddr)]
                 (0 <= p < oldl.list.len() && p != nn) implies ({
-                let i = oldl.slot_index_at(p);
+                let i = meta_to_index(oldl.list[p].paddr);
                 let np = if p < nn {
                     p
                 } else {
@@ -1064,7 +1062,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                 &&& (p == nn + 1 ==> fp.prev == oldl.meta_value_at(regions0, nn).prev)
                 &&& (p != nn + 1 ==> fp.prev == oldl.meta_value_at(regions0, p).prev)
             }) by {
-                let i = oldl.slot_index_at(p);
+                let i = meta_to_index(oldl.list[p].paddr);
                 let np = if p < nn {
                     p
                 } else {
@@ -1109,7 +1107,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
             Tracked(frame_own): Tracked<&mut UniqueFrameOwner<Link<M>>>
     )]
     #[verifier::spinoff_prover]
-    #[verifier::rlimit(120)]
+    #[verifier::rlimit(240)]
     pub fn insert_before(&mut self, mut frame: UniqueFrame<Link<M>>)
         requires
             old(self).wf_region(*old(owner), *old(regions)),
@@ -1150,14 +1148,17 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
             if nn < owner.list_own.list.len() {
                 owner.list_own.relate_region_at_facts(*regions, nn);
             }
-            assert forall|p: int| 0 <= p < owner0.list_own.list.len() implies frame_own.slot_index
-                != owner0.list_own.slot_index_at(p) by {
+            assert forall|p: int|
+                #![trigger owner0.list_own.list[p]]
+                0 <= p < owner0.list_own.list.len() implies frame_own.slot_index != meta_to_index(
+                owner0.list_own.list[p].paddr,
+            ) by {
                 owner0.list_own.relate_region_at_facts(regions0, p);
-                if frame_own.slot_index == owner0.list_own.slot_index_at(p) {
+                if frame_own.slot_index == meta_to_index(owner0.list_own.list[p].paddr) {
                     assert(regions0.slot_owners[frame_own.slot_index].inner_perms.in_list.value()
                         == 0);
-                    assert(regions0.slot_owners[owner0.list_own.slot_index_at(
-                        p,
+                    assert(regions0.slot_owners[meta_to_index(
+                        owner0.list_own.list[p].paddr,
                     )].inner_perms.in_list.value() == owner0.list_own.list_id);
                     assert(owner0.list_own.list_id != 0);
                 }
@@ -1170,7 +1171,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
 
         if let Some(current) = self.current {
             proof_decl!{
-                let ghost idx = frame_to_index(meta_to_frame(current.addr()));
+                let ghost idx = meta_to_index(current.addr());
                 let tracked points_to = regions.slots.tracked_borrow(idx);
                 let tracked slot_owner = regions.slot_owners.tracked_borrow(idx);
                 let tracked repr_perm = owner.list_own.repr_perms.tracked_borrow(owner.index);
@@ -1192,7 +1193,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                 (#[verus_spec(with Tracked(frame_own), Tracked(regions))]
                 frame.meta_mut()).next = Some(current);
 
-                let ghost prev_idx = owner.list_own.slot_index_at(nn - 1);
+                let ghost prev_idx = meta_to_index(owner.list_own.list[nn - 1].paddr);
                 let tracked prev_points_to = regions.slots.tracked_borrow(prev_idx);
                 let tracked prev_slot_owner = regions.slot_owners.tracked_borrow_mut(prev_idx);
                 let tracked prev_repr_perm = owner.list_own.repr_perms.tracked_borrow_mut(nn - 1);
@@ -1204,7 +1205,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                 );
                 prev_meta.next = Some(frame_ptr);
 
-                let ghost current_idx = owner.list_own.slot_index_at(nn);
+                let ghost current_idx = meta_to_index(owner.list_own.list[nn].paddr);
                 let tracked current_points_to = regions.slots.tracked_borrow(current_idx);
                 let tracked current_slot_owner = regions.slot_owners.tracked_borrow_mut(
                     current_idx,
@@ -1218,20 +1219,22 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                 );
                 current_meta.prev = Some(frame_ptr);
                 proof {
-                    assert(frame_own.slot_index != owner0.list_own.slot_index_at(nn));
+                    assert(frame_own.slot_index != meta_to_index(owner0.list_own.list[nn].paddr));
                     let fpn_local = frame_own.meta_value(*regions);
                     assert(fpn_local.prev.unwrap().addr() == owner0.list_own.list[nn - 1].paddr);
-                    assert(fpn_local.prev.unwrap().ptr.addr()
-                        == regions0.slots[owner0.list_own.slot_index_at(nn - 1)].pptr().addr());
+                    assert(fpn_local.prev.unwrap().ptr.addr() == regions0.slots[meta_to_index(
+                        owner0.list_own.list[nn - 1].paddr,
+                    )].pptr().addr());
                     assert(fpn_local.next.unwrap().addr() == owner0.list_own.list[nn].paddr);
-                    assert(fpn_local.next.unwrap().ptr.addr()
-                        == regions0.slots[owner0.list_own.slot_index_at(nn)].pptr().addr());
+                    assert(fpn_local.next.unwrap().ptr.addr() == regions0.slots[meta_to_index(
+                        owner0.list_own.list[nn].paddr,
+                    )].pptr().addr());
                 }
             } else {
                 (#[verus_spec(with Tracked(frame_own), Tracked(regions))]
                 frame.meta_mut()).next = Some(current);
 
-                let ghost current_idx = owner.list_own.slot_index_at(nn);
+                let ghost current_idx = meta_to_index(owner.list_own.list[nn].paddr);
                 let tracked current_points_to = regions.slots.tracked_borrow(current_idx);
                 let tracked current_slot_owner = regions.slot_owners.tracked_borrow_mut(
                     current_idx,
@@ -1251,7 +1254,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                 (#[verus_spec(with Tracked(frame_own), Tracked(regions))]
                 frame.meta_mut()).prev = Some(back);
 
-                let ghost back_idx = owner.list_own.slot_index_at(nn - 1);
+                let ghost back_idx = meta_to_index(owner.list_own.list[nn - 1].paddr);
                 let tracked back_points_to = regions.slots.tracked_borrow(back_idx);
                 let tracked back_slot_owner = regions.slot_owners.tracked_borrow_mut(back_idx);
                 let tracked back_repr_perm = owner.list_own.repr_perms.tracked_borrow_mut(nn - 1);
@@ -1307,9 +1310,9 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
             let ins = frame_own.slot_index;
 
             assert forall|p: int|
-                #![trigger oldl.slot_index_at(p)]
+                #![trigger meta_to_index(oldl.list[p].paddr)]
                 (0 <= p < oldl.list.len()) implies ({
-                let i = oldl.slot_index_at(p);
+                let i = meta_to_index(oldl.list[p].paddr);
                 let np = if p < nn {
                     p
                 } else {
@@ -1340,7 +1343,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                 })
                 &&& (p != nn ==> fp.prev == oldl.meta_value_at(regions0, p).prev)
             }) by {
-                let i = oldl.slot_index_at(p);
+                let i = meta_to_index(oldl.list[p].paddr);
                 let np = if p < nn {
                     p
                 } else {
@@ -1417,36 +1420,37 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> TrackDrop for LinkedList<M> {
         &&& forall|i: int|
             #![trigger s.0.list[i]]
             0 <= i < s.0.list.len() ==> s.1.slot_owners.contains_key(
-                frame_to_index(meta_to_frame(s.0.list[i].paddr)),
+                meta_to_index(s.0.list[i].paddr),
             )
         &&& forall|i: int|
             #![trigger s.0.list[i]]
             0 <= i < s.0.list.len() ==> {
-                let idx = frame_to_index(meta_to_frame(s.0.list[i].paddr));
+                let idx = meta_to_index(s.0.list[i].paddr);
                 s.1.slots.contains_key(idx)
             }
         &&& forall|i: int|
             #![trigger s.0.list[i]]
             0 <= i < s.0.list.len() ==> {
-                let idx = frame_to_index(meta_to_frame(s.0.list[i].paddr));
+                let idx = meta_to_index(s.0.list[i].paddr);
                 s.1.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE
             }
         &&& forall|i: int|
             #![trigger s.0.list[i]]
             0 <= i < s.0.list.len() ==> {
-                let idx = frame_to_index(meta_to_frame(s.0.list[i].paddr));
+                let idx = meta_to_index(s.0.list[i].paddr);
                 s.1.frame_obligations.count(idx) == 0
             }
         &&& forall|i: int|
             #![trigger s.0.list[i]]
             0 <= i < s.0.list.len() ==> {
-                let idx = frame_to_index(meta_to_frame(s.0.list[i].paddr));
+                let idx = meta_to_index(s.0.list[i].paddr);
                 s.1.slot_owners[idx].paths_in_pt.is_empty()
             }
         &&& forall|i: int, j: int|
             #![trigger s.0.list[i], s.0.list[j]]
-            0 <= i < j < s.0.list.len() ==> frame_to_index(meta_to_frame(s.0.list[i].paddr))
-                != frame_to_index(meta_to_frame(s.0.list[j].paddr))
+            0 <= i < j < s.0.list.len() ==> meta_to_index(s.0.list[i].paddr) != meta_to_index(
+                s.0.list[j].paddr,
+            )
         &&& s.0.relate_region(s.1)
         &&& obl.value() == self.list_id
     }
@@ -1461,16 +1465,14 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> TrackDrop for LinkedList<M> {
         &&& forall|i: int|
             #![trigger s0.0.list[i]]
             0 <= i < s0.0.list.len() ==> {
-                let idx = frame_to_index(meta_to_frame(s0.0.list[i].paddr));
+                let idx = meta_to_index(s0.0.list[i].paddr);
                 s1.1.frame_obligations.count(idx) == s0.1.frame_obligations.count(idx)
             }
         &&& forall|idx: int|
             #![trigger s1.1.slot_owners[idx]]
             (forall|i: int|
                 #![trigger s0.0.list[i]]
-                0 <= i < s0.0.list.len() ==> idx != frame_to_index(
-                    meta_to_frame(s0.0.list[i].paddr),
-                )) ==> {
+                0 <= i < s0.0.list.len() ==> idx != meta_to_index(s0.0.list[i].paddr)) ==> {
                 &&& s1.1.frame_obligations.count(idx) == s0.1.frame_obligations.count(idx)
                 &&& s1.1.slot_owners[idx].usage == s0.1.slot_owners[idx].usage
                 &&& s1.1.slot_owners[idx].slot_vaddr == s0.1.slot_owners[idx].slot_vaddr
@@ -1533,7 +1535,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> Drop for LinkedList<M> {
                 forall|j: int|
                     #![trigger original_list[j]]
                     0 <= j < k ==> {
-                        let idx = frame_to_index(meta_to_frame(original_list[j].paddr));
+                        let idx = meta_to_index(original_list[j].paddr);
                         regions.frame_obligations.count(idx) == 0
                     },
                 // slots values inside the original_list.
@@ -1541,8 +1543,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> Drop for LinkedList<M> {
                     #![trigger regions.slot_owners[idx]]
                     (forall|j: int|
                         #![trigger original_list[j]]
-                        0 <= j < n ==> idx != frame_to_index(meta_to_frame(original_list[j].paddr)))
-                        ==> {
+                        0 <= j < n ==> idx != meta_to_index(original_list[j].paddr)) ==> {
                         &&& regions.frame_obligations.count(idx)
                             == original_regions.frame_obligations.count(idx)
                         &&& regions.slot_owners[idx].usage
@@ -1557,7 +1558,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> Drop for LinkedList<M> {
                 forall|j: int|
                     #![trigger original_list[j]]
                     k <= j < n ==> {
-                        let idx = frame_to_index(meta_to_frame(original_list[j].paddr));
+                        let idx = meta_to_index(original_list[j].paddr);
                         &&& regions.frame_obligations.count(idx)
                             == original_regions.frame_obligations.count(idx)
                         &&& regions.slot_owners[idx].paths_in_pt
@@ -1567,17 +1568,18 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> Drop for LinkedList<M> {
                 forall|j: int|
                     #![trigger original_list[j]]
                     k <= j < n ==> regions.slot_owners.contains_key(
-                        frame_to_index(meta_to_frame(original_list[j].paddr)),
+                        meta_to_index(original_list[j].paddr),
                     ),
                 // Distinct slot indices in original list (from drop_requires)
                 forall|i: int, j: int|
                     #![trigger original_list[i], original_list[j]]
-                    0 <= i < j < n ==> frame_to_index(meta_to_frame(original_list[i].paddr))
-                        != frame_to_index(meta_to_frame(original_list[j].paddr)),
+                    0 <= i < j < n ==> meta_to_index(original_list[i].paddr) != meta_to_index(
+                        original_list[j].paddr,
+                    ),
                 forall|j: int|
                     #![trigger original_list[j]]
                     0 <= j < n ==> {
-                        let idx = frame_to_index(meta_to_frame(original_list[j].paddr));
+                        let idx = meta_to_index(original_list[j].paddr);
                         &&& original_regions.slot_owners.contains_key(idx)
                         &&& original_regions.slots.contains_key(idx)
                         &&& original_regions.frame_obligations.count(idx) == 0
@@ -1606,13 +1608,13 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> Drop for LinkedList<M> {
                     assert forall|i: int|
                         #![trigger cursor_own.list_own.list[i]]
                         0 <= i < cursor_own.list_own.list.len() implies ({
-                        let idx = cursor_own.list_own.slot_index_at(i);
+                        let idx = meta_to_index(cursor_own.list_own.list[i].paddr);
                         &&& regions.slot_owners.contains_key(idx)
                         &&& regions.slot_owners[idx] == regions_pre_drop.slot_owners[idx]
                         &&& regions.frame_obligations.count(idx)
                             == regions_pre_drop.frame_obligations.count(idx)
                     }) by {
-                        let idx = cursor_own.list_own.slot_index_at(i);
+                        let idx = meta_to_index(cursor_own.list_own.list[i].paddr);
                         let ghost _trig_k = original_list[k as int];
                         let ghost _trig_ik = original_list[i + k + 1];
                         assert(cursor_own.list_own.list[i] == original_list[i + k + 1]);
@@ -1630,7 +1632,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> Drop for LinkedList<M> {
                         + k + 1] by {};
 
                     assert forall|j: int| #![trigger original_list[j]] 0 <= j < k implies ({
-                        let idx = frame_to_index(meta_to_frame(original_list[j].paddr));
+                        let idx = meta_to_index(original_list[j].paddr);
                         regions.frame_obligations.count(idx) == 0
                     }) by {
                         let ghost _a = original_list[j as int];

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -1272,7 +1272,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
         let list_id = self.list.lazy_get_id();
 
         proof {
-            assert(regions.slots.contains_key(frame_own.slot_index));
+            assert(regions.contains(frame_own.slot_index));
         }
         let tracked frame_outer = regions.slots.tracked_borrow_mut(frame_own.slot_index);
         let tracked mut frame_so = regions.slot_owners.tracked_borrow_mut(frame_own.slot_index);
@@ -1411,14 +1411,12 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> TrackDrop for LinkedList<M> {
         &&& s.1.inv()
         &&& forall|i: int|
             #![trigger s.0.list[i]]
-            0 <= i < s.0.list.len() ==> s.1.slot_owners.contains_key(
-                meta_to_index(s.0.list[i].paddr),
-            )
+            0 <= i < s.0.list.len() ==> s.1.contains(meta_to_index(s.0.list[i].paddr))
         &&& forall|i: int|
             #![trigger s.0.list[i]]
             0 <= i < s.0.list.len() ==> {
                 let idx = meta_to_index(s.0.list[i].paddr);
-                s.1.slots.contains_key(idx)
+                s.1.contains(idx)
             }
         &&& forall|i: int|
             #![trigger s.0.list[i]]
@@ -1559,9 +1557,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> Drop for LinkedList<M> {
                 // Each remaining element's slot is in slot_owners
                 forall|j: int|
                     #![trigger original_list[j]]
-                    k <= j < n ==> regions.slot_owners.contains_key(
-                        meta_to_index(original_list[j].paddr),
-                    ),
+                    k <= j < n ==> regions.contains(meta_to_index(original_list[j].paddr)),
                 // Distinct slot indices in original list (from drop_requires)
                 forall|i: int, j: int|
                     #![trigger original_list[i], original_list[j]]
@@ -1600,7 +1596,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> Drop for LinkedList<M> {
                         #![trigger cursor_own.list_own.list[i]]
                         0 <= i < cursor_own.list_own.list.len() implies ({
                         let idx = meta_to_index(cursor_own.list_own.list[i].paddr);
-                        &&& regions.slot_owners.contains_key(idx)
+                        &&& regions.contains(idx)
                         &&& regions.slot_owners[idx] == regions_pre_drop.slot_owners[idx]
                         &&& regions.frame_obligations.count(idx)
                             == regions_pre_drop.frame_obligations.count(idx)

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -889,12 +889,6 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
 
         proof {
             owner.list_own.relate_region_at_facts(*regions, owner.index);
-            if owner.index > 0 {
-                owner.list_own.relate_region_at_facts(*regions, owner.index - 1);
-            }
-            if owner.index < owner.list_own.list.len() - 1 {
-                owner.list_own.relate_region_at_facts(*regions, owner.index + 1);
-            }
         }
 
         let meta_ptr = current.addr();
@@ -925,6 +919,9 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
         frame.meta()).prev;
 
         if let Some(prev) = prev_ptr {
+            proof {
+                owner0.list_own.relate_region_at_facts(regions0, owner0.index - 1);
+            }
             let ghost prev_idx = meta_to_index(owner.list_own.list[owner.index - 1].paddr);
             let tracked prev_points_to = regions.slots.tracked_borrow(prev_idx);
             let tracked prev_slot_owner = regions.slot_owners.tracked_borrow_mut(prev_idx);
@@ -965,6 +962,9 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
         }
 
         if let Some(next) = next_ptr {
+            proof {
+                owner0.list_own.relate_region_at_facts(regions0, owner0.index + 1);
+            }
             let ghost next_idx = meta_to_index(owner.list_own.list[owner.index].paddr);
             let tracked next_points_to = regions.slots.tracked_borrow(next_idx);
             let tracked next_slot_owner = regions.slot_owners.tracked_borrow_mut(next_idx);

--- a/ostd/src/mm/frame/mod.rs
+++ b/ostd/src/mm/frame/mod.rs
@@ -566,7 +566,7 @@ impl<M> Frame<M> {
             -> obl: Tracked<vstd_extra::drop_tracking::DropObligation<int>>,
         requires
             Self::from_raw_requires_safety(*old(regions), paddr),
-            old(regions).slots.contains_key(frame_to_index(paddr)),
+            old(regions).contains(frame_to_index(paddr)),
             // Borrow-protocol safety: the slot must be alive (not torn
             // down). The `unsafe` keyword still gates whether the produced
             // Frame corresponds to a real prior `into_raw`; this condition
@@ -725,17 +725,16 @@ impl<M: ?Sized> Drop for Frame<M> {
             // For `idx`, `slot_own.inv()` and the perm/slot agreement at
             // `idx` are already asserted above.
             assert forall|i: int|
-                0 <= i < max_meta_slots() <==> #[trigger] regions.slot_owners.contains_key(i) by {}
+                0 <= i < max_meta_slots() <==> #[trigger] regions.contains(i) by {}
 
-            assert forall|i: int| #[trigger] regions.slots.contains_key(i) implies i
-                < max_meta_slots() by {
+            assert forall|i: int| #[trigger] regions.contains(i) implies i < max_meta_slots() by {
                 if i == idx {
-                    assert(regions.slot_owners.contains_key(idx));
+                    assert(regions.contains(idx));
                 }
             }
 
-            assert forall|i: int| #[trigger] regions.slots.contains_key(i) implies ({
-                &&& regions.slot_owners.contains_key(i)
+            assert forall|i: int| #[trigger] regions.contains(i) implies ({
+                &&& regions.contains(i)
                 &&& regions.slot_owners[i].inv()
                 &&& regions.slots[i].is_init()
                 &&& regions.slots[i].addr() == index_to_meta(i)
@@ -751,7 +750,7 @@ impl<M: ?Sized> Drop for Frame<M> {
             }
 
             assert forall|i: int| #[trigger]
-                regions.slot_owners.contains_key(i) implies regions.slot_owners[i].inv() by {
+                regions.contains(i) implies regions.slot_owners[i].inv() by {
                 if i == idx {
                     assert(slot_own.inv());
                 }
@@ -842,7 +841,7 @@ impl TryFrom<Frame<dyn AnyFrameMeta>> for UFrame {
         Tracked(regions): Tracked<&mut MetaRegionOwners>,
     requires
         old(regions).inv(),
-        old(regions).slots.contains_key(frame_to_index(paddr)),
+        old(regions).contains(frame_to_index(paddr)),
         valid_frame_paddr(paddr),
         // The caller holds a reference, so rc > 0, and the slot must be live
         // (not the UNUSED sentinel). Saturation is caught at runtime by

--- a/ostd/src/mm/frame/segment.rs
+++ b/ostd/src/mm/frame/segment.rs
@@ -103,7 +103,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> RCClone for Segment<M> {
             #![trigger frame_to_index(pa)]
             (self.start_paddr() <= pa < self.end_paddr() && pa % PAGE_SIZE == 0) ==> {
                 let idx = frame_to_index(pa);
-                &&& perm.slots.contains_key(idx)
+                &&& perm.contains(idx)
                 &&& valid_frame_paddr(pa)
                 &&& perm.slot_owners[idx].inner_perms.ref_count.value() > 0
                 &&& perm.slot_owners[idx].inner_perms.ref_count.value() + 1
@@ -146,7 +146,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> RCClone for Segment<M> {
                     #![trigger frame_to_index(pa)]
                     (paddr <= pa < self.range.end && pa % PAGE_SIZE == 0) ==> {
                         let idx = frame_to_index(pa);
-                        &&& perm.slots.contains_key(idx)
+                        &&& perm.contains(idx)
                         &&& valid_frame_paddr(pa)
                         &&& perm.slot_owners[idx].inner_perms.ref_count.value() > 0
                         &&& perm.slot_owners[idx].inner_perms.ref_count.value() + 1
@@ -239,7 +239,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                 &&& forall|paddr: Paddr|
                     #![trigger frame_to_index(paddr)]
                     (range.start <= paddr < range.end && paddr % PAGE_SIZE == 0)
-                        ==> final(regions).slots.contains_key(frame_to_index(paddr))
+                        ==> final(regions).contains(frame_to_index(paddr))
                 &&& range.start < range.end <= MAX_PADDR
             },
     )]
@@ -357,7 +357,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
 
                             assert(addrs[k] == p);
                             assert(index_to_meta(idx_k) == frame_to_meta(p));
-                            assert(regions.slots.contains_key(idx_k));
+                            assert(regions.contains(idx_k));
                         }
                         proof_decl! {
                             let tracked from_raw_obl: vstd_extra::drop_tracking::DropObligation<int>;
@@ -439,7 +439,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
             assert forall|addr: usize|
                 #![trigger frame_to_index(addr)]
                 range.start <= addr < range.end && addr % PAGE_SIZE == 0 implies {
-                regions.slots.contains_key(frame_to_index(addr))
+                regions.contains(frame_to_index(addr))
             } by {
                 let j = (addr - range.start) / PAGE_SIZE as int;
                 assert(addrs[j as int] == addr);
@@ -1306,9 +1306,8 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage>> Segment<M> {
                     },
                 forall|j: int|
                     #![trigger frame_idx_at(self.range.start, j)]
-                    k <= j < n ==> regions.slot_owners.contains_key(
-                        frame_idx_at(self.range.start, j),
-                    ) && regions.slot_owners[frame_idx_at(self.range.start, j)] == old(
+                    k <= j < n ==> regions.contains(frame_idx_at(self.range.start, j))
+                        && regions.slot_owners[frame_idx_at(self.range.start, j)] == old(
                         regions,
                     ).slot_owners[frame_idx_at(self.range.start, j)],
                 regions.slot_owners.dom() == old(regions).slot_owners.dom(),
@@ -1403,7 +1402,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage>> Segment<M> {
                     #![trigger frame_to_index(pa)]
                     (paddr <= pa < self.range.end && pa % PAGE_SIZE == 0) ==> {
                         let idx = frame_to_index(pa);
-                        &&& perm.slots.contains_key(idx)
+                        &&& perm.contains(idx)
                         &&& valid_frame_paddr(pa)
                         &&& perm.slot_owners[idx].inner_perms.ref_count.value() > 0
                         &&& perm.slot_owners[idx].inner_perms.ref_count.value() + 1

--- a/ostd/src/mm/frame/segment.rs
+++ b/ostd/src/mm/frame/segment.rs
@@ -289,8 +289,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                     #![trigger addrs[j]]
                     0 <= j < addrs.len() ==> {
                         let idx = frame_to_index(addrs[j]);
-                        &&& regions.slots.contains_key(idx)
-                        &&& regions.slot_owners.contains_key(idx)
+                        &&& regions.contains(idx)
                         &&& regions.slot_owners[idx].slot_vaddr == index_to_meta(idx)
                         &&& regions.slot_owners[idx].inner_perms.ref_count.value() > 0
                         &&& regions.slot_owners[idx].inner_perms.ref_count.value()
@@ -338,8 +337,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                                 #![trigger addrs[j]]
                                 k <= j < addrs.len() ==> {
                                     let idx = frame_to_index(addrs[j]);
-                                    &&& regions.slots.contains_key(idx)
-                                    &&& regions.slot_owners.contains_key(idx)
+                                    &&& regions.contains(idx)
                                     &&& regions.slot_owners[idx].slot_vaddr == index_to_meta(idx)
                                     &&& regions.slot_owners[idx].inner_perms.ref_count.value() > 0
                                     &&& regions.slot_owners[idx].inner_perms.ref_count.value()
@@ -374,8 +372,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                                 #![trigger addrs[j]]
                                 (k + 1) <= j < addrs.len() implies ({
                                 let idx = frame_to_index(addrs[j]);
-                                &&& regions.slots.contains_key(idx)
-                                &&& regions.slot_owners.contains_key(idx)
+                                &&& regions.contains(idx)
                                 &&& regions.slot_owners[idx] == reclaim_pre.slot_owners[idx]
                             }) by {
                                 assert(addrs[j] != p);
@@ -452,8 +449,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                 0 <= i < crate::specs::mm::frame::segment::seg_nframes(segment.range) implies {
                 let idx = frame_to_index((segment.range.start + i * PAGE_SIZE) as usize);
                 &&& regions.frame_obligations.count(idx) >= 1
-                &&& regions.slot_owners.contains_key(idx)
-                &&& regions.slots.contains_key(idx)
+                &&& regions.contains(idx)
                 &&& regions.slot_owners[idx].slot_vaddr == index_to_meta(idx)
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value() > 0
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value()
@@ -616,8 +612,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                 0 <= i < crate::specs::mm::frame::segment::seg_nframes(seg1.range) implies {
                 let idx = frame_to_index((seg1.range.start + i * PAGE_SIZE) as usize);
                 &&& regions.frame_obligations.count(idx) >= 1
-                &&& regions.slot_owners.contains_key(idx)
-                &&& regions.slots.contains_key(idx)
+                &&& regions.contains(idx)
                 &&& regions.slot_owners[idx].slot_vaddr == index_to_meta(idx)
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value() > 0
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value()
@@ -632,8 +627,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                 0 <= i < crate::specs::mm::frame::segment::seg_nframes(seg2.range) implies {
                 let idx = frame_to_index((seg2.range.start + i * PAGE_SIZE) as usize);
                 &&& regions.frame_obligations.count(idx) >= 1
-                &&& regions.slot_owners.contains_key(idx)
-                &&& regions.slots.contains_key(idx)
+                &&& regions.contains(idx)
                 &&& regions.slot_owners[idx].slot_vaddr == index_to_meta(idx)
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value() > 0
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value()
@@ -1091,8 +1085,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> SegmentIterator<'a, 
                     ) implies {
                     let idx = frame_to_index((new_segment.range.start + i * PAGE_SIZE) as usize);
                     &&& (**regions_ref).frame_obligations.count(idx) >= 1
-                    &&& (**regions_ref).slot_owners.contains_key(idx)
-                    &&& (**regions_ref).slots.contains_key(idx)
+                    &&& (**regions_ref).contains(idx)
                     &&& (**regions_ref).slot_owners[idx].slot_vaddr == index_to_meta(idx)
                     &&& (**regions_ref).slot_owners[idx].inner_perms.ref_count.value() > 0
                     &&& (**regions_ref).slot_owners[idx].inner_perms.ref_count.value()
@@ -1308,8 +1301,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage>> Segment<M> {
                     #![trigger frame_to_index((self.range.start + j * PAGE_SIZE) as usize)]
                     k <= j < n ==> {
                         let idx = frame_to_index((self.range.start + j * PAGE_SIZE) as usize);
-                        &&& regions.slot_owners.contains_key(idx)
-                        &&& regions.slots.contains_key(idx)
+                        &&& regions.contains(idx)
                         &&& regions.slot_owners[idx] == old(regions).slot_owners[idx]
                     },
                 forall|j: int|
@@ -1360,8 +1352,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage>> Segment<M> {
                     #![trigger frame_to_index((self.range.start + j * PAGE_SIZE) as usize)]
                     (k + 1) <= j < n implies {
                     let idx = frame_to_index((self.range.start + j * PAGE_SIZE) as usize);
-                    &&& regions.slot_owners.contains_key(idx)
-                    &&& regions.slots.contains_key(idx)
+                    &&& regions.contains(idx)
                     &&& regions.slot_owners[idx] == old(regions).slot_owners[idx]
                 } by {
                     self.relate_regions_distinct(*old(regions), k, j);

--- a/ostd/src/mm/frame/unique.rs
+++ b/ostd/src/mm/frame/unique.rs
@@ -9,7 +9,7 @@ use vstd_extra::ownership::*;
 
 use crate::specs::arch::*;
 use crate::specs::mm::frame::{
-    mapping::{frame_to_index, group_page_meta, index_to_meta, max_meta_slots},
+    mapping::{frame_to_index, group_page_meta, index_to_meta, max_meta_slots, meta_to_index},
     meta_owners::{MetaSlotStorage, borrow_meta, borrow_meta_mut},
     meta_region_owners::MetaRegionOwners,
     unique::UniqueFrameOwner,
@@ -217,7 +217,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrame<M> {
         let tracked mut new_owner = UniqueFrameOwner::<M1>::tracked_from_unused_owner(
             meta_own_in,
             repr_perm,
-            frame_to_index(meta_to_frame(self.ptr.addr())),
+            meta_to_index(self.ptr.addr()),
         );
 
         // SAFETY: The metadata is initialized with type `M1`.
@@ -639,7 +639,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Frame<M> {
             final(regions).slot_owners.dom() == old(regions).slot_owners.dom(),
     )]
     pub fn from_unique(unique: UniqueFrame<M>) -> Self {
-        let ghost idx = frame_to_index(meta_to_frame(unique.ptr.addr()));
+        let ghost idx = meta_to_index(unique.ptr.addr());
         proof {
             broadcast use group_page_meta;
 
@@ -682,7 +682,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrame<M> {
             final(regions).slot_owners.dom() == old(regions).slot_owners.dom(),
     )]
     pub fn try_from_shared(frame: Frame<M>) -> Result<Self, Frame<M>> {
-        let ghost idx = frame_to_index(meta_to_frame(frame.ptr.addr()));
+        let ghost idx = meta_to_index(frame.ptr.addr());
         proof {
             broadcast use group_page_meta;
 

--- a/ostd/src/mm/frame/unique.rs
+++ b/ostd/src/mm/frame/unique.rs
@@ -69,7 +69,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrame<M> {
             Tracked(repr_perm_in): Tracked<M::ReprPerm>,
                 -> owner: Tracked<Option<UniqueFrameOwner<M>>>,
         requires
-            old(regions).slot_owners.contains_key(frame_to_index(paddr)),
+            old(regions).contains(frame_to_index(paddr)),
             old(regions).slot_owners[frame_to_index(paddr)].usage is Unused,
             old(regions).inv(),
             <M as OwnerOf>::wf(metadata, meta_own_in),
@@ -183,7 +183,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrame<M> {
         let slot = self.slot();
 
         assert(slot_own.inv()) by {
-            assert(old(regions).slot_owners.contains_key(idx));
+            assert(old(regions).contains(idx));
             assert(old(regions).slot_owners[idx].inv());
         }
 
@@ -359,7 +359,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> 
     )]
     pub fn start_paddr(&self) -> Paddr {
         proof {
-            assert(regions.slot_owners.contains_key(owner.slot_index));
+            assert(regions.contains(owner.slot_index));
         }
         let tracked outer = regions.slots.tracked_borrow(owner.slot_index);
         #[verus_spec(with Tracked(outer))]
@@ -432,7 +432,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> 
     }
 
     pub open spec fn into_raw_requires(self, regions: MetaRegionOwners) -> bool {
-        &&& regions.slot_owners.contains_key(
+        &&& regions.contains(
             self.index(),
         )
         // `self` is a live value with a pending Drop; forgetting it (`MD::new`)
@@ -499,7 +499,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> 
         requires
             valid_frame_paddr(paddr),
             old(regions).inv(),
-            old(regions).slot_owners.contains_key(frame_to_index(paddr)),
+            old(regions).contains(frame_to_index(paddr)),
             old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() == REF_COUNT_UNIQUE,
         ensures
             res.0.ptr.addr() == frame_to_meta(paddr),

--- a/ostd/src/mm/kspace/kvirt_area.rs
+++ b/ostd/src/mm/kspace/kvirt_area.rs
@@ -523,7 +523,7 @@ impl KVirtArea {
                 let item_i = MappedItem::Tracked(frames[i], prop);
                 let pa_i = KernelPtConfig::item_into_raw_spec(item_i).0;
                 let idx_i = frame_to_index(pa_i);
-                assert(regions.slot_owners.contains_key(idx_i));
+                assert(regions.contains(idx_i));
             };
         }
 
@@ -731,7 +731,7 @@ impl KVirtArea {
             #![trigger crate::specs::mm::frame::mapping::frame_to_index(pa)]
             pa_range.start <= pa < pa_range.end && pa % PAGE_SIZE == 0 ==> {
                 let idx = crate::specs::mm::frame::mapping::frame_to_index(pa);
-                &&& regions.slots.contains_key(idx)
+                &&& regions.contains(idx)
                 &&& regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
             }
     }
@@ -835,7 +835,7 @@ impl KVirtArea {
                     &&& regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
                 } by {
                     let idx = crate::specs::mm::frame::mapping::frame_to_index(pa);
-                    assert(regions.slot_owners.contains_key(idx));
+                    assert(regions.contains(idx));
                 };
             }
 

--- a/ostd/src/mm/kspace/kvirt_area.rs
+++ b/ostd/src/mm/kspace/kvirt_area.rs
@@ -831,8 +831,7 @@ impl KVirtArea {
                     #![trigger crate::specs::mm::frame::mapping::frame_to_index(pa)]
                     pa_range.start <= pa < pa_range.end && pa % PAGE_SIZE == 0 implies {
                     let idx = crate::specs::mm::frame::mapping::frame_to_index(pa);
-                    &&& regions.slot_owners.contains_key(idx)
-                    &&& regions.slots.contains_key(idx)
+                    &&& regions.contains(idx)
                     &&& regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
                 } by {
                     let idx = crate::specs::mm::frame::mapping::frame_to_index(pa);
@@ -882,8 +881,7 @@ impl KVirtArea {
                         #![trigger crate::specs::mm::frame::mapping::frame_to_index(pa)]
                         pa_range.start <= pa < pa_range.end && pa % PAGE_SIZE == 0 ==> {
                             let idx = crate::specs::mm::frame::mapping::frame_to_index(pa);
-                            &&& regions.slot_owners.contains_key(idx)
-                            &&& regions.slots.contains_key(idx)
+                            &&& regions.contains(idx)
                             &&& regions.slot_owners[idx].inner_perms.ref_count.value()
                                 != REF_COUNT_UNUSED
                         },

--- a/ostd/src/mm/kspace/mod.rs
+++ b/ostd/src/mm/kspace/mod.rs
@@ -371,12 +371,11 @@ unsafe impl PageTableConfig for KernelPtConfig {
         new_regions: MetaRegionOwners,
         res: Self::Item,
     ) {
-        use crate::mm::frame::meta::mapping::meta_to_frame;
-        use crate::specs::mm::frame::mapping::frame_to_index;
+        use crate::specs::mm::frame::mapping::meta_to_index;
 
         match item {
             MappedItem::Tracked(frame, _) => {
-                let frame_idx = frame_to_index(meta_to_frame(frame.ptr.addr()));
+                let frame_idx = meta_to_index(frame.ptr.addr());
                 assert(<MappedItem as RCClone>::clone_ensures(item, old_regions, new_regions, res));
             },
             MappedItem::Untracked(_, _, _) => {},

--- a/ostd/src/mm/page_table/cursor/locking.rs
+++ b/ostd/src/mm/page_table/cursor/locking.rs
@@ -184,8 +184,7 @@ pub fn lock_range<'rcu, C: PageTableConfig, A: InAtomicMode>(
     let ghost cont_slot_idx = cont.entry_own.tracked_borrow_node().slot_index;
     proof {
         assert(cont.entry_own.metaregion_sound(*regions));
-        assert(regions.slots.contains_key(cont_slot_idx));
-        assert(regions.slot_owners.contains_key(cont_slot_idx));
+        assert(regions.contains(cont_slot_idx));
     }
     let tracked cont_node_owner = cont.entry_own.tracked_borrow_node();
     #[verus_spec(with Tracked(cont_node_owner), Tracked(&*regions))]

--- a/ostd/src/mm/page_table/cursor/locking.rs
+++ b/ostd/src/mm/page_table/cursor/locking.rs
@@ -68,14 +68,14 @@ pub assume_specification<Idx: Clone>[ Range::<Idx>::clone ](range: &Range<Idx>) 
         // nodes (bumping some parent ref counts), but ref counts stay within
         // safe bounds during a single lock_range call.
         (forall |i: int| #![trigger old(regions).slot_owners[i]]
-            old(regions).slot_owners.contains_key(i)
+            old(regions).contains(i)
             && old(regions).slot_owners[i].inner_perms.ref_count.value()
                 != REF_COUNT_UNUSED
             ==> old(regions).slot_owners[i].inner_perms.ref_count.value() + 1
                 < REF_COUNT_MAX)
         ==>
         (forall |i: int| #![trigger final(regions).slot_owners[i]]
-            final(regions).slot_owners.contains_key(i)
+            final(regions).contains(i)
             && final(regions).slot_owners[i].inner_perms.ref_count.value()
                 != REF_COUNT_UNUSED
             ==> final(regions).slot_owners[i].inner_perms.ref_count.value() + 1
@@ -92,7 +92,7 @@ pub assume_specification<Idx: Clone>[ Range::<Idx>::clone ](range: &Range<Idx>) 
         // `try_traverse_and_lock_subtree_root`'s in-use preservation with
         // `dfs_acquire_lock`'s `slot_owners ==` preservation.
         forall|idx: int| #![trigger final(regions).slot_owners[idx]]
-            old(regions).slot_owners.contains_key(idx)
+            old(regions).contains(idx)
             && old(regions).slot_owners[idx].inner_perms.ref_count.value()
                 != REF_COUNT_UNUSED
             ==> final(regions).slot_owners[idx].inner_perms.ref_count.value()
@@ -223,15 +223,13 @@ pub fn lock_range<'rcu, C: PageTableConfig, A: InAtomicMode>(
             == pt_own.0.value().path);
         assume((forall|i: int|
             #![trigger old(regions).slot_owners[i]]
-            old(regions).slot_owners.contains_key(i) && old(
-                regions,
-            ).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED ==> old(
-                regions,
-            ).slot_owners[i].inner_perms.ref_count.value() + 1 < REF_COUNT_MAX) ==> (forall|i: int|
+            old(regions).contains(i) && old(regions).slot_owners[i].inner_perms.ref_count.value()
+                != REF_COUNT_UNUSED ==> old(regions).slot_owners[i].inner_perms.ref_count.value()
+                + 1 < REF_COUNT_MAX) ==> (forall|i: int|
             #![trigger regions.slot_owners[i]]
-            regions.slot_owners.contains_key(i)
-                && regions.slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-                ==> regions.slot_owners[i].inner_perms.ref_count.value() + 1 < REF_COUNT_MAX));
+            regions.contains(i) && regions.slot_owners[i].inner_perms.ref_count.value()
+                != REF_COUNT_UNUSED ==> regions.slot_owners[i].inner_perms.ref_count.value() + 1
+                < REF_COUNT_MAX));
     }
     res
 }
@@ -315,7 +313,7 @@ pub fn unlock_range<C: PageTableConfig, A: InAtomicMode>(cursor: &mut Cursor<'_,
         // usage are exactly preserved — locking only allocates fresh PT
         // nodes from UNUSED slots; it never mutates a slot already in use.
         forall|idx: int| #![trigger final(regions).slot_owners[idx]]
-            old(regions).slot_owners.contains_key(idx)
+            old(regions).contains(idx)
             && old(regions).slot_owners[idx].inner_perms.ref_count.value()
                 != REF_COUNT_UNUSED
             ==> final(regions).slot_owners[idx].inner_perms.ref_count.value()

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -41,13 +41,14 @@ use vstd_extra::panic::*;
 use vstd_extra::{assert, assert_eq};
 
 use crate::mm::frame::meta::{
-    META_SLOT_SIZE, REF_COUNT_MAX, REF_COUNT_UNIQUE, REF_COUNT_UNUSED,
-    mapping::{frame_to_meta, meta_to_frame},
+    META_SLOT_SIZE, REF_COUNT_MAX, REF_COUNT_UNIQUE, REF_COUNT_UNUSED, mapping::frame_to_meta,
 };
 use crate::mm::frame::{AnyFrameMeta, Frame};
 use crate::mm::page_table::*;
 use crate::mm::{MAX_PADDR, Paddr, Vaddr, page_size};
-use crate::specs::mm::frame::mapping::{frame_to_index, index_to_meta, max_meta_slots};
+use crate::specs::mm::frame::mapping::{
+    frame_to_index, index_to_meta, max_meta_slots, meta_to_index,
+};
 use crate::specs::mm::frame::meta_owners::{MetaSlotOwner, PageUsage, is_mmio_paddr};
 use crate::specs::mm::frame::meta_region_owners::MetaRegionOwners;
 use crate::specs::mm::page_table::cursor::page_size_lemmas::*;
@@ -2026,7 +2027,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
         let tracked child = parent_continuation.tracked_take_child();
         let tracked parent_own = parent_continuation.entry_own.tracked_take_node();
 
-        let ghost index = frame_to_index(meta_to_frame(parent_own.meta_vaddr()));
+        let ghost index = meta_to_index(parent_own.meta_vaddr());
 
         let ghost ptei = AbstractVaddr::from_vaddr(self.va).index[owner.level - 1];
 
@@ -4353,11 +4354,11 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         // per-frame ledger; mint the entry that `MD::new`
                         // consumes (net-zero), mirroring `into_pte`.
                         let tracked redeem_obl = regions.tracked_mint_frame_obligation(
-                            frame_to_index(meta_to_frame(pt.ptr.addr())),
+                            meta_to_index(pt.ptr.addr()),
                         );
                         regions.tracked_redeem_frame_obligation(redeem_obl);
                         let tracked md_obl = DropObligation::tracked_mint(
-                            frame_to_index(meta_to_frame(pt.ptr.addr())),
+                            meta_to_index(pt.ptr.addr()),
                         );
                     }
                     proof_with!(Tracked(md_obl));

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -168,7 +168,7 @@ fn path_slot_as_mut<'a, 'rcu, C: PageTableConfig>(
 ///
 /// ## Fix path
 /// The proper fix is:
-///   1. Add `ensures old(owner).is_node() ==> regions.slots.contains_key(...)` to
+///   1. Add `ensures old(owner).is_node() ==> regions.contains(...)` to
 ///      `Entry::replace` (derivable from `Child::from_pte`'s `from_pte_regions_spec`).
 ///   2. Replace this call with `pt.into_raw()` + `PageTableNodeRef::borrow_paddr()`.
 /// A fragment of a page table that can be taken out of the page table.
@@ -309,7 +309,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
             // For *in-use* slots, refcount value and usage are exactly
             // preserved across `Cursor::new` (= `lock_range`).
             forall|idx: int| #![trigger final(regions).slot_owners[idx]]
-                old(regions).slot_owners.contains_key(idx)
+                old(regions).contains(idx)
                 && old(regions).slot_owners[idx].inner_perms.ref_count.value()
                     != REF_COUNT_UNUSED
                 ==> final(regions).slot_owners[idx].inner_perms.ref_count.value()
@@ -337,14 +337,14 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                 CursorMut::<C, A>::item_not_mapped(item, *final(regions)),
             // Non-saturation preservation.
             (forall |i: int| #![trigger old(regions).slot_owners[i]]
-                old(regions).slot_owners.contains_key(i)
+                old(regions).contains(i)
                 && old(regions).slot_owners[i].inner_perms.ref_count.value()
                     != REF_COUNT_UNUSED
                 ==> old(regions).slot_owners[i].inner_perms.ref_count.value() + 1
                     < REF_COUNT_MAX)
             ==>
             (forall |i: int| #![trigger final(regions).slot_owners[i]]
-                final(regions).slot_owners.contains_key(i)
+                final(regions).contains(i)
                 && final(regions).slot_owners[i].inner_perms.ref_count.value()
                     != REF_COUNT_UNUSED
                 ==> final(regions).slot_owners[i].inner_perms.ref_count.value() + 1
@@ -472,6 +472,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
 
                 old(self).query_panic_condition(*old(owner), *old(regions)) ==> may_panic(),
                 self.invariants(*owner, *regions, *guards),
+                old(regions).inv(),
                 owner.in_locked_range(),
                 self.va == initial_va,
                 initial_va == old(self).va,
@@ -491,14 +492,14 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                 // single `clone_item` is the last action before `return`).
                 forall|i: int|
                     #![trigger regions.slot_owners[i]]
-                    old(regions).slot_owners.contains_key(i)
+                    old(regions).contains(i)
                         ==> regions.slot_owners[i].inner_perms.ref_count.value() == old(
                         regions,
                     ).slot_owners[i].inner_perms.ref_count.value(),
                 regions.slot_owners.dom() == old(regions).slot_owners.dom(),
                 forall|idx: int|
                     #![trigger regions.slot_owners[idx]]
-                    old(regions).slot_owners.contains_key(idx) ==> {
+                    old(regions).contains(idx) ==> {
                         &&& regions.slot_owners[idx].paths_in_pt == old(
                             regions,
                         ).slot_owners[idx].paths_in_pt
@@ -650,6 +651,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
 
                     proof {
                         let idx = frame_to_index(pa);
+                        old(regions).inv_implies_correct_addr(pa);
                         assert(regions.slot_owners.contains_key(idx));
                         assert(owner.cur_entry_owner().inv_base());
                         if C::tracked(item)
@@ -742,7 +744,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                             #![trigger frame_to_index((pa + j * PAGE_SIZE) as usize)]
                             0 < j < nr_pages implies {
                             let sub_idx = frame_to_index((pa + j * PAGE_SIZE) as usize);
-                            &&& regions.slots.contains_key(sub_idx)
+                            &&& regions.contains(sub_idx)
                             &&& regions.slot_owners[sub_idx].usage !is MMIO ==> {
                                 &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value()
                                     != REF_COUNT_UNUSED
@@ -750,8 +752,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                             }
                         } by {
                             let sub_idx = frame_to_index((pa + j * PAGE_SIZE) as usize);
-                            assert(old(regions).slots.contains_key(sub_idx));
-                            assert(regions.slots.contains_key(sub_idx));
+                            assert(old(regions).contains(sub_idx));
+                            assert(regions.contains(sub_idx));
                         }
                     }
                 };
@@ -2040,7 +2042,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
             assert(regions.inv());
             assert(cont0.entry_own.is_node());
             assert(cont0.entry_own.metaregion_sound(*regions));
-            assert(regions.slots.contains_key(parent_own.slot_index));
+            assert(regions.contains(parent_own.slot_index));
         }
         let res = {
             let tracked child_value = child.tracked_borrow_value();
@@ -2273,7 +2275,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 ==> final(regions).slot_owners[idx].paths_in_pt
                         == old(regions).slot_owners[idx].paths_in_pt,
             forall|idx: int| #![trigger final(regions).slot_owners[idx]]
-                old(regions).slot_owners.contains_key(idx)
+                old(regions).contains(idx)
                 && old(regions).slot_owners[idx].inner_perms.ref_count.value()
                     != REF_COUNT_UNUSED
                 ==> final(regions).slot_owners[idx].inner_perms.ref_count.value()
@@ -2916,7 +2918,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         ) implies #[trigger] Self::item_slot_in_regions(item, *regions) by {
                         assert(Self::item_slot_in_regions(item, regions0));
                         let idx = frame_to_index(C::item_into_raw(item).0);
-                        assert(regions_after_ref.slots.contains_key(idx));
+                        assert(regions_after_ref.contains(idx));
                         assert(Self::item_slot_in_regions(item, regions_after_ref));
                     };
 
@@ -2981,7 +2983,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         ) implies #[trigger] Self::item_slot_in_regions(item, *regions) by {
                         assert(Self::item_slot_in_regions(item, regions0));
                         let idx = frame_to_index(C::item_into_raw(item).0);
-                        assert(regions_after_ref.slots.contains_key(idx));
+                        assert(regions_after_ref.contains(idx));
                         assert(Self::item_slot_in_regions(item, regions_after_ref));
                     };
                     assert forall|idx: int|
@@ -3072,7 +3074,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             res is Err && res.unwrap_err() is StrayPageTable ==> C::item_into_raw(item).1 > 1,
             // For non-UNUSED indices other than the mapped frame, paths_in_pt is preserved.
             forall|idx: int| #![trigger final(regions).slot_owners[idx].paths_in_pt]
-                old(regions).slot_owners.contains_key(idx) &&
+                old(regions).contains(idx) &&
                 idx != frame_to_index(C::item_into_raw(item).0) &&
                 old(regions).slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED ==>
                 final(regions).slot_owners[idx].paths_in_pt == old(regions).slot_owners[idx].paths_in_pt,
@@ -3081,7 +3083,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             // any slot already in use stays in use; replace_cur_entry replaces the
             // current entry without dropping refcounts of unrelated slots.)
             forall|idx: int| #![trigger final(regions).slot_owners[idx].inner_perms.ref_count.value()]
-                old(regions).slot_owners.contains_key(idx) &&
+                old(regions).contains(idx) &&
                 old(regions).slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED ==>
                 final(regions).slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED,
             // ref_count is preserved exactly at non-mapped, non-UNUSED indices.
@@ -3091,7 +3093,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             // [mod.rs:3380]). Lets callers re-derive `item_slot_in_regions`
             // for unrelated paddrs.
             forall|idx: int| #![trigger final(regions).slot_owners[idx].inner_perms.ref_count.value()]
-                old(regions).slot_owners.contains_key(idx) &&
+                old(regions).contains(idx) &&
                 idx != frame_to_index(C::item_into_raw(item).0) &&
                 old(regions).slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED ==>
                 final(regions).slot_owners[idx].inner_perms.ref_count.value()
@@ -3100,7 +3102,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             // already > 0). Together with `slots.contains_key` monotonicity,
             // gives `item_slot_in_regions(item, *final(regions))` post-map.
             (C::tracked(item)
-                && old(regions).slot_owners.contains_key(frame_to_index(C::item_into_raw(item).0))
+                && old(regions).contains(frame_to_index(C::item_into_raw(item).0))
                 && old(regions).slot_owners[
                     frame_to_index(C::item_into_raw(item).0)].inner_perms.ref_count.value() > 0)
                 ==>
@@ -3119,8 +3121,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                     frame_to_index(C::item_into_raw(item).0)].inner_perms.ref_count.value()
                     <= REF_COUNT_MAX,
             // `regions.slots` is monotonic — slot existence is preserved through map.
-            forall|idx: int| #![trigger final(regions).slots.contains_key(idx)]
-                old(regions).slots.contains_key(idx) ==> final(regions).slots.contains_key(idx),
+            forall|idx: int| #![trigger final(regions).contains(idx)]
+                old(regions).contains(idx) ==> final(regions).contains(idx),
             final(self).0.guard_level == old(self).0.guard_level,
             final(self).0.barrier_va == old(self).0.barrier_va,
     )]
@@ -3210,7 +3212,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             pa_slot_install.paths_in_pt = pa_slot_install.paths_in_pt.insert(new_frame_path);
             regions.slot_owners.tracked_insert(pa_idx_install, pa_slot_install);
 
-            assert(regions_before_new_child.slots.contains_key(pa_idx_install)) by {
+            assert(regions_before_new_child.contains(pa_idx_install)) by {
                 assert(Self::item_slot_in_regions(item, regions_before_new_child));
             };
             assert(regions_before_new_child.slot_owners[pa_idx_install].usage !is PageTable) by {
@@ -3342,19 +3344,19 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             };
             let ghost pa_idx2 = frame_to_index(C::item_into_raw(item).0);
             assert forall|idx: int|
-                old(regions).slot_owners.contains_key(idx) && idx != pa_idx2 && old(
+                old(regions).contains(idx) && idx != pa_idx2 && old(
                     regions,
                 ).slot_owners[idx].inner_perms.ref_count.value()
                     != REF_COUNT_UNUSED implies #[trigger] regions.slot_owners[idx].paths_in_pt
                 == old(regions).slot_owners[idx].paths_in_pt by {
                 assert(regions_after_new_child.slot_owners == regions_before_new_child.slot_owners);
             };
-            assert(C::tracked(item) && old(regions).slot_owners.contains_key(pa_idx2) && old(
+            assert(C::tracked(item) && old(regions).contains(pa_idx2) && old(
                 regions,
             ).slot_owners[pa_idx2].inner_perms.ref_count.value() > 0 ==> {
                 &&& regions.slot_owners[pa_idx2].inner_perms.ref_count.value() > 0
             }) by {
-                if C::tracked(item) && old(regions).slot_owners.contains_key(pa_idx2) && old(
+                if C::tracked(item) && old(regions).contains(pa_idx2) && old(
                     regions,
                 ).slot_owners[pa_idx2].inner_perms.ref_count.value() > 0 {
                     assert(regions_before_new_child.slot_owners[pa_idx2].inner_perms.ref_count.value()
@@ -3368,19 +3370,17 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
 
             assert(regions_before_new_child.slots == regions_after_new_child.slots);
             assert(forall|k: int|
-                #![trigger regions_after_replace.slots.contains_key(k)]
-                regions_after_new_child.slots.contains_key(k)
-                    ==> regions_after_replace.slots.contains_key(k));
+                #![trigger regions_after_replace.contains(k)]
+                regions_after_new_child.contains(k) ==> regions_after_replace.contains(k));
             assert(forall|k: int|
-                #![trigger regions.slots.contains_key(k)]
-                regions_after_replace.slots.contains_key(k) ==> regions.slots.contains_key(k));
-            assert forall|idx: int|
-                old(regions).slots.contains_key(idx) implies #[trigger] regions.slots.contains_key(
+                #![trigger regions.contains(k)]
+                regions_after_replace.contains(k) ==> regions.contains(k));
+            assert forall|idx: int| old(regions).contains(idx) implies #[trigger] regions.contains(
                 idx,
             ) by {
-                assert(regions_before_new_child.slots.contains_key(idx));
-                assert(regions_after_new_child.slots.contains_key(idx));
-                assert(regions_after_replace.slots.contains_key(idx));
+                assert(regions_before_new_child.contains(idx));
+                assert(regions_after_new_child.contains(idx));
+                assert(regions_after_replace.contains(idx));
             };
         }
 
@@ -3713,6 +3713,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 assert(regions_pre_remove.slot_owners.contains_key(removed_idx)) by {
                     reveal(<MetaRegionOwners as Inv>::inv);
                 };
+                assert(regions_pre_remove.slots.contains_key(removed_idx)) by {
+                    reveal(<MetaRegionOwners as Inv>::inv);
+                };
                 let tracked mut so_rm = regions.slot_owners.tracked_remove(removed_idx);
                 so_rm.paths_in_pt = so_rm.paths_in_pt.remove(removed_path);
                 regions.slot_owners.tracked_insert(removed_idx, so_rm);
@@ -3957,8 +3960,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 ).slot_owners[idx].paths_in_pt,
             // `regions.slots` keys are monotonic across the entry replacement.
             forall|idx: int|
-                #![trigger final(regions).slots.contains_key(idx)]
-                old(regions).slots.contains_key(idx) ==> final(regions).slots.contains_key(idx),
+                #![trigger final(regions).contains(idx)]
+                old(regions).contains(idx) ==> final(regions).contains(idx),
             // ref_count is preserved per-slot across the whole replace_cur_entry call.
             // The body only touches regions via `Entry::replace` (which preserves
             // ref_count by spec); `dfs_mark_stray_and_unlock` doesn't take regions at

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -984,7 +984,7 @@ impl PageTable<KernelPtConfig> {
             assert(kern_idx != new_idx);
             assert(regions.slot_owners[kern_idx] == regions_before_alloc.slot_owners[kern_idx]);
             assert(kernel_owner.metaregion_sound(*regions));
-            assert(!regions.slots.contains_key(new_idx));
+            assert(!regions.contains(new_idx));
         }
 
         proof_decl! {
@@ -1026,9 +1026,7 @@ impl PageTable<KernelPtConfig> {
             assert(regions_before_self_borrow.slot_owners
                 == regions_after_kroot_borrow.slot_owners);
             assert forall|k: int|
-                regions_before_self_borrow.slots.contains_key(
-                    k,
-                ) implies regions_before_self_borrow.slots[k]
+                regions_before_self_borrow.contains(k) implies regions_before_self_borrow.slots[k]
                 == #[trigger] regions_after_kroot_borrow.slots[k] by {
                 if k == kern_idx {
                     crate::specs::mm::page_table::node::entry_owners::EntryOwner::<
@@ -1046,7 +1044,7 @@ impl PageTable<KernelPtConfig> {
             );
 
             let new_idx = new_idx_g;
-            assert(regions_before_alloc.slots.contains_key(new_idx));
+            assert(regions_before_alloc.contains(new_idx));
             assert(kern_idx != new_idx) by {
                 crate::specs::mm::page_table::node::entry_owners::EntryOwner::<
                     KernelPtConfig,
@@ -1057,12 +1055,11 @@ impl PageTable<KernelPtConfig> {
                 );
             };
 
-            assert(!regions_before_self_borrow.slots.contains_key(new_idx));
-            assert(!regions_after_kroot_borrow.slots.contains_key(new_idx));
+            assert(!regions_before_self_borrow.contains(new_idx));
+            assert(!regions_after_kroot_borrow.contains(new_idx));
             assert forall|k: int|
-                regions_after_kroot_borrow.slots.contains_key(
-                    k,
-                ) implies regions_after_kroot_borrow.slots[k] == #[trigger] regions.slots[k] by {
+                regions_after_kroot_borrow.contains(k) implies regions_after_kroot_borrow.slots[k]
+                == #[trigger] regions.slots[k] by {
                 if k != new_idx {
                     // borrow preserves slots[k] at k != self.index() == new_idx
                 }
@@ -1100,7 +1097,7 @@ impl PageTable<KernelPtConfig> {
                                     #[trigger] crate::specs::mm::frame::mapping::frame_to_index(
                                     (pa + j * PAGE_SIZE) as usize,
                                 );
-                                sub_idx != new_idx || (regions.slots.contains_key(sub_idx)
+                                sub_idx != new_idx || (regions.contains(sub_idx)
                                     && regions.slot_owners[sub_idx].inner_perms.ref_count.value()
                                     != REF_COUNT_UNUSED
                                     && regions.slot_owners[sub_idx].inner_perms.ref_count.value()
@@ -1133,7 +1130,7 @@ impl PageTable<KernelPtConfig> {
                 // The new node owner's invariants and guard relation.
                 new_node_owner.inv(),
                 new_node_owner.relate_guard(new_node),
-                regions.slots.contains_key(new_node_owner.slot_index),
+                regions.contains(new_node_owner.slot_index),
             decreases KernelPtConfig::TOP_LEVEL_INDEX_RANGE().end - i,
         {
             proof {
@@ -1228,7 +1225,7 @@ impl PageTable<KernelPtConfig> {
             let pte = PageTableEntry::new_pt(pt_addr);
 
             proof {
-                assert(regions.slots.contains_key(new_node_owner.slot_index));
+                assert(regions.contains(new_node_owner.slot_index));
             }
             unsafe {
                 #[verus_spec(with Tracked(&mut new_node_owner), Tracked(&*regions))]
@@ -1308,12 +1305,12 @@ impl<C: PageTableConfig> PageTable<C> {
             // that was (un)locked before remains so.
             final(guards).guards == old(guards).guards,
             // The newly allocated slot was in the free pool before the call.
-            old(regions).slots.contains_key(
+            old(regions).contains(
                 crate::specs::mm::frame::mapping::frame_to_index(
                     (final(owner)@->0).0.value().meta_slot_paddr()->0)),
             // After the alloc, the slot is removed from the free pool (now owned
             // by the new pt's NodeOwner).
-            !final(regions).slots.contains_key(
+            !final(regions).contains(
                 crate::specs::mm::frame::mapping::frame_to_index(
                     (final(owner)@->0).0.value().meta_slot_paddr()->0)),
             // Other slots and lock state are preserved.
@@ -1454,7 +1451,7 @@ impl<C: PageTableConfig> PageTable<C> {
                 ==> final(regions).slot_owners[idx].paths_in_pt
                         == old(regions).slot_owners[idx].paths_in_pt,
             forall|idx: int| #![trigger final(regions).slot_owners[idx]]
-                old(regions).slot_owners.contains_key(idx)
+                old(regions).contains(idx)
                 && old(regions).slot_owners[idx].inner_perms.ref_count.value()
                     != REF_COUNT_UNUSED
                 ==> final(regions).slot_owners[idx].inner_perms.ref_count.value()
@@ -1506,14 +1503,14 @@ impl<C: PageTableConfig> PageTable<C> {
                         == old(regions).slot_owners[idx].paths_in_pt,
             // Non-saturation preservation.
             (forall |i: int| #![trigger old(regions).slot_owners[i]]
-                old(regions).slot_owners.contains_key(i)
+                old(regions).contains(i)
                 && old(regions).slot_owners[i].inner_perms.ref_count.value()
                     != REF_COUNT_UNUSED
                 ==> old(regions).slot_owners[i].inner_perms.ref_count.value() + 1
                     < REF_COUNT_MAX)
             ==>
             (forall |i: int| #![trigger final(regions).slot_owners[i]]
-                final(regions).slot_owners.contains_key(i)
+                final(regions).contains(i)
                 && final(regions).slot_owners[i].inner_perms.ref_count.value()
                     != REF_COUNT_UNUSED
                 ==> final(regions).slot_owners[i].inner_perms.ref_count.value() + 1

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -412,8 +412,7 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
             Self::item_from_raw_spec(pa, level, prop) == item,
             Self::raw_item_well_formed(pa, level, prop),
             valid_frame_paddr(pa),
-            regions.slots.contains_key(frame_to_index(pa)),
-            regions.slot_owners.contains_key(frame_to_index(pa)),
+            regions.contains(frame_to_index(pa)),
             Self::tracked(item) ==> regions.slot_owners[frame_to_index(
                 pa,
             )].inner_perms.ref_count.value() > 0,

--- a/ostd/src/mm/page_table/node/child.rs
+++ b/ostd/src/mm/page_table/node/child.rs
@@ -9,7 +9,7 @@ use crate::mm::frame::meta::mapping::{frame_to_meta, meta_to_frame};
 use crate::mm::page_table::*;
 use crate::specs::arch::*;
 use crate::specs::mm::frame::{
-    mapping::{frame_to_index, group_page_meta},
+    mapping::{group_page_meta, meta_to_index},
     meta_region_owners::MetaRegionOwners,
 };
 
@@ -67,7 +67,7 @@ impl<C: PageTableConfig> Child<C> {
         requires
             self.invariants(*old(owner), *old(regions)),
             self matches Child::PageTable(node) ==> old(regions).frame_obligations.count(
-                frame_to_index(meta_to_frame(node.ptr.addr())),
+                meta_to_index(node.ptr.addr()),
             ) > 0,
         ensures
             final(owner).pte_invariants(res, *final(regions)),
@@ -85,7 +85,7 @@ impl<C: PageTableConfig> Child<C> {
         match self {
             Child::PageTable(node) => {
                 let ghost node_owner = owner.node();
-                let ghost node_index = frame_to_index(meta_to_frame(node.ptr.addr()));
+                let ghost node_index = meta_to_index(node.ptr.addr());
 
                 let tracked node_slot_perm = regions.slots.tracked_borrow(node_index);
                 #[verus_spec(with Tracked(node_slot_perm))]

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -15,7 +15,7 @@ use crate::mm::page_table::*;
 use crate::mm::{Paddr, PagingConstsTrait, PagingLevel, Vaddr};
 use crate::specs::arch::{NR_ENTRIES, NR_LEVELS, PAGE_SIZE};
 use crate::specs::mm::frame::{
-    mapping::{frame_to_index, group_page_meta},
+    mapping::{frame_to_index, group_page_meta, meta_to_index},
     meta_region_owners::MetaRegionOwners,
 };
 use crate::specs::mm::page_table::{INC_LEVELS, PageTableOwner};
@@ -283,7 +283,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             old(self).new_owner_compatible(new_child, *old(owner), *old(new_owner), *old(regions)),
             old(parent_owner).metaregion_sound_node(*old(regions)),
             new_child matches Child::PageTable(node) ==> old(regions).frame_obligations.count(
-                frame_to_index(meta_to_frame(node.ptr.addr())),
+                meta_to_index(node.ptr.addr()),
             ) > 0,
         ensures
             final(self).invariants(*final(new_owner), *final(regions)),
@@ -851,16 +851,16 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             forall |i: usize| old(guards).unlocked(i) ==> final(guards).unlocked(i),
             // slot_owners unchanged for all indices except the new PT node's index.
             old(owner).value().is_frame() && old(parent_owner).level > 1 ==> {
-                &&& forall|i: int| i != frame_to_index(meta_to_frame(final(owner).value().node().meta_vaddr())) ==>
+                &&& forall|i: int| i != meta_to_index(final(owner).value().node().meta_vaddr()) ==>
                     (#[trigger] final(regions).slot_owners[i]) == old(regions).slot_owners[i]
                 // slots keys preserved (alloc removes then borrow re-inserts).
                 &&& forall|i: int| old(regions).slots.contains_key(i)
                     ==> (#[trigger] final(regions).slots.contains_key(i))
                 // The new PT node's ref_count is not UNUSED.
-                &&& final(regions).slot_owners[frame_to_index(meta_to_frame(final(owner).value().node().meta_vaddr()))]
+                &&& final(regions).slot_owners[meta_to_index(final(owner).value().node().meta_vaddr())]
                     .inner_perms.ref_count.value() != REF_COUNT_UNUSED
                 // The allocated slot had ref_count == UNUSED before allocation.
-                &&& old(regions).slot_owners[frame_to_index(meta_to_frame(final(owner).value().node().meta_vaddr()))]
+                &&& old(regions).slot_owners[meta_to_index(final(owner).value().node().meta_vaddr())]
                     .inner_perms.ref_count.value() == REF_COUNT_UNUSED
             },
             // Parent's other PTEs are preserved: only the entry at self.idx
@@ -949,7 +949,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             broadcast use crate::specs::mm::frame::meta_owners::axiom_mmio_usage_iff_mmio_paddr;
             broadcast use group_page_meta;
 
-            let new_idx = frame_to_index(meta_to_frame(new_owner_meta_addr));
+            let new_idx = meta_to_index(new_owner_meta_addr);
             let new_paddr = meta_to_frame(new_owner_meta_addr);
             let nr_pages = page_size(level) / PAGE_SIZE;
 
@@ -1017,8 +1017,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 // pending-Drop obligation across the per-child `replace`
                 // calls (each net-zero on the ledger), discharging the
                 // `into_pte` consume after the loop.
-                regions.frame_obligations.count(frame_to_index(meta_to_frame(new_owner_meta_addr)))
-                    > 0,
+                regions.frame_obligations.count(meta_to_index(new_owner_meta_addr)) > 0,
                 parent_owner.inv(),
                 new_owner.value().is_node(),
                 new_owner.inv(),
@@ -1088,13 +1087,13 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 // `metaregion_sound` conjuncts not derivable from
                 // `metaregion_sound_node` (slot_vaddr/wf derive). Carried so
                 // `into_pte`'s `Child::invariants` holds after the loop.
-                regions.slot_owners[frame_to_index(
-                    meta_to_frame(new_owner_meta_addr),
+                regions.slot_owners[meta_to_index(
+                    new_owner_meta_addr,
                 )].inner_perms.ref_count.value() != REF_COUNT_UNUSED,
-                0 < regions.slot_owners[frame_to_index(
-                    meta_to_frame(new_owner_meta_addr),
+                0 < regions.slot_owners[meta_to_index(
+                    new_owner_meta_addr,
                 )].inner_perms.ref_count.value() <= REF_COUNT_MAX,
-                regions.slot_owners[frame_to_index(meta_to_frame(new_owner_meta_addr))].paths_in_pt
+                regions.slot_owners[meta_to_index(new_owner_meta_addr)].paths_in_pt
                     == set![new_owner_path],
         {
             proof {
@@ -1254,7 +1253,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             // Snapshot the node's own-slot facts while the loop invariant still
             // holds (regions unchanged since loop entry), so we can frame them
             // across the `replace` below.
-            let ghost nidx = frame_to_index(meta_to_frame(new_owner_meta_addr));
+            let ghost nidx = meta_to_index(new_owner_meta_addr);
             proof {
                 // The loop invariant still holds for the current `regions`
                 // (unchanged since entry), so pin the node-slot paths_in_pt fact
@@ -1546,7 +1545,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
             },
             old(parent_owner).metaregion_sound_node(*old(regions)),
             new_child matches Child::PageTable(node) ==> old(regions).frame_obligations.count(
-                frame_to_index(meta_to_frame(node.ptr.addr())),
+                meta_to_index(node.ptr.addr()),
             ) > 0,
         ensures
             res.invariants(*final(owner), *final(regions)),

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -1590,9 +1590,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
                     regions,
                 ).slot_owners[slot].paths_in_pt,
             forall|k: int|
-                old(regions).slots.contains_key(k) ==> #[trigger] final(regions).slots.contains_key(
-                    k,
-                ),
+                old(regions).slots.contains_key(k) ==> #[trigger] final(regions).slots.contains_key(k),
             forall|slot: int|
                 #![trigger final(regions).slot_owners[slot].inner_perms.ref_count.value()]
                 final(regions).slot_owners[slot].inner_perms.ref_count.value() == old(

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -540,7 +540,7 @@ impl<C: PageTableConfig> PageTableNode<C> {
 
             final(regions).frame_obligations == old(regions).frame_obligations.insert(
                 meta_to_index(owner@.value().node().meta_vaddr())),
-            old(regions).slots.contains_key(meta_to_index(owner@.value().node().meta_vaddr())),
+            old(regions).contains(meta_to_index(owner@.value().node().meta_vaddr())),
 
             !crate::specs::mm::frame::meta_owners::is_mmio_paddr(
                 meta_to_frame(owner@.value().node().meta_vaddr())),
@@ -558,7 +558,7 @@ impl<C: PageTableConfig> PageTableNode<C> {
                 idx as int,
                 C::E::new_pt_spec(meta_to_frame(owner@.value().node().meta_vaddr())),
             ),
-            final(regions).slots.contains_key(owner@.value().node().slot_index),
+            final(regions).contains(owner@.value().node().slot_index),
             owner@.value().node().metaregion_sound_node(*final(regions)),
     )]
     #[verifier::external_body]
@@ -729,7 +729,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
                 child_owner.parent_level,
             ),
             regions.inv(),
-            regions.slots.contains_key(owner.slot_index),
+            regions.contains(owner.slot_index),
             // Panic condition
             idx < NR_ENTRIES,
         ensures
@@ -823,7 +823,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
         requires
             self.inner.inner@.invariants(*owner),
             regions.inv(),
-            regions.slots.contains_key(owner.slot_index),
+            regions.contains(owner.slot_index),
             idx < NR_ENTRIES,
         ensures
             pte == owner.children_perm.value()[idx as int],
@@ -865,7 +865,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
         requires
             old(self).inner.inner@.invariants(*old(owner)),
             regions.inv(),
-            regions.slots.contains_key(old(owner).slot_index),
+            regions.contains(old(owner).slot_index),
             idx < NR_ENTRIES,
         ensures
             final(owner).inv(),

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -57,7 +57,7 @@ use crate::mm::page_table::*;
 use crate::mm::{Paddr, Vaddr};
 use crate::specs::mm::{
     frame::{
-        mapping::{frame_to_index, lemma_frame_to_index_injective},
+        mapping::{frame_to_index, lemma_frame_to_index_injective, meta_to_index},
         meta_owners::{MetaSlotOwner, MetaSlotStorage, typed_meta_value, typed_meta_wf},
         meta_region_owners::MetaRegionOwners,
     },
@@ -539,15 +539,15 @@ impl<C: PageTableConfig> PageTableNode<C> {
             MetaSlot::slot_perm_reparked_spec(meta_to_frame(owner@.value().node().meta_vaddr()), *old(regions), *final(regions)),
 
             final(regions).frame_obligations == old(regions).frame_obligations.insert(
-                frame_to_index(meta_to_frame(owner@.value().node().meta_vaddr()))),
-            old(regions).slots.contains_key(frame_to_index(meta_to_frame(owner@.value().node().meta_vaddr()))),
+                meta_to_index(owner@.value().node().meta_vaddr())),
+            old(regions).slots.contains_key(meta_to_index(owner@.value().node().meta_vaddr())),
 
             !crate::specs::mm::frame::meta_owners::is_mmio_paddr(
                 meta_to_frame(owner@.value().node().meta_vaddr())),
             owner@.value().metaregion_sound(*final(regions)),
             forall|i: int|
                 #[trigger] old(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-                ==> i != frame_to_index(meta_to_frame(owner@.value().node().meta_vaddr())),
+                ==> i != meta_to_index(owner@.value().node().meta_vaddr()),
             owner@.value().match_pte(C::E::new_pt_spec(meta_to_frame(owner@.value().node().meta_vaddr())), level as PagingLevel),
             final(parent_owner).meta_own == old(parent_owner).meta_own,
             final(parent_owner).slot_index == old(parent_owner).slot_index,

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -1730,8 +1730,8 @@ unsafe impl PageTableConfig for UserPtConfig {
         new_regions: MetaRegionOwners,
         res: Self::Item,
     ) {
-        use crate::specs::mm::frame::mapping::frame_to_index;
-        let frame_idx = frame_to_index(meta_to_frame(item.frame.ptr.addr()));
+        use crate::specs::mm::frame::mapping::{frame_to_index, meta_to_index};
+        let frame_idx = meta_to_index(item.frame.ptr.addr());
         assert(frame_to_index(pa) == frame_idx);
         assert(<MappedItem as RCClone>::clone_ensures(item, old_regions, new_regions, res));
         assert(item.frame.clone_ensures(old_regions, new_regions, res.frame));
@@ -1744,12 +1744,12 @@ unsafe impl PageTableConfig for UserPtConfig {
         prop: PageProperty,
         regions: MetaRegionOwners,
     ) {
-        use crate::specs::mm::frame::mapping::frame_to_index;
+        use crate::specs::mm::frame::mapping::{frame_to_index, meta_to_index};
         broadcast use crate::specs::mm::frame::mapping::group_page_meta;
 
         Self::lemma_item_from_raw_well_formed(pa, level, prop);
         assert(meta_to_frame(item.frame.ptr.addr()) == pa);
-        assert(frame_to_index(meta_to_frame(item.frame.ptr.addr())) == frame_to_index(pa));
+        assert(meta_to_index(item.frame.ptr.addr()) == frame_to_index(pa));
     }
 
     proof fn lemma_page_table_config_constant_requirements() {


### PR DESCRIPTION
Introducing two `spec fn`s to make the spec cleaner:
- `meta_to_index`: an abbreviation of `frame_to_index · meta_to_frame`.
- `MetaRegionOwners::contains`: a conjunction of `slots.contains_key` and `slot_owners.contains_key`.