### PR TITLE
fix: adapt proofs for latest Z3 4.16.0

### DIFF
--- a/ostd/specs/mm/embedding/mod.rs
+++ b/ostd/specs/mm/embedding/mod.rs
@@ -1986,6 +1986,7 @@ proof fn step_protect_next<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId, len
     s.insert_cursor(c, entry);
 }
 
+#[verifier::spinoff_prover]
 proof fn step_map<'rcu>(
     tracked s: &mut VmStore<'rcu>,
     c: CursorId,
@@ -1999,15 +2000,34 @@ proof fn step_map<'rcu>(
     ensures
         final(s).inv(),
 {
+    hide(VmStore::inv);
+    hide(VmStore::structural_inv);
+    hide(VmStore::accounting_inv);
+    assert(s.structural_inv()) by {
+        reveal(VmStore::inv);
+    };
+    assert(s.accounting_inv()) by {
+        reveal(VmStore::inv);
+    };
+    assert(s.regions.inv() && s.tlb_model.inv() && s.cursors[c].inv()
+        && s.cursors[c].owner.metaregion_sound(s.regions) && s.vm_spaces.dom().contains(
+        s.cursors[c].vm_space,
+    )) by {
+        reveal(VmStore::structural_inv);
+    };
     // `usage == Frame` at the mapped slot from `structural_inv`'s
     // FrameId⟹Frame-usage clause.
-    assert(s.regions.slot_owners[frame_to_index(s.frames[fid].paddr)].usage is Frame);
+    assert(s.regions.slot_owners[frame_to_index(s.frames[fid].paddr)].usage is Frame) by {
+        reveal(VmStore::structural_inv);
+    };
     let ghost paddr = s.frames[fid].paddr;
     let ghost target_idx = frame_to_index(paddr);
     let ghost old_frames = s.frames;
     let ghost old_regions = s.regions;
     // From `structural_inv`: every registered handle's paddr is in-bound.
-    assert(valid_frame_paddr(paddr));
+    assert(valid_frame_paddr(paddr)) by {
+        reveal(VmStore::structural_inv);
+    };
     s.regions.inv_implies_correct_addr(paddr);
     // Pre target_idx: we hold a FrameEntry at this paddr, so
     // `handle_count(old_frames, target_idx) >= 1`.
@@ -2020,16 +2040,23 @@ proof fn step_map<'rcu>(
     let ghost pre_rc_target = old_regions.slot_owners[target_idx].inner_perms.ref_count.value();
     let ghost pre_paths_target = old_regions.slot_owners[target_idx].paths_in_pt.len();
     let ghost pre_cover_target = segment_cover_count(s.segments, index_to_frame(target_idx));
-    assert(pre_rc_target != REF_COUNT_UNUSED);
-    assert(pre_rc_target != REF_COUNT_UNIQUE);
-    assert(pre_rc_target == handle_count(old_frames, target_idx) + pre_paths_target
-        + pre_cover_target);
-    assert(old_regions.slot_owners[target_idx].inner_perms.storage.is_init());
+    assert(pre_rc_target != REF_COUNT_UNUSED && pre_rc_target != REF_COUNT_UNIQUE && pre_rc_target
+        == handle_count(old_frames, target_idx) + pre_paths_target + pre_cover_target
+        && old_regions.slot_owners[target_idx].inner_perms.storage.is_init()) by {
+        reveal(VmStore::accounting_inv);
+    };
     let tracked mut entry = s.extract_cursor(c);
     // Consume the FrameEntry: the UFrame's handle ref-count
     // contribution moves to the new PTE; the embedding's `H` at
     // target_idx decrements by 1 in lockstep with `P` incrementing by 1.
+    assert(s.structural_inv()) by {
+        reveal(VmStore::inv);
+    };
     let tracked _frame_entry = s.extract_frame(fid);
+    assert(entry.inv());
+    assert(entry.owner.metaregion_sound(s.regions));
+    assert(s.regions.inv());
+    assert(s.tlb_model.inv());
     cursor::map_step(&mut entry, &mut s.regions, &mut s.tlb_model, paddr, prop);
     // Discharge `accounting_inv` clause-by-clause. The cursor-map axiom
     // gives: rc/usage/storage preserved at target_idx, paths += 1 at
@@ -2044,6 +2071,7 @@ proof fn step_map<'rcu>(
         s.segments,
         index_to_frame(idx),
     ) == 0 by {
+        reveal(VmStore::accounting_inv);
         // post-UNUSED ⟹ slot fully preserved (cursor axiom).
         assert(s.regions.slot_owners[idx] == old_regions.slot_owners[idx]);
         lemma_handle_count_remove(old_frames, fid, idx);
@@ -2064,6 +2092,7 @@ proof fn step_map<'rcu>(
         s.segments,
         index_to_frame(idx),
     ) > 0 by {
+        reveal(VmStore::accounting_inv);
         lemma_handle_count_remove(old_frames, fid, idx);
         if idx == target_idx {
             // post rc preserved at target_idx, paths += 1 ⟹ paths.len > 0.
@@ -2096,6 +2125,7 @@ proof fn step_map<'rcu>(
         )
         &&& so.inner_perms.storage.is_init()
     } by {
+        reveal(VmStore::accounting_inv);
         lemma_handle_count_remove(old_frames, fid, idx);
         if idx == target_idx {
             // Pre clause 4 (new): rc == H_pre + P_pre + cover_pre.
@@ -2121,6 +2151,8 @@ proof fn step_map<'rcu>(
         s.frames.dom().contains(fid_other) implies s.regions.slot_owners[frame_to_index(
         s.frames[fid_other].paddr,
     )].usage is Frame by {
+        reveal(VmStore::structural_inv);
+        reveal(VmStore::accounting_inv);
         let other_idx = frame_to_index(s.frames[fid_other].paddr);
         // pre: usage == Frame from old structural_inv.
         assert(old_regions.slot_owners[other_idx].usage is Frame);
@@ -2155,6 +2187,8 @@ proof fn step_map<'rcu>(
         s.segments.dom().contains(sid) && s.segments[sid].range.start <= paddr_c
             < s.segments[sid].range.end && paddr_c % PAGE_SIZE
             == 0 implies s.regions.slot_owners[frame_to_index(paddr_c)].usage is Frame by {
+        reveal(VmStore::structural_inv);
+        reveal(VmStore::accounting_inv);
         let cov_idx = frame_to_index(paddr_c);
         // pre cover >= 1 at cov_idx ⟹ pre slot is Frame + non-UNUSED.
         lemma_segment_cover_contains(old_regions_segments_helper(s), sid, paddr_c);
@@ -2169,6 +2203,14 @@ proof fn step_map<'rcu>(
             assert(s.regions.slot_owners[cov_idx] == old_regions.slot_owners[cov_idx]);
         }
     };
+    accounting_inv_intro(*s);
+    assert(s.structural_inv()) by {
+        reveal(VmStore::structural_inv);
+    };
+    assert(s.inv()) by {
+        reveal(VmStore::inv);
+    };
+    assert(s.vm_spaces.dom().contains(entry.vm_space));
     s.insert_cursor(c, entry);
 }
 
@@ -2888,12 +2930,25 @@ proof fn step_frame_drop<'rcu>(tracked s: &mut VmStore<'rcu>, fid: FrameId)
 /// covering `range` on success. Discharges `accounting_inv` from the
 /// post-state's per-slot ensures (every covered slot transitions
 /// `UNUSED → Frame, rc=1, raw_count=1`).
+#[verifier::spinoff_prover]
 proof fn step_segment_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, range: Range<Paddr>)
     requires
         old(s).inv(),
     ensures
         final(s).inv(),
 {
+    hide(VmStore::inv);
+    hide(VmStore::structural_inv);
+    hide(VmStore::accounting_inv);
+    assert(s.structural_inv()) by {
+        reveal(VmStore::inv);
+    };
+    assert(s.accounting_inv()) by {
+        reveal(VmStore::inv);
+    };
+    assert(s.regions.inv()) by {
+        reveal(VmStore::structural_inv);
+    };
     // Exec `Segment::from_unused` returns `Err` (NotAligned/OutOfBound)
     // or rolls back its partial allocation (when some frame in `range`
     // is not free), leaving `regions` unchanged in every failure case.
@@ -2914,10 +2969,11 @@ proof fn step_segment_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, range: Ra
         // which fails the PageTable-node coverage exception, so its perm
         // is parked (`slots.contains_key`).
         assert forall|paddr: Paddr|
-            #![trigger frame_to_index(paddr)]
+            #![trigger s.regions.contains(frame_to_index(paddr))]
             (range.start <= paddr < range.end && paddr % PAGE_SIZE == 0) implies s.regions.contains(
             frame_to_index(paddr),
         ) by {
+            reveal(VmStore::structural_inv);
             s.regions.inv_implies_correct_addr(paddr);
         };
         let tracked res = segment::from_unused_step(&mut s.regions, range);
@@ -2948,6 +3004,7 @@ proof fn step_segment_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, range: Ra
                     s.segments,
                     index_to_frame(idx),
                 ) == 0 by {
+                    reveal(VmStore::accounting_inv);
                     let paddr = index_to_frame(idx);
                     // Round-trip: idx < max ⟹ paddr aligned, in-bound.
                     assert(paddr == (idx * PAGE_SIZE) as usize);
@@ -2976,6 +3033,7 @@ proof fn step_segment_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, range: Ra
                     s.segments,
                     index_to_frame(idx),
                 ) > 0 by {
+                    reveal(VmStore::accounting_inv);
                     let paddr = index_to_frame(idx);
                     assert(paddr == (idx * PAGE_SIZE) as usize);
                     assert(paddr % PAGE_SIZE == 0);
@@ -3002,6 +3060,7 @@ proof fn step_segment_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, range: Ra
                         + segment_cover_count(s.segments, index_to_frame(idx))
                     &&& so.inner_perms.storage.is_init()
                 } by {
+                    reveal(VmStore::accounting_inv);
                     let paddr = index_to_frame(idx);
                     assert(paddr == (idx * PAGE_SIZE) as usize);
                     assert(paddr % PAGE_SIZE == 0);
@@ -3023,6 +3082,7 @@ proof fn step_segment_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, range: Ra
                     0 <= idx
                         < max_meta_slots() implies #[trigger] s.regions.slot_owners[idx].inner_perms.in_list.value()
                     == 0 by {
+                    reveal(VmStore::structural_inv);
                     let paddr = index_to_frame(idx);
                     assert(paddr == (idx * PAGE_SIZE) as usize);
                     assert(paddr % PAGE_SIZE == 0);
@@ -3042,6 +3102,8 @@ proof fn step_segment_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, range: Ra
                     s.frames.dom().contains(fid_other) implies s.regions.slot_owners[frame_to_index(
                     s.frames[fid_other].paddr,
                 )].usage is Frame by {
+                    reveal(VmStore::structural_inv);
+                    reveal(VmStore::accounting_inv);
                     let other_idx = frame_to_index(s.frames[fid_other].paddr);
                     let other_paddr = index_to_frame(other_idx);
                     // pre fid_other's slot usage == Frame from old structural.
@@ -3069,6 +3131,7 @@ proof fn step_segment_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, range: Ra
                     &&& so.inner_perms.in_list.value() == 0
                     &&& so.paths_in_pt.is_empty()
                 } by {
+                    reveal(VmStore::structural_inv);
                     let u_idx = frame_to_index(s.unique_frames[u].paddr);
                     assert(old(s).unique_frames.dom().contains(u));
                     // Old UNIQUE validity at `u`.
@@ -3079,6 +3142,15 @@ proof fn step_segment_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, range: Ra
                     // rc != UNUSED ⟹ not in `range` ⟹ slot preserved.
                     assert(s.regions.slot_owners[u_idx] == old_regions.slot_owners[u_idx]);
                 };
+                assert(s.accounting_inv()) by {
+                    reveal(VmStore::accounting_inv);
+                };
+                assert(s.structural_inv()) by {
+                    reveal(VmStore::structural_inv);
+                };
+                assert(s.inv()) by {
+                    reveal(VmStore::inv);
+                };
             },
             Option::None => {
                 assert(s.regions == old_regions);
@@ -3088,9 +3160,142 @@ proof fn step_segment_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, range: Ra
     }
 }
 
