### PR TITLE
fix: Use `&'static PointsTo<MetaSlot>` in `MetaRegionOwners.slots`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,11 +589,11 @@ dependencies = [
 
 [[package]]
 name = "verus_builtin"
-version = "0.0.0-2026-05-17-0151"
+version = "0.0.0-2026-07-27-0206"
 
 [[package]]
 name = "verus_builtin_macros"
-version = "0.0.0-2026-07-12-0122"
+version = "0.0.0-2026-07-27-0206"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -606,7 +606,7 @@ dependencies = [
 
 [[package]]
 name = "verus_prettyplease"
-version = "0.0.0-2026-05-31-0205"
+version = "0.0.0-2026-07-27-0206"
 dependencies = [
  "proc-macro2",
  "verus_syn",
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "verus_state_machines_macros"
-version = "0.0.0-2026-06-14-0213"
+version = "0.0.0-2026-07-27-0206"
 dependencies = [
  "indexmap",
  "proc-macro2",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "verus_syn"
-version = "0.0.0-2026-05-31-0205"
+version = "0.0.0-2026-07-27-0206"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -645,7 +645,7 @@ checksum = "af8ca9a5d4debca0633e697c88269395493cebf2e10db21ca2dbde37c1356452"
 
 [[package]]
 name = "vstd"
-version = "0.0.0-2026-07-12-0122"
+version = "0.0.0-2026-07-27-0206"
 dependencies = [
  "verus_builtin",
  "verus_builtin_macros",

--- a/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
+++ b/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
@@ -275,7 +275,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
     pub open spec fn meta_wf_at(self, regions: MetaRegionOwners, i: int) -> bool {
         let idx = meta_to_index(self.list[i].paddr);
         typed_meta_wf::<Link<M>>(
-            regions.slots[idx],
+            *regions.slots[idx],
             regions.slot_owners[idx].inner_perms.storage,
             self.repr_perms[i],
         )
@@ -541,7 +541,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
                     &&& fr.slot_owners[i].usage is Frame
                     &&& fr.slot_owners[i].inner_perms.in_list.value() == new.list_id
                     &&& typed_meta_wf::<Link<M>>(
-                        fr.slots[i],
+                        *fr.slots[i],
                         fr.slot_owners[i].inner_perms.storage,
                         new.repr_perms[np],
                     )

--- a/ostd/specs/mm/frame/meta_region_owners.rs
+++ b/ostd/specs/mm/frame/meta_region_owners.rs
@@ -47,7 +47,7 @@ verus! {
 /// the verified code that call `from_raw` have a precondition that the frame's index is not a key in `slots`.
 #[verifier::ext_equal]
 pub tracked struct MetaRegionOwners {
-    pub slots: Map<int, simple_pptr::PointsTo<MetaSlot>>,
+    pub slots: Map<int, &'static simple_pptr::PointsTo<MetaSlot>>,
     pub slot_owners: Map<int, MetaSlotOwner>,
     /// Outstanding per-instance obligations for both `Frame<M>` and
     /// `Segment<M>`, as a multiset of slot indices. `ManuallyDrop::new(frame,

--- a/ostd/specs/mm/frame/unique.rs
+++ b/ostd/specs/mm/frame/unique.rs
@@ -115,7 +115,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrame<M> {
 impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrameOwner<M> {
     pub open spec fn meta_wf(self, regions: MetaRegionOwners) -> bool {
         typed_meta_wf::<M>(
-            regions.slots[self.slot_index],
+            *regions.slots[self.slot_index],
             regions.slot_owners[self.slot_index].inner_perms.storage,
             self.repr_perm->0,
         )

--- a/ostd/specs/mm/page_table/node/owners.rs
+++ b/ostd/specs/mm/page_table/node/owners.rs
@@ -260,7 +260,7 @@ impl<C: PageTableConfig> NodeOwner<C> {
 
     pub open spec fn meta_wf(self, regions: MetaRegionOwners) -> bool {
         typed_meta_wf::<PageTablePageMeta<C>>(
-            regions.slots[self.slot_index],
+            *regions.slots[self.slot_index],
             regions.slot_owners[self.slot_index].inner_perms.storage,
             (),
         )

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -20,7 +20,7 @@ use crate::mm::kspace::FRAME_METADATA_RANGE;
 use crate::specs::arch::*;
 use crate::specs::mm::frame::{
     linked_list::linked_list_owners::*,
-    mapping::{frame_to_index, group_page_meta, index_to_meta, max_meta_slots, meta_to_index},
+    mapping::{frame_to_index, group_page_meta, index_to_meta, meta_to_index},
     meta_owners::{
         MetaSlotOwner, MetaSlotStorage, borrow_meta, borrow_meta_mut, typed_meta_value,
         typed_meta_wf,
@@ -410,13 +410,6 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
             return false;
         };
 
-        proof {
-            broadcast use group_page_meta;
-
-            assert(regions.slot_owners.contains_key(idx));
-            assert(regions.slots.contains_key(idx));
-        }
-
         let tracked mut slot_own = regions.slot_owners.tracked_borrow_mut(idx);
 
         let tracked mut inner_perms = slot_own.tracked_borrow_mut_inner_perms();
@@ -476,12 +469,6 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
             };
         };
 
-        proof {
-            broadcast use group_page_meta;
-
-            assert(regions.slot_owners.contains_key(idx));
-            assert(regions.slots.contains_key(idx));
-        }
         let tracked mut slot_own = regions.slot_owners.tracked_borrow_mut(idx);
         let tracked mut inner_perms = slot_own.tracked_borrow_mut_inner_perms();
 

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -394,50 +394,34 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
             old(owner).list_id != 0 ==> *final(owner) == *old(owner),
     )]
     pub fn contains(&mut self, frame: Paddr) -> bool {
-        let ghost idx = frame_to_index(frame);
-        let ghost perm_idx = if valid_frame_paddr(frame) {
-            idx
-        } else {
-            0
-        };
-        proof {
-            assert(0 < max_meta_slots()) by (compute);
-            broadcast use group_page_meta;
-
-            if valid_frame_paddr(frame) {
-                regions.inv_implies_correct_addr(frame);
+        proof_decl! {
+            let ghost idx = frame_to_index(frame);
+                if valid_frame_paddr(frame) {
+                    regions.inv_implies_correct_addr(frame);
+                }
+            let tracked slot_perm = if valid_frame_paddr(frame) {
+                Some(*regions.slots.tracked_borrow(idx))
             } else {
-                assert(regions.slot_owners.contains_key(0));
-                assert(regions.slots.contains_key(0));
-            }
+                None
+            };
         }
-
-        let tracked slot_perm_ref = regions.slots.tracked_borrow(perm_idx);
-        let tracked slot_perm = *slot_perm_ref;
         let Ok(slot) = (#[verus_spec(with Tracked(slot_perm))]
         get_slot(frame)) else {
             return false;
         };
 
         proof {
-            assert(valid_frame_paddr(frame));
             broadcast use group_page_meta;
 
             assert(regions.slot_owners.contains_key(idx));
             assert(regions.slots.contains_key(idx));
-            assert(regions.slots[idx].is_init());
-            assert(regions.slot_owners[idx].inner_perms.in_list.is_for(
-                regions.slots[idx].value().in_list,
-            ));
         }
 
         let tracked mut slot_own = regions.slot_owners.tracked_borrow_mut(idx);
 
         let tracked mut inner_perms = slot_own.tracked_borrow_mut_inner_perms();
 
-        let in_list = slot.in_list.load(Tracked(&mut inner_perms.in_list));
-
-        in_list == #[verus_spec(with Tracked(owner))]
+        slot.in_list.load(Tracked(&mut inner_perms.in_list)) == #[verus_spec(with Tracked(owner))]
         self.lazy_get_id()
     }
 
@@ -472,26 +456,18 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
             final(regions).slot_owners.dom() == old(regions).slot_owners.dom(),
     )]
     pub fn cursor_mut_at(&mut self, frame: Paddr) -> Option<CursorMut<'_, M>> {
-        let ghost idx = frame_to_index(frame);
-        let ghost perm_idx = if valid_frame_paddr(frame) {
-            idx
-        } else {
-            0
-        };
-        proof {
-            assert(0 < max_meta_slots()) by (compute);
-            broadcast use group_page_meta;
-
+        proof_decl! {
+            let ghost idx = frame_to_index(frame);
             if valid_frame_paddr(frame) {
                 regions.inv_implies_correct_addr(frame);
-            } else {
-                assert(regions.slot_owners.contains_key(0));
-                assert(regions.slots.contains_key(0));
             }
-        }
 
-        let tracked slot_perm_ref = regions.slots.tracked_borrow(perm_idx);
-        let tracked slot_perm = *slot_perm_ref;
+            let tracked slot_perm = if valid_frame_paddr(frame) {
+                Some(*regions.slots.tracked_borrow(idx))
+            } else {
+                None
+            };
+        }
         let Ok(slot) = (#[verus_spec(with Tracked(slot_perm))]
         get_slot(frame)) else {
             return {
@@ -501,7 +477,6 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
         };
 
         proof {
-            assert(valid_frame_paddr(frame));
             broadcast use group_page_meta;
 
             assert(regions.slot_owners.contains_key(idx));
@@ -510,20 +485,20 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
         let tracked mut slot_own = regions.slot_owners.tracked_borrow_mut(idx);
         let tracked mut inner_perms = slot_own.tracked_borrow_mut_inner_perms();
 
-        let in_list = slot.in_list.load(Tracked(&mut inner_perms.in_list));
-
-        let contains = in_list == #[verus_spec(with Tracked(&owner))]
+        let contains = slot.in_list.load(Tracked(&mut inner_perms.in_list))
+            == #[verus_spec(with Tracked(&owner))]
         self.lazy_get_id();
 
-        let meta_ptr = ReprPtr::<MetaSlotStorage, Link<M>>::from_pptr(
-            PPtr::<MetaSlotStorage>::from_addr(frame_to_meta(frame)),
-        );
-
         if contains {
-            let ghost link = owner.list.filter(|link: LinkOwner| link.paddr == frame).first();
-            let ghost index = owner.list.index_of(link);
-            let tracked cursor_owner = CursorOwner::tracked_cursor_mut_at_owner(owner, index);
+            proof_decl!{
+                let ghost link = owner.list.filter(|link: LinkOwner| link.paddr == frame).first();
+                let ghost index = owner.list.index_of(link);
+                let tracked cursor_owner = CursorOwner::tracked_cursor_mut_at_owner(owner, index);
+            }
 
+            let meta_ptr = ReprPtr::<MetaSlotStorage, Link<M>>::from_pptr(
+                PPtr::<MetaSlotStorage>::from_addr(frame_to_meta(frame)),
+            );
             proof_with!(|= Tracked(Some(cursor_owner)));
             Some(CursorMut { list: self, current: Some(meta_ptr) })
         } else {

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -31,7 +31,7 @@ use crate::specs::mm::frame::{
 
 use super::{
     MetaSlot, mapping,
-    meta::{AnyFrameMeta, get_slot},
+    meta::{_VERUS_VERIFIED_get_slot, AnyFrameMeta, get_slot},
     unique::UniqueFrame,
 };
 use crate::{
@@ -394,18 +394,35 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
             old(owner).list_id != 0 ==> *final(owner) == *old(owner),
     )]
     pub fn contains(&mut self, frame: Paddr) -> bool {
-        let Ok(slot_ptr) = get_slot(frame) else {
+        let ghost idx = frame_to_index(frame);
+        let ghost perm_idx = if valid_frame_paddr(frame) {
+            idx
+        } else {
+            0
+        };
+        proof {
+            assert(0 < max_meta_slots()) by (compute);
+            broadcast use group_page_meta;
+
+            if valid_frame_paddr(frame) {
+                regions.inv_implies_correct_addr(frame);
+            } else {
+                assert(regions.slot_owners.contains_key(0));
+                assert(regions.slots.contains_key(0));
+            }
+        }
+
+        let tracked slot_perm_ref = regions.slots.tracked_borrow(perm_idx);
+        let tracked slot_perm = *slot_perm_ref;
+        let Ok(slot) = (#[verus_spec(with Tracked(slot_perm))]
+        get_slot(frame)) else {
             return false;
         };
 
         proof {
-            // `get_slot` returned `Ok`, so `valid_frame_paddr(frame)` holds; with
-            // `regions.inv()` that pins the slot in the region maps, its
-            // metadata as init, and its `in_list` permission as governing the
-            // slot's atomic — the same facts `cursor_mut_at` derives in-body.
+            assert(valid_frame_paddr(frame));
             broadcast use group_page_meta;
 
-            let idx = frame_to_index(frame);
             assert(regions.slot_owners.contains_key(idx));
             assert(regions.slots.contains_key(idx));
             assert(regions.slots[idx].is_init());
@@ -414,15 +431,11 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
             ));
         }
 
-        let tracked mut slot_perm = regions.slots.tracked_borrow_mut(frame_to_index(frame));
-        let tracked mut slot_own = regions.slot_owners.tracked_borrow_mut(frame_to_index(frame));
-
-        let slot = slot_ptr.take(Tracked(slot_perm));
+        let tracked mut slot_own = regions.slot_owners.tracked_borrow_mut(idx);
 
         let tracked mut inner_perms = slot_own.tracked_borrow_mut_inner_perms();
 
         let in_list = slot.in_list.load(Tracked(&mut inner_perms.in_list));
-        slot_ptr.put(Tracked(slot_perm), slot);
 
         in_list == #[verus_spec(with Tracked(owner))]
         self.lazy_get_id()
@@ -459,42 +472,61 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
             final(regions).slot_owners.dom() == old(regions).slot_owners.dom(),
     )]
     pub fn cursor_mut_at(&mut self, frame: Paddr) -> Option<CursorMut<'_, M>> {
-        if let Ok(slot_ptr) = get_slot(frame) {
-            let ghost idx = frame_to_index(frame);
-            proof {
-                broadcast use group_page_meta;
+        let ghost idx = frame_to_index(frame);
+        let ghost perm_idx = if valid_frame_paddr(frame) {
+            idx
+        } else {
+            0
+        };
+        proof {
+            assert(0 < max_meta_slots()) by (compute);
+            broadcast use group_page_meta;
 
-                assert(regions.slot_owners.contains_key(idx));
-                assert(regions.slots.contains_key(idx));
-            }
-            let tracked slot_perm = regions.slots.tracked_borrow(idx);
-            let tracked mut slot_own = regions.slot_owners.tracked_borrow_mut(idx);
-            let tracked mut inner_perms = slot_own.tracked_borrow_mut_inner_perms();
-
-            let slot = slot_ptr.borrow(Tracked(slot_perm));
-
-            let in_list = slot.in_list.load(Tracked(&mut inner_perms.in_list));
-
-            let contains = in_list == #[verus_spec(with Tracked(&owner))]
-            self.lazy_get_id();
-
-            let meta_ptr = ReprPtr::<MetaSlotStorage, Link<M>>::from_pptr(
-                PPtr::<MetaSlotStorage>::from_addr(slot_ptr.addr()),
-            );
-
-            if contains {
-                let ghost link = owner.list.filter(|link: LinkOwner| link.paddr == frame).first();
-                let ghost index = owner.list.index_of(link);
-                let tracked cursor_owner = CursorOwner::tracked_cursor_mut_at_owner(owner, index);
-
-                proof_with!(|= Tracked(Some(cursor_owner)));
-                Some(CursorMut { list: self, current: Some(meta_ptr) })
+            if valid_frame_paddr(frame) {
+                regions.inv_implies_correct_addr(frame);
             } else {
+                assert(regions.slot_owners.contains_key(0));
+                assert(regions.slots.contains_key(0));
+            }
+        }
+
+        let tracked slot_perm_ref = regions.slots.tracked_borrow(perm_idx);
+        let tracked slot_perm = *slot_perm_ref;
+        let Ok(slot) = (#[verus_spec(with Tracked(slot_perm))]
+        get_slot(frame)) else {
+            return {
                 proof_with!(|= Tracked(None));
                 None
-            }
+            };
+        };
+
+        proof {
+            assert(valid_frame_paddr(frame));
+            broadcast use group_page_meta;
+
+            assert(regions.slot_owners.contains_key(idx));
+            assert(regions.slots.contains_key(idx));
+        }
+        let tracked mut slot_own = regions.slot_owners.tracked_borrow_mut(idx);
+        let tracked mut inner_perms = slot_own.tracked_borrow_mut_inner_perms();
+
+        let in_list = slot.in_list.load(Tracked(&mut inner_perms.in_list));
+
+        let contains = in_list == #[verus_spec(with Tracked(&owner))]
+        self.lazy_get_id();
+
+        let meta_ptr = ReprPtr::<MetaSlotStorage, Link<M>>::from_pptr(
+            PPtr::<MetaSlotStorage>::from_addr(frame_to_meta(frame)),
+        );
+
+        if contains {
+            let ghost link = owner.list.filter(|link: LinkOwner| link.paddr == frame).first();
+            let ghost index = owner.list.index_of(link);
+            let tracked cursor_owner = CursorOwner::tracked_cursor_mut_at_owner(owner, index);
+
+            proof_with!(|= Tracked(Some(cursor_owner)));
+            Some(CursorMut { list: self, current: Some(meta_ptr) })
         } else {
-            assert(!valid_frame_paddr(frame));
             proof_with!(|= Tracked(None));
             None
         }

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -395,15 +395,15 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
     )]
     pub fn contains(&mut self, frame: Paddr) -> bool {
         proof_decl! {
-            let ghost idx = frame_to_index(frame);
-                if valid_frame_paddr(frame) {
-                    regions.inv_implies_correct_addr(frame);
-                }
-            let tracked slot_perm = if valid_frame_paddr(frame) {
-                Some(*regions.slots.tracked_borrow(idx))
-            } else {
-                None
-            };
+        let ghost idx = frame_to_index(frame);
+            if valid_frame_paddr(frame) {
+                regions.inv_implies_correct_addr(frame);
+            }
+        let tracked slot_perm = if valid_frame_paddr(frame) {
+            Some(*regions.slots.tracked_borrow(idx))
+        } else {
+            None
+        };
         }
         let Ok(slot) = (#[verus_spec(with Tracked(slot_perm))]
         crate::mm::frame::meta::get_slot(frame)) else {

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -31,7 +31,7 @@ use crate::specs::mm::frame::{
 
 use super::{
     MetaSlot, mapping,
-    meta::{_VERUS_VERIFIED_get_slot, AnyFrameMeta, get_slot},
+    meta::{AnyFrameMeta, get_slot},
     unique::UniqueFrame,
 };
 use crate::{
@@ -406,7 +406,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
             };
         }
         let Ok(slot) = (#[verus_spec(with Tracked(slot_perm))]
-        get_slot(frame)) else {
+        crate::mm::frame::meta::get_slot(frame)) else {
             return false;
         };
 
@@ -462,7 +462,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
             };
         }
         let Ok(slot) = (#[verus_spec(with Tracked(slot_perm))]
-        get_slot(frame)) else {
+        crate::mm::frame::meta::get_slot(frame)) else {
             return {
                 proof_with!(|= Tracked(None));
                 None

--- a/ostd/src/mm/frame/meta.rs
+++ b/ostd/src/mm/frame/meta.rs
@@ -103,7 +103,7 @@ use self::mapping::{frame_to_meta, meta_to_frame};
 use crate::mm::io::{Infallible, VmReader};
 use crate::specs::arch::*;
 use crate::specs::mm::frame::{
-    mapping::{frame_to_index, index_to_meta},
+    mapping::{frame_to_index, index_to_meta, max_meta_slots},
     meta_owners::*,
     meta_region_owners::MetaRegionOwners,
 };
@@ -317,12 +317,12 @@ pub enum GetFrameError {
         Tracked(slot_perm): Tracked<&'static vstd::simple_pptr::PointsTo<MetaSlot>>
     requires
         valid_frame_paddr(paddr) ==> {
-            &&& slot_perm.pptr() == frame_to_meta(paddr)
+            &&& slot_perm.addr() == frame_to_meta(paddr)
             &&& slot_perm.is_init()
         }
     ensures
         valid_frame_paddr(paddr) == res is Ok,
-        res is Ok ==> res->Ok_0.addr() == frame_to_meta(paddr),
+        res is Ok ==> res->Ok_0 == slot_perm.value(),
 )]
 pub(super) fn get_slot(paddr: Paddr) -> Result<&'static MetaSlot, GetFrameError> {
     if paddr % PAGE_SIZE != 0 {
@@ -401,20 +401,35 @@ impl MetaSlot {
                     *final(repr_perm),
                 ) == metadata
             },
-            !valid_frame_paddr(paddr) ==> res is Err,
+            res is Ok ==> valid_frame_paddr(paddr),
     )]
     pub(super) fn get_from_unused<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf>(
         paddr: Paddr,
         metadata: M,
         as_unique_ptr: bool,
     ) -> Result<PPtr<Self>, GetFrameError> {
-        let slot = get_slot(paddr)?;
-
-        proof {
-            regions.inv_implies_correct_addr(paddr);
-        }
         let ghost idx = frame_to_index(paddr);
-        let tracked slot_perm = regions.slots.tracked_borrow(idx);
+        let ghost perm_idx = if valid_frame_paddr(paddr) {
+            idx
+        } else {
+            0
+        };
+        proof {
+            assert(0 < max_meta_slots()) by (compute);
+            if valid_frame_paddr(paddr) {
+                regions.inv_implies_correct_addr(paddr);
+            } else {
+                assert(regions.slot_owners.contains_key(0));
+                assert(regions.slots.contains_key(0));
+            }
+        }
+        let tracked slot_perm_ref = regions.slots.tracked_borrow(perm_idx);
+        let tracked slot_perm = *slot_perm_ref;
+        let slot = #[verus_spec(with Tracked(slot_perm))]
+        get_slot(paddr)?;
+        proof {
+            assert(valid_frame_paddr(paddr));
+        }
         let tracked slot_own = regions.slot_owners.tracked_borrow_mut(idx);
         proof {
             axiom_mmio_usage_iff_mmio_paddr(*slot_own);
@@ -422,7 +437,7 @@ impl MetaSlot {
 
         // `Acquire` pairs with the `Release` in `drop_last_in_place` and ensures the metadata
         // initialization won't be reordered before this memory compare-and-exchange.
-        let last_ref_cnt = slot.borrow(Tracked(slot_perm)).ref_count.compare_exchange(
+        let last_ref_cnt = slot.ref_count.compare_exchange(
             Tracked(&mut slot_own.inner_perms.ref_count),
             REF_COUNT_UNUSED,
             0,
@@ -456,23 +471,17 @@ impl MetaSlot {
                 Tracked(repr_perm),
                 Tracked(&mut slot_own.inner_perms.vtable_ptr)
             )]
-            slot.borrow(Tracked(&slot_perm)).write_meta(metadata)
+            slot.write_meta(metadata)
         };
 
         if as_unique_ptr {
             // No one can create a `Frame` instance directly from the page
             // address, so `Relaxed` is fine here.
-            slot.borrow(Tracked(slot_perm)).ref_count.store(
-                Tracked(&mut slot_own.inner_perms.ref_count),
-                REF_COUNT_UNIQUE,
-            );
+            slot.ref_count.store(Tracked(&mut slot_own.inner_perms.ref_count), REF_COUNT_UNIQUE);
         } else {
             // `Release` is used to ensure that the metadata initialization
             // won't be reordered after this memory store.
-            slot.borrow(Tracked(slot_perm)).ref_count.store(
-                Tracked(&mut slot_own.inner_perms.ref_count),
-                1,
-            );
+            slot.ref_count.store(Tracked(&mut slot_own.inner_perms.ref_count), 1);
         }
 
         proof {
@@ -480,7 +489,7 @@ impl MetaSlot {
             axiom_mmio_usage_iff_mmio_paddr(*slot_own);
         }
 
-        Ok(slot)
+        Ok(PPtr::from_addr(frame_to_meta(paddr)))
     }
 
     /// Gets another owning pointer to the metadata slot from the given page.
@@ -504,7 +513,7 @@ impl MetaSlot {
             valid_frame_paddr(paddr) ==> old(regions).ref_count(frame_to_index(paddr)) >= REF_COUNT_MAX ==> may_panic(),
         ensures
             final(regions).inv(),
-            !valid_frame_paddr(paddr) ==> res is Err,
+            res is Ok ==> valid_frame_paddr(paddr),
             res is Ok ==> Self::get_from_in_use_success(paddr, *old(regions), *final(regions)),
             res matches Ok(ptr) ==> ptr == old(regions).slots[frame_to_index(paddr)].pptr(),
             res is Err ==> *final(regions) == *old(regions),
@@ -513,14 +522,28 @@ impl MetaSlot {
     #[verifier::exec_allows_no_decreases_clause]
     #[verifier::loop_isolation(false)]
     pub(super) fn get_from_in_use(paddr: Paddr) -> Result<PPtr<Self>, GetFrameError> {
-        let slot = get_slot(paddr)?;
-
-        proof {
-            regions.inv_implies_correct_addr(paddr);
-        }
-
         let ghost idx = frame_to_index(paddr);
-        let tracked slot_perm = regions.slots.tracked_borrow(idx);
+        let ghost perm_idx = if valid_frame_paddr(paddr) {
+            idx
+        } else {
+            0
+        };
+        proof {
+            assert(0 < max_meta_slots()) by (compute);
+            if valid_frame_paddr(paddr) {
+                regions.inv_implies_correct_addr(paddr);
+            } else {
+                assert(regions.slot_owners.contains_key(0));
+                assert(regions.slots.contains_key(0));
+            }
+        }
+        let tracked slot_perm_ref = regions.slots.tracked_borrow(perm_idx);
+        let tracked slot_perm = *slot_perm_ref;
+        let slot = #[verus_spec(with Tracked(slot_perm))]
+        get_slot(paddr)?;
+        proof {
+            assert(valid_frame_paddr(paddr));
+        }
 
         loop
             invariant
@@ -535,9 +558,7 @@ impl MetaSlot {
 
             let tracked slot_own = regions.slot_owners.tracked_borrow_mut(idx);
 
-            match slot.borrow(Tracked(&slot_perm)).ref_count.load(
-                Tracked(&mut slot_own.inner_perms.ref_count),
-            ) {
+            match slot.ref_count.load(Tracked(&mut slot_own.inner_perms.ref_count)) {
                 REF_COUNT_UNUSED => return Err(GetFrameError::Unused),
                 REF_COUNT_UNIQUE => return Err(GetFrameError::Unique),
                 0 => return Err(GetFrameError::Busy),
@@ -552,12 +573,12 @@ impl MetaSlot {
                     //
                     // It ensures that the written metadata will be visible to us.
 
-                    if slot.borrow(Tracked(&slot_perm)).ref_count.compare_exchange_weak(
+                    if slot.ref_count.compare_exchange_weak(
                         Tracked(&mut slot_own.inner_perms.ref_count),
                         last_ref_cnt,
                         last_ref_cnt + 1,
                     ).is_ok() {
-                        return Ok(slot);
+                        return Ok(PPtr::from_addr(frame_to_meta(paddr)));
                     }
                     proof {
                         vstd_extra::auxiliary::axiom_permission_u64_ext_eq(

--- a/ostd/src/mm/frame/meta.rs
+++ b/ostd/src/mm/frame/meta.rs
@@ -103,9 +103,7 @@ use self::mapping::{frame_to_meta, meta_to_frame};
 use crate::mm::io::{Infallible, VmReader};
 use crate::specs::arch::*;
 use crate::specs::mm::frame::{
-    mapping::{frame_to_index, index_to_meta, max_meta_slots},
-    meta_owners::*,
-    meta_region_owners::MetaRegionOwners,
+    mapping::frame_to_index, meta_owners::*, meta_region_owners::MetaRegionOwners,
 };
 
 use crate::{

--- a/ostd/src/mm/frame/meta.rs
+++ b/ostd/src/mm/frame/meta.rs
@@ -309,15 +309,22 @@ pub enum GetFrameError {
 /// ## Preconditions
 /// `paddr` is the physical address of a frame, with a valid owner.
 /// ## Postconditions
-/// If `paddr` is aligned properly and in-bounds, the function returns a pointer to its metadata slot.
+/// If `paddr` is aligned properly and in-bounds, the function returns a static reference to its metadata slot.
 /// ## Safety
-/// Verus ensures that the pointer will only be used when we have a permission object, so creating it is safe.
+/// Verus ensures that the pointer is properly dereferenced with a permission object, so creating it is safe.
 #[verus_spec(res =>
+    with
+        Tracked(slot_perm): Tracked<&'static vstd::simple_pptr::PointsTo<MetaSlot>>
+    requires
+        valid_frame_paddr(paddr) ==> {
+            &&& slot_perm.pptr() == frame_to_meta(paddr)
+            &&& slot_perm.is_init()
+        }
     ensures
         valid_frame_paddr(paddr) == res is Ok,
         res is Ok ==> res->Ok_0.addr() == frame_to_meta(paddr),
 )]
-pub(super) fn get_slot(paddr: Paddr) -> Result<PPtr<MetaSlot>, GetFrameError> {
+pub(super) fn get_slot(paddr: Paddr) -> Result<&'static MetaSlot, GetFrameError> {
     if paddr % PAGE_SIZE != 0 {
         return Err(GetFrameError::NotAligned);
     }
@@ -330,7 +337,7 @@ pub(super) fn get_slot(paddr: Paddr) -> Result<PPtr<MetaSlot>, GetFrameError> {
     // SAFETY: `ptr` points to a valid `MetaSlot` that will never be
     // mutably borrowed, so taking an immutable reference to it is safe.
     // Ok(unsafe { &*ptr })
-    Ok(ptr)
+    Ok(ptr.borrow(Tracked(slot_perm)))
 }
 
 #[verus_verify]

--- a/ostd/src/mm/frame/meta.rs
+++ b/ostd/src/mm/frame/meta.rs
@@ -314,15 +314,16 @@ pub enum GetFrameError {
 /// Verus ensures that the pointer is properly dereferenced with a permission object, so creating it is safe.
 #[verus_spec(res =>
     with
-        Tracked(slot_perm): Tracked<&'static vstd::simple_pptr::PointsTo<MetaSlot>>
+        Tracked(slot_perm): Tracked<Option<&'static vstd::simple_pptr::PointsTo<MetaSlot>>>
     requires
         valid_frame_paddr(paddr) ==> {
-            &&& slot_perm.addr() == frame_to_meta(paddr)
-            &&& slot_perm.is_init()
+            &&& slot_perm is Some
+            &&& slot_perm->0.addr() == frame_to_meta(paddr)
+            &&& slot_perm->0.is_init()
         }
     ensures
         valid_frame_paddr(paddr) == res is Ok,
-        res is Ok ==> res->Ok_0 == slot_perm.value(),
+        res is Ok ==> res->Ok_0 == slot_perm->0.value(),
 )]
 pub(super) fn get_slot(paddr: Paddr) -> Result<&'static MetaSlot, GetFrameError> {
     if paddr % PAGE_SIZE != 0 {
@@ -337,7 +338,7 @@ pub(super) fn get_slot(paddr: Paddr) -> Result<&'static MetaSlot, GetFrameError>
     // SAFETY: `ptr` points to a valid `MetaSlot` that will never be
     // mutably borrowed, so taking an immutable reference to it is safe.
     // Ok(unsafe { &*ptr })
-    Ok(ptr.borrow(Tracked(slot_perm)))
+    Ok(ptr.borrow(Tracked(slot_perm.tracked_borrow())))
 }
 
 #[verus_verify]
@@ -408,28 +409,22 @@ impl MetaSlot {
         metadata: M,
         as_unique_ptr: bool,
     ) -> Result<PPtr<Self>, GetFrameError> {
-        let ghost idx = frame_to_index(paddr);
-        let ghost perm_idx = if valid_frame_paddr(paddr) {
-            idx
-        } else {
-            0
-        };
-        proof {
-            assert(0 < max_meta_slots()) by (compute);
+        proof_decl! {
+            let ghost idx = frame_to_index(paddr);
             if valid_frame_paddr(paddr) {
                 regions.inv_implies_correct_addr(paddr);
-            } else {
-                assert(regions.slot_owners.contains_key(0));
-                assert(regions.slots.contains_key(0));
             }
+
+            let tracked slot_perm = if valid_frame_paddr(paddr) {
+                Some(*regions.slots.tracked_borrow(idx))
+            } else {
+                None
+            };
         }
-        let tracked slot_perm_ref = regions.slots.tracked_borrow(perm_idx);
-        let tracked slot_perm = *slot_perm_ref;
+
         let slot = #[verus_spec(with Tracked(slot_perm))]
         get_slot(paddr)?;
-        proof {
-            assert(valid_frame_paddr(paddr));
-        }
+
         let tracked slot_own = regions.slot_owners.tracked_borrow_mut(idx);
         proof {
             axiom_mmio_usage_iff_mmio_paddr(*slot_own);
@@ -522,28 +517,19 @@ impl MetaSlot {
     #[verifier::exec_allows_no_decreases_clause]
     #[verifier::loop_isolation(false)]
     pub(super) fn get_from_in_use(paddr: Paddr) -> Result<PPtr<Self>, GetFrameError> {
-        let ghost idx = frame_to_index(paddr);
-        let ghost perm_idx = if valid_frame_paddr(paddr) {
-            idx
-        } else {
-            0
-        };
-        proof {
-            assert(0 < max_meta_slots()) by (compute);
+        proof_decl! {
+            let ghost idx = frame_to_index(paddr);
             if valid_frame_paddr(paddr) {
                 regions.inv_implies_correct_addr(paddr);
-            } else {
-                assert(regions.slot_owners.contains_key(0));
-                assert(regions.slots.contains_key(0));
             }
+            let tracked slot_perm = if valid_frame_paddr(paddr) {
+                Some(*regions.slots.tracked_borrow(idx))
+            } else {
+                None
+            };
         }
-        let tracked slot_perm_ref = regions.slots.tracked_borrow(perm_idx);
-        let tracked slot_perm = *slot_perm_ref;
         let slot = #[verus_spec(with Tracked(slot_perm))]
         get_slot(paddr)?;
-        proof {
-            assert(valid_frame_paddr(paddr));
-        }
 
         loop
             invariant


### PR DESCRIPTION
Replace `MetaRegionOwners.slots` with  `Map<int, &'static PointsTo<MetaSlot>>` and align `MetaSlot::get_slot` with the Asterinas source code. It is much easier than I thought.