### PR TITLE
Cpu local model

### DIFF
--- a/ostd/specs/task/cpu_core.rs
+++ b/ostd/specs/task/cpu_core.rs
@@ -1,23 +1,23 @@
 // SPDX-License-Identifier: MPL-2.0
-//! Proof model for one CPU core.
+//! Proof model for ownership of one CPU's local resources.
 //!
-//! A [`CpuCore`] permanently owns the CPU-local resources assigned to one
-//! logical CPU. Scheduling changes only the core's `current_task`; it never
+//! A [`CpuCoreOwner`] permanently owns the CPU-local resources assigned to one
+//! logical CPU. Scheduling changes only the owner's `current_task`; it never
 //! transfers those resources to the task. Runtime CPU-local access temporarily
-//! opens the core into a linear [`CpuCoreHandle`] and its typed local state,
-//! then restores that state before returning the core to the scheduler.
+//! opens the owner into a linear [`CpuCoreOwnerHandle`] and its typed local
+//! state, then restores that state before returning the owner to the scheduler.
 use core::marker::PhantomData;
 
 use vstd::{prelude::*, resource::Loc};
 use vstd_extra::resource::ghost_resource::excl::ExclusiveGhost;
 
 use crate::specs::mm::cpu::CpuId;
-use crate::specs::task::cpu_local::CpuLocalInstance;
+use crate::specs::task::cpu_local::CpuLocalAuth;
 
 verus! {
 
-/// Logical state of a CPU core that is independent of its CPU-local payload.
-pub ghost struct CpuCoreView {
+/// Logical scheduling state carried by a CPU-local resource owner.
+pub ghost struct CpuCoreOwnerView {
     /// Stable logical CPU represented by this core.
     pub cpu: CpuId,
     /// Task currently executing on this core, or `None` while the core is idle.
@@ -66,41 +66,41 @@ impl<A: CpuCoreLocalState, B: CpuCoreLocalState> CpuCoreLocalState for (A, B) {
 /// Linear identity and scheduling state left while CPU-local resources are
 /// temporarily being accessed.
 ///
-/// A handle cannot be duplicated. Restoring a [`CpuCore`] requires returning a
-/// local-state aggregate of the same type, with the same ordered resource
-/// identities, whose resources all belong to this handle's CPU.
-pub tracked struct CpuCoreHandle<L: CpuCoreLocalState> {
-    state: ExclusiveGhost<CpuCoreView>,
+/// A handle cannot be duplicated. Restoring a [`CpuCoreOwner`] requires
+/// returning a local-state aggregate of the same type, with the same ordered
+/// resource identities, whose resources all belong to this handle's CPU.
+pub tracked struct CpuCoreOwnerHandle<L: CpuCoreLocalState> {
+    state: ExclusiveGhost<CpuCoreOwnerView>,
     marker: PhantomData<L>,
 }
 
-/// Proof-owned state of one CPU core.
+/// Scheduler-owned proof state for one CPU's local resources.
 ///
 /// `L` is deliberately generic instead of type-erased. A subsystem can define
 /// a tracked aggregate containing all CPU-local resources it needs and use that
-/// aggregate as the core's payload.
-pub tracked struct CpuCore<L: CpuCoreLocalState> {
-    handle: CpuCoreHandle<L>,
+/// aggregate as the owner's payload.
+pub tracked struct CpuCoreOwner<L: CpuCoreLocalState> {
+    handle: CpuCoreOwnerHandle<L>,
     locals: L,
 }
 
-impl<L: CpuCoreLocalState> View for CpuCoreHandle<L> {
-    type V = CpuCoreView;
+impl<L: CpuCoreLocalState> View for CpuCoreOwnerHandle<L> {
+    type V = CpuCoreOwnerView;
 
     closed spec fn view(&self) -> Self::V {
         self.state.view()
     }
 }
 
-impl<L: CpuCoreLocalState> View for CpuCore<L> {
-    type V = CpuCoreView;
+impl<L: CpuCoreLocalState> View for CpuCoreOwner<L> {
+    type V = CpuCoreOwnerView;
 
     closed spec fn view(&self) -> Self::V {
         self.handle@
     }
 }
 
-impl<L: CpuCoreLocalState> CpuCoreHandle<L> {
+impl<L: CpuCoreLocalState> CpuCoreOwnerHandle<L> {
     /// Unique identity of this core resource.
     pub closed spec fn id(&self) -> Loc {
         self.state.id()
@@ -132,7 +132,7 @@ impl<L: CpuCoreLocalState> CpuCoreHandle<L> {
     }
 
     /// Restores a complete core after a temporary CPU-local access.
-    pub proof fn tracked_restore(tracked self, tracked locals: L) -> (tracked res: CpuCore<L>)
+    pub proof fn tracked_restore(tracked self, tracked locals: L) -> (tracked res: CpuCoreOwner<L>)
         requires
             self.wf(),
             locals.belongs_to_cpu(self.cpu()),
@@ -144,11 +144,11 @@ impl<L: CpuCoreLocalState> CpuCoreHandle<L> {
             res.locals() == locals,
             res.locals().local_key() == self.expected_locals_key(),
     {
-        CpuCore { handle: self, locals }
+        CpuCoreOwner { handle: self, locals }
     }
 }
 
-impl<L: CpuCoreLocalState> CpuCore<L> {
+impl<L: CpuCoreLocalState> CpuCoreOwner<L> {
     /// Creates an idle core with its permanent CPU-local resource aggregate.
     pub proof fn new(cpu: CpuId, tracked locals: L) -> (tracked res: Self)
         requires
@@ -161,10 +161,10 @@ impl<L: CpuCoreLocalState> CpuCore<L> {
     {
         let ghost locals_key = locals.local_key();
         let tracked state = ExclusiveGhost::alloc(
-            CpuCoreView { cpu, current_task: None, locals_key },
+            CpuCoreOwnerView { cpu, current_task: None, locals_key },
         );
-        let tracked handle = CpuCoreHandle { state, marker: PhantomData };
-        CpuCore { handle, locals }
+        let tracked handle = CpuCoreOwnerHandle { state, marker: PhantomData };
+        CpuCoreOwner { handle, locals }
     }
 
     /// Unique identity of this core resource.
@@ -217,7 +217,7 @@ impl<L: CpuCoreLocalState> CpuCore<L> {
             final(self).locals_key() == old(self).locals_key(),
             final(self).wf(),
     {
-        let ghost next = CpuCoreView {
+        let ghost next = CpuCoreOwnerView {
             cpu: self.cpu(),
             current_task: Some(task),
             locals_key: self.locals_key(),
@@ -240,7 +240,7 @@ impl<L: CpuCoreLocalState> CpuCore<L> {
             final(self).wf(),
     {
         let task = self.current_task()->0;
-        let ghost next = CpuCoreView {
+        let ghost next = CpuCoreOwnerView {
             cpu: self.cpu(),
             current_task: None,
             locals_key: self.locals_key(),
@@ -252,9 +252,9 @@ impl<L: CpuCoreLocalState> CpuCore<L> {
     /// Temporarily separates the typed CPU-local state from the core handle.
     ///
     /// The caller may update the returned resources, but must eventually call
-    /// [`CpuCoreHandle::tracked_restore`] with resources that still belong to
-    /// this CPU.
-    pub proof fn tracked_open(tracked self) -> (tracked res: (CpuCoreHandle<L>, L))
+    /// [`CpuCoreOwnerHandle::tracked_restore`] with resources that still
+    /// belong to this CPU.
+    pub proof fn tracked_open(tracked self) -> (tracked res: (CpuCoreOwnerHandle<L>, L))
         requires
             self.wf(),
         ensures
@@ -276,17 +276,17 @@ proof fn cpu_core_owns_cpu_local_points_to<V>(initial: Map<CpuId, V>, cpu: CpuId
     requires
         initial.contains_key(cpu),
 {
-    let tracked (mut instance, mut points_to_set) = CpuLocalInstance::new(initial);
+    let tracked (mut auth, mut points_to_set) = CpuLocalAuth::new(initial);
     let tracked points_to = points_to_set.tracked_take(cpu);
-    let tracked mut core = CpuCore::new(cpu, points_to);
+    let tracked mut core = CpuCoreOwner::new(cpu, points_to);
 
-    let ghost task = instance.id();
+    let ghost task = auth.id();
     core.tracked_schedule_in(task);
     let tracked (handle, mut points_to) = core.tracked_open();
     assert(handle.cpu() == cpu);
     assert(handle.current_task() == Some(task));
 
-    points_to.tracked_update(&mut instance, new_value);
+    points_to.tracked_update(&mut auth, new_value);
     let tracked mut core = handle.tracked_restore(points_to);
     assert(core.cpu() == cpu);
     assert(core.current_task() == Some(task));

--- a/ostd/specs/task/cpu_core.rs
+++ b/ostd/specs/task/cpu_core.rs
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: MPL-2.0
+//! Proof model for one CPU core.
+//!
+//! A [`CpuCore`] permanently owns the CPU-local resources assigned to one
+//! logical CPU. Scheduling changes only the core's `current_task`; it never
+//! transfers those resources to the task. Runtime CPU-local access temporarily
+//! opens the core into a linear [`CpuCoreHandle`] and its typed local state,
+//! then restores that state before returning the core to the scheduler.
+use core::marker::PhantomData;
+
+use vstd::{prelude::*, resource::Loc};
+use vstd_extra::resource::ghost_resource::excl::ExclusiveGhost;
+
+use crate::specs::mm::cpu::CpuId;
+use crate::specs::task::cpu_local::CpuLocalInstance;
+
+verus! {
+
+/// Logical state of a CPU core that is independent of its CPU-local payload.
+pub ghost struct CpuCoreView {
+    /// Stable logical CPU represented by this core.
+    pub cpu: CpuId,
+    /// Task currently executing on this core, or `None` while the core is idle.
+    pub current_task: Option<Loc>,
+    /// Ordered identities of the CPU-local resources assigned to this core.
+    pub locals_key: Seq<Loc>,
+}
+
+/// A typed collection of resources that belongs permanently to one CPU.
+///
+/// Implementations may aggregate any number of differently typed CPU-local
+/// points-to resources in a tracked struct. The predicate must state that all
+/// resources in the aggregate belong to `cpu`. `local_key` must faithfully and
+/// stably list their identities: changing, replacing, reordering, adding, or
+/// removing a resource must change the key.
+pub trait CpuCoreLocalState {
+    spec fn belongs_to_cpu(self, cpu: CpuId) -> bool;
+
+    /// Ordered identities of the resources comprising this local state.
+    ///
+    /// The key must remain unchanged while the payload is detached from its
+    /// core. Ordering makes two same-typed fields distinguishable.
+    spec fn local_key(self) -> Seq<Loc>;
+}
+
+impl CpuCoreLocalState for () {
+    open spec fn belongs_to_cpu(self, _cpu: CpuId) -> bool {
+        true
+    }
+
+    open spec fn local_key(self) -> Seq<Loc> {
+        Seq::empty()
+    }
+}
+
+impl<A: CpuCoreLocalState, B: CpuCoreLocalState> CpuCoreLocalState for (A, B) {
+    open spec fn belongs_to_cpu(self, cpu: CpuId) -> bool {
+        self.0.belongs_to_cpu(cpu) && self.1.belongs_to_cpu(cpu)
+    }
+
+    open spec fn local_key(self) -> Seq<Loc> {
+        self.0.local_key() + self.1.local_key()
+    }
+}
+
+/// Linear identity and scheduling state left while CPU-local resources are
+/// temporarily being accessed.
+///
+/// A handle cannot be duplicated. Restoring a [`CpuCore`] requires returning a
+/// local-state aggregate of the same type, with the same ordered resource
+/// identities, whose resources all belong to this handle's CPU.
+pub tracked struct CpuCoreHandle<L: CpuCoreLocalState> {
+    state: ExclusiveGhost<CpuCoreView>,
+    marker: PhantomData<L>,
+}
+
+/// Proof-owned state of one CPU core.
+///
+/// `L` is deliberately generic instead of type-erased. A subsystem can define
+/// a tracked aggregate containing all CPU-local resources it needs and use that
+/// aggregate as the core's payload.
+pub tracked struct CpuCore<L: CpuCoreLocalState> {
+    handle: CpuCoreHandle<L>,
+    locals: L,
+}
+
+impl<L: CpuCoreLocalState> View for CpuCoreHandle<L> {
+    type V = CpuCoreView;
+
+    closed spec fn view(&self) -> Self::V {
+        self.state.view()
+    }
+}
+
+impl<L: CpuCoreLocalState> View for CpuCore<L> {
+    type V = CpuCoreView;
+
+    closed spec fn view(&self) -> Self::V {
+        self.handle@
+    }
+}
+
+impl<L: CpuCoreLocalState> CpuCoreHandle<L> {
+    /// Unique identity of this core resource.
+    pub closed spec fn id(&self) -> Loc {
+        self.state.id()
+    }
+
+    /// Stable CPU represented by this handle.
+    pub closed spec fn cpu(&self) -> CpuId {
+        self@.cpu
+    }
+
+    /// Task currently running on this CPU.
+    pub closed spec fn current_task(&self) -> Option<Loc> {
+        self@.current_task
+    }
+
+    /// Whether no task is currently associated with this core.
+    pub open spec fn is_idle(&self) -> bool {
+        self.current_task() is None
+    }
+
+    /// Internal validity of the exclusive core state.
+    pub closed spec fn wf(&self) -> bool {
+        self.state.wf()
+    }
+
+    /// Ordered resource identities expected when restoring the core.
+    pub closed spec fn expected_locals_key(&self) -> Seq<Loc> {
+        self@.locals_key
+    }
+
+    /// Restores a complete core after a temporary CPU-local access.
+    pub proof fn tracked_restore(tracked self, tracked locals: L) -> (tracked res: CpuCore<L>)
+        requires
+            self.wf(),
+            locals.belongs_to_cpu(self.cpu()),
+            locals.local_key() == self.expected_locals_key(),
+        ensures
+            res.id() == self.id(),
+            res@ == self@,
+            res.wf(),
+            res.locals() == locals,
+            res.locals().local_key() == self.expected_locals_key(),
+    {
+        CpuCore { handle: self, locals }
+    }
+}
+
+impl<L: CpuCoreLocalState> CpuCore<L> {
+    /// Creates an idle core with its permanent CPU-local resource aggregate.
+    pub proof fn new(cpu: CpuId, tracked locals: L) -> (tracked res: Self)
+        requires
+            locals.belongs_to_cpu(cpu),
+        ensures
+            res.cpu() == cpu,
+            res.is_idle(),
+            res.wf(),
+            res.locals() == locals,
+    {
+        let ghost locals_key = locals.local_key();
+        let tracked state = ExclusiveGhost::alloc(
+            CpuCoreView { cpu, current_task: None, locals_key },
+        );
+        let tracked handle = CpuCoreHandle { state, marker: PhantomData };
+        CpuCore { handle, locals }
+    }
+
+    /// Unique identity of this core resource.
+    pub closed spec fn id(&self) -> Loc {
+        self.handle.id()
+    }
+
+    /// Stable CPU represented by this core.
+    pub closed spec fn cpu(&self) -> CpuId {
+        self@.cpu
+    }
+
+    /// Task currently running on this CPU.
+    pub closed spec fn current_task(&self) -> Option<Loc> {
+        self@.current_task
+    }
+
+    /// Whether no task is currently associated with this core.
+    pub open spec fn is_idle(&self) -> bool {
+        self.current_task() is None
+    }
+
+    /// CPU-local resource aggregate permanently assigned to this core.
+    pub closed spec fn locals(&self) -> L {
+        self.locals
+    }
+
+    /// Ordered identities of the CPU-local resources assigned to this core.
+    pub closed spec fn locals_key(&self) -> Seq<Loc> {
+        self.handle.expected_locals_key()
+    }
+
+    /// The core identity is valid and every local resource belongs to its CPU.
+    pub closed spec fn wf(&self) -> bool {
+        &&& self.handle.wf()
+        &&& self.locals().belongs_to_cpu(self.cpu())
+        &&& self.locals().local_key() == self.locals_key()
+    }
+
+    /// Associates a task with an idle CPU core.
+    pub proof fn tracked_schedule_in(tracked &mut self, task: Loc)
+        requires
+            old(self).wf(),
+            old(self).is_idle(),
+        ensures
+            final(self).id() == old(self).id(),
+            final(self).cpu() == old(self).cpu(),
+            final(self).current_task() == Some(task),
+            final(self).locals() == old(self).locals(),
+            final(self).locals_key() == old(self).locals_key(),
+            final(self).wf(),
+    {
+        let ghost next = CpuCoreView {
+            cpu: self.cpu(),
+            current_task: Some(task),
+            locals_key: self.locals_key(),
+        };
+        self.handle.state.update(next);
+    }
+
+    /// Makes this CPU idle and returns the task that was running on it.
+    pub proof fn tracked_schedule_out(tracked &mut self) -> (task: Loc)
+        requires
+            old(self).wf(),
+            !old(self).is_idle(),
+        ensures
+            old(self).current_task() == Some(task),
+            final(self).id() == old(self).id(),
+            final(self).cpu() == old(self).cpu(),
+            final(self).is_idle(),
+            final(self).locals() == old(self).locals(),
+            final(self).locals_key() == old(self).locals_key(),
+            final(self).wf(),
+    {
+        let task = self.current_task()->0;
+        let ghost next = CpuCoreView {
+            cpu: self.cpu(),
+            current_task: None,
+            locals_key: self.locals_key(),
+        };
+        self.handle.state.update(next);
+        task
+    }
+
+    /// Temporarily separates the typed CPU-local state from the core handle.
+    ///
+    /// The caller may update the returned resources, but must eventually call
+    /// [`CpuCoreHandle::tracked_restore`] with resources that still belong to
+    /// this CPU.
+    pub proof fn tracked_open(tracked self) -> (tracked res: (CpuCoreHandle<L>, L))
+        requires
+            self.wf(),
+        ensures
+            res.0.id() == self.id(),
+            res.0@ == self@,
+            res.0.wf(),
+            res.0.expected_locals_key() == self.locals_key(),
+            res.1 == self.locals(),
+            res.1.belongs_to_cpu(res.0.cpu()),
+            res.1.local_key() == res.0.expected_locals_key(),
+    {
+        (self.handle, self.locals)
+    }
+}
+
+/// Regression proof that a CPU-local points-to resource remains owned by the
+/// same core across scheduling and a temporary local-state access.
+proof fn cpu_core_owns_cpu_local_points_to<V>(initial: Map<CpuId, V>, cpu: CpuId, new_value: V)
+    requires
+        initial.contains_key(cpu),
+{
+    let tracked (mut instance, mut points_to_set) = CpuLocalInstance::new(initial);
+    let tracked points_to = points_to_set.tracked_take(cpu);
+    let tracked mut core = CpuCore::new(cpu, points_to);
+
+    let ghost task = instance.id();
+    core.tracked_schedule_in(task);
+    let tracked (handle, mut points_to) = core.tracked_open();
+    assert(handle.cpu() == cpu);
+    assert(handle.current_task() == Some(task));
+
+    points_to.tracked_update(&mut instance, new_value);
+    let tracked mut core = handle.tracked_restore(points_to);
+    assert(core.cpu() == cpu);
+    assert(core.current_task() == Some(task));
+
+    let finished_task = core.tracked_schedule_out();
+    assert(finished_task == task);
+    assert(core.is_idle());
+}
+
+} // verus!

--- a/ostd/specs/task/cpu_local.rs
+++ b/ostd/specs/task/cpu_local.rs
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: MPL-2.0
+//! Proof model for CPU-local state.
+//!
+//! A CPU-local object is modeled as one logical value for every CPU in its
+//! configured domain.
+//! [`CpuLocalInstance`] owns the authoritative map, while
+//! [`CpuLocalPointsTo`] is the exclusive points-to resource for one CPU's
+//! entry. Distinct CPUs therefore have independently owned resources and may
+//! operate on them concurrently.
+//!
+//! This module only defines the resource algebra used by CPU-local clients. It
+//! does not yet connect the resources to executable CPU-local storage,
+//! preemption guards, or scheduler transitions. Those layers should keep the
+//! authoritative instance in an invariant and transfer each points-to resource
+//! into the corresponding CPU core's proof state.
+use vstd::{
+    prelude::*,
+    resource::{
+        map::{GhostMapAuth, GhostPointsTo, GhostSubmap},
+        Loc,
+    },
+};
+
+use crate::specs::mm::cpu::CpuId;
+use crate::specs::task::cpu_core::CpuCoreLocalState;
+
+verus! {
+
+/// Authoritative logical contents of one CPU-local object.
+///
+/// The domain is fixed at allocation time. Updating a value requires both this
+/// authority and the matching [`CpuLocalPointsTo`], so the executable invariant
+/// cannot change a CPU's entry without its exclusive per-CPU permission.
+pub tracked struct CpuLocalInstance<V> {
+    auth: GhostMapAuth<CpuId, V>,
+}
+
+/// CPU-local points-to resources that have not yet been distributed.
+///
+/// A newly allocated model returns all resources in this collection. CPU setup
+/// can split them into individual [`CpuLocalPointsTo`] resources and install
+/// each resource in the corresponding CPU core's proof state.
+pub tracked struct CpuLocalPointsToSet<V> {
+    points_to: GhostSubmap<CpuId, V>,
+}
+
+/// Exclusive ownership of one CPU's entry in a CPU-local object.
+///
+/// Two live points-to resources associated with the same
+/// [`CpuLocalInstance`] necessarily refer to different CPUs. Holding this
+/// token does not by itself establish that the holder is currently executing
+/// on that CPU; the scheduler glue must additionally bind `cpu()` to its
+/// current-CPU token.
+pub tracked struct CpuLocalPointsTo<V> {
+    points_to: GhostPointsTo<CpuId, V>,
+}
+
+impl<V> CpuCoreLocalState for CpuLocalPointsTo<V> {
+    open spec fn belongs_to_cpu(self, cpu: CpuId) -> bool {
+        self.cpu() == cpu
+    }
+
+    open spec fn local_key(self) -> Seq<Loc> {
+        seq![self.id()]
+    }
+}
+
+impl<V> View for CpuLocalInstance<V> {
+    type V = Map<CpuId, V>;
+
+    closed spec fn view(&self) -> Self::V {
+        self.auth@
+    }
+}
+
+impl<V> View for CpuLocalPointsToSet<V> {
+    type V = Map<CpuId, V>;
+
+    closed spec fn view(&self) -> Self::V {
+        self.points_to@
+    }
+}
+
+impl<V> CpuLocalInstance<V> {
+    /// Allocates proof state for CPU-local contents described by `initial`.
+    ///
+    /// Allocation returns the authoritative state and exclusive ownership of
+    /// every points-to resource. No executable storage is allocated by this
+    /// proof function.
+    pub proof fn new(initial: Map<CpuId, V>) -> (tracked res: (
+        CpuLocalInstance<V>,
+        CpuLocalPointsToSet<V>,
+    ))
+        ensures
+            res.0.id() == res.1.id(),
+            res.0@ == initial,
+            res.1@ == initial,
+            res.0.cpus() == initial.dom(),
+            res.1.cpus() == initial.dom(),
+    {
+        let tracked (auth, points_to) = GhostMapAuth::new(initial);
+        (CpuLocalInstance { auth }, CpuLocalPointsToSet { points_to })
+    }
+
+    /// Identity shared by the authority and all of its points-to resources.
+    pub closed spec fn id(&self) -> Loc {
+        self.auth.id()
+    }
+
+    /// CPUs represented by this CPU-local object.
+    pub open spec fn cpus(&self) -> Set<CpuId> {
+        self@.dom()
+    }
+
+    /// The value currently associated with `cpu`.
+    pub open spec fn value(&self, cpu: CpuId) -> V
+        recommends
+            self.cpus().contains(cpu),
+    {
+        self@[cpu]
+    }
+
+    /// Whether this instance contains exactly the configured CPU set.
+    pub open spec fn covers(&self, cpus: Set<CpuId>) -> bool {
+        self.cpus() == cpus
+    }
+}
+
+impl<V> CpuLocalPointsToSet<V> {
+    /// Identity of the corresponding [`CpuLocalInstance`].
+    pub closed spec fn id(&self) -> Loc {
+        self.points_to.id()
+    }
+
+    /// CPUs whose exclusive points-to resources are still held here.
+    pub open spec fn cpus(&self) -> Set<CpuId> {
+        self@.dom()
+    }
+
+    /// Whether this collection currently owns `cpu`'s points-to resource.
+    pub open spec fn contains(&self, cpu: CpuId) -> bool {
+        self.cpus().contains(cpu)
+    }
+
+    /// Splits out exclusive ownership of one CPU's entry.
+    pub proof fn tracked_take(tracked &mut self, cpu: CpuId) -> (tracked res: CpuLocalPointsTo<V>)
+        requires
+            old(self).contains(cpu),
+        ensures
+            final(self).id() == old(self).id(),
+            res.id() == final(self).id(),
+            res.cpu() == cpu,
+            res.value() == old(self)@[cpu],
+            final(self)@ == old(self)@.remove(cpu),
+            final(self).cpus() == old(self).cpus().remove(cpu),
+    {
+        let tracked points_to = self.points_to.split_points_to(cpu);
+        let tracked res = CpuLocalPointsTo { points_to };
+        assert(res.value() == old(self)@[cpu]);
+        res
+    }
+
+    /// Returns an individual points-to resource to this collection.
+    pub proof fn tracked_return(tracked &mut self, tracked points_to: CpuLocalPointsTo<V>)
+        requires
+            old(self).id() == points_to.id(),
+            !old(self).contains(points_to.cpu()),
+        ensures
+            final(self).id() == old(self).id(),
+            final(self)@ == old(self)@.insert(points_to.cpu(), points_to.value()),
+            final(self).cpus() == old(self).cpus().insert(points_to.cpu()),
+    {
+        self.points_to.combine_points_to(points_to.points_to);
+    }
+}
+
+impl<V> CpuLocalPointsTo<V> {
+    /// Identity of the corresponding [`CpuLocalInstance`].
+    pub closed spec fn id(&self) -> Loc {
+        self.points_to.id()
+    }
+
+    /// CPU whose entry is owned by this points-to resource.
+    pub closed spec fn cpu(&self) -> CpuId {
+        self.points_to.key()
+    }
+
+    /// Current logical value of this CPU's entry.
+    pub closed spec fn value(&self) -> V {
+        self.points_to.value()
+    }
+
+    /// Establishes agreement with the authoritative CPU-local contents.
+    pub proof fn lemma_agree(tracked &self, tracked instance: &CpuLocalInstance<V>)
+        requires
+            self.id() == instance.id(),
+        ensures
+            instance.cpus().contains(self.cpu()),
+            instance.value(self.cpu()) == self.value(),
+    {
+        self.points_to.agree(&instance.auth);
+    }
+
+    /// Updates this CPU's logical value.
+    ///
+    /// Other CPUs' points-to resources remain disjoint and retain their values.
+    pub proof fn tracked_update(
+        tracked &mut self,
+        tracked instance: &mut CpuLocalInstance<V>,
+        value: V,
+    )
+        requires
+            old(self).id() == old(instance).id(),
+        ensures
+            final(self).id() == old(self).id(),
+            final(self).cpu() == old(self).cpu(),
+            final(self).value() == value,
+            final(instance).id() == old(instance).id(),
+            final(instance).cpus() == old(instance).cpus(),
+            final(instance)@ == old(instance)@.insert(old(self).cpu(), value),
+    {
+        self.points_to.agree(&instance.auth);
+        let ghost cpu = self.cpu();
+        self.points_to.update(&mut instance.auth, value);
+        assert(instance@ == old(instance)@.insert(cpu, value));
+        assert(instance@.dom() == old(instance)@.dom());
+    }
+
+    /// Two points-to resources belonging to one instance refer to distinct CPUs.
+    pub proof fn lemma_distinct(tracked &mut self, tracked other: &CpuLocalPointsTo<V>)
+        requires
+            old(self).id() == other.id(),
+        ensures
+            final(self).id() == old(self).id(),
+            final(self).cpu() == old(self).cpu(),
+            final(self).value() == old(self).value(),
+            final(self).cpu() != other.cpu(),
+    {
+        self.points_to.disjoint(&other.points_to);
+    }
+
+    /// Two live points-to resources for the same CPU cannot belong to the same
+    /// CPU-local instance.
+    pub proof fn lemma_same_cpu_has_distinct_instance(
+        tracked &mut self,
+        tracked other: &CpuLocalPointsTo<V>,
+    )
+        requires
+            old(self).cpu() == other.cpu(),
+        ensures
+            final(self).id() == old(self).id(),
+            final(self).cpu() == old(self).cpu(),
+            final(self).value() == old(self).value(),
+            final(self).id() != other.id(),
+    {
+        if self.id() == other.id() {
+            self.points_to.disjoint(&other.points_to);
+        }
+    }
+}
+
+/// Regression proof for splitting, independently updating, and returning two
+/// CPU-local points-to resources.
+proof fn cpu_local_points_to_smoke_test<V>(
+    initial: Map<CpuId, V>,
+    cpu1: CpuId,
+    cpu2: CpuId,
+    new_value: V,
+)
+    requires
+        initial.contains_key(cpu1),
+        initial.contains_key(cpu2),
+        cpu1 != cpu2,
+{
+    let tracked (mut instance, mut points_to_set) = CpuLocalInstance::new(initial);
+    let tracked mut points_to1 = points_to_set.tracked_take(cpu1);
+    let tracked mut points_to2 = points_to_set.tracked_take(cpu2);
+
+    points_to1.lemma_distinct(&points_to2);
+    let ghost old_cpu2_value = points_to2.value();
+    points_to1.tracked_update(&mut instance, new_value);
+    points_to2.lemma_agree(&instance);
+    assert(points_to2.value() == old_cpu2_value);
+
+    points_to_set.tracked_return(points_to1);
+    points_to_set.tracked_return(points_to2);
+    assert(points_to_set.cpus() == initial.dom());
+}
+
+} // verus!

--- a/ostd/specs/task/cpu_local.rs
+++ b/ostd/specs/task/cpu_local.rs
@@ -16,8 +16,8 @@
 use vstd::{
     prelude::*,
     resource::{
-        map::{GhostMapAuth, GhostPointsTo, GhostSubmap},
         Loc,
+        map::{GhostMapAuth, GhostPointsTo, GhostSubmap},
     },
 };
 

--- a/ostd/specs/task/cpu_local.rs
+++ b/ostd/specs/task/cpu_local.rs
@@ -3,7 +3,7 @@
 //!
 //! A CPU-local object is modeled as one logical value for every CPU in its
 //! configured domain.
-//! [`CpuLocalInstance`] owns the authoritative map, while
+//! [`CpuLocalAuth`] owns the authoritative map, while
 //! [`CpuLocalPointsTo`] is the exclusive points-to resource for one CPU's
 //! entry. Distinct CPUs therefore have independently owned resources and may
 //! operate on them concurrently.
@@ -11,7 +11,7 @@
 //! This module only defines the resource algebra used by CPU-local clients. It
 //! does not yet connect the resources to executable CPU-local storage,
 //! preemption guards, or scheduler transitions. Those layers should keep the
-//! authoritative instance in an invariant and transfer each points-to resource
+//! authority in an invariant and transfer each points-to resource
 //! into the corresponding CPU core's proof state.
 use vstd::{
     prelude::*,
@@ -31,7 +31,7 @@ verus! {
 /// The domain is fixed at allocation time. Updating a value requires both this
 /// authority and the matching [`CpuLocalPointsTo`], so the executable invariant
 /// cannot change a CPU's entry without its exclusive per-CPU permission.
-pub tracked struct CpuLocalInstance<V> {
+pub tracked struct CpuLocalAuth<V> {
     auth: GhostMapAuth<CpuId, V>,
 }
 
@@ -47,7 +47,7 @@ pub tracked struct CpuLocalPointsToSet<V> {
 /// Exclusive ownership of one CPU's entry in a CPU-local object.
 ///
 /// Two live points-to resources associated with the same
-/// [`CpuLocalInstance`] necessarily refer to different CPUs. Holding this
+/// [`CpuLocalAuth`] necessarily refer to different CPUs. Holding this
 /// token does not by itself establish that the holder is currently executing
 /// on that CPU; the scheduler glue must additionally bind `cpu()` to its
 /// current-CPU token.
@@ -65,7 +65,7 @@ impl<V> CpuCoreLocalState for CpuLocalPointsTo<V> {
     }
 }
 
-impl<V> View for CpuLocalInstance<V> {
+impl<V> View for CpuLocalAuth<V> {
     type V = Map<CpuId, V>;
 
     closed spec fn view(&self) -> Self::V {
@@ -81,14 +81,14 @@ impl<V> View for CpuLocalPointsToSet<V> {
     }
 }
 
-impl<V> CpuLocalInstance<V> {
+impl<V> CpuLocalAuth<V> {
     /// Allocates proof state for CPU-local contents described by `initial`.
     ///
     /// Allocation returns the authoritative state and exclusive ownership of
     /// every points-to resource. No executable storage is allocated by this
     /// proof function.
     pub proof fn new(initial: Map<CpuId, V>) -> (tracked res: (
-        CpuLocalInstance<V>,
+        CpuLocalAuth<V>,
         CpuLocalPointsToSet<V>,
     ))
         ensures
@@ -99,7 +99,7 @@ impl<V> CpuLocalInstance<V> {
             res.1.cpus() == initial.dom(),
     {
         let tracked (auth, points_to) = GhostMapAuth::new(initial);
-        (CpuLocalInstance { auth }, CpuLocalPointsToSet { points_to })
+        (CpuLocalAuth { auth }, CpuLocalPointsToSet { points_to })
     }
 
     /// Identity shared by the authority and all of its points-to resources.
@@ -120,14 +120,14 @@ impl<V> CpuLocalInstance<V> {
         self@[cpu]
     }
 
-    /// Whether this instance contains exactly the configured CPU set.
+    /// Whether this authority contains exactly the configured CPU set.
     pub open spec fn covers(&self, cpus: Set<CpuId>) -> bool {
         self.cpus() == cpus
     }
 }
 
 impl<V> CpuLocalPointsToSet<V> {
-    /// Identity of the corresponding [`CpuLocalInstance`].
+    /// Identity of the corresponding [`CpuLocalAuth`].
     pub closed spec fn id(&self) -> Loc {
         self.points_to.id()
     }
@@ -175,7 +175,7 @@ impl<V> CpuLocalPointsToSet<V> {
 }
 
 impl<V> CpuLocalPointsTo<V> {
-    /// Identity of the corresponding [`CpuLocalInstance`].
+    /// Identity of the corresponding [`CpuLocalAuth`].
     pub closed spec fn id(&self) -> Loc {
         self.points_to.id()
     }
@@ -191,42 +191,38 @@ impl<V> CpuLocalPointsTo<V> {
     }
 
     /// Establishes agreement with the authoritative CPU-local contents.
-    pub proof fn lemma_agree(tracked &self, tracked instance: &CpuLocalInstance<V>)
+    pub proof fn lemma_agree(tracked &self, tracked auth: &CpuLocalAuth<V>)
         requires
-            self.id() == instance.id(),
+            self.id() == auth.id(),
         ensures
-            instance.cpus().contains(self.cpu()),
-            instance.value(self.cpu()) == self.value(),
+            auth.cpus().contains(self.cpu()),
+            auth.value(self.cpu()) == self.value(),
     {
-        self.points_to.agree(&instance.auth);
+        self.points_to.agree(&auth.auth);
     }
 
     /// Updates this CPU's logical value.
     ///
     /// Other CPUs' points-to resources remain disjoint and retain their values.
-    pub proof fn tracked_update(
-        tracked &mut self,
-        tracked instance: &mut CpuLocalInstance<V>,
-        value: V,
-    )
+    pub proof fn tracked_update(tracked &mut self, tracked auth: &mut CpuLocalAuth<V>, value: V)
         requires
-            old(self).id() == old(instance).id(),
+            old(self).id() == old(auth).id(),
         ensures
             final(self).id() == old(self).id(),
             final(self).cpu() == old(self).cpu(),
             final(self).value() == value,
-            final(instance).id() == old(instance).id(),
-            final(instance).cpus() == old(instance).cpus(),
-            final(instance)@ == old(instance)@.insert(old(self).cpu(), value),
+            final(auth).id() == old(auth).id(),
+            final(auth).cpus() == old(auth).cpus(),
+            final(auth)@ == old(auth)@.insert(old(self).cpu(), value),
     {
-        self.points_to.agree(&instance.auth);
+        self.points_to.agree(&auth.auth);
         let ghost cpu = self.cpu();
-        self.points_to.update(&mut instance.auth, value);
-        assert(instance@ == old(instance)@.insert(cpu, value));
-        assert(instance@.dom() == old(instance)@.dom());
+        self.points_to.update(&mut auth.auth, value);
+        assert(auth@ == old(auth)@.insert(cpu, value));
+        assert(auth@.dom() == old(auth)@.dom());
     }
 
-    /// Two points-to resources belonging to one instance refer to distinct CPUs.
+    /// Two points-to resources belonging to one authority refer to distinct CPUs.
     pub proof fn lemma_distinct(tracked &mut self, tracked other: &CpuLocalPointsTo<V>)
         requires
             old(self).id() == other.id(),
@@ -240,8 +236,8 @@ impl<V> CpuLocalPointsTo<V> {
     }
 
     /// Two live points-to resources for the same CPU cannot belong to the same
-    /// CPU-local instance.
-    pub proof fn lemma_same_cpu_has_distinct_instance(
+    /// CPU-local authority.
+    pub proof fn lemma_same_cpu_has_distinct_auth(
         tracked &mut self,
         tracked other: &CpuLocalPointsTo<V>,
     )
@@ -272,14 +268,14 @@ proof fn cpu_local_points_to_smoke_test<V>(
         initial.contains_key(cpu2),
         cpu1 != cpu2,
 {
-    let tracked (mut instance, mut points_to_set) = CpuLocalInstance::new(initial);
+    let tracked (mut auth, mut points_to_set) = CpuLocalAuth::new(initial);
     let tracked mut points_to1 = points_to_set.tracked_take(cpu1);
     let tracked mut points_to2 = points_to_set.tracked_take(cpu2);
 
     points_to1.lemma_distinct(&points_to2);
     let ghost old_cpu2_value = points_to2.value();
-    points_to1.tracked_update(&mut instance, new_value);
-    points_to2.lemma_agree(&instance);
+    points_to1.tracked_update(&mut auth, new_value);
+    points_to2.lemma_agree(&auth);
     assert(points_to2.value() == old_cpu2_value);
 
     points_to_set.tracked_return(points_to1);

--- a/ostd/specs/task/mod.rs
+++ b/ostd/specs/task/mod.rs
@@ -15,3 +15,5 @@ impl InAtomicMode for AnyAtomicGuard {
 }
 
 } // verus!
+pub mod cpu_core;
+pub mod cpu_local;


### PR DESCRIPTION
`CpuCore` is a spec-only model for the current CPU core and the handle is the linear resource you'd "open" the current core for verification so you can store anything inside a CPU core.