+proof fn accounting_inv_intro<'rcu>(store: VmStore<'rcu>)
+    requires
+        forall|idx: int|
+            #![trigger store.regions.slot_owners[idx]]
+            0 <= idx < max_meta_slots()
+                && store.regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNUSED
+                ==> handle_count(store.frames, idx) == 0
+                && store.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
+                store.segments,
+                index_to_frame(idx),
+            ) == 0,
+        forall|idx: int|
+            #![trigger store.regions.slot_owners[idx]]
+            0 <= idx < max_meta_slots() && store.regions.slot_owners[idx].usage is Frame
+                && store.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
+                && store.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNIQUE
+                ==> handle_count(store.frames, idx) > 0
+                || store.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
+                store.segments,
+                index_to_frame(idx),
+            ) > 0,
+        forall|idx: int|
+            #![trigger store.regions.slot_owners[idx]]
+            0 <= idx < max_meta_slots() && store.regions.slot_owners[idx].usage is Frame && (
+            handle_count(store.frames, idx) > 0 || store.regions.slot_owners[idx].paths_in_pt.len()
+                > 0 || segment_cover_count(store.segments, index_to_frame(idx)) > 0) ==> {
+                let so = store.regions.slot_owners[idx];
+                let rc = so.inner_perms.ref_count.value();
+                &&& rc != REF_COUNT_UNUSED
+                &&& rc != REF_COUNT_UNIQUE
+                &&& rc == handle_count(store.frames, idx) + so.paths_in_pt.len()
+                    + segment_cover_count(store.segments, index_to_frame(idx))
+                &&& so.inner_perms.storage.is_init()
+            },
+    ensures
+        store.accounting_inv(),
+{
+    reveal(VmStore::accounting_inv);
+}
+
+#[verifier::spinoff_prover]
+proof fn drop_segment_with_store_inv<'rcu>(
+    tracked regions: &mut MetaRegionOwners,
+    tracked entry: SegmentEntry,
+    store: VmStore<'rcu>,
+    sid: SegmentId,
+)
+    requires
+        store.inv(),
+        store.segments.dom().contains(sid),
+        entry == store.segments[sid],
+        *old(regions) == store.regions,
+    ensures
+        final(regions).inv(),
+        final(regions).slots == old(regions).slots,
+        forall|paddr: Paddr|
+            #![trigger frame_to_index(paddr)]
+            (entry.range.start <= paddr < entry.range.end && paddr % PAGE_SIZE == 0) ==> {
+                let idx = frame_to_index(paddr);
+                let so_old = old(regions).slot_owners[idx];
+                let so_new = final(regions).slot_owners[idx];
+                &&& so_old.inner_perms.ref_count.value() >= 1
+                &&& so_old.inner_perms.ref_count.value() <= REF_COUNT_MAX
+                &&& so_old.usage is Frame
+                &&& so_old.inner_perms.ref_count.value() == 1 ==> so_old.paths_in_pt.is_empty()
+                &&& so_new.usage == so_old.usage
+                &&& so_new.paths_in_pt == so_old.paths_in_pt
+                &&& so_new.slot_vaddr == so_old.slot_vaddr
+                &&& so_new.inner_perms.in_list == so_old.inner_perms.in_list
+                &&& so_old.inner_perms.ref_count.value() == 1
+                    ==> so_new.inner_perms.ref_count.value() == REF_COUNT_UNUSED
+                &&& so_old.inner_perms.ref_count.value() > 1
+                    ==> so_new.inner_perms.ref_count.value() == (
+                so_old.inner_perms.ref_count.value() - 1) as u64
+            },
+        forall|i: int|
+            #![trigger final(regions).slot_owners[i]]
+            i < max_meta_slots() && !(entry.range.start <= index_to_frame(i) < entry.range.end)
+                ==> final(regions).slot_owners[i] == old(regions).slot_owners[i],
+        forall|i: int|
+            #![trigger final(regions).slot_owners[i]]
+            !old(regions).slots.contains_key(i) ==> final(regions).slot_owners[i] == old(
+                regions,
+            ).slot_owners[i],
+        forall|c: CursorOwner<'_, UserPtConfig>|
+            #![auto]
+            c.metaregion_sound(*old(regions)) ==> c.metaregion_sound(*final(regions)),
+{
+    hide(VmStore::inv);
+    hide(VmStore::structural_inv);
+    hide(VmStore::accounting_inv);
+    assert(store.structural_inv()) by {
+        reveal(VmStore::inv);
+    };
+    assert(store.accounting_inv()) by {
+        reveal(VmStore::inv);
+    };
+    assert(store.regions.inv()) by {
+        reveal(VmStore::structural_inv);
+    };
+    assert(entry.range.start % PAGE_SIZE == 0 && entry.range.end % PAGE_SIZE == 0
+        && entry.range.start < entry.range.end && entry.range.end <= MAX_PADDR) by {
+        reveal(VmStore::structural_inv);
+    };
+    assert forall|paddr: Paddr|
+        #![trigger store.regions.slot_owners[frame_to_index(paddr)]]
+        (entry.range.start <= paddr < entry.range.end && paddr % PAGE_SIZE == 0) implies {
+        let so = store.regions.slot_owners[frame_to_index(paddr)];
+        &&& so.inner_perms.ref_count.value() >= 1
+        &&& so.inner_perms.ref_count.value() <= REF_COUNT_MAX
+        &&& so.usage is Frame
+        &&& so.inner_perms.ref_count.value() == 1 ==> so.paths_in_pt.is_empty()
+    } by {
+        reveal(VmStore::structural_inv);
+        reveal(VmStore::accounting_inv);
+        let idx = frame_to_index(paddr);
+        lemma_segment_cover_contains(store.segments, sid, paddr);
+        let so = store.regions.slot_owners[idx];
+        let rc = so.inner_perms.ref_count.value();
+        assert(store.regions.contains(idx));
+        if rc == 1 {
+            assert(handle_count(store.frames, idx) + so.paths_in_pt.len() + segment_cover_count(
+                store.segments,
+                paddr,
+            ) == 1);
+            assert(so.paths_in_pt.len() == 0);
+            assert(so.paths_in_pt == Set::empty());
+        }
+    };
+    segment::drop_step(regions, entry);
+}
+
 /// `Op::SegmentDrop` step. Removes the `SegmentEntry` at `sid` and
 /// releases the segment's forgotten reference at each covered frame.
 /// Frames whose `rc` reaches 1 transition to UNUSED.
+#[verifier::spinoff_prover]
 proof fn step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
     requires
         old(s).inv(),
