### PR TITLE
change `CountResource::take_resource` signature and upgrade `rwlock` verification

### DIFF
--- a/ostd/src/sync/rwlock.rs
+++ b/ostd/src/sync/rwlock.rs
@@ -67,12 +67,8 @@ tracked struct RwPerms<T> {
     upread_retract_token: Option<UniqueToken>,
     /// Tracks whether there is a live `RwLockUpgradeableGuard`, also stores half of the permission for read access.
     upreader_guard_token: Option<OneLeftOwner<HalfPerm<T>, NoPerm<T>, 3>>,
-    /// Tracks the number of live `RwLockReadGuard`s. If it is `Left`, it stores the remaining read permissions.
-    /// If it is `Right`, it stores an empty token indicating the permission has been given out.
-    read_guard_token: Sum<
-        CountResource<ReadPerm<T>, MAX_READER_U64>,
-        EmptyCount<ReadPerm<T>, MAX_READER_U64>,
-    >,
+    /// Tracks the remaining read permissions, or an empty state while a writer owns the resource.
+    read_guard_token: CountResource<ReadPerm<T>, MAX_READER_U64>,
 }
 
 ghost struct RwId {
@@ -210,10 +206,10 @@ closed spec fn wf(self) -> bool {
         // The number of active `RwLockUpgradeableGuard`, which can only be 0 or 1.
         let active_upgrade_guard: bool = !active_writer && g.upreader_guard_token is None;
         // The number of active `RwLockReadGuard`s.
-        let active_read_guards: int = if g.read_guard_token is Left {
-            MAX_READER_U64 - g.read_guard_token.left().frac()
-        } else {
+        let active_read_guards: int = if g.read_guard_token.is_resource_vacant() {
             0
+        } else {
+            MAX_READER_U64 - g.read_guard_token.frac()
         };
         // The first `try_upread` that fails, which has not returned yet.
         let pending_failed_upread_attempt: bool = g.upread_retract_token is None;
@@ -221,10 +217,10 @@ closed spec fn wf(self) -> bool {
         let failed_reader_attempts: int = V_MAX_READ_RETRACT_FRACS - g.read_retract_token.frac();
 
         &&& if g.core_token.is_left() {
-            g.read_guard_token is Left
+            !g.read_guard_token.is_resource_vacant()
         } else {
             &&& g.upreader_guard_token is None
-            &&& g.read_guard_token is Right
+            &&& g.read_guard_token.is_resource_vacant()
         }
         // The `UPGRADEABLE_READER` bit is set iff there is an active `RwLockUpgradeableGuard` or a pending failed `try_upread` attempt.
         &&& has_upgrade_bit <==> (active_upgrade_guard || pending_failed_upread_attempt)
@@ -262,25 +258,17 @@ closed spec fn wf(self) -> bool {
             let token = g.upreader_guard_token->0;
             wf_upgradeable_guard_token(ghost_id@.core_token_id, ghost_id@.frac_id, val.id(), token)
         }
-        &&& match g.read_guard_token {
-            Sum::Left(token) => {
-                &&& token.wf()
-                &&& token.id() == ghost_id@.read_guard_token_id
-                &&& token.not_empty() ==> {
-                    let resource = token.resource();
-                    let read_half_cell_perm = resource.0;
-                    let mode_knowledge = resource.1;
-                    &&& mode_knowledge.id() == ghost_id@.core_token_id
-                    &&& read_half_cell_perm.id() == ghost_id@.frac_id
-                    &&& read_half_cell_perm.resource().id() == val.id()
-                    &&& read_half_cell_perm.frac() == 1
-                }
-            },
-            Sum::Right(empty) => {
-                &&& empty.id() == ghost_id@.read_guard_token_id
-            },
+        &&& g.read_guard_token.wf()
+        &&& g.read_guard_token.id() == ghost_id@.read_guard_token_id
+        &&& g.read_guard_token.not_empty() ==> {
+            let resource = g.read_guard_token.resource();
+            let read_half_cell_perm = resource.0;
+            let mode_knowledge = resource.1;
+            &&& mode_knowledge.id() == ghost_id@.core_token_id
+            &&& read_half_cell_perm.id() == ghost_id@.frac_id
+            &&& read_half_cell_perm.resource().id() == val.id()
+            &&& read_half_cell_perm.frac() == 1
         }
-
     }
 }
 
@@ -392,7 +380,7 @@ impl<T, G> RwLock<T, G> {
             read_retract_token,
             upread_retract_token: Some(upread_retract_token),
             upreader_guard_token: Some(upreader_guard_token),
-            read_guard_token: Sum::Left(read_guard_token),
+            read_guard_token,
         };
 
         Self {
@@ -490,9 +478,7 @@ impl<T  /*: ?Sized*/ , G: SpinGuardian> RwLock<T, G> {
                 lemma_consts_properties_value(prev_usize);
                 lemma_consts_properties_prev_next(prev_usize, next_usize);
                 if prev_usize & (WRITER | MAX_READER | BEING_UPGRADED) == 0 {
-                    let tracked mut tmp = g.read_guard_token.tracked_take_left();
-                    read_token = Some(tmp.split_one());
-                    g.read_guard_token = Sum::Left(tmp);
+                    read_token = Some(g.read_guard_token.split_one());
                 } else {
                     retract_read_token = Some(g.read_retract_token.split_one());
                 }
@@ -551,9 +537,7 @@ impl<T  /*: ?Sized*/ , G: SpinGuardian> RwLock<T, G> {
                 let next_usize = next as usize;
                 if res is Ok {
                     // Retract the fractional permission for read access.
-                    let tracked read_guard_token = g.read_guard_token.tracked_take_left();
-                    let tracked (read_resource, read_empty) = read_guard_token.take_resource();
-                    g.read_guard_token = Sum::Right(read_empty);
+                    let tracked read_resource = g.read_guard_token.take_resource();
                     let tracked (read_half_cell_perm, left_token) = read_resource;
                     g.core_token.join_one_left_knowledge(left_token);
                     // Retract the fractional permission for upgradeable reader.
@@ -810,9 +794,7 @@ impl<T  /*: ?Sized*/ , G: SpinGuardian> RwLockReadGuard<'_, T, G> {
                 lemma_consts_properties_value(next_usize);
                 lemma_consts_properties_prev_next(prev_usize, next_usize);
                 g.core_token.validate_with_one_left_knowledge(&token.borrow().1);
-                let tracked mut tmp = g.read_guard_token.tracked_take_left();
-                tmp.combine(token);
-                g.read_guard_token = Sum::Left(tmp);
+                g.read_guard_token.combine(token);
             }
         );
     }
@@ -938,12 +920,7 @@ impl<T  /*: ?Sized*/ , G: SpinGuardian> RwLockWriteGuard<'_, T, G> {
                 let tracked upreader_guard_token = g.core_token.split_one_left_owner();
                 g.upreader_guard_token = Some(upreader_guard_token);
                 let tracked left_token = g.core_token.split_one_left_knowledge();
-                let tracked read_guard_empty = g.read_guard_token.tracked_take_right();
-                let tracked read_guard_token = CountResource::alloc_from_empty(
-                    read_guard_empty,
-                    (read_half_cell_perm, left_token),
-                );
-                g.read_guard_token = Sum::Left(read_guard_token);
+                g.read_guard_token.put_resource((read_half_cell_perm, left_token));
             }
         };
     }
@@ -1068,9 +1045,7 @@ impl<'a, T  /*: ?Sized*/ , G: SpinGuardian> RwLockUpgradeableGuard<'a, T, G> {
                         upread_guard_token.validate_with_one_left_owner(g.upreader_guard_token.tracked_borrow());
                     }
                     g.core_token.join_one_left_owner(upread_guard_token);
-                    let tracked read_guard_token = g.read_guard_token.tracked_take_left();
-                    let tracked (read_resource, read_empty) = read_guard_token.take_resource();
-                    g.read_guard_token = Sum::Right(read_empty);
+                    let tracked read_resource = g.read_guard_token.take_resource();
                     let tracked (read_half_cell_perm, left_token) = read_resource;
                     g.core_token.join_one_left_knowledge(left_token);
                     let tracked mut pointsto = g.core_token.take_resource_left();

--- a/ostd/src/sync/rwmutex.rs
+++ b/ostd/src/sync/rwmutex.rs
@@ -45,10 +45,7 @@ tracked struct RwPerms<T> {
     read_retract_token: TokenResource<V_MAX_READ_RETRACT_FRACS>,
     upread_retract_token: Option<UniqueToken>,
     upreader_guard_token: Option<OneLeftOwner<HalfPerm<T>, NoPerm<T>, 3>>,
-    read_guard_token: Sum<
-        CountResource<ReadPerm<T>, MAX_READER_U64>,
-        EmptyCount<ReadPerm<T>, MAX_READER_U64>,
-    >,
+    read_guard_token: CountResource<ReadPerm<T>, MAX_READER_U64>,
 }
 
 ghost struct RwId {
@@ -162,19 +159,19 @@ closed spec fn wf(self) -> bool {
 
         let active_writer: bool = g.core_token.is_right();
         let active_upgrade_guard: bool = !active_writer && g.upreader_guard_token is None;
-        let active_read_guards: int = if g.read_guard_token is Left {
-            MAX_READER_U64 - g.read_guard_token.left().frac()
-        } else {
+        let active_read_guards: int = if g.read_guard_token.is_resource_vacant() {
             0
+        } else {
+            MAX_READER_U64 - g.read_guard_token.frac()
         };
         let pending_failed_upread_attempt: bool = g.upread_retract_token is None;
         let failed_reader_attempts: int = V_MAX_READ_RETRACT_FRACS - g.read_retract_token.frac();
 
         &&& if g.core_token.is_left() {
-            g.read_guard_token is Left
+            !g.read_guard_token.is_resource_vacant()
         } else {
             &&& g.upreader_guard_token is None
-            &&& g.read_guard_token is Right
+            &&& g.read_guard_token.is_resource_vacant()
         }
         &&& has_upgrade_bit <==> (active_upgrade_guard || pending_failed_upread_attempt)
         &&& !(active_upgrade_guard && pending_failed_upread_attempt)
@@ -205,23 +202,16 @@ closed spec fn wf(self) -> bool {
             let token = g.upreader_guard_token->0;
             wf_upgradeable_guard_token(ghost_id@.core_token_id, ghost_id@.frac_id, val.id(), token)
         }
-        &&& match g.read_guard_token {
-            Sum::Left(token) => {
-                &&& token.wf()
-                &&& token.id() == ghost_id@.read_guard_token_id
-                &&& token.not_empty() ==> {
-                    let resource = token.resource();
-                    let read_half_cell_perm = resource.0;
-                    let mode_knowledge = resource.1;
-                    &&& mode_knowledge.id() == ghost_id@.core_token_id
-                    &&& read_half_cell_perm.id() == ghost_id@.frac_id
-                    &&& read_half_cell_perm.resource().id() == val.id()
-                    &&& read_half_cell_perm.frac() == 1
-                }
-            },
-            Sum::Right(empty) => {
-                &&& empty.id() == ghost_id@.read_guard_token_id
-            },
+        &&& g.read_guard_token.wf()
+        &&& g.read_guard_token.id() == ghost_id@.read_guard_token_id
+        &&& g.read_guard_token.not_empty() ==> {
+            let resource = g.read_guard_token.resource();
+            let read_half_cell_perm = resource.0;
+            let mode_knowledge = resource.1;
+            &&& mode_knowledge.id() == ghost_id@.core_token_id
+            &&& read_half_cell_perm.id() == ghost_id@.frac_id
+            &&& read_half_cell_perm.resource().id() == val.id()
+            &&& read_half_cell_perm.frac() == 1
         }
     }
 }
@@ -321,7 +311,7 @@ impl<T> RwMutex<T> {
             read_retract_token,
             upread_retract_token: Some(upread_retract_token),
             upreader_guard_token: Some(upreader_guard_token),
-            read_guard_token: Sum::Left(read_guard_token),
+            read_guard_token,
         };
 
         Self {
@@ -398,9 +388,7 @@ impl<T  /*: ?Sized*/ > RwMutex<T> {
                 lemma_consts_properties_value(prev_usize);
                 lemma_consts_properties_prev_next(prev_usize, next_usize);
                 if prev_usize & (WRITER | BEING_UPGRADED | MAX_READER) == 0 {
-                    let tracked mut tmp = g.read_guard_token.tracked_take_left();
-                    read_token = Some(tmp.split_one());
-                    g.read_guard_token = Sum::Left(tmp);
+                    read_token = Some(g.read_guard_token.split_one());
                 } else {
                     retract_read_token = Some(g.read_retract_token.split_one());
                 }
@@ -451,9 +439,7 @@ impl<T  /*: ?Sized*/ > RwMutex<T> {
                 let prev_usize = prev as usize;
                 let next_usize = next as usize;
                 if res is Ok {
-                    let tracked read_guard_token = g.read_guard_token.tracked_take_left();
-                    let tracked (read_resource, read_empty) = read_guard_token.take_resource();
-                    g.read_guard_token = Sum::Right(read_empty);
+                    let tracked read_resource = g.read_guard_token.take_resource();
                     let tracked (read_half_cell_perm, left_token) = read_resource;
                     g.core_token.join_one_left_knowledge(left_token);
                     let tracked upreader_guard_token = g.upreader_guard_token.tracked_take();
@@ -657,9 +643,7 @@ impl<T  /* : ?Sized */ > RwMutexReadGuard<'_, T> {
                 lemma_consts_properties_value(next_usize);
                 lemma_consts_properties_prev_next(prev_usize, next_usize);
                 g.core_token.validate_with_one_left_knowledge(&token.borrow().1);
-                let tracked mut tmp = g.read_guard_token.tracked_take_left();
-                tmp.combine(token);
-                g.read_guard_token = Sum::Left(tmp);
+                g.read_guard_token.combine(token);
             }
         )
             == READER {
@@ -755,12 +739,7 @@ impl<'a, T  /*: ?Sized*/ > RwMutexWriteGuard<'a, T> {
                     g.core_token.change_to_left(full);
                     upgrade_guard_token = Some(g.core_token.split_one_left_owner());
                     let tracked left_token = g.core_token.split_one_left_knowledge();
-                    let tracked read_guard_empty = g.read_guard_token.tracked_take_right();
-                    let tracked read_guard_token = CountResource::alloc_from_empty(
-                        read_guard_empty,
-                        (read_half_cell_perm, left_token),
-                    );
-                    g.read_guard_token = Sum::Left(read_guard_token);
+                    g.read_guard_token.put_resource((read_half_cell_perm, left_token));
                 } else {
                     err_perm = Some(perm);
                     err_write_guard_token = Some(token);
@@ -835,12 +814,7 @@ impl<'a, T  /*: ?Sized*/ > RwMutexWriteGuard<'a, T> {
                 let tracked upreader_guard_token = g.core_token.split_one_left_owner();
                 g.upreader_guard_token = Some(upreader_guard_token);
                 let tracked left_token = g.core_token.split_one_left_knowledge();
-                let tracked read_guard_empty = g.read_guard_token.tracked_take_right();
-                let tracked read_guard_token = CountResource::alloc_from_empty(
-                    read_guard_empty,
-                    (read_half_cell_perm, left_token),
-                );
-                g.read_guard_token = Sum::Left(read_guard_token);
+                g.read_guard_token.put_resource((read_half_cell_perm, left_token));
             }
         };
         // When the current writer releases, wake up all the sleeping threads.
@@ -965,9 +939,7 @@ impl<'a, T> RwMutexUpgradeableGuard<'a, T> {
                         upread_guard_token.validate_with_one_left_owner(g.upreader_guard_token.tracked_borrow());
                     }
                     g.core_token.join_one_left_owner(upread_guard_token);
-                    let tracked read_guard_token = g.read_guard_token.tracked_take_left();
-                    let tracked (read_resource, read_empty) = read_guard_token.take_resource();
-                    g.read_guard_token = Sum::Right(read_empty);
+                    let tracked read_resource = g.read_guard_token.take_resource();
                     let tracked (read_half_cell_perm, left_token) = read_resource;
                     g.core_token.join_one_left_knowledge(left_token);
                     let tracked mut pointsto = g.core_token.take_resource_left();

--- a/verified_libs/vstd_extra/src/resource/ghost_resource/count.rs
+++ b/verified_libs/vstd_extra/src/resource/ghost_resource/count.rs
@@ -158,7 +158,7 @@ impl<T, const TOTAL: u64> CountGhost<T, TOTAL> {
         requires
             TOTAL > 0,
         ensures
-            result.frac() == TOTAL as int,
+            result.frac() == TOTAL,
             result@ == v,
     {
         let f = FractionalCarrier::<T, TOTAL>::new(v);

--- a/verified_libs/vstd_extra/src/resource/ghost_resource/tokens.rs
+++ b/verified_libs/vstd_extra/src/resource/ghost_resource/tokens.rs
@@ -218,6 +218,7 @@ pub type Token<const TOTAL: u64> = CountGhost<(), TOTAL>;
 /// Unlike `Frac`, it provides an `empty` state.
 pub tracked struct CountResource<T, const TOTAL: u64> {
     tracked r: Option<Count<T, TOTAL>>,
+    tracked empty: Option<EmptyCount<T, TOTAL>>,
     ghost id: Loc,
 }
 
@@ -228,6 +229,10 @@ impl<T, const TOTAL: u64> CountResource<T, TOTAL> {
         &&& 0 <= self.frac() <= TOTAL
         &&& match self.r {
             Some(frac) => self.id == frac.id(),
+            None => true,
+        }
+        &&& match self.empty {
+            Some(empty) => self.r is None && self.id == empty.id(),
             None => true,
         }
     }
@@ -244,7 +249,10 @@ impl<T, const TOTAL: u64> CountResource<T, TOTAL> {
         &&& self.type_inv()
     }
 
-    /// Whether this `CountResource` is empty, i.e., has no fraction.
+    /// Whether this `CountResource` has no fraction.
+    ///
+    /// This does not imply [`Self::is_resource_vacant`]: it may have reached fraction zero
+    /// because all of its fractions were split out.
     pub open spec fn is_empty(self) -> bool {
         self.frac() == 0
     }
@@ -257,6 +265,26 @@ impl<T, const TOTAL: u64> CountResource<T, TOTAL> {
     /// Whether this `CountResource` has the full fraction, i.e., `TOTAL`.
     pub open spec fn is_full(self) -> bool {
         self.frac() == TOTAL
+    }
+
+    /// Whether the associated resource slot is vacant and can accept a new resource.
+    ///
+    /// This state is produced by [`Self::take_resource`] and owns the underlying empty token
+    /// needed by [`Self::put_resource`]. Resource vacancy implies [`Self::is_empty`], but the
+    /// converse does not hold when all fractions were removed using [`Self::split`] or
+    /// [`Self::split_one`].
+    pub closed spec fn is_resource_vacant(self) -> bool {
+        self.empty is Some
+    }
+
+    /// A resource-vacant `CountResource` has no fraction.
+    pub proof fn lemma_resource_vacant_implies_empty(tracked &self)
+        requires
+            self.is_resource_vacant(),
+        ensures
+            self.is_empty(),
+    {
+        use_type_invariant(self);
     }
 
     /// Returns the value of type `T` stored in this `CountResource`.
@@ -289,7 +317,7 @@ impl<T, const TOTAL: u64> CountResource<T, TOTAL> {
         requires
             TOTAL > 0,
     {
-        Self { r: None, id: arbitrary() }
+        Self { r: None, empty: None, id: arbitrary() }
     }
 
     /// Allocates a new `CountResource` with the given tracked object.
@@ -299,11 +327,12 @@ impl<T, const TOTAL: u64> CountResource<T, TOTAL> {
         ensures
             res.not_empty(),
             res.is_full(),
+            !res.is_resource_vacant(),
             res@ == value,
             res.wf(),
     {
         let tracked r = Count::new(value);
-        Self { r: Some(r), id: r.id() }
+        Self { r: Some(r), empty: None, id: r.id() }
     }
 
     /// Allocates a new `CountResource` from an `EmptyCount<T,TOTAL>` with the given tracked object.
@@ -315,12 +344,13 @@ impl<T, const TOTAL: u64> CountResource<T, TOTAL> {
             TOTAL > 0,
         ensures
             res.is_full(),
+            !res.is_resource_vacant(),
             res.id() == empty.id(),
             res.view() == value,
             res.wf(),
     {
         let tracked r = empty.put_resource(value);
-        Self { r: Some(r), id: r.id() }
+        Self { r: Some(r), empty: None, id: r.id() }
     }
 
     /// Splits a `Count` with fraction 1.
@@ -335,6 +365,7 @@ impl<T, const TOTAL: u64> CountResource<T, TOTAL> {
             res.id() == final(self).id(),
             res.resource() == old(self)@,
             old(self).frac() == 1 ==> final(self).is_empty(),
+            !final(self).is_resource_vacant(),
             final(self).wf(),
     {
         use_type_invariant(&*self);
@@ -361,6 +392,7 @@ impl<T, const TOTAL: u64> CountResource<T, TOTAL> {
             res.id() == final(self).id(),
             res.resource() == old(self)@,
             old(self).frac() == n ==> final(self).is_empty(),
+            !final(self).is_resource_vacant(),
             final(self).wf(),
     {
         use_type_invariant(&*self);
@@ -385,15 +417,17 @@ impl<T, const TOTAL: u64> CountResource<T, TOTAL> {
                 &&& final(self).id() == old(self).id()
                 &&& final(self).resource() == other.resource()
                 &&& final(self).frac() == old(self).frac() + other.frac()
+                &&& !final(self).is_resource_vacant()
                 &&& final(self).wf()
                 &&& old(self).frac() > 0 ==> final(self)@ == old(self)@
             },
     {
+        use_type_invariant(&*self);
         if self.is_empty() {
             other.bounded();
+            self.empty = None;
             self.r = Some(other);
         } else {
-            use_type_invariant(&*self);
             self.validate_with_frac(&other);
             let tracked mut r = self.r.tracked_take();
             r.combine(other);
@@ -432,17 +466,39 @@ impl<T, const TOTAL: u64> CountResource<T, TOTAL> {
         frac.agree(self.r.tracked_borrow());
     }
 
-    /// Consumes the token and takes out the resource.
-    pub proof fn take_resource(tracked self) -> (tracked (res, empty): (T, EmptyCount<T, TOTAL>))
+    /// Takes the resource out and leaves this token ready to accept a new resource.
+    pub proof fn take_resource(tracked &mut self) -> (tracked res: T)
         requires
             self.is_full(),
         ensures
-            res == self@,
-            empty.id() == self.id(),
+            final(self).is_empty(),
+            final(self).is_resource_vacant(),
+            final(self).id() == old(self).id(),
+            res == old(self)@,
+            final(self).wf(),
     {
-        use_type_invariant(&self);
-        let tracked r = self.r.tracked_unwrap();
-        r.take_resource()
+        use_type_invariant(&*self);
+        let tracked r = self.r.tracked_take();
+        let tracked (res, empty) = r.take_resource();
+        self.empty = Some(empty);
+        res
+    }
+
+    /// Puts a resource into a token returned to the empty state by `take_resource`.
+    pub proof fn put_resource(tracked &mut self, tracked value: T)
+        requires
+            old(self).is_resource_vacant(),
+        ensures
+            final(self).is_full(),
+            !final(self).is_resource_vacant(),
+            final(self).id() == old(self).id(),
+            final(self)@ == value,
+            final(self).wf(),
+    {
+        use_type_invariant(&*self);
+        let tracked empty = self.empty.tracked_take();
+        let tracked r = empty.put_resource(value);
+        self.r = Some(r);
     }
 
     /// Updates the resource stored in this `CountResource` and retunrs the old resource if it exists.
@@ -452,15 +508,13 @@ impl<T, const TOTAL: u64> CountResource<T, TOTAL> {
             old(self).is_full(),
         ensures
             final(self).is_full(),
+            !final(self).is_resource_vacant(),
             res == old(self)@,
             final(self).id() == old(self).id(),
             final(self).wf(),
     {
-        use_type_invariant(&*self);
-        let tracked mut r = self.r.tracked_take();
-        let tracked (res, empty) = r.take_resource();
-        let tracked r = empty.put_resource(value);
-        self.r = Some(r);
+        let tracked res = self.take_resource();
+        self.put_resource(value);
         res
     }
 }


### PR DESCRIPTION
Now `CountResource::take_resource` does not consume `Self` or emit an `EmptyCount`. Instead, it takes `&mut Self` and only produces the resource. There is a new `is_resource_vacant` state to state the resource has been taken out as a whole.