@@ -3098,54 +3303,26 @@ proof fn step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
     ensures
         final(s).inv(),
 {
+    hide(VmStore::inv);
+    hide(VmStore::structural_inv);
+    hide(VmStore::accounting_inv);
+    assert(s.structural_inv()) by {
+        reveal(VmStore::inv);
+    };
+    assert(s.accounting_inv()) by {
+        reveal(VmStore::inv);
+    };
+    assert(s.regions.inv()) by {
+        reveal(VmStore::structural_inv);
+    };
     let ghost s_before = *s;
     let ghost old_regions = s.regions;
     let ghost old_frames = s.frames;
     let ghost old_segments = s.segments;
     let ghost range = s.segments[sid].range;
-    // Discharge segment::drop_step's preconditions from `s.inv()`
-    // BEFORE extracting (we need old_regions and old_segments).
-    assert forall|paddr: Paddr|
-        #![trigger frame_to_index(paddr)]
-        (range.start <= paddr < range.end && paddr % PAGE_SIZE == 0) implies {
-        let so = old_regions.slot_owners[frame_to_index(paddr)];
-        &&& so.inner_perms.ref_count.value() >= 1
-        &&& so.inner_perms.ref_count.value() <= REF_COUNT_MAX
-        &&& so.usage is Frame
-        &&& so.inner_perms.ref_count.value() == 1 ==> so.paths_in_pt.is_empty()
-    } by {
-        let idx = frame_to_index(paddr);
-        // Cover >= 1 at paddr (this segment covers it).
-        lemma_segment_cover_contains(old_segments, sid, paddr);
-        // Usage == Frame from structural segment-covered ⟹ Frame clause.
-        assert(old_regions.slot_owners[idx].usage is Frame);
-        // Accounting clause 4: active head (cover > 0) ⟹ rc != UNUSED,
-        // rc != UNIQUE, rc == H + P + cover, storage init.
-        let so = old_regions.slot_owners[idx];
-        let rc = so.inner_perms.ref_count.value();
-        assert(rc != REF_COUNT_UNUSED);
-        assert(rc != REF_COUNT_UNIQUE);
-        assert(rc == handle_count(old_frames, idx) + so.paths_in_pt.len() + segment_cover_count(
-            old_segments,
-            paddr,
-        ));
-        // rc >= 1 since cover >= 1 ⟹ H + P + cover >= 1.
-        // Triggers MetaSlotOwner::inv's SHARED branch (Item 1): rc in
-        // [1, MAX] ⟹ storage init, in_list == 0.
-        assert(old_regions.contains(idx));
-        // rc == 1 case: rc = H + P + cover = 1, cover >= 1 ⟹ cover == 1
-        // and H == 0 and P == 0 ⟹ paths empty.
-        if rc == 1 {
-            assert(handle_count(old_frames, idx) + so.paths_in_pt.len() + segment_cover_count(
-                old_segments,
-                paddr,
-            ) == 1);
-            assert(so.paths_in_pt.len() == 0);
-            assert(so.paths_in_pt == Set::empty());
-        }
-    };
     let tracked entry = s.extract_segment(sid);
-    segment::drop_step(&mut s.regions, entry);
+    assert(entry.range == range);
+    drop_segment_with_store_inv(&mut s.regions, entry, s_before, sid);
     // Slot-perm coverage: drop preserves `slots` and never touches an
     // unparked PT-root slot, so the coverage exception carries.
     lemma_coverage_preserved_slots_eq(s_before, *s);
@@ -3170,6 +3347,7 @@ proof fn step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
         0 <= idx
             < max_meta_slots() implies #[trigger] s.regions.slot_owners[idx].inner_perms.in_list.value()
         == 0 by {
+        reveal(VmStore::structural_inv);
         let paddr = index_to_frame(idx);
         assert(paddr == (idx * PAGE_SIZE) as usize);
         assert(paddr % PAGE_SIZE == 0);
@@ -3189,6 +3367,7 @@ proof fn step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
         s.segments,
         index_to_frame(idx),
     ) == 0 by {
+        reveal(VmStore::accounting_inv);
         let paddr = index_to_frame(idx);
         assert(paddr == (idx * PAGE_SIZE) as usize);
         assert(paddr % PAGE_SIZE == 0);
@@ -3222,6 +3401,7 @@ proof fn step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
         s.segments,
         index_to_frame(idx),
     ) > 0 by {
+        reveal(VmStore::accounting_inv);
         let paddr = index_to_frame(idx);
         assert(paddr == (idx * PAGE_SIZE) as usize);
         assert(paddr % PAGE_SIZE == 0);
@@ -3258,6 +3438,7 @@ proof fn step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
         )
         &&& so.inner_perms.storage.is_init()
     } by {
+        reveal(VmStore::accounting_inv);
         let paddr = index_to_frame(idx);
         assert(paddr == (idx * PAGE_SIZE) as usize);
         assert(paddr % PAGE_SIZE == 0);
@@ -3303,6 +3484,8 @@ proof fn step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
         s.frames.dom().contains(fid_other) implies s.regions.slot_owners[frame_to_index(
         s.frames[fid_other].paddr,
     )].usage is Frame by {
+        reveal(VmStore::structural_inv);
+        reveal(VmStore::accounting_inv);
         let other_idx = frame_to_index(s.frames[fid_other].paddr);
         let other_paddr = index_to_frame(other_idx);
         // Pre fid_other's slot: usage == Frame (old structural).
@@ -3332,6 +3515,7 @@ proof fn step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
         s.segments.dom().contains(sid_other) && s.segments[sid_other].range.start <= paddr_c
             < s.segments[sid_other].range.end && paddr_c % PAGE_SIZE
             == 0 implies s.regions.slot_owners[frame_to_index(paddr_c)].usage is Frame by {
+        reveal(VmStore::structural_inv);
         let cov_idx = frame_to_index(paddr_c);
         // sid_other != sid (since sid was removed from s.segments).
         assert(sid_other != sid);
@@ -3353,6 +3537,8 @@ proof fn step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
         &&& so.inner_perms.in_list.value() == 0
         &&& so.paths_in_pt.is_empty()
     } by {
+        reveal(VmStore::structural_inv);
+        reveal(VmStore::accounting_inv);
         let u_paddr = s.unique_frames[u].paddr;
         let u_idx = frame_to_index(u_paddr);
         assert(old(s).unique_frames.dom().contains(u));
@@ -3369,6 +3555,13 @@ proof fn step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
         };
         // Outside range ⟹ teardown axiom preserves the slot fully.
         assert(s.regions.slot_owners[u_idx] == old_regions.slot_owners[u_idx]);
+    };
+    accounting_inv_intro(*s);
+    assert(s.structural_inv()) by {
+        reveal(VmStore::structural_inv);
+    };
+    assert(s.inv()) by {
+        reveal(VmStore::inv);
     };
 }
 
@@ -3816,6 +4009,7 @@ proof fn step_segment_next<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
     };
 }
 
+#[verifier::spinoff_prover]
 proof fn step_segment_clone_range<'rcu>(
     tracked s: &mut VmStore<'rcu>,
     sid: SegmentId,
@@ -3838,6 +4032,18 @@ proof fn step_segment_clone_range<'rcu>(
     ensures
         final(s).inv(),
 {
+    hide(VmStore::inv);
+    hide(VmStore::structural_inv);
+    hide(VmStore::accounting_inv);
+    assert(s.structural_inv()) by {
+        reveal(VmStore::inv);
+    };
+    assert(s.accounting_inv()) by {
+        reveal(VmStore::inv);
+    };
+    assert(s.regions.inv()) by {
+        reveal(VmStore::structural_inv);
+    };
     let ghost old_regions = s.regions;
     let ghost old_frames = s.frames;
     let ghost old_segments = s.segments;
@@ -3846,7 +4052,9 @@ proof fn step_segment_clone_range<'rcu>(
 
     // `sub_range ⊆ sid`'s range, and `sid`'s range is in-bound, so the
     // new entry's range is well-formed (aligned / non-empty / bound).
-    assert(sid_range.end <= MAX_PADDR);
+    assert(sid_range.end <= MAX_PADDR) by {
+        reveal(VmStore::structural_inv);
+    };
     assert(sub_range.end <= MAX_PADDR);
 
     // Derive the clone axiom's per-frame preconditions from `s.inv()`:
@@ -3857,13 +4065,15 @@ proof fn step_segment_clone_range<'rcu>(
     // exec `inc_frame_ref_count` saturation guard) comes from this fn's
     // `requires`.
     assert forall|paddr: Paddr|
-        #![trigger frame_to_index(paddr)]
+        #![trigger old_regions.slot_owners[frame_to_index(paddr)]]
         (sub_range.start <= paddr < sub_range.end && paddr % PAGE_SIZE == 0) implies {
         let so = old_regions.slot_owners[frame_to_index(paddr)];
         &&& so.usage is Frame
         &&& so.inner_perms.ref_count.value() >= 1
         &&& so.inner_perms.ref_count.value() + 1 <= REF_COUNT_MAX
     } by {
+        reveal(VmStore::structural_inv);
+        reveal(VmStore::accounting_inv);
         // `paddr` is covered by `sid` (sub_range ⊆ sid's range).
         assert(old_segments.dom().contains(sid));
         assert(sid_range.start <= paddr < sid_range.end);
@@ -3905,6 +4115,7 @@ proof fn step_segment_clone_range<'rcu>(
     assert forall|idx: int|
         0 <= idx < max_meta_slots() implies #[trigger] s.regions.slot_owners[idx].usage
         == old_regions.slot_owners[idx].usage by {
+        reveal(VmStore::structural_inv);
         let aligned = index_to_frame(idx);
         assert(aligned == (idx * PAGE_SIZE) as usize);
         assert(frame_to_index(aligned) == idx);
@@ -3919,6 +4130,7 @@ proof fn step_segment_clone_range<'rcu>(
         0 <= idx
             < max_meta_slots() implies #[trigger] s.regions.slot_owners[idx].inner_perms.in_list.value()
         == 0 by {
+        reveal(VmStore::structural_inv);
         let aligned = index_to_frame(idx);
         assert(aligned == (idx * PAGE_SIZE) as usize);
         assert(frame_to_index(aligned) == idx);
@@ -3937,6 +4149,7 @@ proof fn step_segment_clone_range<'rcu>(
         s.segments.dom().contains(sid_other) && s.segments[sid_other].range.start <= paddr_c
             < s.segments[sid_other].range.end && paddr_c % PAGE_SIZE
             == 0 implies s.regions.slot_owners[frame_to_index(paddr_c)].usage is Frame by {
+        reveal(VmStore::structural_inv);
         let cov_idx = frame_to_index(paddr_c);
         if sid_other == sid2 {
             // Covered by the new entry ⟹ in sub_range ⊆ sid's range.
@@ -3963,6 +4176,7 @@ proof fn step_segment_clone_range<'rcu>(
         s.frames.dom().contains(fid_other) implies s.regions.slot_owners[frame_to_index(
         s.frames[fid_other].paddr,
     )].usage is Frame by {
+        reveal(VmStore::structural_inv);
         let other_idx = frame_to_index(s.frames[fid_other].paddr);
         assert(old_frames.dom().contains(fid_other));
         assert(old_regions.slot_owners[other_idx].usage is Frame);
@@ -3982,6 +4196,7 @@ proof fn step_segment_clone_range<'rcu>(
         s.segments,
         index_to_frame(idx),
     ) == 0 by {
+        reveal(VmStore::accounting_inv);
         let aligned = index_to_frame(idx);
         assert(aligned == (idx * PAGE_SIZE) as usize);
         assert(frame_to_index(aligned) == idx);
@@ -4003,6 +4218,7 @@ proof fn step_segment_clone_range<'rcu>(
         s.segments,
         index_to_frame(idx),
     ) > 0 by {
+        reveal(VmStore::accounting_inv);
         let aligned = index_to_frame(idx);
         assert(aligned == (idx * PAGE_SIZE) as usize);
         assert(frame_to_index(aligned) == idx);
@@ -4032,6 +4248,7 @@ proof fn step_segment_clone_range<'rcu>(
         )
         &&& so.inner_perms.storage.is_init()
     } by {
+        reveal(VmStore::accounting_inv);
         let aligned = index_to_frame(idx);
         assert(aligned == (idx * PAGE_SIZE) as usize);
         assert(frame_to_index(aligned) == idx);
@@ -4053,6 +4270,8 @@ proof fn step_segment_clone_range<'rcu>(
         &&& so.inner_perms.in_list.value() == 0
         &&& so.paths_in_pt.is_empty()
     } by {
+        reveal(VmStore::structural_inv);
+        reveal(VmStore::accounting_inv);
         let u_paddr = s.unique_frames[u].paddr;
         let u_idx = frame_to_index(u_paddr);
         assert(old(s).unique_frames.dom().contains(u));
@@ -4068,6 +4287,13 @@ proof fn step_segment_clone_range<'rcu>(
             }
         };
         assert(s.regions.slot_owners[u_idx] == old_regions.slot_owners[u_idx]);
+    };
+    accounting_inv_intro(*s);
+    assert(s.structural_inv()) by {
+        reveal(VmStore::structural_inv);
+    };
+    assert(s.inv()) by {
+        reveal(VmStore::inv);
     };
 }
 

--- a/ostd/specs/mm/embedding/mod.rs
+++ b/ostd/specs/mm/embedding/mod.rs
@@ -459,7 +459,7 @@ pub proof fn lemma_frame_drop_pre_derivable<'rcu>(s: VmStore<'rcu>, fid: FrameId
 {
     let paddr = s.frames[fid].paddr;
     let idx = frame_to_index(paddr);
-    s.regions.inv_implies_correct_addr(paddr);
+
     assert(s.frames.dom().filter(
         |gid: FrameId| frame_to_index(s.frames[gid].paddr) == idx,
     ).contains(fid));
@@ -2931,6 +2931,7 @@ proof fn step_frame_drop<'rcu>(tracked s: &mut VmStore<'rcu>, fid: FrameId)
 /// post-state's per-slot ensures (every covered slot transitions
 /// `UNUSED → Frame, rc=1, raw_count=1`).
 #[verifier::spinoff_prover]
+#[verifier::rlimit(200)]
 proof fn step_segment_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, range: Range<Paddr>)
     requires
         old(s).inv(),

--- a/ostd/specs/mm/frame/frame_specs.rs
+++ b/ostd/specs/mm/frame/frame_specs.rs
@@ -126,11 +126,7 @@ impl<M: ?Sized> Frame<M> {
         paddr: Paddr,
         pre: MetaRegionOwners,
         post: MetaRegionOwners,
-    ) -> bool
-        recommends
-            valid_frame_paddr(paddr),
-            pre.inv(),
-    {
+    ) -> bool {
         let idx = frame_to_index(paddr);
         let pre_owner = pre.slot_owners[idx];
         let post_owner = post.slot_owners[idx];

--- a/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
+++ b/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
@@ -282,10 +282,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
         )
     }
 
-    pub open spec fn meta_value_at(self, regions: MetaRegionOwners, i: int) -> Link<M>
-        recommends
-            self.meta_wf_at(regions, i),
-    {
+    pub open spec fn meta_value_at(self, regions: MetaRegionOwners, i: int) -> Link<M> {
         let idx = meta_to_index(self.list[i].paddr);
         typed_meta_value::<Link<M>>(
             regions.slot_owners[idx].inner_perms.storage,
@@ -646,6 +643,80 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
     /// (or `None` at the ends), and old `n-1`'s `next` / old `n`'s `prev` are
     /// rewired to point at the inserted link. Mirror of
     /// [`pop_preserves_relate_region`].
+    pub open spec fn insert_old_slot_post_clauses(
+        self,
+        fr: MetaRegionOwners,
+        old: LinkedListOwner<M>,
+        r0: MetaRegionOwners,
+        n: int,
+        link: LinkOwner,
+        p: int,
+    ) -> bool {
+        let i = meta_to_index(old.list[p].paddr);
+        let ins = meta_to_index(self.list[n].paddr);
+        let np = if p < n {
+            p
+        } else {
+            p + 1
+        };
+        let fp = typed_meta_value::<Link<M>>(
+            fr.slot_owners[i].inner_perms.storage,
+            self.repr_perms[np],
+        );
+        &&& fr.contains(i)
+        &&& fr.slots[i].addr() == old.list[p].paddr
+        &&& fr.slots[i].pptr() == r0.slots[i].pptr()
+        &&& fr.slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+        &&& fr.slot_owners[i].usage is Frame
+        &&& fr.slot_owners[i].inner_perms.in_list.value() == self.list_id
+        &&& self.meta_wf_at(fr, np)
+        &&& fr.slots[i].addr() % META_SLOT_SIZE == 0
+        &&& FRAME_METADATA_RANGE.start <= fr.slots[i].addr() < FRAME_METADATA_RANGE.start
+            + MAX_NR_PAGES * META_SLOT_SIZE
+        &&& (p == n - 1 ==> {
+            &&& fp.next is Some
+            &&& fp.next->0.addr() == link.paddr
+            &&& fp.next->0.ptr.addr() == fr.slots[ins].pptr().addr()
+        })
+        &&& (p != n - 1 ==> fp.next == old.meta_value_at(r0, p).next)
+        &&& (p == n ==> {
+            &&& fp.prev is Some
+            &&& fp.prev->0.addr() == link.paddr
+            &&& fp.prev->0.ptr.addr() == fr.slots[ins].pptr().addr()
+        })
+        &&& (p != n ==> fp.prev == old.meta_value_at(r0, p).prev)
+    }
+
+    #[verifier::opaque]
+    pub open spec fn insert_old_slot_post_at(
+        self,
+        fr: MetaRegionOwners,
+        old: LinkedListOwner<M>,
+        r0: MetaRegionOwners,
+        n: int,
+        link: LinkOwner,
+        p: int,
+    ) -> bool {
+        self.insert_old_slot_post_clauses(fr, old, r0, n, link, p)
+    }
+
+    pub proof fn insert_old_slot_post_at_facts(
+        self,
+        fr: MetaRegionOwners,
+        old: LinkedListOwner<M>,
+        r0: MetaRegionOwners,
+        n: int,
+        link: LinkOwner,
+        p: int,
+    )
+        requires
+            self.insert_old_slot_post_at(fr, old, r0, n, link, p),
+        ensures
+            self.insert_old_slot_post_clauses(fr, old, r0, n, link, p),
+    {
+        reveal(LinkedListOwner::insert_old_slot_post_at);
+    }
+
     #[verifier::spinoff_prover]
     #[verifier::rlimit(120)]
     pub proof fn insert_preserves_relate_region(
@@ -686,52 +757,17 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
                 &&& (n > 0 ==> {
                     &&& fpn.prev is Some
                     &&& fpn.prev->0.addr() == old.list[n - 1].paddr
-                    &&& fpn.prev->0.ptr.addr() == r0.slots[meta_to_index(
-                        old.list[n - 1].paddr,
-                    )].pptr().addr()
+                    &&& fpn.prev->0.ptr.addr() == old.meta_pptr_at(r0, n - 1).addr()
                 })
                 &&& (n < old.list.len() ==> {
                     &&& fpn.next is Some
                     &&& fpn.next->0.addr() == old.list[n].paddr
-                    &&& fpn.next->0.ptr.addr() == r0.slots[meta_to_index(
-                        old.list[n].paddr,
-                    )].pptr().addr()
+                    &&& fpn.next->0.ptr.addr() == old.meta_pptr_at(r0, n).addr()
                 })
             }),
             forall|p: int|
-                #![trigger meta_to_index(old.list[p].paddr)]
-                (0 <= p < old.list.len()) ==> ({
-                    let i = meta_to_index(old.list[p].paddr);
-                    let ins = meta_to_index(new.list[n].paddr);
-                    let np = if p < n {
-                        p
-                    } else {
-                        p + 1
-                    };
-                    let fp = new.meta_value_at(fr, np);
-                    &&& fr.contains(i)
-                    &&& fr.slots[i].addr() == old.list[p].paddr
-                    &&& fr.slots[i].pptr() == r0.slots[i].pptr()
-                    &&& fr.slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNIQUE
-                    &&& fr.slot_owners[i].usage is Frame
-                    &&& fr.slot_owners[i].inner_perms.in_list.value() == new.list_id
-                    &&& new.meta_wf_at(fr, np)
-                    &&& fr.slots[i].addr() % META_SLOT_SIZE == 0
-                    &&& FRAME_METADATA_RANGE.start <= fr.slots[i].addr()
-                        < FRAME_METADATA_RANGE.start + MAX_NR_PAGES * META_SLOT_SIZE
-                    &&& (p == n - 1 ==> {
-                        &&& fp.next is Some
-                        &&& fp.next->0.addr() == link.paddr
-                        &&& fp.next->0.ptr.addr() == fr.slots[ins].pptr().addr()
-                    })
-                    &&& (p != n - 1 ==> fp.next == old.meta_value_at(r0, p).next)
-                    &&& (p == n ==> {
-                        &&& fp.prev is Some
-                        &&& fp.prev->0.addr() == link.paddr
-                        &&& fp.prev->0.ptr.addr() == fr.slots[ins].pptr().addr()
-                    })
-                    &&& (p != n ==> fp.prev == old.meta_value_at(r0, p).prev)
-                }),
+                #![trigger new.insert_old_slot_post_at(fr, old, r0, n, link, p)]
+                (0 <= p < old.list.len()) ==> new.insert_old_slot_post_at(fr, old, r0, n, link, p),
         ensures
             new.relate_region(fr),
     {
@@ -762,10 +798,12 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
             if m < n {
                 let _ = old.list[m];
                 old.relate_region_at_facts(r0, m);
+                new.insert_old_slot_post_at_facts(fr, old, r0, n, link, m);
             }
             if m > n {
                 let _ = old.list[m - 1];
                 old.relate_region_at_facts(r0, m - 1);
+                new.insert_old_slot_post_at_facts(fr, old, r0, n, link, m - 1);
             }
         }
 
@@ -775,10 +813,12 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
             if k < n {
                 let _ = old.list[k];
                 old.relate_region_at_facts(r0, k);
+                new.insert_old_slot_post_at_facts(fr, old, r0, n, link, k);
             }
             if k > n {
                 let _ = old.list[k - 1];
                 old.relate_region_at_facts(r0, k - 1);
+                new.insert_old_slot_post_at_facts(fr, old, r0, n, link, k - 1);
             }
             if n - 1 >= 0 && n - 1 < old.list.len() {
                 let _ = old.list[n - 1];
@@ -1063,13 +1103,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorOwner<M> {
         link: LinkOwner,
         repr_perm: LinkInnerPerms<M>,
         list_id: u64,
-    ) -> (Self, LinkOwner)
-        recommends
-            list_id != 0,
-            0 <= cursor.index <= cursor.list_own.list.len(),
-            cursor.list_own.repr_perms.len() == cursor.list_own.list.len(),
-            cursor.list_own.list.len() > 0 ==> list_id == cursor.list_own.list_id,
-    {
+    ) -> (Self, LinkOwner) {
         let link = LinkOwner { paddr: link.paddr, in_list: list_id };
         (
             Self {

--- a/ostd/specs/mm/frame/linked_list/linked_list_specs.rs
+++ b/ostd/specs/mm/frame/linked_list/linked_list_specs.rs
@@ -75,10 +75,7 @@ impl CursorModel {
 }
 
 impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorOwner<M> {
-    pub open spec fn remove_owner_spec(self, post: Self) -> bool
-        recommends
-            self.index < self.length(),
-    {
+    pub open spec fn remove_owner_spec(self, post: Self) -> bool {
         &&& post.list_own.list == self.list_own.list.remove(self.index)
         &&& post.index == self.index
     }
@@ -131,10 +128,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorOwner<M> {
         assert(post@.list_model == self@.remove().list_model);
     }
 
-    pub open spec fn insert_owner_spec(self, link: LinkOwner, post: Self) -> bool
-        recommends
-            self.index < self.length(),
-    {
+    pub open spec fn insert_owner_spec(self, link: LinkOwner, post: Self) -> bool {
         // The list model (`view_helper`) depends only on the element sequence,
         // not on `list_id`, so this carries no `list_id` clause — letting it
         // hold even when the insert mints a fresh id for a previously-empty list.

--- a/ostd/specs/mm/frame/mapping.rs
+++ b/ostd/specs/mm/frame/mapping.rs
@@ -29,7 +29,7 @@ pub open spec fn frame_to_index(paddr: Paddr) -> int
     (paddr / PAGE_SIZE) as int
 }
 
-pub open spec fn index_to_meta(i: int) -> (res: Vaddr)
+pub open spec fn index_to_meta(i: int) -> Vaddr
     recommends
         0 <= i < max_meta_slots(),
 {

--- a/ostd/specs/mm/frame/meta_owners.rs
+++ b/ostd/specs/mm/frame/meta_owners.rs
@@ -218,11 +218,7 @@ pub open spec fn typed_meta_wf<M: AnyFrameMeta + Repr<MetaSlotStorage>>(
 pub open spec fn typed_meta_value<M: AnyFrameMeta + Repr<MetaSlotStorage>>(
     storage: pcell_maybe_uninit::PointsTo<MetaSlotStorage>,
     repr_perm: M::ReprPerm,
-) -> M
-    recommends
-        storage.is_init(),
-        M::wf(storage.value(), repr_perm),
-{
+) -> M {
     M::from_repr_spec(storage.value(), repr_perm)
 }
 

--- a/ostd/specs/mm/frame/meta_region_owners.rs
+++ b/ostd/specs/mm/frame/meta_region_owners.rs
@@ -131,7 +131,6 @@ impl MetaRegionOwners {
 
     pub open spec fn ref_count(self, i: int) -> (res: u64)
         recommends
-            self.inv(),
             0 <= i < max_meta_slots(),
     {
         self.slot_owners[i].inner_perms.ref_count.value()
@@ -147,7 +146,6 @@ impl MetaRegionOwners {
 
     pub open spec fn paddr_range_in_region(self, range: Range<Paddr>) -> bool
         recommends
-            self.inv(),
             range.start < range.end < MAX_PADDR,
     {
         forall|paddr: Paddr|
@@ -159,7 +157,6 @@ impl MetaRegionOwners {
 
     pub open spec fn paddr_range_not_mapped(self, range: Range<Paddr>) -> bool
         recommends
-            self.inv(),
             range.start < range.end < MAX_PADDR,
     {
         forall|paddr: Paddr|
@@ -170,7 +167,6 @@ impl MetaRegionOwners {
 
     pub open spec fn paddr_range_not_in_region(self, range: Range<Paddr>) -> bool
         recommends
-            self.inv(),
             range.start < range.end < MAX_PADDR,
     {
         forall|paddr: Paddr|

--- a/ostd/specs/mm/frame/meta_specs.rs
+++ b/ostd/specs/mm/frame/meta_specs.rs
@@ -67,11 +67,7 @@ impl MetaSlot {
         as_unique: bool,
         pre: MetaRegionOwners,
         post: MetaRegionOwners,
-    ) -> bool
-        recommends
-            valid_frame_paddr(paddr),
-            pre.inv(),
-    {
+    ) -> bool {
         let idx = frame_to_index(paddr);
         let pre_owner = pre.slot_owners[idx];
         let post_owner = post.slot_owners[idx];
@@ -96,11 +92,7 @@ impl MetaSlot {
         paddr: Paddr,
         pre: MetaRegionOwners,
         post: MetaRegionOwners,
-    ) -> bool
-        recommends
-            valid_frame_paddr(paddr),
-            pre.inv(),
-    {
+    ) -> bool {
         let idx = frame_to_index(paddr);
         {
             &&& post.slot_owners.dom() =~= pre.slot_owners.dom()
@@ -179,11 +171,7 @@ impl MetaSlot {
         paddr: Paddr,
         pre: MetaRegionOwners,
         post: MetaRegionOwners,
-    ) -> bool
-        recommends
-            valid_frame_paddr(paddr),
-            pre.inv(),
-    {
+    ) -> bool {
         let idx = frame_to_index(paddr);
         let pre_perms = pre.slot_owners[idx].inner_perms.ref_count.value();
         {
@@ -221,7 +209,6 @@ impl MetaSlot {
 
     pub open spec fn inc_ref_count_spec(&self, pre: MetaSlotModel) -> (MetaSlotModel)
         recommends
-            pre.inv(),
             pre.status == MetaSlotStatus::SHARED,
     {
         MetaSlotModel { ref_count: (pre.ref_count + 1) as u64, ..pre }

--- a/ostd/specs/mm/frame/unique.rs
+++ b/ostd/specs/mm/frame/unique.rs
@@ -121,10 +121,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrameOwner<M> {
         )
     }
 
-    pub open spec fn meta_value(self, regions: MetaRegionOwners) -> M
-        recommends
-            self.meta_wf(regions),
-    {
+    pub open spec fn meta_value(self, regions: MetaRegionOwners) -> M {
         typed_meta_value::<M>(
             regions.slot_owners[self.slot_index].inner_perms.storage,
             self.repr_perm->0,

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -954,8 +954,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
                 self.va.index_increment_adds_page_size(self.level as int);
 
-                let inc_va = inc.va.to_vaddr() as nat;
-                assert(inc_va == self_va + ps);
                 vstd::arithmetic::div_mod::lemma_mod_add_multiples_vanish(
                     self_va as int,
                     ps as int,
@@ -966,12 +964,10 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
                 AbstractVaddr::to_vaddr_from_vaddr_roundtrip(self.va.align_up(self.level as int));
             }
-            // The wrap (`index+1 == NR_ENTRIES`) at `level == guard_level` is
-            // precluded by the strengthened precondition.
-
             return;
         }
         if self.index() + 1 < NR_ENTRIES {
+            self.lemma_inc_index_va_inv();
             let inc = self.inc_index();
 
             inc.va.align_down_concrete(self.level as int);
@@ -981,8 +977,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
 
             self.va.index_increment_adds_page_size(self.level as int);
 
-            let inc_va = inc.va.to_vaddr() as nat;
-            assert(inc_va == self_va + ps);
             vstd::arithmetic::div_mod::lemma_mod_add_multiples_vanish(self_va as int, ps as int);
 
             vstd::arithmetic::div_mod::lemma_fundamental_div_mod(self_va as int, ps as int);

--- a/ostd/specs/mm/page_table/cursor/cursor_steps.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_steps.rs
@@ -704,10 +704,6 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
     }
 
     pub open spec fn move_forward_owner_spec(self) -> Self
-        recommends
-            self.inv(),
-            self.level < NR_LEVELS,
-            self.in_locked_range(),
         decreases NR_LEVELS - self.level,
         when self.level <= NR_LEVELS
     {

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -941,6 +941,18 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         }
     }
 
+    /// Incrementing a nonterminal cursor index preserves the abstract-VA invariant.
+    pub proof fn lemma_inc_index_va_inv(self)
+        requires
+            self.inv(),
+            self.index() + 1 < NR_ENTRIES,
+        ensures
+            self.inc_index().va.inv(),
+    {
+        let new_index = self.continuations[self.level - 1].inc_index().idx as int;
+        self.va.lemma_insert_preserves_inv(self.level - 1, new_index);
+    }
+
     #[verifier::spinoff_prover]
     pub proof fn do_inc_index(tracked &mut self)
         requires
@@ -954,6 +966,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             final(self).inv(),
             *final(self) == old(self).inc_index(),
     {
+        old(self).lemma_inc_index_va_inv();
         self.popped_too_high = false;
         let tracked mut cont = self.continuations.tracked_remove(self.level - 1);
         cont.do_inc_index();

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -1436,7 +1436,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
     /// When the cursor is in the locked range, va.index[guard_level - 1]
     /// matches prefix.index[guard_level - 1]. This is because both va and
     /// prefix are within the same page_size(guard_level)-aligned block.
-    #[verifier::rlimit(2000)]
+    #[verifier::rlimit(200)]
     pub proof fn in_locked_range_guard_index_eq_prefix(self)
         requires
             self.inv(),
@@ -1703,7 +1703,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
     }
 
     /// The node at `level+1` containing `va` fits within the locked range.
-    #[verifier::rlimit(20000)]
+    #[verifier::rlimit(200)]
     pub proof fn node_within_locked_range(self, level: PagingLevel)
         requires
             self.inv(),

--- a/ostd/specs/mm/page_table/cursor/split_while_huge_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/split_while_huge_lemmas.rs
@@ -5,7 +5,7 @@ use vstd_extra::{arithmetic::*, ghost_tree::*, ownership::*};
 
 use crate::specs::{
     arch::{MAX_PADDR, NR_ENTRIES, NR_LEVELS, PAGE_SIZE},
-    mm::page_table::{Mapping, cursor::owners::*, owners::PageTableOwner},
+    mm::page_table::{Mapping, cursor::owners::*, owners::PageTableOwner, vaddr_range_spec},
 };
 
 use crate::arch::mm::PagingConsts;
@@ -18,6 +18,43 @@ verus! {
 broadcast use group_ghost_tree_lemmas;
 
 impl<C: PageTableConfig> CursorView<C> {
+    proof fn lemma_split_index_inv(m: Mapping, new_size: usize, k: int)
+        requires
+            m.inv(),
+            new_size > 0,
+            m.page_size % new_size == 0,
+            set![4096usize, 2097152, 1073741824].contains(new_size),
+            m.va_range.start % new_size as int == 0,
+            0 <= k < m.page_size as int / new_size as int,
+        ensures
+            Self::split_index(m, new_size, k as usize).inv(),
+            m.va_range.start <= Self::split_index(m, new_size, k as usize).va_range.start,
+            Self::split_index(m, new_size, k as usize).va_range.end <= m.va_range.end,
+    {
+        let ps = m.page_size as int;
+        let ns = new_size as int;
+        let count = ps / ns;
+        let sub = Self::split_index(m, new_size, k as usize);
+
+        vstd::arithmetic::div_mod::lemma_fundamental_div_mod(ps, ns);
+        assert(ps == count * ns) by {
+            vstd::arithmetic::mul::lemma_mul_is_commutative(ns, count);
+        };
+        vstd::arithmetic::mul::lemma_mul_inequality(k + 1, count, ns);
+        vstd::arithmetic::mul::lemma_mul_is_distributive_add_other_way(ns, k, 1);
+
+        vstd::arithmetic::div_mod::lemma_mod_mod(m.pa_range.start as int, ns, count);
+        assert((m.pa_range.start as int) % ns == 0);
+        vstd::arithmetic::div_mod::lemma_mod_multiples_basic(k, ns);
+        vstd::arithmetic::div_mod::lemma_mod_multiples_basic(k + 1, ns);
+        vstd_extra::arithmetic::lemma_mod_0_add(m.pa_range.start as int, k * ns, ns);
+        vstd_extra::arithmetic::lemma_mod_0_add(m.pa_range.start as int, (k + 1) * ns, ns);
+        vstd_extra::arithmetic::lemma_mod_0_add(m.va_range.start, k * ns, ns);
+        vstd_extra::arithmetic::lemma_mod_0_add(m.va_range.start, (k + 1) * ns, ns);
+
+        assert(sub.inv());
+    }
+
     /// After `split_if_mapped_huge_spec(new_size)`, a sub-mapping at `cur_va`
     /// still exists.  The witness is `split_index(m, new_size, k)` where
     /// `k = (cur_va - m.va_range.start) / new_size`.
@@ -171,6 +208,31 @@ impl<C: PageTableConfig> CursorView<C> {
         assert(m.va_range.start % new_size as int == 0) by {
             vstd::arithmetic::mul::lemma_mul_is_commutative(count, ns);
             vstd::arithmetic::div_mod::lemma_mod_mod(m.va_range.start as int, ns, count);
+        };
+
+        let domain = Set::<int>::range(0int, count);
+        let new_mappings = domain.map(|n: int| Self::split_index(m, new_size, n as usize));
+        let new_self = v.split_if_mapped_huge_spec(new_size);
+
+        assert forall|m2: Mapping| #[trigger] new_self.mappings.contains(m2) implies m2.inv() by {
+            if v.mappings.contains(m2) && m2 != m {
+            } else {
+                let k = choose|k: int|
+                    0 <= k < count && #[trigger] Self::split_index(m, new_size, k as usize) == m2;
+                Self::lemma_split_index_inv(m, new_size, k);
+            }
+        };
+
+        assert forall|m2: Mapping| #[trigger] new_self.mappings.contains(m2) implies {
+            &&& vaddr_range_spec::<C>()@.start <= m2.va_range.start
+            &&& m2.va_range.end <= vaddr_range_spec::<C>()@.end + 1
+        } by {
+            if v.mappings.contains(m2) && m2 != m {
+            } else {
+                let k = choose|k: int|
+                    0 <= k < count && #[trigger] Self::split_index(m, new_size, k as usize) == m2;
+                Self::lemma_split_index_inv(m, new_size, k);
+            }
         };
     }
 

--- a/ostd/specs/mm/page_table/cursor/va_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/va_lemmas.rs
@@ -145,10 +145,21 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
         let ghost start = old_self.locked_range().start as nat;
 
         vstd_extra::arithmetic::lemma_nat_align_down_monotone(prefix_va_val, ps, guard_ps);
-        assert(start % ps == 0);
-        vstd::arithmetic::div_mod::lemma_add_mod_noop(start as int, guard_ps as int, ps as int);
+        vstd_extra::arithmetic::lemma_mod_0_add(start as int, guard_ps as int, ps as int);
 
         vstd_extra::arithmetic::lemma_nat_align_down_sound(old_va_val, ps);
+        if !self.popped_too_high && (self.in_locked_range() || self.level < self.guard_level) {
+            if self.level == self.guard_level {
+                let new_va_val = self.va.to_vaddr() as nat;
+                let diff = (new_va_val - start) as nat;
+                vstd::arithmetic::div_mod::lemma_mod_equivalence(
+                    new_va_val as int,
+                    start as int,
+                    ps as int,
+                );
+                vstd::arithmetic::div_mod::lemma_small_mod(diff, ps);
+            }
+        }
     }
 
     pub proof fn zero_rec_preserves_all_but_va(self, level: PagingLevel)
@@ -187,6 +198,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
     {
         // inc_index increments va.index[level-1] by 1. zero_below_level zeroes
         // indices below level (= align_down). The result is align_up(va, ps).
+        self.lemma_inc_index_va_inv();
         let inc = self.inc_index();
         inc.zero_preserves_all_but_va();
         inc.zero_below_level_va();

--- a/ostd/specs/mm/page_table/mod.rs
+++ b/ostd/specs/mm/page_table/mod.rs
@@ -1601,7 +1601,7 @@ impl AbstractVaddr {
     /// positional (ignoring `leading_bits`); add `leading_bits * 2^48`
     /// manually to obtain the canonical form — see `to_path_vaddr_concrete`
     /// for the canonical statement.
-    #[verifier::rlimit(400)]
+    #[verifier::rlimit(200)]
     pub proof fn to_path_vaddr(self, level: int)
         requires
             self.inv(),

--- a/ostd/specs/mm/page_table/mod.rs
+++ b/ostd/specs/mm/page_table/mod.rs
@@ -369,6 +369,53 @@ impl AbstractVaddr {
         }
     }
 
+    proof fn lemma_zero_offset_preserves_inv(self)
+        requires
+            self.inv(),
+        ensures
+            (AbstractVaddr { offset: 0, ..self }).inv(),
+    {
+        let new = AbstractVaddr { offset: 0, ..self };
+        assert(new.index == self.index);
+        assert forall|i: int| #![trigger new.index.contains_key(i)] 0 <= i < NR_LEVELS implies {
+            &&& new.index.contains_key(i)
+            &&& 0 <= new.index[i] < NR_ENTRIES
+        } by {
+            assert(self.index.contains_key(i));
+        }
+    }
+
+    /// Updating one valid page-table index with an in-range value preserves the VA invariant.
+    pub proof fn lemma_insert_preserves_inv(self, index: int, value: int)
+        requires
+            self.inv(),
+            0 <= index < NR_LEVELS,
+            0 <= value < NR_ENTRIES,
+        ensures
+            (AbstractVaddr { index: self.index.insert(index, value), ..self }).inv(),
+    {
+        let new = AbstractVaddr { index: self.index.insert(index, value), ..self };
+        assert(new.index.dom() == Set::<int>::range(0, NR_LEVELS as int));
+        assert forall|i: int| #![trigger new.index.contains_key(i)] 0 <= i < NR_LEVELS implies {
+            &&& new.index.contains_key(i)
+            &&& 0 <= new.index[i] < NR_ENTRIES
+        } by {
+            if i != index {
+                assert(self.index.contains_key(i));
+            }
+        }
+    }
+
+    proof fn lemma_insert_zero_preserves_inv(self, index: int)
+        requires
+            self.inv(),
+            0 <= index < NR_LEVELS,
+        ensures
+            (AbstractVaddr { index: self.index.insert(index, 0), ..self }).inv(),
+    {
+        self.lemma_insert_preserves_inv(index, 0);
+    }
+
     pub proof fn align_down_inv(self, level: int)
         requires
             1 <= level <= NR_LEVELS,
@@ -382,21 +429,12 @@ impl AbstractVaddr {
         decreases level,
     {
         if level == 1 {
-            assert(self.align_down(1).index == self.index);
+            self.lemma_zero_offset_preserves_inv();
+
         } else {
             let tmp = self.align_down(level - 1);
             self.align_down_inv(level - 1);
-            let new = self.align_down(level);
-            assert(new.index.dom() == Set::<int>::range(0, NR_LEVELS as int));
-            assert forall|i: int| #![trigger new.index.contains_key(i)] 0 <= i < NR_LEVELS implies {
-                &&& new.index.contains_key(i)
-                &&& 0 <= new.index[i]
-                &&& new.index[i] < NR_ENTRIES
-            } by {
-                if i != level - 2 {
-                    assert(tmp.index.contains_key(i));
-                }
-            }
+            tmp.lemma_insert_zero_preserves_inv(level - 2);
         }
     }
 
@@ -425,20 +463,19 @@ impl AbstractVaddr {
                     == self.index[i],
         decreases level,
     {
+        self.align_down_inv(level);
         if level == 1 {
-            assert(self.align_down(1).index == self.index);
         } else {
             let tmp = self.align_down(level - 1);
             self.align_down_shape(level - 1);
             let new = self.align_down(level);
-            assert(new.index.dom() == Set::<int>::range(0, NR_LEVELS as int));
+
             assert forall|i: int| #![trigger new.index.contains_key(i)] 0 <= i < NR_LEVELS implies {
                 &&& new.index.contains_key(i)
                 &&& 0 <= new.index[i]
                 &&& new.index[i] < NR_ENTRIES
             } by {
                 if i != level - 2 {
-                    assert(tmp.index.contains_key(i));
                 }
             }
         }
@@ -1486,6 +1523,7 @@ impl AbstractVaddr {
         if next_index == NR_ENTRIES {
             if level < NR_LEVELS {
                 let next_va = Self { index: self.index.insert(level - 1, 0), ..self };
+                self.lemma_insert_zero_preserves_inv(level - 1);
                 next_va.next_index_wrap_condition(level + 1);
                 self.wrapped_after_carry_equiv(level, level + 1);
                 next_va.next_index_preserves_lower_indices(level + 1, level);

--- a/ostd/specs/mm/page_table/node/owners.rs
+++ b/ostd/specs/mm/page_table/node/owners.rs
@@ -266,10 +266,7 @@ impl<C: PageTableConfig> NodeOwner<C> {
         )
     }
 
-    pub open spec fn meta_value(self, regions: MetaRegionOwners) -> PageTablePageMeta<C>
-        recommends
-            self.meta_wf(regions),
-    {
+    pub open spec fn meta_value(self, regions: MetaRegionOwners) -> PageTablePageMeta<C> {
         typed_meta_value::<PageTablePageMeta<C>>(
             regions.slot_owners[self.slot_index].inner_perms.storage,
             (),

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -1293,6 +1293,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
 
         if self.0.value().is_frame() {
             lemma_page_size_spec_values();
+            ;
             let frame = self.0.value().frame();
             let pt_level = (INC_LEVELS - path.len()) as PagingLevel;
             Self::lemma_vaddr_path_alignment_and_bound(path);
@@ -1310,11 +1311,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             };
             assert(self.view_rec(path) == set![m]);
             let ps = page_size(pt_level) as int;
-            assert((frame.mapped_pa + ps) % ps == 0) by (nonlinear_arith)
-                requires
-                    (frame.mapped_pa as int) % ps == 0,
-                    ps > 0,
-            ;
+            vstd_extra::arithmetic::lemma_mod_0_add(frame.mapped_pa as int, ps, ps);
             // Bridge `vaddr_of(path) == vaddr(path) + LB * 2^48`.
             lemma_vaddr_of_eq_int::<C>(path);
             C::lemma_page_table_config_constant_properties();
@@ -1337,15 +1334,32 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             // (B) Overflow: `vaddr_of(path) + ps <= 2^64`.
             //     `vaddr(path) + ps <= 2^48`: from strict bound plus alignment.
             let v = vaddr(path) as int;
-            assert(vaddr_of::<C>(path) + ps <= pow2(64)) by (nonlinear_arith)
+            let limit = 0x1_0000_0000_0000int;
+            assert(limit % ps == 0) by {
+                if ps == 0x1000int {
+                    assert(0x1_0000_0000_0000int % 0x1000int == 0) by (compute_only);
+                } else if ps == 0x20_0000int {
+                    assert(0x1_0000_0000_0000int % 0x20_0000int == 0) by (compute_only);
+                } else {
+                    assert(ps == 0x4000_0000int);
+                    assert(0x1_0000_0000_0000int % 0x4000_0000int == 0) by (compute_only);
+                }
+            };
+            vstd::arithmetic::div_mod::lemma_mod_equivalence(limit, v, ps);
+            let diff = limit - v;
+            let q = diff / ps;
+            vstd::arithmetic::div_mod::lemma_fundamental_div_mod(diff, ps);
+            assert(q >= 1) by (nonlinear_arith)
                 requires
-                    vaddr_of::<C>(path) == v + lb * 0x1_0000_0000_0000int,
-                    v + ps <= 0x1_0000_0000_0000int,
-                    lb < 0x1_0000int,
-                    lb >= 0,
-                    pow2(64) == 0x1_0000_0000_0000_0000int,
+                    diff > 0,
+                    ps > 0,
+                    diff == ps * q,
             ;
-            assert(m.inv());
+            vstd::arithmetic::mul::lemma_mul_inequality(1, q, ps);
+            vstd::arithmetic::mul::lemma_mul_inequality(lb, 0xffffint, 0x1_0000_0000_0000int);
+            assert(0x1_0000_0000_0000int + 0xffffint * 0x1_0000_0000_0000int
+                == 0x1_0000_0000_0000_0000int) by (compute_only);
+            vstd_extra::arithmetic::lemma_mod_0_add(m.va_range.start, ps, ps);
         } else if self.0.value().is_node() && path.len() < INC_LEVELS - 1 {
             assert forall|m: Mapping| #[trigger]
                 self.view_rec(path).contains(m) implies m.inv() by {

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -57,14 +57,7 @@ pub open spec fn vaddr_make<const L: usize>(idx: int, offset: usize) -> usize
     (vaddr_shift::<L>(idx) * offset) as usize
 }
 
-pub open spec fn rec_vaddr(
-    path: TreePath<NR_ENTRIES>,
-    idx: int,
-) -> usize/*        recommends
-        0 < NR_LEVELS,
-        path.len() <= NR_LEVELS,
-        0 <= idx <= path.len(),*/
-
+pub open spec fn rec_vaddr(path: TreePath<NR_ENTRIES>, idx: int) -> usize
     decreases path.len() - idx,
     when 0 <= idx <= path.len()
 {

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -783,7 +783,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     }
 
     /// Closed-form for `vaddr(path.push_tail(i))` by case-split on `path.len() ∈ {0,1,2,3}`.
-    #[verifier::rlimit(400)]
+    #[verifier::rlimit(200)]
     pub proof fn lemma_vaddr_push_tail_eq(path: TreePath<NR_ENTRIES>, i: int)
         requires
             path.inv(),
@@ -1169,7 +1169,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     ///
     /// Proved by case analysis on `path.len() ∈ {0, 1, 2, 3, 4}`, unrolling
     /// `rec_vaddr` and using concrete `pow2` values.
-    #[verifier::rlimit(400)]
+    #[verifier::rlimit(200)]
     proof fn lemma_vaddr_path_alignment_and_bound(path: TreePath<NR_ENTRIES>)
         requires
             path.inv(),

--- a/ostd/specs/mm/vm_space.rs
+++ b/ostd/specs/mm/vm_space.rs
@@ -266,10 +266,7 @@ impl<'a> VmSpaceOwner {
     ///
     /// This specification function enforces memory isolation by ensuring that the
     /// requested memory range does not intersect with the domain of any active writer.
-    pub open spec fn can_create_reader(&self, vaddr: Vaddr, len: usize) -> bool
-        recommends
-            self.inv(),
-    {
+    pub open spec fn can_create_reader(&self, vaddr: Vaddr, len: usize) -> bool {
         &&& forall|i: int|
             #![trigger self.writers[i]]
             0 <= i < self.writers.len() ==> !self.writers[i].overlaps_with_range(
@@ -280,10 +277,7 @@ impl<'a> VmSpaceOwner {
     /// Checks if we can create a new writer under this VM space owner.
     ///
     /// Similar to [`can_create_reader`], but checks both active readers and writers.
-    pub open spec fn can_create_writer(&self, vaddr: Vaddr, len: usize) -> bool
-        recommends
-            self.inv(),
-    {
+    pub open spec fn can_create_writer(&self, vaddr: Vaddr, len: usize) -> bool {
         &&& forall|i: int|
             #![trigger self.readers[i]]
             0 <= i < self.readers.len() ==> !self.readers[i].overlaps_with_range(
@@ -301,10 +295,7 @@ impl<'a> VmSpaceOwner {
     /// This assumes that we always generate a fresh ID that is not used by any existing
     /// readers or writers. This should be safe as the ID space is unbounded and only used
     /// to reason about different VM IO owners in verification.
-    pub uninterp spec fn new_vm_io_id(&self) -> nat
-        recommends
-            self.inv(),
-    ;
+    pub uninterp spec fn new_vm_io_id(&self) -> nat;
 
     /// Activates the given reader to read data from the user space of the current task.
     /// # Verified Properties

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -830,7 +830,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
             Tracked(owner) : Tracked<&mut CursorOwner<M>>
     )]
     #[verifier::spinoff_prover]
-    #[verifier::rlimit(240)]
+    #[verifier::rlimit(200)]
     pub fn take_current(&mut self) -> (res: Option<
         (UniqueFrame<Link<M>>, Tracked<UniqueFrameOwner<Link<M>>>),
     >)
@@ -1110,6 +1110,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
             Tracked(frame_own): Tracked<&mut UniqueFrameOwner<Link<M>>>
     )]
     #[verifier::spinoff_prover]
+    #[verifier::rlimit(200)]
     pub fn insert_before(&mut self, mut frame: UniqueFrame<Link<M>>)
         requires
             old(self).wf_region(*old(owner), *old(regions)),

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -138,6 +138,20 @@ pub struct CursorMut<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> {
     pub current: Option<ReprPtr<MetaSlotStorage, Link<M>>>,
 }
 
+proof fn meta_region_inv_at(regions: MetaRegionOwners, i: int)
+    requires
+        regions.inv(),
+        regions.contains(i),
+    ensures
+        regions.slot_owners[i].inv(),
+        regions.slots[i].is_init(),
+        regions.slots[i].addr() == index_to_meta(i),
+        regions.slots[i].value().wf(regions.slot_owners[i]),
+        regions.slot_owners[i].slot_vaddr == regions.slots[i].addr(),
+{
+    reveal(<MetaRegionOwners as Inv>::inv);
+}
+
 impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
     /// Creates a new linked list.
     pub const fn new() -> Self {
@@ -1096,7 +1110,6 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
             Tracked(frame_own): Tracked<&mut UniqueFrameOwner<Link<M>>>
     )]
     #[verifier::spinoff_prover]
-    #[verifier::rlimit(240)]
     pub fn insert_before(&mut self, mut frame: UniqueFrame<Link<M>>)
         requires
             old(self).wf_region(*old(owner), *old(regions)),
@@ -1125,23 +1138,45 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
             final(frame_own).meta_own.in_list == final(owner).list_own.list_id,
             final(owner)@ == old(owner)@.insert(final(frame_own).meta_own@),
     {
+        hide(LinkedListOwner::relate_region);
+        hide(<MetaRegionOwners as Inv>::inv);
         let ghost owner0 = *owner;
         let ghost regions0 = *regions;
         let ghost nn = owner.index as int;
 
         proof {
+            assert(owner0.list_own.repr_perms.len() == owner0.list_own.list.len()) by {
+                reveal(LinkedListOwner::relate_region);
+            };
+            assert(owner0.list_own.list.len() > 0 ==> owner0.list_own.list_id != 0) by {
+                reveal(LinkedListOwner::relate_region);
+            };
+            assert(regions0.contains(frame_own.slot_index));
+            meta_region_inv_at(regions0, frame_own.slot_index);
             owner0.list_own.length_lt_usize_max(regions0);
             if nn > 0 {
+                assert(owner0.list_own.relate_region_at(regions0, nn - 1)) by {
+                    reveal(LinkedListOwner::relate_region);
+                };
                 owner.list_own.relate_region_at_facts(*regions, nn - 1);
+                meta_region_inv_at(regions0, meta_to_index(owner0.list_own.list[nn - 1].paddr));
             }
             if nn < owner.list_own.list.len() {
+                assert(owner0.list_own.relate_region_at(regions0, nn)) by {
+                    reveal(LinkedListOwner::relate_region);
+                };
                 owner.list_own.relate_region_at_facts(*regions, nn);
+                meta_region_inv_at(regions0, meta_to_index(owner0.list_own.list[nn].paddr));
             }
             assert forall|p: int|
-                #![trigger owner0.list_own.list[p]]
+                #![trigger
+                    regions0.slot_owners[meta_to_index(owner0.list_own.list[p].paddr)]]
                 0 <= p < owner0.list_own.list.len() implies frame_own.slot_index != meta_to_index(
                 owner0.list_own.list[p].paddr,
             ) by {
+                assert(owner0.list_own.relate_region_at(regions0, p)) by {
+                    reveal(LinkedListOwner::relate_region);
+                };
                 owner0.list_own.relate_region_at_facts(regions0, p);
                 if frame_own.slot_index == meta_to_index(owner0.list_own.list[p].paddr) {
                     assert(regions0.slot_owners[frame_own.slot_index].inner_perms.in_list.value()
@@ -1183,6 +1218,11 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                 frame.meta_mut()).next = Some(current);
 
                 let ghost prev_idx = meta_to_index(owner.list_own.list[nn - 1].paddr);
+                proof {
+                    assert(prev_idx != idx) by {
+                        reveal(LinkedListOwner::relate_region);
+                    };
+                }
                 let tracked prev_points_to = regions.slots.tracked_borrow(prev_idx);
                 let tracked prev_slot_owner = regions.slot_owners.tracked_borrow_mut(prev_idx);
                 let tracked prev_repr_perm = owner.list_own.repr_perms.tracked_borrow_mut(nn - 1);
@@ -1244,6 +1284,9 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                 frame.meta_mut()).prev = Some(back);
 
                 let ghost back_idx = meta_to_index(owner.list_own.list[nn - 1].paddr);
+                proof {
+                    assert(0 <= nn - 1 < owner.list_own.repr_perms.len());
+                }
                 let tracked back_points_to = regions.slots.tracked_borrow(back_idx);
                 let tracked back_slot_owner = regions.slot_owners.tracked_borrow_mut(back_idx);
                 let tracked back_repr_perm = owner.list_own.repr_perms.tracked_borrow_mut(nn - 1);
@@ -1267,6 +1310,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
 
         proof {
             assert(regions.contains(frame_own.slot_index));
+            assert(owner0.list_own.list.len() > 0 ==> list_id == owner0.list_own.list_id);
         }
         let tracked frame_outer = regions.slots.tracked_borrow_mut(frame_own.slot_index);
         let tracked mut frame_so = regions.slot_owners.tracked_borrow_mut(frame_own.slot_index);
@@ -1275,7 +1319,9 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
         let slot = frame.slot();
         slot.in_list.store(Tracked(&mut fip.in_list), list_id);
         proof {
-            assert(regions.inv());
+            assert(regions.inv()) by {
+                reveal(<MetaRegionOwners as Inv>::inv);
+            };
         }
 
         #[verus_spec(with Tracked(&*frame_own), Tracked(regions))]
@@ -1299,51 +1345,60 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
             let ins = frame_own.slot_index;
 
             assert forall|p: int|
-                #![trigger meta_to_index(oldl.list[p].paddr)]
-                (0 <= p < oldl.list.len()) implies ({
+                #![trigger
+                    owner.list_own.insert_old_slot_post_at(
+                        *regions,
+                        oldl,
+                        regions0,
+                        nn,
+                        flink,
+                        p,
+                    )]
+                (0 <= p < oldl.list.len()) implies owner.list_own.insert_old_slot_post_at(
+                *regions,
+                oldl,
+                regions0,
+                nn,
+                flink,
+                p,
+            ) by {
+                reveal(LinkedListOwner::insert_old_slot_post_at);
                 let i = meta_to_index(oldl.list[p].paddr);
-                let np = if p < nn {
-                    p
-                } else {
-                    p + 1
+                assert(oldl.relate_region_at(regions0, p)) by {
+                    reveal(LinkedListOwner::relate_region);
                 };
-                let fp = owner.list_own.meta_value_at(*regions, np);
-                &&& regions.contains(i)
-                &&& regions.slots[i].addr() == oldl.list[p].paddr
-                &&& regions.slots[i].pptr() == regions0.slots[i].pptr()
-                &&& regions.slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNIQUE
-                &&& regions.slot_owners[i].usage is Frame
-                &&& regions.slot_owners[i].inner_perms.in_list.value() == owner.list_own.list_id
-                &&& owner.list_own.meta_wf_at(*regions, np)
-                &&& regions.slots[i].addr() % META_SLOT_SIZE == 0
-                &&& FRAME_METADATA_RANGE.start <= regions.slots[i].addr()
-                    < FRAME_METADATA_RANGE.start + MAX_NR_PAGES * META_SLOT_SIZE
-                &&& (p == nn - 1 ==> {
-                    &&& fp.next is Some
-                    &&& fp.next.unwrap().addr() == flink.paddr
-                    &&& fp.next.unwrap().ptr.addr() == regions.slots[ins].pptr().addr()
-                })
-                &&& (p != nn - 1 ==> fp.next == oldl.meta_value_at(regions0, p).next)
-                &&& (p == nn ==> {
-                    &&& fp.prev is Some
-                    &&& fp.prev.unwrap().addr() == flink.paddr
-                    &&& fp.prev.unwrap().ptr.addr() == regions.slots[ins].pptr().addr()
-                })
-                &&& (p != nn ==> fp.prev == oldl.meta_value_at(regions0, p).prev)
-            }) by {
-                let i = meta_to_index(oldl.list[p].paddr);
-                let np = if p < nn {
-                    p
-                } else {
-                    p + 1
-                };
-                let fp = owner.list_own.meta_value_at(*regions, np);
                 oldl.relate_region_at_facts(regions0, p);
+                if nn - 1 >= 0 && nn - 1 < oldl.list.len() && p != nn - 1 {
+                    assert(meta_to_index(oldl.list[p].paddr) != meta_to_index(
+                        oldl.list[nn - 1].paddr,
+                    )) by {
+                        reveal(LinkedListOwner::relate_region);
+                    };
+                }
+                if nn >= 0 && nn < oldl.list.len() && p != nn {
+                    assert(meta_to_index(oldl.list[p].paddr) != meta_to_index(oldl.list[nn].paddr))
+                        by {
+                        reveal(LinkedListOwner::relate_region);
+                    };
+                }
                 if nn - 1 >= 0 && nn - 1 < oldl.list.len() {
+                    assert(oldl.relate_region_at(regions0, nn - 1)) by {
+                        reveal(LinkedListOwner::relate_region);
+                    };
                     oldl.relate_region_at_facts(regions0, nn - 1);
                 }
                 if nn >= 0 && nn < oldl.list.len() {
+                    assert(oldl.relate_region_at(regions0, nn)) by {
+                        reveal(LinkedListOwner::relate_region);
+                    };
                     oldl.relate_region_at_facts(regions0, nn);
+                }
+                if nn - 1 >= 0 && nn - 1 < oldl.list.len() && p != nn - 1 {
+                    assert(meta_to_index(oldl.list[p].paddr) != meta_to_index(
+                        oldl.list[nn - 1].paddr,
+                    )) by {
+                        reveal(LinkedListOwner::relate_region);
+                    };
                 }
                 assert(regions.contains(i));
             }

--- a/ostd/src/mm/frame/segment.rs
+++ b/ostd/src/mm/frame/segment.rs
@@ -838,17 +838,13 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
 
     /// Returns the number of pages of the contiguous frames.
     #[verifier::inline]
-    pub open spec fn nrpage_spec(&self) -> usize
-        recommends
-            self.inv(),
-    {
+    pub open spec fn nrpage_spec(&self) -> usize {
         self.size() / PAGE_SIZE
     }
 
     /// Splits the contiguous frames into two at the given byte offset from the start in spec mode.
     pub closed spec fn split_spec(self, offset: usize) -> (Self, Self)
         recommends
-            self.inv(),
             offset % PAGE_SIZE == 0,
             0 < offset < self.size(),
     {

--- a/ostd/src/mm/io.rs
+++ b/ostd/src/mm/io.rs
@@ -1184,29 +1184,17 @@ type Result<T> = core::result::Result<T, Error>;
 pub trait VmIo<P: Sized>: Send + Sync + Sized {
     spec fn obeys_vmio_spec() -> bool;
 
-    open spec fn obeys_vmio_read_requires() -> bool
-        recommends
-            Self::obeys_vmio_spec(),
-    {
+    open spec fn obeys_vmio_read_requires() -> bool {
         false
     }
 
-    open spec fn obeys_vmio_write_requires() -> bool
-        recommends
-            Self::obeys_vmio_spec(),
-    {
+    open spec fn obeys_vmio_write_requires() -> bool {
         false
     }
 
-    spec fn obeys_vmio_read_spec() -> bool
-        recommends
-            Self::obeys_vmio_spec(),
-    ;
+    spec fn obeys_vmio_read_spec() -> bool;
 
-    spec fn obeys_vmio_write_spec() -> bool
-        recommends
-            Self::obeys_vmio_spec(),
-    ;
+    spec fn obeys_vmio_write_spec() -> bool;
 
     open spec fn read_requires(
         self,

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -439,7 +439,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
             final(self).va == old(self).va,
     )]
     #[verifier::spinoff_prover]
-    #[verifier::rlimit(infinity)]
+    #[verifier::rlimit(200)]
     pub fn query(&mut self) -> Result<PagesState<C>, PageTableError> {
         if self.va >= self.barrier_va.end {
             proof {
@@ -877,7 +877,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
     /// ## Safety
     /// - This function never accesses nodes outside the locked range, because it is impossible to
     /// create a cursor below the range, and if the cursor is above the range this function will always panic.
-    #[verifier::rlimit(800)]
+    #[verifier::rlimit(200)]
     #[verus_spec(res =>
         with Tracked(owner): Tracked<&mut CursorOwner<'rcu, C>>,
              Tracked(regions): Tracked<&mut MetaRegionOwners>,
@@ -1509,7 +1509,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
     ///   by ascending to a common ancestor and updating the slot index within a node.
     /// - On a successful jump the cursor is guaranteed to be within the locked range, so
     ///   it will be safe to use.
-    #[verifier::rlimit(8000)]
+    #[verifier::rlimit(200)]
     #[verus_spec(res =>
         with Tracked(owner): Tracked<&mut CursorOwner<'rcu, C>>,
              Tracked(regions): Tracked<&mut MetaRegionOwners>,
@@ -1639,7 +1639,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
     /// ## Safety
     /// - This function is safe because it only manipulates the cursor, it does not modify
     ///   any of the entries. It can advance the cursor outside of the locked range, however.
-    #[verifier::rlimit(800)]
+    #[verifier::rlimit(200)]
     #[verus_spec(
         with Tracked(owner): Tracked<&mut CursorOwner<'rcu, C>>,
              Tracked(regions): Tracked<&mut MetaRegionOwners>,
@@ -3127,7 +3127,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             final(self).0.barrier_va == old(self).0.barrier_va,
     )]
     #[verifier::spinoff_prover]
-    #[verifier::rlimit(infinity)]
+    #[verifier::rlimit(200)]
     pub unsafe fn map(&mut self, item: C::Item) -> (res: Result<(), PageTableFrag<C>>) {
         let ghost self0 = *self;
         let ghost owner0 = *owner;
@@ -3979,7 +3979,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 final(regions).slot_owners[idx] == old(regions).slot_owners[idx],
     )]
     #[verifier::spinoff_prover]
-    #[verifier::rlimit(infinity)]
+    #[verifier::rlimit(200)]
     fn replace_cur_entry(&mut self, new_child: Child<C>) -> Option<PageTableFrag<C>> {
         broadcast use {CursorContinuation::group_lemmas, CursorOwner::group_lemmas};
 

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -768,7 +768,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
     /// - **Safety Invariants**: The node allocated in place of the split page satisfies the safety invariants.
     /// - **Safety**: All other nodes have their invariants preserved.
     #[verifier::spinoff_prover]
-    #[verifier::rlimit(infinity)]
+    #[verifier::rlimit(200)]
     #[verus_spec(res =>
         with Tracked(owner) : Tracked<&mut OwnerSubtree<C>>,
              Tracked(parent_owner): Tracked<&mut NodeOwner<C>>,

--- a/verified_libs/vstd_extra/src/arithmetic.rs
+++ b/verified_libs/vstd_extra/src/arithmetic.rs
@@ -116,7 +116,7 @@ pub proof fn lemma_nat_align_down_monotone(x: nat, k1: nat, k2: nat)
     let r = k2 as int / k1 as int;
     lemma_fundamental_div_mod(a, k2 as int);
     lemma_fundamental_div_mod(k2 as int, k1 as int);
-    assert(k2 as int == r * k1 as int);
+    lemma_mul_is_commutative(k2 as int, q);
     lemma_mul_is_associative(q, r, k1 as int);
     lemma_mod_multiples_basic(q * r, k1 as int);
 }


### PR DESCRIPTION
Several proofs fail because Verus now uses the latest Z3. This PR stabilizes the proofs and tries to keep the verification time. `asterinas/verus` has not been updated yet.