### PR TITLE
refactor: add `MetadataPerms` perms and remove `MetadataInnerPerms`

### DIFF
--- a/ostd/specs/mm/embedding/cursor.rs
+++ b/ostd/specs/mm/embedding/cursor.rs
@@ -109,9 +109,7 @@ pub axiom fn vm_space_cursor_embedded<'a, 'rcu>(
         final(regions).slots == old(regions).slots,
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
-            final(regions).slot_owners[i].in_list_perm == old(
-                regions,
-            ).slot_owners[i].in_list_perm,
+            final(regions).slot_owners[i].in_list_perm == old(regions).slot_owners[i].in_list_perm,
         // Stage 5.3: opening a cursor only allocates fresh PT nodes —
         // every *changed* slot was UNUSED before and becomes a
         // non-UNUSED PT node (usage != Frame). `accounting_inv` chains
@@ -156,9 +154,7 @@ pub axiom fn vm_space_cursor_mut_embedded<'a, 'rcu>(
         final(regions).slots == old(regions).slots,
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
-            final(regions).slot_owners[i].in_list_perm == old(
-                regions,
-            ).slot_owners[i].in_list_perm,
+            final(regions).slot_owners[i].in_list_perm == old(regions).slot_owners[i].in_list_perm,
         // Stage 5.3: opening a cursor only allocates fresh PT nodes —
         // every *changed* slot was UNUSED before and becomes a
         // non-UNUSED PT node (usage != Frame). `accounting_inv` chains
@@ -238,11 +234,10 @@ pub axiom fn cursor_query_embedded<'rcu>(
         res matches Some(paddr) ==> {
             &&& valid_frame_paddr(paddr)
             &&& old(regions).slot_owners[frame_to_index(paddr)].usage is Frame
-            &&& final(regions).slot_owners[frame_to_index(paddr)].ref_count() == (
-            old(regions).slot_owners[frame_to_index(paddr)].ref_count()
-                + 1) as nat
-            &&& final(regions).slot_owners[frame_to_index(paddr)].ref_count()
-                <= REF_COUNT_MAX
+            &&& final(regions).slot_owners[frame_to_index(paddr)].ref_count() == (old(
+                regions,
+            ).slot_owners[frame_to_index(paddr)].ref_count() + 1) as nat
+            &&& final(regions).slot_owners[frame_to_index(paddr)].ref_count() <= REF_COUNT_MAX
             &&& forall|i: int|
                 #![trigger final(regions).slot_owners[i]]
                 i != frame_to_index(paddr) ==> final(regions).slot_owners[i] == old(
@@ -370,9 +365,7 @@ pub axiom fn cursor_mut_map_embedded<'rcu>(
         // forget references or touch the free-list).
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
-            final(regions).slot_owners[i].in_list_perm == old(
-                regions,
-            ).slot_owners[i].in_list_perm,
+            final(regions).slot_owners[i].in_list_perm == old(regions).slot_owners[i].in_list_perm,
         // Per exec cursor/mod.rs:2853 + 2836: at non-mapped slots that
         // were already in use (pre rc != UNUSED), the entire
         // slot_owner is preserved. NB: slots that were UNUSED pre may
@@ -437,8 +430,8 @@ pub axiom fn cursor_mut_map_embedded<'rcu>(
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             i != frame_to_index(paddr) && old(regions).slot_owners[i].ref_count()
-                == REF_COUNT_UNUSED && final(regions).slot_owners[i].ref_count()
-                != REF_COUNT_UNUSED ==> final(regions).slot_owners[i].usage !is Frame,
+                == REF_COUNT_UNUSED && final(regions).slot_owners[i].ref_count() != REF_COUNT_UNUSED
+                ==> final(regions).slot_owners[i].usage !is Frame,
         forall|c: CursorOwner<'rcu, UserPtConfig>|
             #![auto]
             c.metaregion_sound(*old(regions)) ==> c.metaregion_sound(*final(regions)),
@@ -531,9 +524,7 @@ pub axiom fn cursor_mut_unmap_embedded<'rcu>(
             old(regions).slot_owners[i].usage is Frame ==> {
                 &&& final(regions).slot_owners[i].ref_count() + old(
                     regions,
-                ).slot_owners[i].paths_in_pt.len() == old(
-                    regions,
-                ).slot_owners[i].ref_count()
+                ).slot_owners[i].paths_in_pt.len() == old(regions).slot_owners[i].ref_count()
                     + final(regions).slot_owners[i].paths_in_pt.len()
                 &&& final(regions).slot_owners[i].ref_count() <= old(
                     regions,
@@ -602,9 +593,7 @@ pub(super) proof fn open_cursor_step<'a, 'rcu>(
         final(regions).slots == old(regions).slots,
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
-            final(regions).slot_owners[i].in_list_perm == old(
-                regions,
-            ).slot_owners[i].in_list_perm,
+            final(regions).slot_owners[i].in_list_perm == old(regions).slot_owners[i].in_list_perm,
         // Stage 5.3: opening a cursor only allocates fresh PT nodes —
         // every *changed* slot was UNUSED before and becomes a
         // non-UNUSED PT node (usage != Frame). `accounting_inv` chains
@@ -658,9 +647,7 @@ pub(super) proof fn open_cursor_mut_step<'a, 'rcu>(
         final(regions).slots == old(regions).slots,
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
-            final(regions).slot_owners[i].in_list_perm == old(
-                regions,
-            ).slot_owners[i].in_list_perm,
+            final(regions).slot_owners[i].in_list_perm == old(regions).slot_owners[i].in_list_perm,
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners[i] != old(regions).slot_owners[i] ==> {
@@ -734,11 +721,10 @@ pub(super) proof fn cursor_query_step<'rcu>(
         res matches Some(paddr) ==> {
             &&& valid_frame_paddr(paddr)
             &&& old(regions).slot_owners[frame_to_index(paddr)].usage is Frame
-            &&& final(regions).slot_owners[frame_to_index(paddr)].ref_count() == (
-            old(regions).slot_owners[frame_to_index(paddr)].ref_count()
-                + 1) as nat
-            &&& final(regions).slot_owners[frame_to_index(paddr)].ref_count()
-                <= REF_COUNT_MAX
+            &&& final(regions).slot_owners[frame_to_index(paddr)].ref_count() == (old(
+                regions,
+            ).slot_owners[frame_to_index(paddr)].ref_count() + 1) as nat
+            &&& final(regions).slot_owners[frame_to_index(paddr)].ref_count() <= REF_COUNT_MAX
             &&& forall|i: int|
                 #![trigger final(regions).slot_owners[i]]
                 i != frame_to_index(paddr) ==> final(regions).slot_owners[i] == old(
@@ -895,8 +881,7 @@ pub(super) proof fn cursor_mut_regions_step<'rcu>(
                     regions,
                 ).slot_owners[i].vtable_ptr_perm()
                 &&& old(regions).slot_owners[i].ref_count() != REF_COUNT_UNIQUE
-                    ==> final(regions).slot_owners[i].ref_count()
-                    != REF_COUNT_UNIQUE
+                    ==> final(regions).slot_owners[i].ref_count() != REF_COUNT_UNIQUE
                 &&& final(regions).slot_owners[i].ref_count() != REF_COUNT_UNUSED
                     ==> final(regions).slot_owners[i].storage_perm() == old(
                     regions,
@@ -914,9 +899,7 @@ pub(super) proof fn cursor_mut_regions_step<'rcu>(
             old(regions).slot_owners[i].usage is Frame ==> {
                 &&& final(regions).slot_owners[i].ref_count() + old(
                     regions,
-                ).slot_owners[i].paths_in_pt.len() == old(
-                    regions,
-                ).slot_owners[i].ref_count()
+                ).slot_owners[i].paths_in_pt.len() == old(regions).slot_owners[i].ref_count()
                     + final(regions).slot_owners[i].paths_in_pt.len()
                 &&& final(regions).slot_owners[i].ref_count() <= old(
                     regions,
@@ -974,9 +957,7 @@ pub(super) proof fn map_step<'rcu>(
         // Mirror the strengthened `cursor_mut_map_embedded` ensures.
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
-            final(regions).slot_owners[i].in_list_perm == old(
-                regions,
-            ).slot_owners[i].in_list_perm,
+            final(regions).slot_owners[i].in_list_perm == old(regions).slot_owners[i].in_list_perm,
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             i != frame_to_index(paddr) && old(regions).slot_owners[i].ref_count()
@@ -1006,8 +987,8 @@ pub(super) proof fn map_step<'rcu>(
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             i != frame_to_index(paddr) && old(regions).slot_owners[i].ref_count()
-                == REF_COUNT_UNUSED && final(regions).slot_owners[i].ref_count()
-                != REF_COUNT_UNUSED ==> final(regions).slot_owners[i].usage !is Frame,
+                == REF_COUNT_UNUSED && final(regions).slot_owners[i].ref_count() != REF_COUNT_UNUSED
+                ==> final(regions).slot_owners[i].usage !is Frame,
         forall|c: CursorOwner<'rcu, UserPtConfig>|
             #![auto]
             c.metaregion_sound(*old(regions)) ==> c.metaregion_sound(*final(regions)),

--- a/ostd/specs/mm/embedding/cursor.rs
+++ b/ostd/specs/mm/embedding/cursor.rs
@@ -109,9 +109,9 @@ pub axiom fn vm_space_cursor_embedded<'a, 'rcu>(
         final(regions).slots == old(regions).slots,
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
-            final(regions).slot_owners[i].inner_perms.in_list == old(
+            final(regions).slot_owners[i].in_list_perm == old(
                 regions,
-            ).slot_owners[i].inner_perms.in_list,
+            ).slot_owners[i].in_list_perm,
         // Stage 5.3: opening a cursor only allocates fresh PT nodes —
         // every *changed* slot was UNUSED before and becomes a
         // non-UNUSED PT node (usage != Frame). `accounting_inv` chains
@@ -119,8 +119,8 @@ pub axiom fn vm_space_cursor_embedded<'a, 'rcu>(
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners[i] != old(regions).slot_owners[i] ==> {
-                &&& old(regions).slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNUSED
-                &&& final(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
+                &&& old(regions).slot_owners[i].ref_count() == REF_COUNT_UNUSED
+                &&& final(regions).slot_owners[i].ref_count() != REF_COUNT_UNUSED
                 &&& final(regions).slot_owners[i].usage !is Frame
             },
         forall|c: CursorOwner<'rcu, UserPtConfig>|
@@ -156,9 +156,9 @@ pub axiom fn vm_space_cursor_mut_embedded<'a, 'rcu>(
         final(regions).slots == old(regions).slots,
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
-            final(regions).slot_owners[i].inner_perms.in_list == old(
+            final(regions).slot_owners[i].in_list_perm == old(
                 regions,
-            ).slot_owners[i].inner_perms.in_list,
+            ).slot_owners[i].in_list_perm,
         // Stage 5.3: opening a cursor only allocates fresh PT nodes —
         // every *changed* slot was UNUSED before and becomes a
         // non-UNUSED PT node (usage != Frame). `accounting_inv` chains
@@ -166,8 +166,8 @@ pub axiom fn vm_space_cursor_mut_embedded<'a, 'rcu>(
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners[i] != old(regions).slot_owners[i] ==> {
-                &&& old(regions).slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNUSED
-                &&& final(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
+                &&& old(regions).slot_owners[i].ref_count() == REF_COUNT_UNUSED
+                &&& final(regions).slot_owners[i].ref_count() != REF_COUNT_UNUSED
                 &&& final(regions).slot_owners[i].usage !is Frame
             },
         forall|c: CursorOwner<'rcu, UserPtConfig>|
@@ -238,10 +238,10 @@ pub axiom fn cursor_query_embedded<'rcu>(
         res matches Some(paddr) ==> {
             &&& valid_frame_paddr(paddr)
             &&& old(regions).slot_owners[frame_to_index(paddr)].usage is Frame
-            &&& final(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() == (
-            old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
+            &&& final(regions).slot_owners[frame_to_index(paddr)].ref_count() == (
+            old(regions).slot_owners[frame_to_index(paddr)].ref_count()
                 + 1) as nat
-            &&& final(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
+            &&& final(regions).slot_owners[frame_to_index(paddr)].ref_count()
                 <= REF_COUNT_MAX
             &&& forall|i: int|
                 #![trigger final(regions).slot_owners[i]]
@@ -260,15 +260,15 @@ pub axiom fn cursor_query_embedded<'rcu>(
             &&& final(regions).slot_owners[frame_to_index(paddr)].paths_in_pt == old(
                 regions,
             ).slot_owners[frame_to_index(paddr)].paths_in_pt
-            &&& final(regions).slot_owners[frame_to_index(paddr)].inner_perms.in_list == old(
+            &&& final(regions).slot_owners[frame_to_index(paddr)].in_list_perm == old(
                 regions,
-            ).slot_owners[frame_to_index(paddr)].inner_perms.in_list
-            &&& final(regions).slot_owners[frame_to_index(paddr)].inner_perms.storage == old(
+            ).slot_owners[frame_to_index(paddr)].in_list_perm
+            &&& final(regions).slot_owners[frame_to_index(paddr)].storage_perm() == old(
                 regions,
-            ).slot_owners[frame_to_index(paddr)].inner_perms.storage
-            &&& final(regions).slot_owners[frame_to_index(paddr)].inner_perms.vtable_ptr == old(
+            ).slot_owners[frame_to_index(paddr)].storage_perm()
+            &&& final(regions).slot_owners[frame_to_index(paddr)].vtable_ptr_perm() == old(
                 regions,
-            ).slot_owners[frame_to_index(paddr)].inner_perms.vtable_ptr
+            ).slot_owners[frame_to_index(paddr)].vtable_ptr_perm()
         },
         forall|c: CursorOwner<'rcu, UserPtConfig>|
             #![auto]
@@ -370,9 +370,9 @@ pub axiom fn cursor_mut_map_embedded<'rcu>(
         // forget references or touch the free-list).
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
-            final(regions).slot_owners[i].inner_perms.in_list == old(
+            final(regions).slot_owners[i].in_list_perm == old(
                 regions,
-            ).slot_owners[i].inner_perms.in_list,
+            ).slot_owners[i].in_list_perm,
         // Per exec cursor/mod.rs:2853 + 2836: at non-mapped slots that
         // were already in use (pre rc != UNUSED), the entire
         // slot_owner is preserved. NB: slots that were UNUSED pre may
@@ -380,16 +380,16 @@ pub axiom fn cursor_mut_map_embedded<'rcu>(
         // nodes, so the "fully preserved" guard requires `pre rc != UNUSED`.
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
-            i != frame_to_index(paddr) && old(regions).slot_owners[i].inner_perms.ref_count.value()
+            i != frame_to_index(paddr) && old(regions).slot_owners[i].ref_count()
                 != REF_COUNT_UNUSED ==> final(regions).slot_owners[i] == old(
                 regions,
             ).slot_owners[i],
         // Per exec cursor/mod.rs:2844-2846: any pre-non-UNUSED slot
         // stays non-UNUSED.
         forall|i: int|
-            #![trigger final(regions).slot_owners[i].inner_perms.ref_count.value()]
-            old(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-                ==> final(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED,
+            #![trigger final(regions).slot_owners[i].ref_count()]
+            old(regions).slot_owners[i].ref_count() != REF_COUNT_UNUSED
+                ==> final(regions).slot_owners[i].ref_count() != REF_COUNT_UNUSED,
         // **`ref_count` PRESERVED at the mapped slot.** Faithful axiom
         // strengthening relative to the exec contract (which only says
         // `pre rc > 0 ⟹ post rc > 0`): exec map `ManuallyDrop`s the
@@ -402,9 +402,9 @@ pub axiom fn cursor_mut_map_embedded<'rcu>(
         // (`P_post = P_pre + 1`), `accounting_inv` clause 4
         // (`rc == H + P`) chains: `pre rc == pre H + pre P` ⟹
         // `post rc = pre rc = (H_post + 1) + (P_post - 1) = H_post + P_post`.
-        final(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() == old(
+        final(regions).slot_owners[frame_to_index(paddr)].ref_count() == old(
             regions,
-        ).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value(),
+        ).slot_owners[frame_to_index(paddr)].ref_count(),
         // **`paths_in_pt.len() += 1` at the mapped slot.** The cursor's
         // current path is inserted into the mapped slot's `paths_in_pt`
         // (this is the bookkeeping side of writing the PTE; see
@@ -418,13 +418,13 @@ pub axiom fn cursor_mut_map_embedded<'rcu>(
         final(regions).slot_owners[frame_to_index(paddr)].usage == old(
             regions,
         ).slot_owners[frame_to_index(paddr)].usage,
-        final(regions).slot_owners[frame_to_index(paddr)].inner_perms.storage == old(
+        final(regions).slot_owners[frame_to_index(paddr)].storage_perm() == old(
             regions,
-        ).slot_owners[frame_to_index(paddr)].inner_perms.storage,
+        ).slot_owners[frame_to_index(paddr)].storage_perm(),
         // Slots that stay UNUSED are fully preserved.
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
-            final(regions).slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNUSED
+            final(regions).slot_owners[i].ref_count() == REF_COUNT_UNUSED
                 ==> final(regions).slot_owners[i] == old(regions).slot_owners[i],
         // **Changed-slots clause.** At any slot *other* than the
         // mapped frame, a pre-UNUSED → post-non-UNUSED transition
@@ -436,8 +436,8 @@ pub axiom fn cursor_mut_map_embedded<'rcu>(
         // above.
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
-            i != frame_to_index(paddr) && old(regions).slot_owners[i].inner_perms.ref_count.value()
-                == REF_COUNT_UNUSED && final(regions).slot_owners[i].inner_perms.ref_count.value()
+            i != frame_to_index(paddr) && old(regions).slot_owners[i].ref_count()
+                == REF_COUNT_UNUSED && final(regions).slot_owners[i].ref_count()
                 != REF_COUNT_UNUSED ==> final(regions).slot_owners[i].usage !is Frame,
         forall|c: CursorOwner<'rcu, UserPtConfig>|
             #![auto]
@@ -489,21 +489,21 @@ pub axiom fn cursor_mut_unmap_embedded<'rcu>(
                     regions,
                 ).slot_owners[i].slot_vaddr
                 &&& final(regions).slot_owners[i].usage == old(regions).slot_owners[i].usage
-                &&& final(regions).slot_owners[i].inner_perms.in_list == old(
+                &&& final(regions).slot_owners[i].in_list_perm == old(
                     regions,
-                ).slot_owners[i].inner_perms.in_list
-                &&& final(regions).slot_owners[i].inner_perms.vtable_ptr == old(
+                ).slot_owners[i].in_list_perm
+                &&& final(regions).slot_owners[i].vtable_ptr_perm() == old(
                     regions,
-                ).slot_owners[i].inner_perms.vtable_ptr
+                ).slot_owners[i].vtable_ptr_perm()
                 // `rc` doesn't bump to UNIQUE.
-                &&& old(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNIQUE
-                    ==> final(regions).slot_owners[i].inner_perms.ref_count.value()
+                &&& old(regions).slot_owners[i].ref_count() != REF_COUNT_UNIQUE
+                    ==> final(regions).slot_owners[i].ref_count()
                     != REF_COUNT_UNIQUE
                 // Storage preserved at slots that end non-UNUSED.
-                &&& final(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-                    ==> final(regions).slot_owners[i].inner_perms.storage == old(
+                &&& final(regions).slot_owners[i].ref_count() != REF_COUNT_UNUSED
+                    ==> final(regions).slot_owners[i].storage_perm() == old(
                     regions,
-                ).slot_owners[i].inner_perms.storage
+                ).slot_owners[i].storage_perm()
             },
         // Unparked (page-table-node) slots are untouched: a slot whose
         // perm is not parked in `regions.slots` is a PT root, an ancestor
@@ -529,19 +529,19 @@ pub axiom fn cursor_mut_unmap_embedded<'rcu>(
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             old(regions).slot_owners[i].usage is Frame ==> {
-                &&& final(regions).slot_owners[i].inner_perms.ref_count.value() + old(
+                &&& final(regions).slot_owners[i].ref_count() + old(
                     regions,
                 ).slot_owners[i].paths_in_pt.len() == old(
                     regions,
-                ).slot_owners[i].inner_perms.ref_count.value()
+                ).slot_owners[i].ref_count()
                     + final(regions).slot_owners[i].paths_in_pt.len()
-                &&& final(regions).slot_owners[i].inner_perms.ref_count.value() <= old(
+                &&& final(regions).slot_owners[i].ref_count() <= old(
                     regions,
-                ).slot_owners[i].inner_perms.ref_count.value()
+                ).slot_owners[i].ref_count()
                 &&& final(regions).slot_owners[i].paths_in_pt.len() <= old(
                     regions,
                 ).slot_owners[i].paths_in_pt.len()
-                &&& final(regions).slot_owners[i].inner_perms.ref_count.value() != 0
+                &&& final(regions).slot_owners[i].ref_count() != 0
             },
         // **MMIO slots untouched.** Unmap only walks tracked user VAs;
         // MMIO PTEs (`PageUsage::MMIO`) require explicit
@@ -602,9 +602,9 @@ pub(super) proof fn open_cursor_step<'a, 'rcu>(
         final(regions).slots == old(regions).slots,
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
-            final(regions).slot_owners[i].inner_perms.in_list == old(
+            final(regions).slot_owners[i].in_list_perm == old(
                 regions,
-            ).slot_owners[i].inner_perms.in_list,
+            ).slot_owners[i].in_list_perm,
         // Stage 5.3: opening a cursor only allocates fresh PT nodes —
         // every *changed* slot was UNUSED before and becomes a
         // non-UNUSED PT node (usage != Frame). `accounting_inv` chains
@@ -612,8 +612,8 @@ pub(super) proof fn open_cursor_step<'a, 'rcu>(
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners[i] != old(regions).slot_owners[i] ==> {
-                &&& old(regions).slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNUSED
-                &&& final(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
+                &&& old(regions).slot_owners[i].ref_count() == REF_COUNT_UNUSED
+                &&& final(regions).slot_owners[i].ref_count() != REF_COUNT_UNUSED
                 &&& final(regions).slot_owners[i].usage !is Frame
             },
         forall|c: CursorOwner<'rcu, UserPtConfig>|
@@ -658,14 +658,14 @@ pub(super) proof fn open_cursor_mut_step<'a, 'rcu>(
         final(regions).slots == old(regions).slots,
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
-            final(regions).slot_owners[i].inner_perms.in_list == old(
+            final(regions).slot_owners[i].in_list_perm == old(
                 regions,
-            ).slot_owners[i].inner_perms.in_list,
+            ).slot_owners[i].in_list_perm,
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners[i] != old(regions).slot_owners[i] ==> {
-                &&& old(regions).slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNUSED
-                &&& final(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
+                &&& old(regions).slot_owners[i].ref_count() == REF_COUNT_UNUSED
+                &&& final(regions).slot_owners[i].ref_count() != REF_COUNT_UNUSED
                 &&& final(regions).slot_owners[i].usage !is Frame
             },
         forall|c: CursorOwner<'rcu, UserPtConfig>|
@@ -734,10 +734,10 @@ pub(super) proof fn cursor_query_step<'rcu>(
         res matches Some(paddr) ==> {
             &&& valid_frame_paddr(paddr)
             &&& old(regions).slot_owners[frame_to_index(paddr)].usage is Frame
-            &&& final(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() == (
-            old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
+            &&& final(regions).slot_owners[frame_to_index(paddr)].ref_count() == (
+            old(regions).slot_owners[frame_to_index(paddr)].ref_count()
                 + 1) as nat
-            &&& final(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
+            &&& final(regions).slot_owners[frame_to_index(paddr)].ref_count()
                 <= REF_COUNT_MAX
             &&& forall|i: int|
                 #![trigger final(regions).slot_owners[i]]
@@ -750,12 +750,12 @@ pub(super) proof fn cursor_query_step<'rcu>(
             &&& final(regions).slot_owners[frame_to_index(paddr)].paths_in_pt == old(
                 regions,
             ).slot_owners[frame_to_index(paddr)].paths_in_pt
-            &&& final(regions).slot_owners[frame_to_index(paddr)].inner_perms.in_list == old(
+            &&& final(regions).slot_owners[frame_to_index(paddr)].in_list_perm == old(
                 regions,
-            ).slot_owners[frame_to_index(paddr)].inner_perms.in_list
-            &&& final(regions).slot_owners[frame_to_index(paddr)].inner_perms.storage == old(
+            ).slot_owners[frame_to_index(paddr)].in_list_perm
+            &&& final(regions).slot_owners[frame_to_index(paddr)].storage_perm() == old(
                 regions,
-            ).slot_owners[frame_to_index(paddr)].inner_perms.storage
+            ).slot_owners[frame_to_index(paddr)].storage_perm()
         },
         forall|c: CursorOwner<'rcu, UserPtConfig>|
             #![auto]
@@ -888,19 +888,19 @@ pub(super) proof fn cursor_mut_regions_step<'rcu>(
                     regions,
                 ).slot_owners[i].slot_vaddr
                 &&& final(regions).slot_owners[i].usage == old(regions).slot_owners[i].usage
-                &&& final(regions).slot_owners[i].inner_perms.in_list == old(
+                &&& final(regions).slot_owners[i].in_list_perm == old(
                     regions,
-                ).slot_owners[i].inner_perms.in_list
-                &&& final(regions).slot_owners[i].inner_perms.vtable_ptr == old(
+                ).slot_owners[i].in_list_perm
+                &&& final(regions).slot_owners[i].vtable_ptr_perm() == old(
                     regions,
-                ).slot_owners[i].inner_perms.vtable_ptr
-                &&& old(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNIQUE
-                    ==> final(regions).slot_owners[i].inner_perms.ref_count.value()
+                ).slot_owners[i].vtable_ptr_perm()
+                &&& old(regions).slot_owners[i].ref_count() != REF_COUNT_UNIQUE
+                    ==> final(regions).slot_owners[i].ref_count()
                     != REF_COUNT_UNIQUE
-                &&& final(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-                    ==> final(regions).slot_owners[i].inner_perms.storage == old(
+                &&& final(regions).slot_owners[i].ref_count() != REF_COUNT_UNUSED
+                    ==> final(regions).slot_owners[i].storage_perm() == old(
                     regions,
-                ).slot_owners[i].inner_perms.storage
+                ).slot_owners[i].storage_perm()
             },
         // Unparked (page-table-node) slots untouched (see
         // `cursor_mut_unmap_embedded`); preserves the coverage exception.
@@ -912,19 +912,19 @@ pub(super) proof fn cursor_mut_regions_step<'rcu>(
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             old(regions).slot_owners[i].usage is Frame ==> {
-                &&& final(regions).slot_owners[i].inner_perms.ref_count.value() + old(
+                &&& final(regions).slot_owners[i].ref_count() + old(
                     regions,
                 ).slot_owners[i].paths_in_pt.len() == old(
                     regions,
-                ).slot_owners[i].inner_perms.ref_count.value()
+                ).slot_owners[i].ref_count()
                     + final(regions).slot_owners[i].paths_in_pt.len()
-                &&& final(regions).slot_owners[i].inner_perms.ref_count.value() <= old(
+                &&& final(regions).slot_owners[i].ref_count() <= old(
                     regions,
-                ).slot_owners[i].inner_perms.ref_count.value()
+                ).slot_owners[i].ref_count()
                 &&& final(regions).slot_owners[i].paths_in_pt.len() <= old(
                     regions,
                 ).slot_owners[i].paths_in_pt.len()
-                &&& final(regions).slot_owners[i].inner_perms.ref_count.value() != 0
+                &&& final(regions).slot_owners[i].ref_count() != 0
             },
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
@@ -974,39 +974,39 @@ pub(super) proof fn map_step<'rcu>(
         // Mirror the strengthened `cursor_mut_map_embedded` ensures.
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
-            final(regions).slot_owners[i].inner_perms.in_list == old(
+            final(regions).slot_owners[i].in_list_perm == old(
                 regions,
-            ).slot_owners[i].inner_perms.in_list,
+            ).slot_owners[i].in_list_perm,
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
-            i != frame_to_index(paddr) && old(regions).slot_owners[i].inner_perms.ref_count.value()
+            i != frame_to_index(paddr) && old(regions).slot_owners[i].ref_count()
                 != REF_COUNT_UNUSED ==> final(regions).slot_owners[i] == old(
                 regions,
             ).slot_owners[i],
         forall|i: int|
-            #![trigger final(regions).slot_owners[i].inner_perms.ref_count.value()]
-            old(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-                ==> final(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED,
-        final(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() == old(
+            #![trigger final(regions).slot_owners[i].ref_count()]
+            old(regions).slot_owners[i].ref_count() != REF_COUNT_UNUSED
+                ==> final(regions).slot_owners[i].ref_count() != REF_COUNT_UNUSED,
+        final(regions).slot_owners[frame_to_index(paddr)].ref_count() == old(
             regions,
-        ).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value(),
+        ).slot_owners[frame_to_index(paddr)].ref_count(),
         final(regions).slot_owners[frame_to_index(paddr)].paths_in_pt.len() == old(
             regions,
         ).slot_owners[frame_to_index(paddr)].paths_in_pt.len() + 1,
         final(regions).slot_owners[frame_to_index(paddr)].usage == old(
             regions,
         ).slot_owners[frame_to_index(paddr)].usage,
-        final(regions).slot_owners[frame_to_index(paddr)].inner_perms.storage == old(
+        final(regions).slot_owners[frame_to_index(paddr)].storage_perm() == old(
             regions,
-        ).slot_owners[frame_to_index(paddr)].inner_perms.storage,
+        ).slot_owners[frame_to_index(paddr)].storage_perm(),
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
-            final(regions).slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNUSED
+            final(regions).slot_owners[i].ref_count() == REF_COUNT_UNUSED
                 ==> final(regions).slot_owners[i] == old(regions).slot_owners[i],
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
-            i != frame_to_index(paddr) && old(regions).slot_owners[i].inner_perms.ref_count.value()
-                == REF_COUNT_UNUSED && final(regions).slot_owners[i].inner_perms.ref_count.value()
+            i != frame_to_index(paddr) && old(regions).slot_owners[i].ref_count()
+                == REF_COUNT_UNUSED && final(regions).slot_owners[i].ref_count()
                 != REF_COUNT_UNUSED ==> final(regions).slot_owners[i].usage !is Frame,
         forall|c: CursorOwner<'rcu, UserPtConfig>|
             #![auto]

--- a/ostd/specs/mm/embedding/frame.rs
+++ b/ostd/specs/mm/embedding/frame.rs
@@ -106,7 +106,7 @@ pub axiom fn frame_from_unused_embedded(
 ;
 
 /// Mirror of [`crate::mm::frame::Frame::from_in_use`]. On `Some`,
-/// `inner_perms.ref_count` increments by 1 at `frame_to_index(paddr)`
+/// `ref_count` increments by 1 at `frame_to_index(paddr)`
 /// and all other slots are preserved.
 pub axiom fn frame_from_in_use_embedded(
     tracked regions: &mut MetaRegionOwners,
@@ -142,9 +142,9 @@ pub axiom fn frame_from_in_use_embedded(
         // `vtable_ptr.is_init()` for SHARED slots, not `storage`.
         res is Some ==> {
             let so = final(regions).slot_owners[frame_to_index(paddr)];
-            &&& so.inner_perms.ref_count.value() != REF_COUNT_UNUSED
-            &&& so.inner_perms.ref_count.value() != REF_COUNT_UNIQUE
-            &&& so.inner_perms.storage.is_init()
+            &&& so.ref_count() != REF_COUNT_UNUSED
+            &&& so.ref_count() != REF_COUNT_UNIQUE
+            &&& so.storage_perm().is_init()
             // Op::FrameFromInUse models `Frame::<dyn AnyFrameMeta>::
             // from_in_use` for data frames; success implies the slot
             // is Frame-usage. This matches `VmStore::structural_inv`'s
@@ -187,14 +187,14 @@ pub axiom fn frame_drop_embedded(tracked regions: &mut MetaRegionOwners, paddr: 
     requires
         old(regions).inv(),
         old(regions).contains(frame_to_index(paddr)),
-        old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() > 0,
-        old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
+        old(regions).slot_owners[frame_to_index(paddr)].ref_count() > 0,
+        old(regions).slot_owners[frame_to_index(paddr)].ref_count()
             != REF_COUNT_UNUSED,
-        old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
+        old(regions).slot_owners[frame_to_index(paddr)].ref_count()
             <= REF_COUNT_MAX,
-        old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() == 1 ==> {
-            &&& old(regions).slot_owners[frame_to_index(paddr)].inner_perms.storage.is_init()
-            &&& old(regions).slot_owners[frame_to_index(paddr)].inner_perms.in_list.value()
+        old(regions).slot_owners[frame_to_index(paddr)].ref_count() == 1 ==> {
+            &&& old(regions).slot_owners[frame_to_index(paddr)].storage_perm().is_init()
+            &&& old(regions).slot_owners[frame_to_index(paddr)].in_list_perm.value()
                 == 0
             // Mirrors the FUTURE-plan strengthening of exec
             // `Frame::drop_requires`: at `rc == 1` the dropped handle is
@@ -232,37 +232,37 @@ pub axiom fn frame_drop_embedded(tracked regions: &mut MetaRegionOwners, paddr: 
         // is empty — same epistemic status as the `metaregion_sound`-
         // preserves clause (sound to assert, reflecting real exec; not
         // derivable from the incomplete `drop_pre` predicate alone).
-        old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() == 1
+        old(regions).slot_owners[frame_to_index(paddr)].ref_count() == 1
             ==> final(regions).slot_owners[frame_to_index(paddr)].paths_in_pt.is_empty(),
         // `drop` never touches the free-list `in_list` field (the
         // decrement branch leaves it; `drop_last_in_place` preserves
         // it). Needed for `VmStore::inv`'s `in_list` coverage (#4).
-        final(regions).slot_owners[frame_to_index(paddr)].inner_perms.in_list == old(
+        final(regions).slot_owners[frame_to_index(paddr)].in_list_perm == old(
             regions,
-        ).slot_owners[frame_to_index(paddr)].inner_perms.in_list,
-        old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() == 1
+        ).slot_owners[frame_to_index(paddr)].in_list_perm,
+        old(regions).slot_owners[frame_to_index(paddr)].ref_count() == 1
             ==> final(regions).slot_owners[frame_to_index(paddr)].paths_in_pt.is_empty(),
         // `drop` never touches the free-list `in_list` field (the
         // decrement branch leaves it; `drop_last_in_place` preserves
         // it). Needed for `VmStore::inv`'s `in_list` coverage (#4).
-        final(regions).slot_owners[frame_to_index(paddr)].inner_perms.in_list == old(
+        final(regions).slot_owners[frame_to_index(paddr)].in_list_perm == old(
             regions,
-        ).slot_owners[frame_to_index(paddr)].inner_perms.in_list,
-        old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() == 1
-            ==> final(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
+        ).slot_owners[frame_to_index(paddr)].in_list_perm,
+        old(regions).slot_owners[frame_to_index(paddr)].ref_count() == 1
+            ==> final(regions).slot_owners[frame_to_index(paddr)].ref_count()
             == REF_COUNT_UNUSED,
-        old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() > 1
-            ==> final(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() == (
-        old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() - 1) as u64,
+        old(regions).slot_owners[frame_to_index(paddr)].ref_count() > 1
+            ==> final(regions).slot_owners[frame_to_index(paddr)].ref_count() == (
+        old(regions).slot_owners[frame_to_index(paddr)].ref_count() - 1) as u64,
         // Storage preservation in the decrement branch (rc>1): the
         // exec `fetch_sub` only touches `ref_count`; only the rc==1
         // teardown branch invokes `drop_last_in_place` (which uninits
         // storage). Needed so the embedding accounting clause's
         // `storage.is_init` carries across non-teardown drops.
-        old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() > 1
-            ==> final(regions).slot_owners[frame_to_index(paddr)].inner_perms.storage == old(
+        old(regions).slot_owners[frame_to_index(paddr)].ref_count() > 1
+            ==> final(regions).slot_owners[frame_to_index(paddr)].storage_perm() == old(
             regions,
-        ).slot_owners[frame_to_index(paddr)].inner_perms.storage,
+        ).slot_owners[frame_to_index(paddr)].storage_perm(),
         // ---- embedding inv chaining ----
         forall|c: CursorOwner<'_, UserPtConfig>|
             #![auto]
@@ -328,9 +328,9 @@ pub(super) proof fn from_in_use_step(
         // [`frame_from_in_use_embedded`].
         res is Some ==> {
             let so = final(regions).slot_owners[frame_to_index(paddr)];
-            &&& so.inner_perms.ref_count.value() != REF_COUNT_UNUSED
-            &&& so.inner_perms.ref_count.value() != REF_COUNT_UNIQUE
-            &&& so.inner_perms.storage.is_init()
+            &&& so.ref_count() != REF_COUNT_UNUSED
+            &&& so.ref_count() != REF_COUNT_UNIQUE
+            &&& so.storage_perm().is_init()
             &&& so.usage is Frame
         },
         final(regions).slots == old(regions).slots,
@@ -353,12 +353,12 @@ pub(super) proof fn from_in_use_step(
 pub open spec fn drop_pre(regions: MetaRegionOwners, paddr: Paddr) -> bool {
     let so = regions.slot_owners[frame_to_index(paddr)];
     &&& regions.contains(frame_to_index(paddr))
-    &&& so.inner_perms.ref_count.value() > 0
-    &&& so.inner_perms.ref_count.value() != REF_COUNT_UNUSED
-    &&& so.inner_perms.ref_count.value() <= REF_COUNT_MAX
-    &&& so.inner_perms.ref_count.value() == 1 ==> {
-        &&& so.inner_perms.storage.is_init()
-        &&& so.inner_perms.in_list.value() == 0
+    &&& so.ref_count() > 0
+    &&& so.ref_count() != REF_COUNT_UNUSED
+    &&& so.ref_count() <= REF_COUNT_MAX
+    &&& so.ref_count() == 1 ==> {
+        &&& so.storage_perm().is_init()
+        &&& so.in_list_perm.value() == 0
         &&& so.paths_in_pt.is_empty()
     }
 }
@@ -382,9 +382,9 @@ pub(super) proof fn drop_step(tracked regions: &mut MetaRegionOwners, tracked en
         // `in_list` preserved at the dropped slot too — `drop` touches
         // only `ref_count` (+ storage on teardown). Keeps `VmStore::inv`'s
         // `in_list` coverage (#4).
-        final(regions).slot_owners[frame_to_index(entry.paddr)].inner_perms.in_list == old(
+        final(regions).slot_owners[frame_to_index(entry.paddr)].in_list_perm == old(
             regions,
-        ).slot_owners[frame_to_index(entry.paddr)].inner_perms.in_list,
+        ).slot_owners[frame_to_index(entry.paddr)].in_list_perm,
         // Surface the rest of `frame_drop_embedded`'s ensures at the
         // dropped slot — needed by `lemma_step_frame_drop` to discharge the
         // accounting clause (Stage 5).
@@ -396,24 +396,24 @@ pub(super) proof fn drop_step(tracked regions: &mut MetaRegionOwners, tracked en
         ).slot_owners[frame_to_index(entry.paddr)].paths_in_pt,
         // `ref_count == 1` ⟹ no mappings ⟹ empty `paths_in_pt` at the
         // torn-down slot — see [`frame_drop_embedded`].
-        old(regions).slot_owners[frame_to_index(entry.paddr)].inner_perms.ref_count.value() == 1
+        old(regions).slot_owners[frame_to_index(entry.paddr)].ref_count() == 1
             ==> final(regions).slot_owners[frame_to_index(entry.paddr)].paths_in_pt.is_empty(),
         // rc transition (mirrors `frame_drop_embedded` exactly).
-        old(regions).slot_owners[frame_to_index(entry.paddr)].inner_perms.ref_count.value() == 1
+        old(regions).slot_owners[frame_to_index(entry.paddr)].ref_count() == 1
             ==> final(regions).slot_owners[frame_to_index(
             entry.paddr,
-        )].inner_perms.ref_count.value() == REF_COUNT_UNUSED,
-        old(regions).slot_owners[frame_to_index(entry.paddr)].inner_perms.ref_count.value() > 1
+        )].ref_count() == REF_COUNT_UNUSED,
+        old(regions).slot_owners[frame_to_index(entry.paddr)].ref_count() > 1
             ==> final(regions).slot_owners[frame_to_index(
             entry.paddr,
-        )].inner_perms.ref_count.value() == (old(regions).slot_owners[frame_to_index(
+        )].ref_count() == (old(regions).slot_owners[frame_to_index(
             entry.paddr,
-        )].inner_perms.ref_count.value() - 1) as u64,
+        )].ref_count() - 1) as u64,
         // Storage preservation in the decrement branch (rc>1).
-        old(regions).slot_owners[frame_to_index(entry.paddr)].inner_perms.ref_count.value() > 1
-            ==> final(regions).slot_owners[frame_to_index(entry.paddr)].inner_perms.storage == old(
+        old(regions).slot_owners[frame_to_index(entry.paddr)].ref_count() > 1
+            ==> final(regions).slot_owners[frame_to_index(entry.paddr)].storage_perm() == old(
             regions,
-        ).slot_owners[frame_to_index(entry.paddr)].inner_perms.storage,
+        ).slot_owners[frame_to_index(entry.paddr)].storage_perm(),
         forall|c: CursorOwner<'_, UserPtConfig>|
             #![auto]
             c.metaregion_sound(*old(regions)) ==> c.metaregion_sound(*final(regions)),

--- a/ostd/specs/mm/embedding/frame.rs
+++ b/ostd/specs/mm/embedding/frame.rs
@@ -188,10 +188,8 @@ pub axiom fn frame_drop_embedded(tracked regions: &mut MetaRegionOwners, paddr: 
         old(regions).inv(),
         old(regions).contains(frame_to_index(paddr)),
         old(regions).slot_owners[frame_to_index(paddr)].ref_count() > 0,
-        old(regions).slot_owners[frame_to_index(paddr)].ref_count()
-            != REF_COUNT_UNUSED,
-        old(regions).slot_owners[frame_to_index(paddr)].ref_count()
-            <= REF_COUNT_MAX,
+        old(regions).slot_owners[frame_to_index(paddr)].ref_count() != REF_COUNT_UNUSED,
+        old(regions).slot_owners[frame_to_index(paddr)].ref_count() <= REF_COUNT_MAX,
         old(regions).slot_owners[frame_to_index(paddr)].ref_count() == 1 ==> {
             &&& old(regions).slot_owners[frame_to_index(paddr)].storage_perm().is_init()
             &&& old(regions).slot_owners[frame_to_index(paddr)].in_list_perm.value()
@@ -249,11 +247,11 @@ pub axiom fn frame_drop_embedded(tracked regions: &mut MetaRegionOwners, paddr: 
             regions,
         ).slot_owners[frame_to_index(paddr)].in_list_perm,
         old(regions).slot_owners[frame_to_index(paddr)].ref_count() == 1
-            ==> final(regions).slot_owners[frame_to_index(paddr)].ref_count()
-            == REF_COUNT_UNUSED,
+            ==> final(regions).slot_owners[frame_to_index(paddr)].ref_count() == REF_COUNT_UNUSED,
         old(regions).slot_owners[frame_to_index(paddr)].ref_count() > 1
-            ==> final(regions).slot_owners[frame_to_index(paddr)].ref_count() == (
-        old(regions).slot_owners[frame_to_index(paddr)].ref_count() - 1) as u64,
+            ==> final(regions).slot_owners[frame_to_index(paddr)].ref_count() == (old(
+            regions,
+        ).slot_owners[frame_to_index(paddr)].ref_count() - 1) as u64,
         // Storage preservation in the decrement branch (rc>1): the
         // exec `fetch_sub` only touches `ref_count`; only the rc==1
         // teardown branch invokes `drop_last_in_place` (which uninits
@@ -400,15 +398,12 @@ pub(super) proof fn drop_step(tracked regions: &mut MetaRegionOwners, tracked en
             ==> final(regions).slot_owners[frame_to_index(entry.paddr)].paths_in_pt.is_empty(),
         // rc transition (mirrors `frame_drop_embedded` exactly).
         old(regions).slot_owners[frame_to_index(entry.paddr)].ref_count() == 1
-            ==> final(regions).slot_owners[frame_to_index(
-            entry.paddr,
-        )].ref_count() == REF_COUNT_UNUSED,
+            ==> final(regions).slot_owners[frame_to_index(entry.paddr)].ref_count()
+            == REF_COUNT_UNUSED,
         old(regions).slot_owners[frame_to_index(entry.paddr)].ref_count() > 1
-            ==> final(regions).slot_owners[frame_to_index(
-            entry.paddr,
-        )].ref_count() == (old(regions).slot_owners[frame_to_index(
-            entry.paddr,
-        )].ref_count() - 1) as u64,
+            ==> final(regions).slot_owners[frame_to_index(entry.paddr)].ref_count() == (old(
+            regions,
+        ).slot_owners[frame_to_index(entry.paddr)].ref_count() - 1) as u64,
         // Storage preservation in the decrement branch (rc>1).
         old(regions).slot_owners[frame_to_index(entry.paddr)].ref_count() > 1
             ==> final(regions).slot_owners[frame_to_index(entry.paddr)].storage_perm() == old(

--- a/ostd/specs/mm/embedding/list_store.rs
+++ b/ostd/specs/mm/embedding/list_store.rs
@@ -157,8 +157,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
                 &&& self.loose[lid].inv()
                 &&& self.loose[lid].global_inv(self.regions)
                 &&& self.loose[lid].frame_link_inv(self.regions)
-                &&& self.regions.slot_owners[self.loose[lid].slot_index].in_list_perm.value()
-                    == 0
+                &&& self.regions.slot_owners[self.loose[lid].slot_index].in_list_perm.value() == 0
             }
             // Distinct lists carry distinct *nonzero* ids (`lazy_get_id`
             // mints a globally fresh id per list — even a list emptied by
@@ -788,8 +787,7 @@ pub axiom fn list_drop_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
             #![trigger meta_to_index(owner.list[i].paddr)]
             0 <= i < owner.list.len() ==> {
                 let idx = meta_to_index(owner.list[i].paddr);
-                &&& final(regions).slot_owners[idx].ref_count()
-                    == REF_COUNT_UNUSED
+                &&& final(regions).slot_owners[idx].ref_count() == REF_COUNT_UNUSED
                 &&& final(regions).slot_owners[idx].in_list_perm.value() == 0
             },
         // Every slot outside the dropped list is fully preserved.
@@ -1030,14 +1028,12 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
             &&& self.loose[lid2].inv()
             &&& self.loose[lid2].global_inv(self.regions)
             &&& self.loose[lid2].frame_link_inv(self.regions)
-            &&& self.regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
-                == 0
+            &&& self.regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value() == 0
         } by {
             assert(old_self.loose.dom().contains(lid2));
             assert(old_self.loose[lid2].global_inv(old_regions));
             assert(old_self.loose[lid2].frame_link_inv(old_regions));
-            assert(old_regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
-                == 0);
+            assert(old_regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value() == 0);
         };
 
         // --- per-cursor preserved (cursor lists are "other lists") ---
@@ -1186,16 +1182,14 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
             &&& self.loose[lid2].inv()
             &&& self.loose[lid2].global_inv(self.regions)
             &&& self.loose[lid2].frame_link_inv(self.regions)
-            &&& self.regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
-                == 0
+            &&& self.regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value() == 0
         } by {
             assert(lid2 != lid);
             assert(old_self.loose.dom().contains(lid2));
             assert(old_self.loose[lid2] == self.loose[lid2]);
             assert(old_self.loose[lid2].global_inv(old_regions));
             assert(old_self.loose[lid2].frame_link_inv(old_regions));
-            assert(old_regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
-                == 0);
+            assert(old_regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value() == 0);
             assert(self.loose[lid2].slot_index != fidx);
         };
 
@@ -1330,8 +1324,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
                 &&& self.loose[lid2].inv()
                 &&& self.loose[lid2].global_inv(self.regions)
                 &&& self.loose[lid2].frame_link_inv(self.regions)
-                &&& self.regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
-                    == 0
+                &&& self.regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value() == 0
             } by {
                 if lid2 != new_loose {
                     assert(old_self.loose.dom().contains(lid2));
@@ -1472,16 +1465,14 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
             &&& self.loose[lid2].inv()
             &&& self.loose[lid2].global_inv(self.regions)
             &&& self.loose[lid2].frame_link_inv(self.regions)
-            &&& self.regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
-                == 0
+            &&& self.regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value() == 0
         } by {
             assert(lid2 != lid);
             assert(old_self.loose.dom().contains(lid2));
             assert(old_self.loose[lid2] == self.loose[lid2]);
             assert(old_self.loose[lid2].global_inv(old_regions));
             assert(old_self.loose[lid2].frame_link_inv(old_regions));
-            assert(old_regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
-                == 0);
+            assert(old_regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value() == 0);
             assert(self.loose[lid2].slot_index != fidx);
         };
 
@@ -1611,8 +1602,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
                 &&& self.loose[lid2].inv()
                 &&& self.loose[lid2].global_inv(self.regions)
                 &&& self.loose[lid2].frame_link_inv(self.regions)
-                &&& self.regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
-                    == 0
+                &&& self.regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value() == 0
             } by {
                 if lid2 != new_loose {
                     assert(old_self.loose.dom().contains(lid2));
@@ -1753,16 +1743,14 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
             &&& self.loose[lid2].inv()
             &&& self.loose[lid2].global_inv(self.regions)
             &&& self.loose[lid2].frame_link_inv(self.regions)
-            &&& self.regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
-                == 0
+            &&& self.regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value() == 0
         } by {
             assert(lid2 != lid);
             assert(old_self.loose.dom().contains(lid2));
             assert(old_self.loose[lid2] == self.loose[lid2]);
             assert(old_self.loose[lid2].global_inv(old_regions));
             assert(old_self.loose[lid2].frame_link_inv(old_regions));
-            assert(old_regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
-                == 0);
+            assert(old_regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value() == 0);
             assert(self.loose[lid2].slot_index != fidx);
         };
 
@@ -1893,8 +1881,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
                 &&& self.loose[lid2].inv()
                 &&& self.loose[lid2].global_inv(self.regions)
                 &&& self.loose[lid2].frame_link_inv(self.regions)
-                &&& self.regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
-                    == 0
+                &&& self.regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value() == 0
             } by {
                 if lid2 != new_loose {
                     assert(old_self.loose.dom().contains(lid2));
@@ -2536,16 +2523,14 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
             &&& self.loose[lid2].inv()
             &&& self.loose[lid2].global_inv(self.regions)
             &&& self.loose[lid2].frame_link_inv(self.regions)
-            &&& self.regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
-                == 0
+            &&& self.regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value() == 0
         } by {
             assert(lid2 != lid);
             assert(old_self.loose.dom().contains(lid2));
             assert(old_self.loose[lid2] == self.loose[lid2]);
             assert(old_self.loose[lid2].global_inv(old_regions));
             assert(old_self.loose[lid2].frame_link_inv(old_regions));
-            assert(old_regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
-                == 0);
+            assert(old_regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value() == 0);
             assert(self.loose[lid2].slot_index != fidx);
         };
 
@@ -2675,8 +2660,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
                 &&& self.loose[lid2].inv()
                 &&& self.loose[lid2].global_inv(self.regions)
                 &&& self.loose[lid2].frame_link_inv(self.regions)
-                &&& self.regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
-                    == 0
+                &&& self.regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value() == 0
             } by {
                 if lid2 != new_loose {
                     assert(old_self.loose.dom().contains(lid2));

--- a/ostd/specs/mm/embedding/list_store.rs
+++ b/ostd/specs/mm/embedding/list_store.rs
@@ -112,10 +112,10 @@ pub open spec fn list_registry_ok<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
         #![trigger meta_to_index(lo.list[i].paddr)]
         0 <= i < lo.list.len() ==> regions.slot_owners[meta_to_index(
             lo.list[i].paddr,
-        )].inner_perms.in_list.value() == lo.list_id
+        )].in_list_perm.value() == lo.list_id
     &&& lo.list_id != 0 ==> forall|idx: int|
         #![trigger regions.slot_owners[idx]]
-        regions.contains(idx) && regions.slot_owners[idx].inner_perms.in_list.value() == lo.list_id
+        regions.contains(idx) && regions.slot_owners[idx].in_list_perm.value() == lo.list_id
             ==> exists|i: int|
             0 <= i < lo.list.len() && #[trigger] meta_to_index(lo.list[i].paddr) == idx
 }
@@ -157,7 +157,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
                 &&& self.loose[lid].inv()
                 &&& self.loose[lid].global_inv(self.regions)
                 &&& self.loose[lid].frame_link_inv(self.regions)
-                &&& self.regions.slot_owners[self.loose[lid].slot_index].inner_perms.in_list.value()
+                &&& self.regions.slot_owners[self.loose[lid].slot_index].in_list_perm.value()
                     == 0
             }
             // Distinct lists carry distinct *nonzero* ids (`lazy_get_id`
@@ -305,7 +305,7 @@ pub proof fn push_front_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
         old(frame_own).inv(),
         old(frame_own).global_inv(*old(regions)),
         old(frame_own).frame_link_inv(*old(regions)),
-        old(regions).slot_owners[old(frame_own).slot_index].inner_perms.in_list.value() == 0,
+        old(regions).slot_owners[old(frame_own).slot_index].in_list_perm.value() == 0,
     ensures
         final(regions).inv(),
         final(owner).inv(),
@@ -351,10 +351,10 @@ pub proof fn push_front_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
             #![trigger fo.global_inv(*old(regions))]
             fo.global_inv(*old(regions)) && fo.frame_link_inv(*old(regions)) && old(
                 regions,
-            ).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0 && fo.slot_index != old(
+            ).slot_owners[fo.slot_index].in_list_perm.value() == 0 && fo.slot_index != old(
                 frame_own,
             ).slot_index ==> fo.global_inv(*final(regions)) && fo.frame_link_inv(*final(regions))
-                && final(regions).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0,
+                && final(regions).slot_owners[fo.slot_index].in_list_perm.value() == 0,
 {
     insert_before_at_embedded(regions, owner, frame_own, 0, used_ids);
 }
@@ -410,7 +410,7 @@ pub proof fn tracked_pop_front_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
         frame_own.global_inv(*final(regions)),
         frame_own.frame_link_inv(*final(regions)),
         frame_own.slot_index == meta_to_index(old(owner).list[0].paddr),
-        final(regions).slot_owners[frame_own.slot_index].inner_perms.in_list.value() == 0,
+        final(regions).slot_owners[frame_own.slot_index].in_list_perm.value() == 0,
         // `from_raw` re-mints the drop-obligation.
         final(regions).frame_obligations =~= old(regions).frame_obligations.insert(
             meta_to_index(old(owner).list[0].paddr),
@@ -447,10 +447,10 @@ pub proof fn tracked_pop_front_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
             #![trigger fo.global_inv(*old(regions))]
             fo.global_inv(*old(regions)) && fo.frame_link_inv(*old(regions)) && old(
                 regions,
-            ).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0 ==> fo.global_inv(
+            ).slot_owners[fo.slot_index].in_list_perm.value() == 0 ==> fo.global_inv(
                 *final(regions),
             ) && fo.frame_link_inv(*final(regions))
-                && final(regions).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0
+                && final(regions).slot_owners[fo.slot_index].in_list_perm.value() == 0
                 && fo.slot_index != meta_to_index(old(owner).list[0].paddr),
 {
     let tracked frame_own = take_at_embedded(regions, owner, 0);
@@ -474,7 +474,7 @@ pub proof fn lemma_push_back_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
         old(frame_own).inv(),
         old(frame_own).global_inv(*old(regions)),
         old(frame_own).frame_link_inv(*old(regions)),
-        old(regions).slot_owners[old(frame_own).slot_index].inner_perms.in_list.value() == 0,
+        old(regions).slot_owners[old(frame_own).slot_index].in_list_perm.value() == 0,
     ensures
         final(regions).inv(),
         final(owner).inv(),
@@ -524,10 +524,10 @@ pub proof fn lemma_push_back_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
             #![trigger fo.global_inv(*old(regions))]
             fo.global_inv(*old(regions)) && fo.frame_link_inv(*old(regions)) && old(
                 regions,
-            ).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0 && fo.slot_index != old(
+            ).slot_owners[fo.slot_index].in_list_perm.value() == 0 && fo.slot_index != old(
                 frame_own,
             ).slot_index ==> fo.global_inv(*final(regions)) && fo.frame_link_inv(*final(regions))
-                && final(regions).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0,
+                && final(regions).slot_owners[fo.slot_index].in_list_perm.value() == 0,
 {
     let ghost n = if owner.list.len() > 0 {
         owner.list.len() - 1
@@ -560,7 +560,7 @@ pub proof fn tracked_pop_back_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
         frame_own.global_inv(*final(regions)),
         frame_own.frame_link_inv(*final(regions)),
         frame_own.slot_index == meta_to_index(old(owner).list[old(owner).list.len() - 1].paddr),
-        final(regions).slot_owners[frame_own.slot_index].inner_perms.in_list.value() == 0,
+        final(regions).slot_owners[frame_own.slot_index].in_list_perm.value() == 0,
         final(regions).frame_obligations =~= old(regions).frame_obligations.insert(
             meta_to_index(old(owner).list[old(owner).list.len() - 1].paddr),
         ),
@@ -593,10 +593,10 @@ pub proof fn tracked_pop_back_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
             #![trigger fo.global_inv(*old(regions))]
             fo.global_inv(*old(regions)) && fo.frame_link_inv(*old(regions)) && old(
                 regions,
-            ).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0 ==> fo.global_inv(
+            ).slot_owners[fo.slot_index].in_list_perm.value() == 0 ==> fo.global_inv(
                 *final(regions),
             ) && fo.frame_link_inv(*final(regions))
-                && final(regions).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0
+                && final(regions).slot_owners[fo.slot_index].in_list_perm.value() == 0
                 && fo.slot_index != meta_to_index(old(owner).list[old(owner).list.len() - 1].paddr),
 {
     let ghost n = owner.list.len() - 1;
@@ -623,7 +623,7 @@ pub axiom fn insert_before_at_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
         old(frame_own).inv(),
         old(frame_own).global_inv(*old(regions)),
         old(frame_own).frame_link_inv(*old(regions)),
-        old(regions).slot_owners[old(frame_own).slot_index].inner_perms.in_list.value() == 0,
+        old(regions).slot_owners[old(frame_own).slot_index].in_list_perm.value() == 0,
         0 <= n <= old(owner).list.len(),
     ensures
         final(regions).inv(),
@@ -666,10 +666,10 @@ pub axiom fn insert_before_at_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
             #![trigger fo.global_inv(*old(regions))]
             fo.global_inv(*old(regions)) && fo.frame_link_inv(*old(regions)) && old(
                 regions,
-            ).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0 && fo.slot_index != old(
+            ).slot_owners[fo.slot_index].in_list_perm.value() == 0 && fo.slot_index != old(
                 frame_own,
             ).slot_index ==> fo.global_inv(*final(regions)) && fo.frame_link_inv(*final(regions))
-                && final(regions).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0,
+                && final(regions).slot_owners[fo.slot_index].in_list_perm.value() == 0,
 ;
 
 /// Trusted reflection of [`crate::mm::frame::CursorMut::take_current`]
@@ -697,7 +697,7 @@ pub axiom fn take_at_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
         frame_own.global_inv(*final(regions)),
         frame_own.frame_link_inv(*final(regions)),
         frame_own.slot_index == meta_to_index(old(owner).list[n].paddr),
-        final(regions).slot_owners[frame_own.slot_index].inner_perms.in_list.value() == 0,
+        final(regions).slot_owners[frame_own.slot_index].in_list_perm.value() == 0,
         final(regions).frame_obligations =~= old(regions).frame_obligations.insert(
             meta_to_index(old(owner).list[n].paddr),
         ),
@@ -730,10 +730,10 @@ pub axiom fn take_at_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
             #![trigger fo.global_inv(*old(regions))]
             fo.global_inv(*old(regions)) && fo.frame_link_inv(*old(regions)) && old(
                 regions,
-            ).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0 ==> fo.global_inv(
+            ).slot_owners[fo.slot_index].in_list_perm.value() == 0 ==> fo.global_inv(
                 *final(regions),
             ) && fo.frame_link_inv(*final(regions))
-                && final(regions).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0
+                && final(regions).slot_owners[fo.slot_index].in_list_perm.value() == 0
                 && fo.slot_index != meta_to_index(old(owner).list[n].paddr),
 ;
 
@@ -788,9 +788,9 @@ pub axiom fn list_drop_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
             #![trigger meta_to_index(owner.list[i].paddr)]
             0 <= i < owner.list.len() ==> {
                 let idx = meta_to_index(owner.list[i].paddr);
-                &&& final(regions).slot_owners[idx].inner_perms.ref_count.value()
+                &&& final(regions).slot_owners[idx].ref_count()
                     == REF_COUNT_UNUSED
-                &&& final(regions).slot_owners[idx].inner_perms.in_list.value() == 0
+                &&& final(regions).slot_owners[idx].in_list_perm.value() == 0
             },
         // Every slot outside the dropped list is fully preserved.
         forall|idx: int|
@@ -817,10 +817,10 @@ pub axiom fn list_drop_embedded<M: AnyFrameMeta + Repr<MetaSlotSmall>>(
             #![trigger fo.global_inv(*old(regions))]
             fo.global_inv(*old(regions)) && fo.frame_link_inv(*old(regions)) && old(
                 regions,
-            ).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0 ==> fo.global_inv(
+            ).slot_owners[fo.slot_index].in_list_perm.value() == 0 ==> fo.global_inv(
                 *final(regions),
             ) && fo.frame_link_inv(*final(regions))
-                && final(regions).slot_owners[fo.slot_index].inner_perms.in_list.value() == 0,
+                && final(regions).slot_owners[fo.slot_index].in_list_perm.value() == 0,
 ;
 
 // =============================================================================
@@ -877,7 +877,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
             if self.lists[id].list_id != 0 {
                 // The registry for list `id` (forward + reverse) from `inv`.
                 assert(list_registry_ok(self.regions, self.lists[id]));
-                let res = self.regions.slot_owners[idx].inner_perms.in_list.value()
+                let res = self.regions.slot_owners[idx].in_list_perm.value()
                     == self.lists[id].list_id;
                 if res {
                     // reverse: a slot tagged with the id is one of the links.
@@ -894,7 +894,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
                     ) != idx by {
                         assert(self.regions.slot_owners[meta_to_index(
                             self.lists[id].list[i].paddr,
-                        )].inner_perms.in_list.value() == self.lists[id].list_id);
+                        )].in_list_perm.value() == self.lists[id].list_id);
                     };
                 }
                 res
@@ -993,7 +993,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
             let _ = self.lists[id].list[i];
             self.lists[id].relate_region_at_facts(self.regions, i);
             assert(self.regions.contains(idx));
-            assert(self.regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
+            assert(self.regions.slot_owners[idx].ref_count() == REF_COUNT_UNIQUE);
             assert(self.regions.slot_owners[idx].usage is Frame);
         };
 
@@ -1030,13 +1030,13 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
             &&& self.loose[lid2].inv()
             &&& self.loose[lid2].global_inv(self.regions)
             &&& self.loose[lid2].frame_link_inv(self.regions)
-            &&& self.regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+            &&& self.regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
                 == 0
         } by {
             assert(old_self.loose.dom().contains(lid2));
             assert(old_self.loose[lid2].global_inv(old_regions));
             assert(old_self.loose[lid2].frame_link_inv(old_regions));
-            assert(old_regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+            assert(old_regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
                 == 0);
         };
 
@@ -1139,7 +1139,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
         assert(self.lists[id].relate_region(self.regions));
         assert(self.loose[lid].global_inv(self.regions));
         assert(self.loose[lid].frame_link_inv(self.regions));
-        assert(self.regions.slot_owners[fidx].inner_perms.in_list.value() == 0);
+        assert(self.regions.slot_owners[fidx].in_list_perm.value() == 0);
 
         let tracked mut owner = self.lists.tracked_remove(id);
         let tracked mut frame_own = self.loose.tracked_remove(lid);
@@ -1186,7 +1186,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
             &&& self.loose[lid2].inv()
             &&& self.loose[lid2].global_inv(self.regions)
             &&& self.loose[lid2].frame_link_inv(self.regions)
-            &&& self.regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+            &&& self.regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
                 == 0
         } by {
             assert(lid2 != lid);
@@ -1194,7 +1194,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
             assert(old_self.loose[lid2] == self.loose[lid2]);
             assert(old_self.loose[lid2].global_inv(old_regions));
             assert(old_self.loose[lid2].frame_link_inv(old_regions));
-            assert(old_regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+            assert(old_regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
                 == 0);
             assert(self.loose[lid2].slot_index != fidx);
         };
@@ -1330,7 +1330,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
                 &&& self.loose[lid2].inv()
                 &&& self.loose[lid2].global_inv(self.regions)
                 &&& self.loose[lid2].frame_link_inv(self.regions)
-                &&& self.regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                &&& self.regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
                     == 0
             } by {
                 if lid2 != new_loose {
@@ -1338,7 +1338,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
                     assert(old_self.loose[lid2] == self.loose[lid2]);
                     assert(old_self.loose[lid2].global_inv(old_regions));
                     assert(old_self.loose[lid2].frame_link_inv(old_regions));
-                    assert(old_regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                    assert(old_regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
                         == 0);
                 }
             };
@@ -1432,7 +1432,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
         assert(self.lists[id].relate_region(self.regions));
         assert(self.loose[lid].global_inv(self.regions));
         assert(self.loose[lid].frame_link_inv(self.regions));
-        assert(self.regions.slot_owners[fidx].inner_perms.in_list.value() == 0);
+        assert(self.regions.slot_owners[fidx].in_list_perm.value() == 0);
 
         let tracked mut owner = self.lists.tracked_remove(id);
         let tracked mut frame_own = self.loose.tracked_remove(lid);
@@ -1472,7 +1472,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
             &&& self.loose[lid2].inv()
             &&& self.loose[lid2].global_inv(self.regions)
             &&& self.loose[lid2].frame_link_inv(self.regions)
-            &&& self.regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+            &&& self.regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
                 == 0
         } by {
             assert(lid2 != lid);
@@ -1480,7 +1480,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
             assert(old_self.loose[lid2] == self.loose[lid2]);
             assert(old_self.loose[lid2].global_inv(old_regions));
             assert(old_self.loose[lid2].frame_link_inv(old_regions));
-            assert(old_regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+            assert(old_regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
                 == 0);
             assert(self.loose[lid2].slot_index != fidx);
         };
@@ -1611,7 +1611,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
                 &&& self.loose[lid2].inv()
                 &&& self.loose[lid2].global_inv(self.regions)
                 &&& self.loose[lid2].frame_link_inv(self.regions)
-                &&& self.regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                &&& self.regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
                     == 0
             } by {
                 if lid2 != new_loose {
@@ -1619,7 +1619,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
                     assert(old_self.loose[lid2] == self.loose[lid2]);
                     assert(old_self.loose[lid2].global_inv(old_regions));
                     assert(old_self.loose[lid2].frame_link_inv(old_regions));
-                    assert(old_regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                    assert(old_regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
                         == 0);
                 }
             };
@@ -1713,7 +1713,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
         assert(self.lists[id].relate_region(self.regions));
         assert(self.loose[lid].global_inv(self.regions));
         assert(self.loose[lid].frame_link_inv(self.regions));
-        assert(self.regions.slot_owners[fidx].inner_perms.in_list.value() == 0);
+        assert(self.regions.slot_owners[fidx].in_list_perm.value() == 0);
 
         let tracked mut owner = self.lists.tracked_remove(id);
         let tracked mut frame_own = self.loose.tracked_remove(lid);
@@ -1753,7 +1753,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
             &&& self.loose[lid2].inv()
             &&& self.loose[lid2].global_inv(self.regions)
             &&& self.loose[lid2].frame_link_inv(self.regions)
-            &&& self.regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+            &&& self.regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
                 == 0
         } by {
             assert(lid2 != lid);
@@ -1761,7 +1761,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
             assert(old_self.loose[lid2] == self.loose[lid2]);
             assert(old_self.loose[lid2].global_inv(old_regions));
             assert(old_self.loose[lid2].frame_link_inv(old_regions));
-            assert(old_regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+            assert(old_regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
                 == 0);
             assert(self.loose[lid2].slot_index != fidx);
         };
@@ -1893,7 +1893,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
                 &&& self.loose[lid2].inv()
                 &&& self.loose[lid2].global_inv(self.regions)
                 &&& self.loose[lid2].frame_link_inv(self.regions)
-                &&& self.regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                &&& self.regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
                     == 0
             } by {
                 if lid2 != new_loose {
@@ -1901,7 +1901,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
                     assert(old_self.loose[lid2] == self.loose[lid2]);
                     assert(old_self.loose[lid2].global_inv(old_regions));
                     assert(old_self.loose[lid2].frame_link_inv(old_regions));
-                    assert(old_regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                    assert(old_regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
                         == 0);
                 }
             };
@@ -2004,7 +2004,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
             &&& new_self.loose[lid].inv()
             &&& new_self.loose[lid].global_inv(new_self.regions)
             &&& new_self.loose[lid].frame_link_inv(new_self.regions)
-            &&& new_self.regions.slot_owners[new_self.loose[lid].slot_index].inner_perms.in_list.value()
+            &&& new_self.regions.slot_owners[new_self.loose[lid].slot_index].in_list_perm.value()
                 == 0
         } by {
             assert(old_self.loose.dom().contains(lid));
@@ -2101,7 +2101,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
             &&& new_self.loose[lid].inv()
             &&& new_self.loose[lid].global_inv(new_self.regions)
             &&& new_self.loose[lid].frame_link_inv(new_self.regions)
-            &&& new_self.regions.slot_owners[new_self.loose[lid].slot_index].inner_perms.in_list.value()
+            &&& new_self.regions.slot_owners[new_self.loose[lid].slot_index].in_list_perm.value()
                 == 0
         } by {
             assert(old_self.loose.dom().contains(lid));
@@ -2197,7 +2197,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
             &&& new_self.loose[lid].inv()
             &&& new_self.loose[lid].global_inv(new_self.regions)
             &&& new_self.loose[lid].frame_link_inv(new_self.regions)
-            &&& new_self.regions.slot_owners[new_self.loose[lid].slot_index].inner_perms.in_list.value()
+            &&& new_self.regions.slot_owners[new_self.loose[lid].slot_index].in_list_perm.value()
                 == 0
         } by {
             assert(old_self.loose.dom().contains(lid));
@@ -2482,7 +2482,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
         assert(self.cursors[id].list_own.relate_region(self.regions));
         assert(self.loose[lid].global_inv(self.regions));
         assert(self.loose[lid].frame_link_inv(self.regions));
-        assert(self.regions.slot_owners[fidx].inner_perms.in_list.value() == 0);
+        assert(self.regions.slot_owners[fidx].in_list_perm.value() == 0);
 
         let tracked cur = self.cursors.tracked_remove(id);
         let tracked CursorOwner { list_own: mut owner, index: _ } = cur;
@@ -2536,7 +2536,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
             &&& self.loose[lid2].inv()
             &&& self.loose[lid2].global_inv(self.regions)
             &&& self.loose[lid2].frame_link_inv(self.regions)
-            &&& self.regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+            &&& self.regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
                 == 0
         } by {
             assert(lid2 != lid);
@@ -2544,7 +2544,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
             assert(old_self.loose[lid2] == self.loose[lid2]);
             assert(old_self.loose[lid2].global_inv(old_regions));
             assert(old_self.loose[lid2].frame_link_inv(old_regions));
-            assert(old_regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+            assert(old_regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
                 == 0);
             assert(self.loose[lid2].slot_index != fidx);
         };
@@ -2675,7 +2675,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
                 &&& self.loose[lid2].inv()
                 &&& self.loose[lid2].global_inv(self.regions)
                 &&& self.loose[lid2].frame_link_inv(self.regions)
-                &&& self.regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                &&& self.regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
                     == 0
             } by {
                 if lid2 != new_loose {
@@ -2683,7 +2683,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> ListStore<M> {
                     assert(old_self.loose[lid2] == self.loose[lid2]);
                     assert(old_self.loose[lid2].global_inv(old_regions));
                     assert(old_self.loose[lid2].frame_link_inv(old_regions));
-                    assert(old_regions.slot_owners[self.loose[lid2].slot_index].inner_perms.in_list.value()
+                    assert(old_regions.slot_owners[self.loose[lid2].slot_index].in_list_perm.value()
                         == 0);
                 }
             };

--- a/ostd/specs/mm/embedding/mod.rs
+++ b/ostd/specs/mm/embedding/mod.rs
@@ -40,8 +40,8 @@
 //!
 //! 1. **Strengthen [`crate::specs::mm::frame::meta_owners::MetaSlotOwner::inv`]'s
 //!    SHARED branch** — DONE. The branch (`0 < rc <= REF_COUNT_MAX`)
-//!    now carries `inner_perms.storage.is_init()` and
-//!    `inner_perms.in_list.value() == 0`. The `rc == 1 ⟹ ...` guards
+//!    now carries `storage_perm().is_init()` and
+//!    `in_list_perm.value() == 0`. The `rc == 1 ⟹ ...` guards
 //!    on `storage`/`in_list` in
 //!    [`crate::mm::frame::Frame::drop_requires`] were dropped.
 //!
@@ -168,7 +168,7 @@ use crate::specs::{
     mm::{
         frame::{
             mapping::{frame_to_index, index_to_frame, max_meta_slots},
-            meta_owners::PageUsage,
+            meta_owners::{MetaSlotOwner, PageUsage},
             meta_region_owners::MetaRegionOwners,
         },
         io::VmIoOwner,
@@ -219,7 +219,7 @@ pub type UniqueId = int;
 /// `regions.slot_owners[frame_to_index(paddr)]`.
 ///
 /// Multiple `FrameEntry`s may share the same `paddr`; each contributes
-/// `+1` to that slot's `inner_perms.ref_count`.
+/// `+1` to that slot's `ref_count`.
 pub tracked struct FrameEntry {
     pub ghost paddr: Paddr,
 }
@@ -454,11 +454,13 @@ pub proof fn lemma_frame_drop_pre_derivable<'rcu>(s: VmStore<'rcu>, fid: FrameId
         segment_cover_count(s.segments, s.frames[fid].paddr) == 0,
     ensures
         frame::drop_pre(s.regions, s.frames[fid].paddr),
-        s.regions.slot_owners[frame_to_index(s.frames[fid].paddr)].inner_perms.ref_count.value()
+        s.regions.slot_owners[frame_to_index(s.frames[fid].paddr)].ref_count()
             == 1 ==> handle_count(s.frames, frame_to_index(s.frames[fid].paddr)) == 1,
 {
     let paddr = s.frames[fid].paddr;
     let idx = frame_to_index(paddr);
+    assert(s.regions.slot_owners[idx].ref_count()
+        == s.regions.slot_owners[idx].ref_count_perm.value());
 
     assert(s.frames.dom().filter(
         |gid: FrameId| frame_to_index(s.frames[gid].paddr) == idx,
@@ -644,7 +646,7 @@ impl<'a, 'rcu> VmStore<'rcu> {
         &&& forall|idx: int|
             0 <= idx < max_meta_slots() ==> #[trigger] self.regions.slots.contains_key(idx) || (
             self.regions.slot_owners[idx].usage is PageTable
-                && self.regions.slot_owners[idx].inner_perms.ref_count.value()
+                && self.regions.slot_owners[idx].ref_count()
                 != REF_COUNT_UNUSED)
             // Segment-cover info is sourced directly from the `segments` map
             // via `segment_cover_count` (see `accounting_inv`'s rc equation).
@@ -652,7 +654,7 @@ impl<'a, 'rcu> VmStore<'rcu> {
             // been retired.
         &&& forall|idx: int|
             0 <= idx < max_meta_slots()
-                ==> #[trigger] self.regions.slot_owners[idx].inner_perms.in_list.value() == 0
+                ==> #[trigger] self.regions.slot_owners[idx].in_list_perm.value() == 0
         &&& self.tlb_model.inv()
         &&& forall|id: VmSpaceId| #[trigger]
             self.vm_spaces.dom().contains(id) ==> self.vm_spaces[id].inv()
@@ -744,8 +746,8 @@ impl<'a, 'rcu> VmStore<'rcu> {
             self.unique_frames.dom().contains(uid) ==> {
                 let so = self.regions.slot_owners[frame_to_index(self.unique_frames[uid].paddr)];
                 &&& so.usage is Frame
-                &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
-                &&& so.inner_perms.in_list.value() == 0
+                &&& so.ref_count() == REF_COUNT_UNIQUE
+                &&& so.in_list_perm.value() == 0
                 &&& so.paths_in_pt.is_empty()
             }
             // At most one `UniqueEntry` per slot — the exclusivity of
@@ -830,7 +832,7 @@ impl<'a, 'rcu> VmStore<'rcu> {
         &&& forall|idx: int|
             #![trigger self.regions.slot_owners[idx]]
             0 <= idx < max_meta_slots()
-                && self.regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNUSED
+                && self.regions.slot_owners[idx].ref_count() == REF_COUNT_UNUSED
                 ==> handle_count(self.frames, idx) == 0
                 && self.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
                 self.segments,
@@ -844,8 +846,8 @@ impl<'a, 'rcu> VmStore<'rcu> {
         &&& forall|idx: int|
             #![trigger self.regions.slot_owners[idx]]
             0 <= idx < max_meta_slots() && self.regions.slot_owners[idx].usage is Frame
-                && self.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-                && self.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNIQUE
+                && self.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
+                && self.regions.slot_owners[idx].ref_count() != REF_COUNT_UNIQUE
                 ==> handle_count(self.frames, idx) > 0
                 || self.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
                 self.segments,
@@ -865,12 +867,12 @@ impl<'a, 'rcu> VmStore<'rcu> {
             handle_count(self.frames, idx) > 0 || self.regions.slot_owners[idx].paths_in_pt.len()
                 > 0 || segment_cover_count(self.segments, index_to_frame(idx)) > 0) ==> {
                 let so = self.regions.slot_owners[idx];
-                let rc = so.inner_perms.ref_count.value();
+                let rc = so.ref_count();
                 &&& rc != REF_COUNT_UNUSED
                 &&& rc != REF_COUNT_UNIQUE
                 &&& rc == handle_count(self.frames, idx) + so.paths_in_pt.len()
                     + segment_cover_count(self.segments, index_to_frame(idx))
-                &&& so.inner_perms.storage.is_init()
+                &&& so.storage_perm().is_init()
             }
     }
 }
@@ -1117,7 +1119,7 @@ pub open spec fn op_pre<'rcu>(s: VmStore<'rcu>, op: Op) -> bool {
         Op::SegmentClone { sid } => s.segments.dom().contains(sid) && forall|paddr: Paddr|
             #![trigger frame_to_index(paddr)]
             (s.segments[sid].range.start <= paddr < s.segments[sid].range.end && paddr % PAGE_SIZE
-                == 0) ==> s.regions.slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
+                == 0) ==> s.regions.slot_owners[frame_to_index(paddr)].ref_count()
                 + 1 <= REF_COUNT_MAX,
         // `Segment::slice`: id-existence + the sub-range is a
         // page-aligned, non-empty, absolute physical range contained in
@@ -1130,7 +1132,7 @@ pub open spec fn op_pre<'rcu>(s: VmStore<'rcu>, op: Op) -> bool {
             <= s.segments[sid].range.end && forall|paddr: Paddr|
             #![trigger frame_to_index(paddr)]
             (sub_range.start <= paddr < sub_range.end && paddr % PAGE_SIZE == 0)
-                ==> s.regions.slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() + 1
+                ==> s.regions.slot_owners[frame_to_index(paddr)].ref_count() + 1
                 <= REF_COUNT_MAX,
         // `UniqueFrame::from_unused`: no precondition (mirrors
         // `FrameFromUnused`). The exec returns `Err` and leaves the slot
@@ -1586,8 +1588,8 @@ proof fn lemma_accounting_preserved_by_pt_alloc<'rcu>(s_old: VmStore<'rcu>, s_ne
         forall|i: int|
             #![trigger s_new.regions.slot_owners[i]]
             s_new.regions.slot_owners[i] != s_old.regions.slot_owners[i] ==> {
-                &&& s_old.regions.slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNUSED
-                &&& s_new.regions.slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
+                &&& s_old.regions.slot_owners[i].ref_count() == REF_COUNT_UNUSED
+                &&& s_new.regions.slot_owners[i].ref_count() != REF_COUNT_UNUSED
                 &&& s_new.regions.slot_owners[i].usage !is Frame
             },
     ensures
@@ -1613,7 +1615,7 @@ proof fn lemma_accounting_preserved_by_pt_alloc<'rcu>(s_old: VmStore<'rcu>, s_ne
     // unchanged (a transitioned slot is non-UNUSED in `s_new`).
     assert forall|idx: int|
         #![trigger s_new.regions.slot_owners[idx]]
-        0 <= idx < max_meta_slots() && s_new.regions.slot_owners[idx].inner_perms.ref_count.value()
+        0 <= idx < max_meta_slots() && s_new.regions.slot_owners[idx].ref_count()
             == REF_COUNT_UNUSED implies handle_count(s_new.frames, idx) == 0
         && s_new.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
         s_new.segments,
@@ -1626,8 +1628,8 @@ proof fn lemma_accounting_preserved_by_pt_alloc<'rcu>(s_old: VmStore<'rcu>, s_ne
     assert forall|idx: int|
         #![trigger s_new.regions.slot_owners[idx]]
         0 <= idx < max_meta_slots() && s_new.regions.slot_owners[idx].usage is Frame
-            && s_new.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-            && s_new.regions.slot_owners[idx].inner_perms.ref_count.value()
+            && s_new.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
+            && s_new.regions.slot_owners[idx].ref_count()
             != REF_COUNT_UNIQUE implies handle_count(s_new.frames, idx) > 0
         || s_new.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
         s_new.segments,
@@ -1643,14 +1645,14 @@ proof fn lemma_accounting_preserved_by_pt_alloc<'rcu>(s_old: VmStore<'rcu>, s_ne
         handle_count(s_new.frames, idx) > 0 || s_new.regions.slot_owners[idx].paths_in_pt.len() > 0
             || segment_cover_count(s_new.segments, index_to_frame(idx)) > 0) implies {
         let so = s_new.regions.slot_owners[idx];
-        let rc = so.inner_perms.ref_count.value();
+        let rc = so.ref_count();
         &&& rc != REF_COUNT_UNUSED
         &&& rc != REF_COUNT_UNIQUE
         &&& rc == handle_count(s_new.frames, idx) + so.paths_in_pt.len() + segment_cover_count(
             s_new.segments,
             index_to_frame(idx),
         )
-        &&& so.inner_perms.storage.is_init()
+        &&& so.storage_perm().is_init()
     } by {
         assert(s_new.regions.slot_owners[idx] == s_old.regions.slot_owners[idx]);
     };
@@ -1671,7 +1673,7 @@ proof fn lemma_accounting_preserved_by_pt_alloc<'rcu>(s_old: VmStore<'rcu>, s_ne
         // From old accounting clause 4: cover >= 1 ⟹ active head ⟹
         // rc ∈ valid SHARED range ⟹ rc != UNUSED.
         lemma_segment_cover_contains(s_old.segments, sid, paddr);
-        assert(s_old.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED);
+        assert(s_old.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED);
         // PT-alloc unchanged.
         assert(s_new.regions.slot_owners[idx] == s_old.regions.slot_owners[idx]);
     };
@@ -1692,7 +1694,7 @@ proof fn lemma_accounting_preserved_by_pt_alloc<'rcu>(s_old: VmStore<'rcu>, s_ne
         assert(handle_count(s_old.frames, idx) >= 1);
         // pre accounting_inv clause 4 ⟹ pre rc != UNUSED.
         assert(s_old.regions.slot_owners[idx].usage is Frame);
-        assert(s_old.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED);
+        assert(s_old.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED);
         // PT-alloc's requires: changed ⟹ pre UNUSED. Contrapositive:
         // pre non-UNUSED ⟹ unchanged.
         assert(s_new.regions.slot_owners[idx] == s_old.regions.slot_owners[idx]);
@@ -1718,13 +1720,13 @@ proof fn lemma_coverage_preserved_slots_eq<'rcu>(s_old: VmStore<'rcu>, s_new: Vm
         forall|idx: int|
             0 <= idx < max_meta_slots() ==> #[trigger] s_new.regions.slots.contains_key(idx) || (
             s_new.regions.slot_owners[idx].usage is PageTable
-                && s_new.regions.slot_owners[idx].inner_perms.ref_count.value()
+                && s_new.regions.slot_owners[idx].ref_count()
                 != REF_COUNT_UNUSED),
 {
     assert forall|idx: int|
         0 <= idx < max_meta_slots() implies #[trigger] s_new.regions.slots.contains_key(idx) || (
     s_new.regions.slot_owners[idx].usage is PageTable
-        && s_new.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED) by {
+        && s_new.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED) by {
         if !s_new.regions.slots.contains_key(idx) {
             // `slots == old` ⟹ unparked in `s_old` too ⟹ old coverage's
             // PageTable-node disjunct ⟹ (slot unchanged) carries.
@@ -1756,7 +1758,7 @@ proof fn lemma_step_new_vm_space<'rcu>(tracked s: &mut VmStore<'rcu>)
     assert forall|idx: int|
         0 <= idx < max_meta_slots() implies #[trigger] s.regions.slots.contains_key(idx) || (
     s.regions.slot_owners[idx].usage is PageTable
-        && s.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED) by {
+        && s.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED) by {
         if idx == root_idx {
             // The extracted root is an active PageTable node (axiom).
         } else {
@@ -1767,7 +1769,7 @@ proof fn lemma_step_new_vm_space<'rcu>(tracked s: &mut VmStore<'rcu>)
                 // A changed non-root slot was pre-UNUSED (axiom) ⟹ by old
                 // coverage's contrapositive it was parked, and stays
                 // parked (only the root left `slots`).
-                assert(s_before.regions.slot_owners[idx].inner_perms.ref_count.value()
+                assert(s_before.regions.slot_owners[idx].ref_count()
                     == REF_COUNT_UNUSED);
                 assert(s_before.regions.slots.contains_key(idx));
             }
@@ -1896,7 +1898,7 @@ proof fn lemma_step_query<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId)
             assert forall|idx: int|
                 #![trigger s.regions.slot_owners[idx]]
                 0 <= idx < max_meta_slots()
-                    && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+                    && s.regions.slot_owners[idx].ref_count()
                     == REF_COUNT_UNUSED implies handle_count(s.frames, idx) == 0
                 && s.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
                 s.segments,
@@ -1918,8 +1920,8 @@ proof fn lemma_step_query<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId)
             assert forall|idx: int|
                 #![trigger s.regions.slot_owners[idx]]
                 0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
-                    && s.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-                    && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+                    && s.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
+                    && s.regions.slot_owners[idx].ref_count()
                     != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
                 || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
                 s.segments,
@@ -1939,39 +1941,39 @@ proof fn lemma_step_query<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId)
                 handle_count(s.frames, idx) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0
                     || segment_cover_count(s.segments, index_to_frame(idx)) > 0) implies {
                 let so = s.regions.slot_owners[idx];
-                let rc = so.inner_perms.ref_count.value();
+                let rc = so.ref_count();
                 &&& rc != REF_COUNT_UNUSED
                 &&& rc != REF_COUNT_UNIQUE
                 &&& rc == handle_count(s.frames, idx) + so.paths_in_pt.len() + segment_cover_count(
                     s.segments,
                     index_to_frame(idx),
                 )
-                &&& so.inner_perms.storage.is_init()
+                &&& so.storage_perm().is_init()
             } by {
                 lemma_handle_count_insert_fresh(old_frames, id, frame_entry, idx);
                 if idx == target_idx {
-                    if old_regions.slot_owners[target_idx].inner_perms.ref_count.value()
+                    if old_regions.slot_owners[target_idx].ref_count()
                         == REF_COUNT_UNUSED {
                         // Pre UNUSED at Frame slot: clause 1 ⟹ pre paths
                         // empty ∧ pre H == 0 ∧ pre cover == 0.
                         // Post H == 1, paths preserved, cover preserved.
                         // Post rc = pre rc + 1 = UNUSED + 1.
                         assert(REF_COUNT_UNUSED == 0u32);
-                        assert(s.regions.slot_owners[target_idx].inner_perms.ref_count.value()
+                        assert(s.regions.slot_owners[target_idx].ref_count()
                             == 1);
                         assert(handle_count(s.frames, target_idx) == 1);
                         assert(s.regions.slot_owners[target_idx].paths_in_pt.len()
                             == old_regions.slot_owners[target_idx].paths_in_pt.len());
                         assert(old_regions.slot_owners[target_idx].paths_in_pt.len() == 0);
                         assert(segment_cover_count(s.segments, index_to_frame(target_idx)) == 0);
-                    } else if old_regions.slot_owners[target_idx].inner_perms.ref_count.value()
+                    } else if old_regions.slot_owners[target_idx].ref_count()
                         == REF_COUNT_UNIQUE {
                         assert(false);
                     } else {
                         // Pre non-sentinel SHARED rc: pre clause 4 applies
                         // with the new cover term.
                         let pre_so = old_regions.slot_owners[target_idx];
-                        let pre_rc = pre_so.inner_perms.ref_count.value();
+                        let pre_rc = pre_so.ref_count();
                         let pre_paths = pre_so.paths_in_pt.len();
                         let pre_H = handle_count(old_frames, target_idx);
                         let pre_cover = segment_cover_count(s.segments, index_to_frame(target_idx));
@@ -2081,12 +2083,12 @@ proof fn lemma_step_map<'rcu>(
     assert(handle_count(old_frames, target_idx) >= 1);
     // Pre target_idx is usage == Frame (op_pre) and active head
     // (H >= 1), so pre `accounting_inv` clauses 3 and 4 apply.
-    let ghost pre_rc_target = old_regions.slot_owners[target_idx].inner_perms.ref_count.value();
+    let ghost pre_rc_target = old_regions.slot_owners[target_idx].ref_count();
     let ghost pre_paths_target = old_regions.slot_owners[target_idx].paths_in_pt.len();
     let ghost pre_cover_target = segment_cover_count(s.segments, index_to_frame(target_idx));
     assert(pre_rc_target != REF_COUNT_UNUSED && pre_rc_target != REF_COUNT_UNIQUE && pre_rc_target
         == handle_count(old_frames, target_idx) + pre_paths_target + pre_cover_target
-        && old_regions.slot_owners[target_idx].inner_perms.storage.is_init()) by {
+        && old_regions.slot_owners[target_idx].storage_perm().is_init()) by {
         reveal(VmStore::accounting_inv);
     };
     let tracked mut entry = s.tracked_extract_cursor(c);
@@ -2109,7 +2111,7 @@ proof fn lemma_step_map<'rcu>(
     // non-Frame (PT nodes). `s.segments` is unchanged across map.
     assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].ref_count()
             == REF_COUNT_UNUSED implies handle_count(s.frames, idx) == 0
         && s.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
         s.segments,
@@ -2122,15 +2124,15 @@ proof fn lemma_step_map<'rcu>(
         if idx == target_idx {
             // post-UNUSED at target_idx contradicts rc preserved at
             // target_idx + pre_rc_target != UNUSED.
-            assert(s.regions.slot_owners[idx].inner_perms.ref_count.value() == pre_rc_target);
+            assert(s.regions.slot_owners[idx].ref_count() == pre_rc_target);
             assert(false);
         }
     };
     assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
         0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
-            && s.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-            && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+            && s.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
+            && s.regions.slot_owners[idx].ref_count()
             != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
         || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
         s.segments,
@@ -2141,7 +2143,7 @@ proof fn lemma_step_map<'rcu>(
         if idx == target_idx {
             // post rc preserved at target_idx, paths += 1 ⟹ paths.len > 0.
             assert(s.regions.slot_owners[idx].paths_in_pt.len() == pre_paths_target + 1);
-        } else if old_regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNUSED {
+        } else if old_regions.slot_owners[idx].ref_count() == REF_COUNT_UNUSED {
             // Newly-non-UNUSED slot ⟹ usage != Frame (changed-slots clause).
             assert(s.regions.slot_owners[idx].usage !is Frame);
         } else {
@@ -2160,14 +2162,14 @@ proof fn lemma_step_map<'rcu>(
             index_to_frame(idx),
         ) > 0) implies {
         let so = s.regions.slot_owners[idx];
-        let rc = so.inner_perms.ref_count.value();
+        let rc = so.ref_count();
         &&& rc != REF_COUNT_UNUSED
         &&& rc != REF_COUNT_UNIQUE
         &&& rc == handle_count(s.frames, idx) + so.paths_in_pt.len() + segment_cover_count(
             s.segments,
             index_to_frame(idx),
         )
-        &&& so.inner_perms.storage.is_init()
+        &&& so.storage_perm().is_init()
     } by {
         reveal(VmStore::accounting_inv);
         lemma_handle_count_remove(old_frames, fid, idx);
@@ -2177,10 +2179,10 @@ proof fn lemma_step_map<'rcu>(
             //       P_post = P_pre + 1; cover_post = cover_pre.
             // So rc_post = pre_rc_target = H_pre + P_pre + cover_pre
             //                            = H_post + P_post + cover_post.
-            assert(s.regions.slot_owners[idx].inner_perms.ref_count.value() == pre_rc_target);
+            assert(s.regions.slot_owners[idx].ref_count() == pre_rc_target);
             assert(s.regions.slot_owners[idx].paths_in_pt.len() == pre_paths_target + 1);
             assert(handle_count(s.frames, idx) == (handle_count(old_frames, idx) - 1) as nat);
-        } else if old_regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNUSED {
+        } else if old_regions.slot_owners[idx].ref_count() == REF_COUNT_UNUSED {
             assert(s.regions.slot_owners[idx].usage !is Frame);
         } else {
             assert(s.regions.slot_owners[idx] == old_regions.slot_owners[idx]);
@@ -2215,7 +2217,7 @@ proof fn lemma_step_map<'rcu>(
                 |gid: FrameId| frame_to_index(old_frames[gid].paddr) == other_idx,
             ).contains(fid_other));
             assert(handle_count(old_frames, other_idx) >= 1);
-            assert(old_regions.slot_owners[other_idx].inner_perms.ref_count.value()
+            assert(old_regions.slot_owners[other_idx].ref_count()
                 != REF_COUNT_UNUSED);
             assert(s.regions.slot_owners[other_idx] == old_regions.slot_owners[other_idx]);
         }
@@ -2237,7 +2239,7 @@ proof fn lemma_step_map<'rcu>(
         // pre cover >= 1 at cov_idx ⟹ pre slot is Frame + non-UNUSED.
         lemma_segment_cover_contains(old_regions_segments_helper(s), sid, paddr_c);
         assert(old_regions.slot_owners[cov_idx].usage is Frame);
-        assert(old_regions.slot_owners[cov_idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED);
+        assert(old_regions.slot_owners[cov_idx].ref_count() != REF_COUNT_UNUSED);
         if cov_idx == target_idx {
             // Map preserves usage at target.
             assert(s.regions.slot_owners[target_idx].usage
@@ -2292,7 +2294,7 @@ proof fn lemma_step_unmap<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId, len:
     // with both monotonically non-increasing. `s.frames` is unchanged.
     assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].ref_count()
             == REF_COUNT_UNUSED implies handle_count(s.frames, idx) == 0
         && s.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
         s.segments,
@@ -2323,11 +2325,11 @@ proof fn lemma_step_unmap<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId, len:
                 // structural `covered ⟹ Frame` at the witness (old state).
                 assert(old_regions.slot_owners[idx].usage is Frame);
                 // active head (cover > 0 ∧ Frame) ⟹ pre rc != UNUSED, <= MAX.
-                assert(old_regions.slot_owners[idx].inner_perms.ref_count.value()
+                assert(old_regions.slot_owners[idx].ref_count()
                     != REF_COUNT_UNUSED);
-                assert(old_regions.slot_owners[idx].inner_perms.ref_count.value() <= REF_COUNT_MAX);
+                assert(old_regions.slot_owners[idx].ref_count() <= REF_COUNT_MAX);
                 // unmap (Frame): post rc <= pre rc <= MAX < UNUSED.
-                assert(s.regions.slot_owners[idx].inner_perms.ref_count.value() <= REF_COUNT_MAX);
+                assert(s.regions.slot_owners[idx].ref_count() <= REF_COUNT_MAX);
             }
         };
         // Case-split on pre.usage: usage is preserved by the axiom.
@@ -2370,8 +2372,8 @@ proof fn lemma_step_unmap<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId, len:
     assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
         0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
-            && s.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-            && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+            && s.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
+            && s.regions.slot_owners[idx].ref_count()
             != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
         || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
         s.segments,
@@ -2386,8 +2388,8 @@ proof fn lemma_step_unmap<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId, len:
         // ⟹ post paths == 0 ⟹ post rc == pre rc == UNUSED). So at
         // post non-UNUSED Frame slot, pre rc != UNUSED.
         assert(s.regions.contains(idx));
-        assert(old_regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED) by {
-            if old_regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNUSED {
+        assert(old_regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED) by {
+            if old_regions.slot_owners[idx].ref_count() == REF_COUNT_UNUSED {
                 // Trigger MetaSlotOwner::inv on pre at this idx.
                 assert(old_regions.contains(idx));
                 assert(old_regions.slot_owners[idx].paths_in_pt == Set::empty());
@@ -2422,14 +2424,14 @@ proof fn lemma_step_unmap<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId, len:
             idx,
         ) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0) implies {
         let so = s.regions.slot_owners[idx];
-        let rc = so.inner_perms.ref_count.value();
+        let rc = so.ref_count();
         &&& rc != REF_COUNT_UNUSED
         &&& rc != REF_COUNT_UNIQUE
         &&& rc == handle_count(s.frames, idx) + so.paths_in_pt.len() + segment_cover_count(
             s.segments,
             index_to_frame(idx),
         )
-        &&& so.inner_perms.storage.is_init()
+        &&& so.storage_perm().is_init()
     } by {
         // Post is active head. H unchanged ⟹ pre H == post H. Pre
         // usage == Frame (preserved). Either pre H > 0 (pre active head)
@@ -2481,32 +2483,32 @@ proof fn lemma_step_unmap<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId, len:
     assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
         let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
         &&& so.usage is Frame
-        &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
-        &&& so.inner_perms.in_list.value() == 0
+        &&& so.ref_count() == REF_COUNT_UNIQUE
+        &&& so.in_list_perm.value() == 0
         &&& so.paths_in_pt.is_empty()
     } by {
         let u_idx = frame_to_index(s.unique_frames[u].paddr);
         assert(old(s).unique_frames.dom().contains(u));
         // Old validity at `u`.
         assert(old_regions.slot_owners[u_idx].usage is Frame);
-        assert(old_regions.slot_owners[u_idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
+        assert(old_regions.slot_owners[u_idx].ref_count() == REF_COUNT_UNIQUE);
         assert(old_regions.slot_owners[u_idx].paths_in_pt.is_empty());
-        assert(old_regions.slot_owners[u_idx].inner_perms.in_list.value() == 0);
+        assert(old_regions.slot_owners[u_idx].in_list_perm.value() == 0);
         // `u_idx` is a managed slot.
         assert(valid_frame_paddr(s.unique_frames[u].paddr));
         s.regions.inv_implies_correct_addr(s.unique_frames[u].paddr);
         assert(s.regions.contains(u_idx));
         // usage / in_list preserved universally by the unmap axiom.
         assert(s.regions.slot_owners[u_idx].usage == old_regions.slot_owners[u_idx].usage);
-        assert(s.regions.slot_owners[u_idx].inner_perms.in_list
-            == old_regions.slot_owners[u_idx].inner_perms.in_list);
+        assert(s.regions.slot_owners[u_idx].in_list_perm
+            == old_regions.slot_owners[u_idx].in_list_perm);
         // Frame rc-paths invariant: pre paths empty ⟹ post paths empty,
         // post rc == pre rc == UNIQUE.
         assert(s.regions.slot_owners[u_idx].paths_in_pt.len()
             <= old_regions.slot_owners[u_idx].paths_in_pt.len());
         assert(old_regions.slot_owners[u_idx].paths_in_pt.len() == 0);
         assert(s.regions.slot_owners[u_idx].paths_in_pt =~= Set::empty());
-        assert(s.regions.slot_owners[u_idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
+        assert(s.regions.slot_owners[u_idx].ref_count() == REF_COUNT_UNIQUE);
     };
     s.lemma_insert_cursor(c, entry);
 }
@@ -2657,7 +2659,7 @@ proof fn lemma_step_frame_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, paddr
                 assert forall|idx: int|
                     #![trigger s.regions.slot_owners[idx]]
                     0 <= idx < max_meta_slots()
-                        && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+                        && s.regions.slot_owners[idx].ref_count()
                         == REF_COUNT_UNUSED implies handle_count(s.frames, idx) == 0
                     && s.regions.slot_owners[idx].paths_in_pt.is_empty() by {
                     lemma_handle_count_insert_fresh(old_frames, id, entry, idx);
@@ -2675,9 +2677,9 @@ proof fn lemma_step_frame_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, paddr
                 assert forall|idx: int|
                     #![trigger s.regions.slot_owners[idx]]
                     0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
-                        && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+                        && s.regions.slot_owners[idx].ref_count()
                         != REF_COUNT_UNUSED
-                        && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+                        && s.regions.slot_owners[idx].ref_count()
                         != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
                     || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
                     s.segments,
@@ -2698,16 +2700,16 @@ proof fn lemma_step_frame_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, paddr
                     handle_count(s.frames, idx) > 0 || s.regions.slot_owners[idx].paths_in_pt.len()
                         > 0 || segment_cover_count(s.segments, index_to_frame(idx)) > 0) implies {
                     let so = s.regions.slot_owners[idx];
-                    let rc = so.inner_perms.ref_count.value();
+                    let rc = so.ref_count();
                     &&& rc != REF_COUNT_UNUSED
                     &&& rc != REF_COUNT_UNIQUE
                     &&& rc == handle_count(s.frames, idx) + so.paths_in_pt.len()
                         + segment_cover_count(s.segments, index_to_frame(idx))
-                    &&& so.inner_perms.storage.is_init()
+                    &&& so.storage_perm().is_init()
                 } by {
                     lemma_handle_count_insert_fresh(old_frames, id, entry, idx);
                     if idx == target_idx {
-                        assert(old_regions.slot_owners[idx].inner_perms.ref_count.value()
+                        assert(old_regions.slot_owners[idx].ref_count()
                             == REF_COUNT_UNUSED);
                         assert(handle_count(old_frames, idx) == 0);
                         assert(handle_count(s.frames, idx) == 1);
@@ -2756,7 +2758,7 @@ proof fn lemma_step_frame_from_in_use<'rcu>(tracked s: &mut VmStore<'rcu>, paddr
                 assert forall|idx: int|
                     #![trigger s.regions.slot_owners[idx]]
                     0 <= idx < max_meta_slots()
-                        && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+                        && s.regions.slot_owners[idx].ref_count()
                         == REF_COUNT_UNUSED implies handle_count(s.frames, idx) == 0
                     && s.regions.slot_owners[idx].paths_in_pt.is_empty() by {
                     lemma_handle_count_insert_fresh(old_frames, id, entry, idx);
@@ -2772,9 +2774,9 @@ proof fn lemma_step_frame_from_in_use<'rcu>(tracked s: &mut VmStore<'rcu>, paddr
                 assert forall|idx: int|
                     #![trigger s.regions.slot_owners[idx]]
                     0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
-                        && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+                        && s.regions.slot_owners[idx].ref_count()
                         != REF_COUNT_UNUSED
-                        && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+                        && s.regions.slot_owners[idx].ref_count()
                         != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
                     || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
                     s.segments,
@@ -2795,12 +2797,12 @@ proof fn lemma_step_frame_from_in_use<'rcu>(tracked s: &mut VmStore<'rcu>, paddr
                     handle_count(s.frames, idx) > 0 || s.regions.slot_owners[idx].paths_in_pt.len()
                         > 0 || segment_cover_count(s.segments, index_to_frame(idx)) > 0) implies {
                     let so = s.regions.slot_owners[idx];
-                    let rc = so.inner_perms.ref_count.value();
+                    let rc = so.ref_count();
                     &&& rc != REF_COUNT_UNUSED
                     &&& rc != REF_COUNT_UNIQUE
                     &&& rc == handle_count(s.frames, idx) + so.paths_in_pt.len()
                         + segment_cover_count(s.segments, index_to_frame(idx))
-                    &&& so.inner_perms.storage.is_init()
+                    &&& so.storage_perm().is_init()
                 } by {
                     lemma_handle_count_insert_fresh(old_frames, id, entry, idx);
                     if idx == target_idx {
@@ -2862,7 +2864,7 @@ proof fn lemma_step_frame_drop<'rcu>(tracked s: &mut VmStore<'rcu>, fid: FrameId
     // ⟹ post H==0 (fid removed) and post paths == pre paths == empty.
     assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].ref_count()
             == REF_COUNT_UNUSED implies handle_count(s.frames, idx) == 0
         && s.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
         s.segments,
@@ -2871,7 +2873,7 @@ proof fn lemma_step_frame_drop<'rcu>(tracked s: &mut VmStore<'rcu>, fid: FrameId
         lemma_handle_count_remove(old_frames, fid, idx);
         if idx == target_idx {
             // Post rc==UNUSED ⟹ pre rc was 1 (drop_step rc transition).
-            assert(old_regions.slot_owners[idx].inner_perms.ref_count.value() == 1);
+            assert(old_regions.slot_owners[idx].ref_count() == 1);
             // Old handle clause: pre rc (== 1) >= pre handle_count, and
             // `fid` contributes ⟹ pre handle_count == 1 ⟹ post == 0.
             assert(handle_count(old_frames, idx) == 1);
@@ -2890,8 +2892,8 @@ proof fn lemma_step_frame_drop<'rcu>(tracked s: &mut VmStore<'rcu>, fid: FrameId
     assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
         0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
-            && s.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-            && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+            && s.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
+            && s.regions.slot_owners[idx].ref_count()
             != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
         || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
         s.segments,
@@ -2919,14 +2921,14 @@ proof fn lemma_step_frame_drop<'rcu>(tracked s: &mut VmStore<'rcu>, fid: FrameId
             index_to_frame(idx),
         ) > 0) implies {
         let so = s.regions.slot_owners[idx];
-        let rc = so.inner_perms.ref_count.value();
+        let rc = so.ref_count();
         &&& rc != REF_COUNT_UNUSED
         &&& rc != REF_COUNT_UNIQUE
         &&& rc == handle_count(s.frames, idx) + so.paths_in_pt.len() + segment_cover_count(
             s.segments,
             index_to_frame(idx),
         )
-        &&& so.inner_perms.storage.is_init()
+        &&& so.storage_perm().is_init()
     } by {
         lemma_handle_count_remove(old_frames, fid, idx);
         if idx == target_idx {
@@ -2935,7 +2937,7 @@ proof fn lemma_step_frame_drop<'rcu>(tracked s: &mut VmStore<'rcu>, fid: FrameId
             // and the clause antecedent gives post `usage == Frame`.
             assert(old_regions.slot_owners[idx].usage is Frame);
             assert(handle_count(old_frames, idx) > 0);
-            let ghost pre_rc = old_regions.slot_owners[idx].inner_perms.ref_count.value();
+            let ghost pre_rc = old_regions.slot_owners[idx].ref_count();
             let ghost pre_h = handle_count(old_frames, idx);
             let ghost pre_p = old_regions.slot_owners[idx].paths_in_pt.len();
             assert(pre_rc == pre_h + pre_p);
@@ -2945,13 +2947,13 @@ proof fn lemma_step_frame_drop<'rcu>(tracked s: &mut VmStore<'rcu>, fid: FrameId
             // drop_step now exposes paths preservation at idx.
             let ghost post_p = s.regions.slot_owners[idx].paths_in_pt.len();
             assert(post_p == pre_p);
-            let ghost post_rc = s.regions.slot_owners[idx].inner_perms.ref_count.value();
+            let ghost post_rc = s.regions.slot_owners[idx].ref_count();
             if pre_rc > 1 {
                 // drop_step rc>1 branch: post rc = pre - 1, storage preserved.
                 assert(post_rc == (pre_rc - 1) as u64);
                 assert(post_rc as nat == post_h + post_p);
-                assert(s.regions.slot_owners[idx].inner_perms.storage
-                    == old_regions.slot_owners[idx].inner_perms.storage);
+                assert(s.regions.slot_owners[idx].storage_perm()
+                    == old_regions.slot_owners[idx].storage_perm());
             } else {
                 // pre_rc == 1: pre eqn 1 == pre_h + pre_p with
                 // pre_h >= 1 forces pre_h = 1, pre_p = 0.
@@ -3008,9 +3010,9 @@ proof fn lemma_step_segment_from_unused_accounting<'rcu>(
                 let idx = frame_to_index(paddr);
                 let so = s_after.regions.slot_owners[idx];
                 &&& so.usage is Frame
-                &&& so.inner_perms.ref_count.value() == 1
+                &&& so.ref_count() == 1
                 &&& so.paths_in_pt.is_empty()
-                &&& so.inner_perms.storage.is_init()
+                &&& so.storage_perm().is_init()
             },
         // Outside-range slots are fully preserved by the allocation axiom.
         forall|i: int|
@@ -3023,7 +3025,7 @@ proof fn lemma_step_segment_from_unused_accounting<'rcu>(
             (range.start <= paddr < range.end && paddr % PAGE_SIZE == 0)
                 ==> old_store.regions.slot_owners[frame_to_index(
                 paddr,
-            )].inner_perms.ref_count.value() == REF_COUNT_UNUSED,
+            )].ref_count() == REF_COUNT_UNUSED,
     ensures
         s_after.accounting_inv(),
 {
@@ -3033,7 +3035,7 @@ proof fn lemma_step_segment_from_unused_accounting<'rcu>(
     assert forall|idx: int|
         #![trigger s_after.regions.slot_owners[idx]]
         0 <= idx < max_meta_slots()
-            && s_after.regions.slot_owners[idx].inner_perms.ref_count.value()
+            && s_after.regions.slot_owners[idx].ref_count()
             == REF_COUNT_UNUSED implies handle_count(s_after.frames, idx) == 0
         && s_after.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
         s_after.segments,
@@ -3049,8 +3051,8 @@ proof fn lemma_step_segment_from_unused_accounting<'rcu>(
     assert forall|idx: int|
         #![trigger s_after.regions.slot_owners[idx]]
         0 <= idx < max_meta_slots() && s_after.regions.slot_owners[idx].usage is Frame
-            && s_after.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-            && s_after.regions.slot_owners[idx].inner_perms.ref_count.value()
+            && s_after.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
+            && s_after.regions.slot_owners[idx].ref_count()
             != REF_COUNT_UNIQUE implies handle_count(s_after.frames, idx) > 0
         || s_after.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
         s_after.segments,
@@ -3069,14 +3071,14 @@ proof fn lemma_step_segment_from_unused_accounting<'rcu>(
         handle_count(s_after.frames, idx) > 0 || s_after.regions.slot_owners[idx].paths_in_pt.len()
             > 0 || segment_cover_count(s_after.segments, index_to_frame(idx)) > 0) implies {
         let so = s_after.regions.slot_owners[idx];
-        let rc = so.inner_perms.ref_count.value();
+        let rc = so.ref_count();
         &&& rc != REF_COUNT_UNUSED
         &&& rc != REF_COUNT_UNIQUE
         &&& rc == handle_count(s_after.frames, idx) + so.paths_in_pt.len() + segment_cover_count(
             s_after.segments,
             index_to_frame(idx),
         )
-        &&& so.inner_perms.storage.is_init()
+        &&& so.storage_perm().is_init()
     } by {
         let paddr = index_to_frame(idx);
         if range.start <= paddr < range.end {
@@ -3111,7 +3113,7 @@ proof fn lemma_step_segment_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, ran
         && range.end <= MAX_PADDR && (forall|paddr: Paddr|
         #![trigger frame_to_index(paddr)]
         (range.start <= paddr < range.end && paddr % PAGE_SIZE == 0)
-            ==> s.regions.slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
+            ==> s.regions.slot_owners[frame_to_index(paddr)].ref_count()
             == REF_COUNT_UNUSED) {
         let ghost s_before = *s;
         let ghost old_regions = s.regions;
@@ -3151,7 +3153,7 @@ proof fn lemma_accounting_inv_intro<'rcu>(store: VmStore<'rcu>)
         forall|idx: int|
             #![trigger store.regions.slot_owners[idx]]
             0 <= idx < max_meta_slots()
-                && store.regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNUSED
+                && store.regions.slot_owners[idx].ref_count() == REF_COUNT_UNUSED
                 ==> handle_count(store.frames, idx) == 0
                 && store.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
                 store.segments,
@@ -3160,8 +3162,8 @@ proof fn lemma_accounting_inv_intro<'rcu>(store: VmStore<'rcu>)
         forall|idx: int|
             #![trigger store.regions.slot_owners[idx]]
             0 <= idx < max_meta_slots() && store.regions.slot_owners[idx].usage is Frame
-                && store.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-                && store.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNIQUE
+                && store.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
+                && store.regions.slot_owners[idx].ref_count() != REF_COUNT_UNIQUE
                 ==> handle_count(store.frames, idx) > 0
                 || store.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
                 store.segments,
@@ -3173,12 +3175,12 @@ proof fn lemma_accounting_inv_intro<'rcu>(store: VmStore<'rcu>)
             handle_count(store.frames, idx) > 0 || store.regions.slot_owners[idx].paths_in_pt.len()
                 > 0 || segment_cover_count(store.segments, index_to_frame(idx)) > 0) ==> {
                 let so = store.regions.slot_owners[idx];
-                let rc = so.inner_perms.ref_count.value();
+                let rc = so.ref_count();
                 &&& rc != REF_COUNT_UNUSED
                 &&& rc != REF_COUNT_UNIQUE
                 &&& rc == handle_count(store.frames, idx) + so.paths_in_pt.len()
                     + segment_cover_count(store.segments, index_to_frame(idx))
-                &&& so.inner_perms.storage.is_init()
+                &&& so.storage_perm().is_init()
             },
     ensures
         store.accounting_inv(),
@@ -3207,19 +3209,19 @@ proof fn lemma_drop_segment_with_store_inv<'rcu>(
                 let idx = frame_to_index(paddr);
                 let so_old = old(regions).slot_owners[idx];
                 let so_new = final(regions).slot_owners[idx];
-                &&& so_old.inner_perms.ref_count.value() >= 1
-                &&& so_old.inner_perms.ref_count.value() <= REF_COUNT_MAX
+                &&& so_old.ref_count() >= 1
+                &&& so_old.ref_count() <= REF_COUNT_MAX
                 &&& so_old.usage is Frame
-                &&& so_old.inner_perms.ref_count.value() == 1 ==> so_old.paths_in_pt.is_empty()
+                &&& so_old.ref_count() == 1 ==> so_old.paths_in_pt.is_empty()
                 &&& so_new.usage == so_old.usage
                 &&& so_new.paths_in_pt == so_old.paths_in_pt
                 &&& so_new.slot_vaddr == so_old.slot_vaddr
-                &&& so_new.inner_perms.in_list == so_old.inner_perms.in_list
-                &&& so_old.inner_perms.ref_count.value() == 1
-                    ==> so_new.inner_perms.ref_count.value() == REF_COUNT_UNUSED
-                &&& so_old.inner_perms.ref_count.value() > 1
-                    ==> so_new.inner_perms.ref_count.value() == (
-                so_old.inner_perms.ref_count.value() - 1) as u64
+                &&& so_new.in_list_perm == so_old.in_list_perm
+                &&& so_old.ref_count() == 1
+                    ==> so_new.ref_count() == REF_COUNT_UNUSED
+                &&& so_old.ref_count() > 1
+                    ==> so_new.ref_count() == (
+                so_old.ref_count() - 1) as u64
             },
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
@@ -3254,17 +3256,17 @@ proof fn lemma_drop_segment_with_store_inv<'rcu>(
         #![trigger store.regions.slot_owners[frame_to_index(paddr)]]
         (entry.range.start <= paddr < entry.range.end && paddr % PAGE_SIZE == 0) implies {
         let so = store.regions.slot_owners[frame_to_index(paddr)];
-        &&& so.inner_perms.ref_count.value() >= 1
-        &&& so.inner_perms.ref_count.value() <= REF_COUNT_MAX
+        &&& so.ref_count() >= 1
+        &&& so.ref_count() <= REF_COUNT_MAX
         &&& so.usage is Frame
-        &&& so.inner_perms.ref_count.value() == 1 ==> so.paths_in_pt.is_empty()
+        &&& so.ref_count() == 1 ==> so.paths_in_pt.is_empty()
     } by {
         reveal(VmStore::structural_inv);
         reveal(VmStore::accounting_inv);
         let idx = frame_to_index(paddr);
         lemma_segment_cover_contains(store.segments, sid, paddr);
         let so = store.regions.slot_owners[idx];
-        let rc = so.inner_perms.ref_count.value();
+        let rc = so.ref_count();
         assert(store.regions.contains(idx));
         if rc == 1 {
             assert(handle_count(store.frames, idx) + so.paths_in_pt.len() + segment_cover_count(
@@ -3289,6 +3291,8 @@ proof fn lemma_step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: Segme
     ensures
         final(s).inv(),
 {
+    hide(MetaSlotOwner::storage_perm);
+    hide(MetaSlotOwner::vtable_ptr_perm);
     hide(VmStore::inv);
     hide(VmStore::structural_inv);
     hide(VmStore::accounting_inv);
@@ -3331,7 +3335,7 @@ proof fn lemma_step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: Segme
 
     assert forall|idx: int|
         0 <= idx
-            < max_meta_slots() implies #[trigger] s.regions.slot_owners[idx].inner_perms.in_list.value()
+            < max_meta_slots() implies #[trigger] s.regions.slot_owners[idx].in_list_perm.value()
         == 0 by {
         reveal(VmStore::structural_inv);
         let paddr = index_to_frame(idx);
@@ -3347,7 +3351,7 @@ proof fn lemma_step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: Segme
     // Discharge accounting_inv clauses.
     assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].ref_count()
             == REF_COUNT_UNUSED implies handle_count(s.frames, idx) == 0
         && s.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
         s.segments,
@@ -3367,7 +3371,7 @@ proof fn lemma_step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: Segme
             // post cover == 0.
             lemma_segment_cover_contains(old_segments, sid, paddr);
             lemma_segment_cover_remove_inside(old_segments, sid, paddr);
-            assert(old_regions.slot_owners[idx].inner_perms.ref_count.value() == 1);
+            assert(old_regions.slot_owners[idx].ref_count() == 1);
             assert(handle_count(old_frames, idx) == 0);
             assert(s.regions.slot_owners[idx].paths_in_pt == Set::empty());
         } else {
@@ -3380,8 +3384,8 @@ proof fn lemma_step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: Segme
     assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
         0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
-            && s.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-            && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+            && s.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
+            && s.regions.slot_owners[idx].ref_count()
             != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
         || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
         s.segments,
@@ -3415,14 +3419,14 @@ proof fn lemma_step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: Segme
             index_to_frame(idx),
         ) > 0) implies {
         let so = s.regions.slot_owners[idx];
-        let rc = so.inner_perms.ref_count.value();
+        let rc = so.ref_count();
         &&& rc != REF_COUNT_UNUSED
         &&& rc != REF_COUNT_UNIQUE
         &&& rc == handle_count(s.frames, idx) + so.paths_in_pt.len() + segment_cover_count(
             s.segments,
             index_to_frame(idx),
         )
-        &&& so.inner_perms.storage.is_init()
+        &&& so.storage_perm().is_init()
     } by {
         reveal(VmStore::accounting_inv);
         let paddr = index_to_frame(idx);
@@ -3433,13 +3437,13 @@ proof fn lemma_step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: Segme
             lemma_segment_cover_contains(old_segments, sid, paddr);
             lemma_segment_cover_remove_inside(old_segments, sid, paddr);
             // Pre eq: pre rc == pre H + pre P + pre cover.
-            let pre_rc = old_regions.slot_owners[idx].inner_perms.ref_count.value();
+            let pre_rc = old_regions.slot_owners[idx].ref_count();
             let pre_H = handle_count(old_frames, idx);
             let pre_P = old_regions.slot_owners[idx].paths_in_pt.len();
             let pre_cover = segment_cover_count(old_segments, paddr);
             assert(pre_rc == pre_H + pre_P + pre_cover);
             assert(pre_rc != REF_COUNT_UNIQUE);
-            let post_rc = s.regions.slot_owners[idx].inner_perms.ref_count.value();
+            let post_rc = s.regions.slot_owners[idx].ref_count();
             assert(post_rc != REF_COUNT_UNUSED);
             assert(pre_rc > 1) by {
                 if pre_rc == 1 {
@@ -3455,7 +3459,7 @@ proof fn lemma_step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: Segme
             // storage.is_init at post: post rc ∈ SHARED (1 <= post rc <= MAX)
             // ⟹ MetaSlotOwner::inv SHARED branch ⟹ storage.is_init.
             assert(s.regions.contains(idx));
-            assert(s.regions.slot_owners[idx].inner_perms.storage.is_init());
+            assert(s.regions.slot_owners[idx].storage_perm().is_init());
         } else {
             assert(s.regions.slot_owners[idx] == old_regions.slot_owners[idx]);
             assert(!(entry.range.start <= paddr < entry.range.end));
@@ -3482,7 +3486,7 @@ proof fn lemma_step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: Segme
         ).contains(fid_other));
         assert(handle_count(old_frames, other_idx) >= 1);
         // Pre clause 4: pre rc == H + P + cover ≥ 1 ⟹ rc != UNUSED.
-        assert(old_regions.slot_owners[other_idx].inner_perms.ref_count.value() >= 1);
+        assert(old_regions.slot_owners[other_idx].ref_count() >= 1);
         // Axiom preserves usage (universal).
         if range.start <= other_paddr < range.end {
             // In-range: usage preserved by axiom.
@@ -3519,8 +3523,8 @@ proof fn lemma_step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: Segme
     assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
         let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
         &&& so.usage is Frame
-        &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
-        &&& so.inner_perms.in_list.value() == 0
+        &&& so.ref_count() == REF_COUNT_UNIQUE
+        &&& so.in_list_perm.value() == 0
         &&& so.paths_in_pt.is_empty()
     } by {
         reveal(VmStore::structural_inv);
@@ -3531,7 +3535,7 @@ proof fn lemma_step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: Segme
         assert(valid_frame_paddr(u_paddr));
         s.regions.inv_implies_correct_addr(u_paddr);
         // Old UNIQUE validity at `u`.
-        assert(old_regions.slot_owners[u_idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
+        assert(old_regions.slot_owners[u_idx].ref_count() == REF_COUNT_UNIQUE);
         assert(old_regions.slot_owners[u_idx].usage is Frame);
         // UNIQUE ⟹ uncovered ⟹ not in the dropped segment's range.
         assert(!(range.start <= u_paddr < range.end)) by {
@@ -3652,7 +3656,7 @@ proof fn lemma_step_segment_split<'rcu>(
     // per-paddr via lemma_segment_cover_split.
     assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].ref_count()
             == REF_COUNT_UNUSED implies handle_count(s.frames, idx) == 0
         && s.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
         s.segments,
@@ -3674,8 +3678,8 @@ proof fn lemma_step_segment_split<'rcu>(
     assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
         0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
-            && s.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-            && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+            && s.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
+            && s.regions.slot_owners[idx].ref_count()
             != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
         || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
         s.segments,
@@ -3704,14 +3708,14 @@ proof fn lemma_step_segment_split<'rcu>(
             index_to_frame(idx),
         ) > 0) implies {
         let so = s.regions.slot_owners[idx];
-        let rc = so.inner_perms.ref_count.value();
+        let rc = so.ref_count();
         &&& rc != REF_COUNT_UNUSED
         &&& rc != REF_COUNT_UNIQUE
         &&& rc == handle_count(s.frames, idx) + so.paths_in_pt.len() + segment_cover_count(
             s.segments,
             index_to_frame(idx),
         )
-        &&& so.inner_perms.storage.is_init()
+        &&& so.storage_perm().is_init()
     } by {
         let paddr = index_to_frame(idx);
         assert(paddr == (idx * PAGE_SIZE) as usize);
@@ -3779,7 +3783,7 @@ proof fn lemma_step_segment_next<'rcu>(tracked s: &mut VmStore<'rcu>, sid: Segme
     assert(segment_cover_count(old_segments, paddr) >= 1);
     assert(old_regions.slot_owners[target_idx].usage is Frame);
     let ghost so_pre = old_regions.slot_owners[target_idx];
-    let ghost pre_rc = so_pre.inner_perms.ref_count.value();
+    let ghost pre_rc = so_pre.ref_count();
     let ghost pre_H = handle_count(old_frames, target_idx);
     let ghost pre_P = so_pre.paths_in_pt.len();
     let ghost pre_cover = segment_cover_count(old_segments, paddr);
@@ -3848,7 +3852,7 @@ proof fn lemma_step_segment_next<'rcu>(tracked s: &mut VmStore<'rcu>, sid: Segme
     // Structural in_list == 0.
     assert forall|idx: int|
         0 <= idx
-            < max_meta_slots() implies #[trigger] s.regions.slot_owners[idx].inner_perms.in_list.value()
+            < max_meta_slots() implies #[trigger] s.regions.slot_owners[idx].in_list_perm.value()
         == 0 by {
         let paddr_c = index_to_frame(idx);
         assert(paddr_c == (idx * PAGE_SIZE) as usize);
@@ -3904,7 +3908,7 @@ proof fn lemma_step_segment_next<'rcu>(tracked s: &mut VmStore<'rcu>, sid: Segme
 
     assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].ref_count()
             == REF_COUNT_UNUSED implies handle_count(s.frames, idx) == 0
         && s.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
         s.segments,
@@ -3924,8 +3928,8 @@ proof fn lemma_step_segment_next<'rcu>(tracked s: &mut VmStore<'rcu>, sid: Segme
     assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
         0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
-            && s.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-            && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+            && s.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
+            && s.regions.slot_owners[idx].ref_count()
             != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
         || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
         s.segments,
@@ -3952,14 +3956,14 @@ proof fn lemma_step_segment_next<'rcu>(tracked s: &mut VmStore<'rcu>, sid: Segme
             index_to_frame(idx),
         ) > 0) implies {
         let so = s.regions.slot_owners[idx];
-        let rc = so.inner_perms.ref_count.value();
+        let rc = so.ref_count();
         &&& rc != REF_COUNT_UNUSED
         &&& rc != REF_COUNT_UNIQUE
         &&& rc == handle_count(s.frames, idx) + so.paths_in_pt.len() + segment_cover_count(
             s.segments,
             index_to_frame(idx),
         )
-        &&& so.inner_perms.storage.is_init()
+        &&& so.storage_perm().is_init()
     } by {
         let paddr_c = index_to_frame(idx);
         assert(paddr_c == (idx * PAGE_SIZE) as usize);
@@ -3980,8 +3984,8 @@ proof fn lemma_step_segment_next<'rcu>(tracked s: &mut VmStore<'rcu>, sid: Segme
     assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
         let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
         &&& so.usage is Frame
-        &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
-        &&& so.inner_perms.in_list.value() == 0
+        &&& so.ref_count() == REF_COUNT_UNIQUE
+        &&& so.in_list_perm.value() == 0
         &&& so.paths_in_pt.is_empty()
     } by {
         let u_paddr = s.unique_frames[u].paddr;
@@ -3989,7 +3993,7 @@ proof fn lemma_step_segment_next<'rcu>(tracked s: &mut VmStore<'rcu>, sid: Segme
         assert(old(s).unique_frames.dom().contains(u));
         assert(valid_frame_paddr(u_paddr));
         s.regions.inv_implies_correct_addr(u_paddr);
-        assert(old_regions.slot_owners[u_idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
+        assert(old_regions.slot_owners[u_idx].ref_count() == REF_COUNT_UNIQUE);
         assert(old_regions.slot_owners[u_idx].usage is Frame);
         // The popped front slot is covered ⟹ rc != UNIQUE ⟹ != u_idx.
         assert(u_idx != target_idx) by {
@@ -4018,7 +4022,7 @@ proof fn lemma_step_segment_clone_range<'rcu>(
             #![trigger frame_to_index(paddr)]
             (sub_range.start <= paddr < sub_range.end && paddr % PAGE_SIZE == 0) ==> old(
                 s,
-            ).regions.slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() + 1
+            ).regions.slot_owners[frame_to_index(paddr)].ref_count() + 1
                 <= REF_COUNT_MAX,
     ensures
         final(s).inv(),
@@ -4060,8 +4064,8 @@ proof fn lemma_step_segment_clone_range<'rcu>(
         (sub_range.start <= paddr < sub_range.end && paddr % PAGE_SIZE == 0) implies {
         let so = old_regions.slot_owners[frame_to_index(paddr)];
         &&& so.usage is Frame
-        &&& so.inner_perms.ref_count.value() >= 1
-        &&& so.inner_perms.ref_count.value() + 1 <= REF_COUNT_MAX
+        &&& so.ref_count() >= 1
+        &&& so.ref_count() + 1 <= REF_COUNT_MAX
     } by {
         reveal(VmStore::structural_inv);
         reveal(VmStore::accounting_inv);
@@ -4119,7 +4123,7 @@ proof fn lemma_step_segment_clone_range<'rcu>(
     // `in_list == 0` at every slot (preserved by the axiom both ways).
     assert forall|idx: int|
         0 <= idx
-            < max_meta_slots() implies #[trigger] s.regions.slot_owners[idx].inner_perms.in_list.value()
+            < max_meta_slots() implies #[trigger] s.regions.slot_owners[idx].in_list_perm.value()
         == 0 by {
         reveal(VmStore::structural_inv);
         let aligned = index_to_frame(idx);
@@ -4181,7 +4185,7 @@ proof fn lemma_step_segment_clone_range<'rcu>(
     // --- accounting clause 1: UNUSED ⟹ no users ---
     assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
-        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+        0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].ref_count()
             == REF_COUNT_UNUSED implies handle_count(s.frames, idx) == 0
         && s.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
         s.segments,
@@ -4202,8 +4206,8 @@ proof fn lemma_step_segment_clone_range<'rcu>(
     assert forall|idx: int|
         #![trigger s.regions.slot_owners[idx]]
         0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
-            && s.regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-            && s.regions.slot_owners[idx].inner_perms.ref_count.value()
+            && s.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
+            && s.regions.slot_owners[idx].ref_count()
             != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
         || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
         s.segments,
@@ -4230,14 +4234,14 @@ proof fn lemma_step_segment_clone_range<'rcu>(
             index_to_frame(idx),
         ) > 0) implies {
         let so = s.regions.slot_owners[idx];
-        let rc = so.inner_perms.ref_count.value();
+        let rc = so.ref_count();
         &&& rc != REF_COUNT_UNUSED
         &&& rc != REF_COUNT_UNIQUE
         &&& rc == handle_count(s.frames, idx) + so.paths_in_pt.len() + segment_cover_count(
             s.segments,
             index_to_frame(idx),
         )
-        &&& so.inner_perms.storage.is_init()
+        &&& so.storage_perm().is_init()
     } by {
         reveal(VmStore::accounting_inv);
         let aligned = index_to_frame(idx);
@@ -4257,8 +4261,8 @@ proof fn lemma_step_segment_clone_range<'rcu>(
     assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
         let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
         &&& so.usage is Frame
-        &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
-        &&& so.inner_perms.in_list.value() == 0
+        &&& so.ref_count() == REF_COUNT_UNIQUE
+        &&& so.in_list_perm.value() == 0
         &&& so.paths_in_pt.is_empty()
     } by {
         reveal(VmStore::structural_inv);
@@ -4268,7 +4272,7 @@ proof fn lemma_step_segment_clone_range<'rcu>(
         assert(old(s).unique_frames.dom().contains(u));
         assert(valid_frame_paddr(u_paddr));
         s.regions.inv_implies_correct_addr(u_paddr);
-        assert(old_regions.slot_owners[u_idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
+        assert(old_regions.slot_owners[u_idx].ref_count() == REF_COUNT_UNIQUE);
         assert(old_regions.slot_owners[u_idx].usage is Frame);
         assert(!(sub_range.start <= u_paddr < sub_range.end)) by {
             if sub_range.start <= u_paddr < sub_range.end {
@@ -4300,7 +4304,7 @@ proof fn lemma_step_segment_clone<'rcu>(tracked s: &mut VmStore<'rcu>, sid: Segm
             (old(s).segments[sid].range.start <= paddr < old(s).segments[sid].range.end && paddr
                 % PAGE_SIZE == 0) ==> old(s).regions.slot_owners[frame_to_index(
                 paddr,
-            )].inner_perms.ref_count.value() + 1 <= REF_COUNT_MAX,
+            )].ref_count() + 1 <= REF_COUNT_MAX,
     ensures
         final(s).inv(),
 {
@@ -4334,7 +4338,7 @@ proof fn lemma_step_segment_slice<'rcu>(
             #![trigger frame_to_index(paddr)]
             (sub_range.start <= paddr < sub_range.end && paddr % PAGE_SIZE == 0) ==> old(
                 s,
-            ).regions.slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() + 1
+            ).regions.slot_owners[frame_to_index(paddr)].ref_count() + 1
                 <= REF_COUNT_MAX,
     ensures
         final(s).inv(),
@@ -4353,7 +4357,7 @@ proof fn lemma_step_unique_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, padd
     // frame slot; only the success branch mutates the store.
     if valid_frame_paddr(paddr) && s.regions.slots.contains_key(frame_to_index(paddr))
         && s.regions.slot_owners[frame_to_index(paddr)].usage is Unused
-        && s.regions.slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
+        && s.regions.slot_owners[frame_to_index(paddr)].ref_count()
         == REF_COUNT_UNUSED {
         let ghost old_regions = s.regions;
         let ghost old_frames = s.frames;
@@ -4386,7 +4390,7 @@ proof fn lemma_step_unique_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, padd
         // --- structural: in_list == 0 everywhere ---
         assert forall|i: int|
             0 <= i
-                < max_meta_slots() implies #[trigger] s.regions.slot_owners[i].inner_perms.in_list.value()
+                < max_meta_slots() implies #[trigger] s.regions.slot_owners[i].in_list_perm.value()
             == 0 by {
             if i != idx {
                 assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
@@ -4422,8 +4426,8 @@ proof fn lemma_step_unique_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, padd
         assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
             let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
             &&& so.usage is Frame
-            &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
-            &&& so.inner_perms.in_list.value() == 0
+            &&& so.ref_count() == REF_COUNT_UNIQUE
+            &&& so.in_list_perm.value() == 0
             &&& so.paths_in_pt.is_empty()
         } by {
             let u_idx = frame_to_index(s.unique_frames[u].paddr);
@@ -4433,7 +4437,7 @@ proof fn lemma_step_unique_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, padd
             } else {
                 assert(old_unique.dom().contains(u));
                 assert(s.unique_frames[u] == old_unique[u]);
-                assert(old_regions.slot_owners[u_idx].inner_perms.ref_count.value()
+                assert(old_regions.slot_owners[u_idx].ref_count()
                     == REF_COUNT_UNIQUE);
                 assert(u_idx != idx);
                 assert(s.regions.slot_owners[u_idx] == old_regions.slot_owners[u_idx]);
@@ -4457,14 +4461,14 @@ proof fn lemma_step_unique_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, padd
                 assert(old_unique.dom().contains(u2));
                 assert(s.unique_frames[u2].paddr == paddr);
                 assert(frame_to_index(s.unique_frames[u2].paddr) == idx);
-                assert(old_regions.slot_owners[idx].inner_perms.ref_count.value()
+                assert(old_regions.slot_owners[idx].ref_count()
                     == REF_COUNT_UNIQUE);
                 assert(false);
             } else if u2 == uid && u1 != uid {
                 assert(old_unique.dom().contains(u1));
                 assert(s.unique_frames[u1].paddr == paddr);
                 assert(frame_to_index(s.unique_frames[u1].paddr) == idx);
-                assert(old_regions.slot_owners[idx].inner_perms.ref_count.value()
+                assert(old_regions.slot_owners[idx].ref_count()
                     == REF_COUNT_UNIQUE);
                 assert(false);
             } else if u1 != uid && u2 != uid {
@@ -4476,7 +4480,7 @@ proof fn lemma_step_unique_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, padd
         // --- accounting clause 1: UNUSED ⟹ no users ---
         assert forall|i: int|
             #![trigger s.regions.slot_owners[i]]
-            0 <= i < max_meta_slots() && s.regions.slot_owners[i].inner_perms.ref_count.value()
+            0 <= i < max_meta_slots() && s.regions.slot_owners[i].ref_count()
                 == REF_COUNT_UNUSED implies handle_count(s.frames, i) == 0
             && s.regions.slot_owners[i].paths_in_pt.is_empty() && segment_cover_count(
             s.segments,
@@ -4493,8 +4497,8 @@ proof fn lemma_step_unique_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, padd
         assert forall|i: int|
             #![trigger s.regions.slot_owners[i]]
             0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage is Frame
-                && s.regions.slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-                && s.regions.slot_owners[i].inner_perms.ref_count.value()
+                && s.regions.slot_owners[i].ref_count() != REF_COUNT_UNUSED
+                && s.regions.slot_owners[i].ref_count()
                 != REF_COUNT_UNIQUE implies handle_count(s.frames, i) > 0
             || s.regions.slot_owners[i].paths_in_pt.len() > 0 || segment_cover_count(
             s.segments,
@@ -4518,14 +4522,14 @@ proof fn lemma_step_unique_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, padd
                 index_to_frame(i),
             ) > 0) implies {
             let so = s.regions.slot_owners[i];
-            let rc = so.inner_perms.ref_count.value();
+            let rc = so.ref_count();
             &&& rc != REF_COUNT_UNUSED
             &&& rc != REF_COUNT_UNIQUE
             &&& rc == handle_count(s.frames, i) + so.paths_in_pt.len() + segment_cover_count(
                 s.segments,
                 index_to_frame(i),
             )
-            &&& so.inner_perms.storage.is_init()
+            &&& so.storage_perm().is_init()
         } by {
             if i == idx {
                 // `idx` is now UNIQUE with no users (H=P=cover=0) — the
@@ -4568,23 +4572,23 @@ proof fn lemma_step_unique_drop<'rcu>(tracked s: &mut VmStore<'rcu>, uid: Unique
     assert(s.regions.contains(idx));
     assert(index_to_frame(idx) == paddr);
     assert(s.regions.slot_owners[idx].usage is Frame);
-    assert(s.regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
-    assert(s.regions.slot_owners[idx].inner_perms.in_list.value() == 0);
+    assert(s.regions.slot_owners[idx].ref_count() == REF_COUNT_UNIQUE);
+    assert(s.regions.slot_owners[idx].in_list_perm.value() == 0);
     assert(s.regions.slot_owners[idx].paths_in_pt.is_empty());
-    assert(s.regions.slot_owners[idx].inner_perms.storage.is_init());
+    assert(s.regions.slot_owners[idx].storage_perm().is_init());
 
     // Pre "no users" facts at the UNIQUE slot, *derived* from the
     // equation clause: a user (H>0 / cover>0) at a `usage == Frame` slot
     // forces `rc != REF_COUNT_UNIQUE`, contradicting the unique slot.
     assert(handle_count(old_frames, idx) == 0) by {
         if handle_count(old_frames, idx) > 0 {
-            assert(old_regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNIQUE);
+            assert(old_regions.slot_owners[idx].ref_count() != REF_COUNT_UNIQUE);
             assert(false);
         }
     };
     assert(segment_cover_count(old_segments, index_to_frame(idx)) == 0) by {
         if segment_cover_count(old_segments, index_to_frame(idx)) > 0 {
-            assert(old_regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNIQUE);
+            assert(old_regions.slot_owners[idx].ref_count() != REF_COUNT_UNIQUE);
             assert(false);
         }
     };
@@ -4599,7 +4603,7 @@ proof fn lemma_step_unique_drop<'rcu>(tracked s: &mut VmStore<'rcu>, uid: Unique
     // --- structural: in_list == 0 everywhere ---
     assert forall|i: int|
         0 <= i
-            < max_meta_slots() implies #[trigger] s.regions.slot_owners[i].inner_perms.in_list.value()
+            < max_meta_slots() implies #[trigger] s.regions.slot_owners[i].in_list_perm.value()
         == 0 by {
         if i != idx {
             assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
@@ -4634,8 +4638,8 @@ proof fn lemma_step_unique_drop<'rcu>(tracked s: &mut VmStore<'rcu>, uid: Unique
     assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
         let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
         &&& so.usage is Frame
-        &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
-        &&& so.inner_perms.in_list.value() == 0
+        &&& so.ref_count() == REF_COUNT_UNIQUE
+        &&& so.in_list_perm.value() == 0
         &&& so.paths_in_pt.is_empty()
     } by {
         let u_idx = frame_to_index(s.unique_frames[u].paddr);
@@ -4667,7 +4671,7 @@ proof fn lemma_step_unique_drop<'rcu>(tracked s: &mut VmStore<'rcu>, uid: Unique
     // --- accounting clause 1: UNUSED ⟹ no users ---
     assert forall|i: int|
         #![trigger s.regions.slot_owners[i]]
-        0 <= i < max_meta_slots() && s.regions.slot_owners[i].inner_perms.ref_count.value()
+        0 <= i < max_meta_slots() && s.regions.slot_owners[i].ref_count()
             == REF_COUNT_UNUSED implies handle_count(s.frames, i) == 0
         && s.regions.slot_owners[i].paths_in_pt.is_empty() && segment_cover_count(
         s.segments,
@@ -4687,8 +4691,8 @@ proof fn lemma_step_unique_drop<'rcu>(tracked s: &mut VmStore<'rcu>, uid: Unique
     assert forall|i: int|
         #![trigger s.regions.slot_owners[i]]
         0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage is Frame
-            && s.regions.slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-            && s.regions.slot_owners[i].inner_perms.ref_count.value()
+            && s.regions.slot_owners[i].ref_count() != REF_COUNT_UNUSED
+            && s.regions.slot_owners[i].ref_count()
             != REF_COUNT_UNIQUE implies handle_count(s.frames, i) > 0
         || s.regions.slot_owners[i].paths_in_pt.len() > 0 || segment_cover_count(
         s.segments,
@@ -4712,14 +4716,14 @@ proof fn lemma_step_unique_drop<'rcu>(tracked s: &mut VmStore<'rcu>, uid: Unique
             index_to_frame(i),
         ) > 0) implies {
         let so = s.regions.slot_owners[i];
-        let rc = so.inner_perms.ref_count.value();
+        let rc = so.ref_count();
         &&& rc != REF_COUNT_UNUSED
         &&& rc != REF_COUNT_UNIQUE
         &&& rc == handle_count(s.frames, i) + so.paths_in_pt.len() + segment_cover_count(
             s.segments,
             index_to_frame(i),
         )
-        &&& so.inner_perms.storage.is_init()
+        &&& so.storage_perm().is_init()
     } by {
         if i == idx {
             // `idx` is now UNUSED with no users — antecedent false.
@@ -4757,20 +4761,20 @@ proof fn lemma_step_from_unique<'rcu>(tracked s: &mut VmStore<'rcu>, uid: Unique
     assert(s.regions.contains(idx));
     assert(index_to_frame(idx) == paddr);
     assert(s.regions.slot_owners[idx].usage is Frame);
-    assert(s.regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE);
+    assert(s.regions.slot_owners[idx].ref_count() == REF_COUNT_UNIQUE);
     assert(s.regions.slot_owners[idx].paths_in_pt.is_empty());
-    assert(s.regions.slot_owners[idx].inner_perms.storage.is_init());
+    assert(s.regions.slot_owners[idx].storage_perm().is_init());
 
     // Pre "no users" at the UNIQUE slot (a user forces rc != UNIQUE).
     assert(handle_count(old_frames, idx) == 0) by {
         if handle_count(old_frames, idx) > 0 {
-            assert(old_regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNIQUE);
+            assert(old_regions.slot_owners[idx].ref_count() != REF_COUNT_UNIQUE);
             assert(false);
         }
     };
     assert(segment_cover_count(old_segments, index_to_frame(idx)) == 0) by {
         if segment_cover_count(old_segments, index_to_frame(idx)) > 0 {
-            assert(old_regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNIQUE);
+            assert(old_regions.slot_owners[idx].ref_count() != REF_COUNT_UNIQUE);
             assert(false);
         }
     };
@@ -4792,7 +4796,7 @@ proof fn lemma_step_from_unique<'rcu>(tracked s: &mut VmStore<'rcu>, uid: Unique
     // --- structural: in_list == 0 everywhere ---
     assert forall|i: int|
         0 <= i
-            < max_meta_slots() implies #[trigger] s.regions.slot_owners[i].inner_perms.in_list.value()
+            < max_meta_slots() implies #[trigger] s.regions.slot_owners[i].in_list_perm.value()
         == 0 by {
         if i != idx {
             assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
@@ -4833,8 +4837,8 @@ proof fn lemma_step_from_unique<'rcu>(tracked s: &mut VmStore<'rcu>, uid: Unique
     assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
         let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
         &&& so.usage is Frame
-        &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
-        &&& so.inner_perms.in_list.value() == 0
+        &&& so.ref_count() == REF_COUNT_UNIQUE
+        &&& so.in_list_perm.value() == 0
         &&& so.paths_in_pt.is_empty()
     } by {
         let u_idx = frame_to_index(s.unique_frames[u].paddr);
@@ -4862,7 +4866,7 @@ proof fn lemma_step_from_unique<'rcu>(tracked s: &mut VmStore<'rcu>, uid: Unique
     // --- accounting clause 1: UNUSED ⟹ no users ---
     assert forall|i: int|
         #![trigger s.regions.slot_owners[i]]
-        0 <= i < max_meta_slots() && s.regions.slot_owners[i].inner_perms.ref_count.value()
+        0 <= i < max_meta_slots() && s.regions.slot_owners[i].ref_count()
             == REF_COUNT_UNUSED implies handle_count(s.frames, i) == 0
         && s.regions.slot_owners[i].paths_in_pt.is_empty() && segment_cover_count(
         s.segments,
@@ -4879,8 +4883,8 @@ proof fn lemma_step_from_unique<'rcu>(tracked s: &mut VmStore<'rcu>, uid: Unique
     assert forall|i: int|
         #![trigger s.regions.slot_owners[i]]
         0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage is Frame
-            && s.regions.slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-            && s.regions.slot_owners[i].inner_perms.ref_count.value()
+            && s.regions.slot_owners[i].ref_count() != REF_COUNT_UNUSED
+            && s.regions.slot_owners[i].ref_count()
             != REF_COUNT_UNIQUE implies handle_count(s.frames, i) > 0
         || s.regions.slot_owners[i].paths_in_pt.len() > 0 || segment_cover_count(
         s.segments,
@@ -4904,14 +4908,14 @@ proof fn lemma_step_from_unique<'rcu>(tracked s: &mut VmStore<'rcu>, uid: Unique
             index_to_frame(i),
         ) > 0) implies {
         let so = s.regions.slot_owners[i];
-        let rc = so.inner_perms.ref_count.value();
+        let rc = so.ref_count();
         &&& rc != REF_COUNT_UNUSED
         &&& rc != REF_COUNT_UNIQUE
         &&& rc == handle_count(s.frames, i) + so.paths_in_pt.len() + segment_cover_count(
             s.segments,
             index_to_frame(i),
         )
-        &&& so.inner_perms.storage.is_init()
+        &&& so.storage_perm().is_init()
     } by {
         lemma_handle_count_insert_fresh(old_frames, fid, fe, i);
         if i == idx {
@@ -4953,7 +4957,7 @@ proof fn lemma_step_try_from_shared<'rcu>(tracked s: &mut VmStore<'rcu>, fid: Fr
     ).contains(fid));
     assert(handle_count(s.frames, idx) >= 1);
 
-    if s.regions.slot_owners[idx].inner_perms.ref_count.value() == 1 {
+    if s.regions.slot_owners[idx].ref_count() == 1 {
         let ghost old_regions = s.regions;
         let ghost old_frames = s.frames;
         let ghost old_segments = s.segments;
@@ -4986,7 +4990,7 @@ proof fn lemma_step_try_from_shared<'rcu>(tracked s: &mut VmStore<'rcu>, fid: Fr
         // --- structural: in_list == 0 everywhere ---
         assert forall|i: int|
             0 <= i
-                < max_meta_slots() implies #[trigger] s.regions.slot_owners[i].inner_perms.in_list.value()
+                < max_meta_slots() implies #[trigger] s.regions.slot_owners[i].in_list_perm.value()
             == 0 by {
             if i != idx {
                 assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
@@ -5023,8 +5027,8 @@ proof fn lemma_step_try_from_shared<'rcu>(tracked s: &mut VmStore<'rcu>, fid: Fr
         assert forall|u: UniqueId| #[trigger] s.unique_frames.dom().contains(u) implies {
             let so = s.regions.slot_owners[frame_to_index(s.unique_frames[u].paddr)];
             &&& so.usage is Frame
-            &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
-            &&& so.inner_perms.in_list.value() == 0
+            &&& so.ref_count() == REF_COUNT_UNIQUE
+            &&& so.in_list_perm.value() == 0
             &&& so.paths_in_pt.is_empty()
         } by {
             let u_idx = frame_to_index(s.unique_frames[u].paddr);
@@ -5035,7 +5039,7 @@ proof fn lemma_step_try_from_shared<'rcu>(tracked s: &mut VmStore<'rcu>, fid: Fr
                 assert(old_unique.dom().contains(u));
                 assert(s.unique_frames[u] == old_unique[u]);
                 // old entry's slot was UNIQUE (≠ idx, which was rc==1).
-                assert(old_regions.slot_owners[u_idx].inner_perms.ref_count.value()
+                assert(old_regions.slot_owners[u_idx].ref_count()
                     == REF_COUNT_UNIQUE);
                 assert(u_idx != idx);
                 assert(s.regions.slot_owners[u_idx] == old_regions.slot_owners[u_idx]);
@@ -5057,14 +5061,14 @@ proof fn lemma_step_try_from_shared<'rcu>(tracked s: &mut VmStore<'rcu>, fid: Fr
                 assert(old_unique.dom().contains(u2));
                 assert(s.unique_frames[u2].paddr == paddr);
                 assert(frame_to_index(s.unique_frames[u2].paddr) == idx);
-                assert(old_regions.slot_owners[idx].inner_perms.ref_count.value()
+                assert(old_regions.slot_owners[idx].ref_count()
                     == REF_COUNT_UNIQUE);
                 assert(false);
             } else if u2 == uid && u1 != uid {
                 assert(old_unique.dom().contains(u1));
                 assert(s.unique_frames[u1].paddr == paddr);
                 assert(frame_to_index(s.unique_frames[u1].paddr) == idx);
-                assert(old_regions.slot_owners[idx].inner_perms.ref_count.value()
+                assert(old_regions.slot_owners[idx].ref_count()
                     == REF_COUNT_UNIQUE);
                 assert(false);
             } else if u1 != uid && u2 != uid {
@@ -5076,7 +5080,7 @@ proof fn lemma_step_try_from_shared<'rcu>(tracked s: &mut VmStore<'rcu>, fid: Fr
         // --- accounting clause 1: UNUSED ⟹ no users ---
         assert forall|i: int|
             #![trigger s.regions.slot_owners[i]]
-            0 <= i < max_meta_slots() && s.regions.slot_owners[i].inner_perms.ref_count.value()
+            0 <= i < max_meta_slots() && s.regions.slot_owners[i].ref_count()
                 == REF_COUNT_UNUSED implies handle_count(s.frames, i) == 0
             && s.regions.slot_owners[i].paths_in_pt.is_empty() && segment_cover_count(
             s.segments,
@@ -5094,8 +5098,8 @@ proof fn lemma_step_try_from_shared<'rcu>(tracked s: &mut VmStore<'rcu>, fid: Fr
         assert forall|i: int|
             #![trigger s.regions.slot_owners[i]]
             0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage is Frame
-                && s.regions.slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-                && s.regions.slot_owners[i].inner_perms.ref_count.value()
+                && s.regions.slot_owners[i].ref_count() != REF_COUNT_UNUSED
+                && s.regions.slot_owners[i].ref_count()
                 != REF_COUNT_UNIQUE implies handle_count(s.frames, i) > 0
             || s.regions.slot_owners[i].paths_in_pt.len() > 0 || segment_cover_count(
             s.segments,
@@ -5120,14 +5124,14 @@ proof fn lemma_step_try_from_shared<'rcu>(tracked s: &mut VmStore<'rcu>, fid: Fr
                 index_to_frame(i),
             ) > 0) implies {
             let so = s.regions.slot_owners[i];
-            let rc = so.inner_perms.ref_count.value();
+            let rc = so.ref_count();
             &&& rc != REF_COUNT_UNUSED
             &&& rc != REF_COUNT_UNIQUE
             &&& rc == handle_count(s.frames, i) + so.paths_in_pt.len() + segment_cover_count(
                 s.segments,
                 index_to_frame(i),
             )
-            &&& so.inner_perms.storage.is_init()
+            &&& so.storage_perm().is_init()
         } by {
             lemma_handle_count_remove(old_frames, fid, i);
             if i == idx {

--- a/ostd/specs/mm/embedding/mod.rs
+++ b/ostd/specs/mm/embedding/mod.rs
@@ -454,8 +454,8 @@ pub proof fn lemma_frame_drop_pre_derivable<'rcu>(s: VmStore<'rcu>, fid: FrameId
         segment_cover_count(s.segments, s.frames[fid].paddr) == 0,
     ensures
         frame::drop_pre(s.regions, s.frames[fid].paddr),
-        s.regions.slot_owners[frame_to_index(s.frames[fid].paddr)].ref_count()
-            == 1 ==> handle_count(s.frames, frame_to_index(s.frames[fid].paddr)) == 1,
+        s.regions.slot_owners[frame_to_index(s.frames[fid].paddr)].ref_count() == 1
+            ==> handle_count(s.frames, frame_to_index(s.frames[fid].paddr)) == 1,
 {
     let paddr = s.frames[fid].paddr;
     let idx = frame_to_index(paddr);
@@ -831,9 +831,8 @@ impl<'a, 'rcu> VmStore<'rcu> {
         // forgotten Frame handle.
         &&& forall|idx: int|
             #![trigger self.regions.slot_owners[idx]]
-            0 <= idx < max_meta_slots()
-                && self.regions.slot_owners[idx].ref_count() == REF_COUNT_UNUSED
-                ==> handle_count(self.frames, idx) == 0
+            0 <= idx < max_meta_slots() && self.regions.slot_owners[idx].ref_count()
+                == REF_COUNT_UNUSED ==> handle_count(self.frames, idx) == 0
                 && self.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
                 self.segments,
                 index_to_frame(idx),
@@ -847,9 +846,10 @@ impl<'a, 'rcu> VmStore<'rcu> {
             #![trigger self.regions.slot_owners[idx]]
             0 <= idx < max_meta_slots() && self.regions.slot_owners[idx].usage is Frame
                 && self.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
-                && self.regions.slot_owners[idx].ref_count() != REF_COUNT_UNIQUE
-                ==> handle_count(self.frames, idx) > 0
-                || self.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
+                && self.regions.slot_owners[idx].ref_count() != REF_COUNT_UNIQUE ==> handle_count(
+                self.frames,
+                idx,
+            ) > 0 || self.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
                 self.segments,
                 index_to_frame(idx),
             )
@@ -1119,8 +1119,8 @@ pub open spec fn op_pre<'rcu>(s: VmStore<'rcu>, op: Op) -> bool {
         Op::SegmentClone { sid } => s.segments.dom().contains(sid) && forall|paddr: Paddr|
             #![trigger frame_to_index(paddr)]
             (s.segments[sid].range.start <= paddr < s.segments[sid].range.end && paddr % PAGE_SIZE
-                == 0) ==> s.regions.slot_owners[frame_to_index(paddr)].ref_count()
-                + 1 <= REF_COUNT_MAX,
+                == 0) ==> s.regions.slot_owners[frame_to_index(paddr)].ref_count() + 1
+                <= REF_COUNT_MAX,
         // `Segment::slice`: id-existence + the sub-range is a
         // page-aligned, non-empty, absolute physical range contained in
         // `sid`'s range (mirroring exec `slice`'s `assert!`s on the
@@ -1132,8 +1132,7 @@ pub open spec fn op_pre<'rcu>(s: VmStore<'rcu>, op: Op) -> bool {
             <= s.segments[sid].range.end && forall|paddr: Paddr|
             #![trigger frame_to_index(paddr)]
             (sub_range.start <= paddr < sub_range.end && paddr % PAGE_SIZE == 0)
-                ==> s.regions.slot_owners[frame_to_index(paddr)].ref_count() + 1
-                <= REF_COUNT_MAX,
+                ==> s.regions.slot_owners[frame_to_index(paddr)].ref_count() + 1 <= REF_COUNT_MAX,
         // `UniqueFrame::from_unused`: no precondition (mirrors
         // `FrameFromUnused`). The exec returns `Err` and leaves the slot
         // untouched unless the target is genuinely a free frame slot;
@@ -1629,9 +1628,10 @@ proof fn lemma_accounting_preserved_by_pt_alloc<'rcu>(s_old: VmStore<'rcu>, s_ne
         #![trigger s_new.regions.slot_owners[idx]]
         0 <= idx < max_meta_slots() && s_new.regions.slot_owners[idx].usage is Frame
             && s_new.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
-            && s_new.regions.slot_owners[idx].ref_count()
-            != REF_COUNT_UNIQUE implies handle_count(s_new.frames, idx) > 0
-        || s_new.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
+            && s_new.regions.slot_owners[idx].ref_count() != REF_COUNT_UNIQUE implies handle_count(
+        s_new.frames,
+        idx,
+    ) > 0 || s_new.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
         s_new.segments,
         index_to_frame(idx),
     ) > 0 by {
@@ -1720,13 +1720,12 @@ proof fn lemma_coverage_preserved_slots_eq<'rcu>(s_old: VmStore<'rcu>, s_new: Vm
         forall|idx: int|
             0 <= idx < max_meta_slots() ==> #[trigger] s_new.regions.slots.contains_key(idx) || (
             s_new.regions.slot_owners[idx].usage is PageTable
-                && s_new.regions.slot_owners[idx].ref_count()
-                != REF_COUNT_UNUSED),
+                && s_new.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED),
 {
     assert forall|idx: int|
         0 <= idx < max_meta_slots() implies #[trigger] s_new.regions.slots.contains_key(idx) || (
-    s_new.regions.slot_owners[idx].usage is PageTable
-        && s_new.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED) by {
+    s_new.regions.slot_owners[idx].usage is PageTable && s_new.regions.slot_owners[idx].ref_count()
+        != REF_COUNT_UNUSED) by {
         if !s_new.regions.slots.contains_key(idx) {
             // `slots == old` ⟹ unparked in `s_old` too ⟹ old coverage's
             // PageTable-node disjunct ⟹ (slot unchanged) carries.
@@ -1757,8 +1756,8 @@ proof fn lemma_step_new_vm_space<'rcu>(tracked s: &mut VmStore<'rcu>)
     let ghost root_idx = vm_space::vm_space_root_idx(owner);
     assert forall|idx: int|
         0 <= idx < max_meta_slots() implies #[trigger] s.regions.slots.contains_key(idx) || (
-    s.regions.slot_owners[idx].usage is PageTable
-        && s.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED) by {
+    s.regions.slot_owners[idx].usage is PageTable && s.regions.slot_owners[idx].ref_count()
+        != REF_COUNT_UNUSED) by {
         if idx == root_idx {
             // The extracted root is an active PageTable node (axiom).
         } else {
@@ -1769,8 +1768,7 @@ proof fn lemma_step_new_vm_space<'rcu>(tracked s: &mut VmStore<'rcu>)
                 // A changed non-root slot was pre-UNUSED (axiom) ⟹ by old
                 // coverage's contrapositive it was parked, and stays
                 // parked (only the root left `slots`).
-                assert(s_before.regions.slot_owners[idx].ref_count()
-                    == REF_COUNT_UNUSED);
+                assert(s_before.regions.slot_owners[idx].ref_count() == REF_COUNT_UNUSED);
                 assert(s_before.regions.slots.contains_key(idx));
             }
         }
@@ -1897,8 +1895,7 @@ proof fn lemma_step_query<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId)
             // Discharge accounting_inv on (new regions, new frames).
             assert forall|idx: int|
                 #![trigger s.regions.slot_owners[idx]]
-                0 <= idx < max_meta_slots()
-                    && s.regions.slot_owners[idx].ref_count()
+                0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].ref_count()
                     == REF_COUNT_UNUSED implies handle_count(s.frames, idx) == 0
                 && s.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
                 s.segments,
@@ -1952,22 +1949,19 @@ proof fn lemma_step_query<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId)
             } by {
                 lemma_handle_count_insert_fresh(old_frames, id, frame_entry, idx);
                 if idx == target_idx {
-                    if old_regions.slot_owners[target_idx].ref_count()
-                        == REF_COUNT_UNUSED {
+                    if old_regions.slot_owners[target_idx].ref_count() == REF_COUNT_UNUSED {
                         // Pre UNUSED at Frame slot: clause 1 ⟹ pre paths
                         // empty ∧ pre H == 0 ∧ pre cover == 0.
                         // Post H == 1, paths preserved, cover preserved.
                         // Post rc = pre rc + 1 = UNUSED + 1.
                         assert(REF_COUNT_UNUSED == 0u32);
-                        assert(s.regions.slot_owners[target_idx].ref_count()
-                            == 1);
+                        assert(s.regions.slot_owners[target_idx].ref_count() == 1);
                         assert(handle_count(s.frames, target_idx) == 1);
                         assert(s.regions.slot_owners[target_idx].paths_in_pt.len()
                             == old_regions.slot_owners[target_idx].paths_in_pt.len());
                         assert(old_regions.slot_owners[target_idx].paths_in_pt.len() == 0);
                         assert(segment_cover_count(s.segments, index_to_frame(target_idx)) == 0);
-                    } else if old_regions.slot_owners[target_idx].ref_count()
-                        == REF_COUNT_UNIQUE {
+                    } else if old_regions.slot_owners[target_idx].ref_count() == REF_COUNT_UNIQUE {
                         assert(false);
                     } else {
                         // Pre non-sentinel SHARED rc: pre clause 4 applies
@@ -2132,9 +2126,10 @@ proof fn lemma_step_map<'rcu>(
         #![trigger s.regions.slot_owners[idx]]
         0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
             && s.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
-            && s.regions.slot_owners[idx].ref_count()
-            != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
-        || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
+            && s.regions.slot_owners[idx].ref_count() != REF_COUNT_UNIQUE implies handle_count(
+        s.frames,
+        idx,
+    ) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
         s.segments,
         index_to_frame(idx),
     ) > 0 by {
@@ -2217,8 +2212,7 @@ proof fn lemma_step_map<'rcu>(
                 |gid: FrameId| frame_to_index(old_frames[gid].paddr) == other_idx,
             ).contains(fid_other));
             assert(handle_count(old_frames, other_idx) >= 1);
-            assert(old_regions.slot_owners[other_idx].ref_count()
-                != REF_COUNT_UNUSED);
+            assert(old_regions.slot_owners[other_idx].ref_count() != REF_COUNT_UNUSED);
             assert(s.regions.slot_owners[other_idx] == old_regions.slot_owners[other_idx]);
         }
     };
@@ -2325,8 +2319,7 @@ proof fn lemma_step_unmap<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId, len:
                 // structural `covered ⟹ Frame` at the witness (old state).
                 assert(old_regions.slot_owners[idx].usage is Frame);
                 // active head (cover > 0 ∧ Frame) ⟹ pre rc != UNUSED, <= MAX.
-                assert(old_regions.slot_owners[idx].ref_count()
-                    != REF_COUNT_UNUSED);
+                assert(old_regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED);
                 assert(old_regions.slot_owners[idx].ref_count() <= REF_COUNT_MAX);
                 // unmap (Frame): post rc <= pre rc <= MAX < UNUSED.
                 assert(s.regions.slot_owners[idx].ref_count() <= REF_COUNT_MAX);
@@ -2373,9 +2366,10 @@ proof fn lemma_step_unmap<'rcu>(tracked s: &mut VmStore<'rcu>, c: CursorId, len:
         #![trigger s.regions.slot_owners[idx]]
         0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
             && s.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
-            && s.regions.slot_owners[idx].ref_count()
-            != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
-        || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
+            && s.regions.slot_owners[idx].ref_count() != REF_COUNT_UNIQUE implies handle_count(
+        s.frames,
+        idx,
+    ) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
         s.segments,
         index_to_frame(idx),
     ) > 0 by {
@@ -2658,8 +2652,7 @@ proof fn lemma_step_frame_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, paddr
                 // (lemma + slot_owner preservation); target_idx is now rc=1.
                 assert forall|idx: int|
                     #![trigger s.regions.slot_owners[idx]]
-                    0 <= idx < max_meta_slots()
-                        && s.regions.slot_owners[idx].ref_count()
+                    0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].ref_count()
                         == REF_COUNT_UNUSED implies handle_count(s.frames, idx) == 0
                     && s.regions.slot_owners[idx].paths_in_pt.is_empty() by {
                     lemma_handle_count_insert_fresh(old_frames, id, entry, idx);
@@ -2677,8 +2670,7 @@ proof fn lemma_step_frame_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, paddr
                 assert forall|idx: int|
                     #![trigger s.regions.slot_owners[idx]]
                     0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
-                        && s.regions.slot_owners[idx].ref_count()
-                        != REF_COUNT_UNUSED
+                        && s.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
                         && s.regions.slot_owners[idx].ref_count()
                         != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
                     || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
@@ -2709,8 +2701,7 @@ proof fn lemma_step_frame_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, paddr
                 } by {
                     lemma_handle_count_insert_fresh(old_frames, id, entry, idx);
                     if idx == target_idx {
-                        assert(old_regions.slot_owners[idx].ref_count()
-                            == REF_COUNT_UNUSED);
+                        assert(old_regions.slot_owners[idx].ref_count() == REF_COUNT_UNUSED);
                         assert(handle_count(old_frames, idx) == 0);
                         assert(handle_count(s.frames, idx) == 1);
                         // Pre clause 2 (UNUSED) gives pre cover == 0;
@@ -2757,8 +2748,7 @@ proof fn lemma_step_frame_from_in_use<'rcu>(tracked s: &mut VmStore<'rcu>, paddr
                 // rc = pre rc + 1 != UNUSED. For other idx: unchanged.
                 assert forall|idx: int|
                     #![trigger s.regions.slot_owners[idx]]
-                    0 <= idx < max_meta_slots()
-                        && s.regions.slot_owners[idx].ref_count()
+                    0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].ref_count()
                         == REF_COUNT_UNUSED implies handle_count(s.frames, idx) == 0
                     && s.regions.slot_owners[idx].paths_in_pt.is_empty() by {
                     lemma_handle_count_insert_fresh(old_frames, id, entry, idx);
@@ -2774,8 +2764,7 @@ proof fn lemma_step_frame_from_in_use<'rcu>(tracked s: &mut VmStore<'rcu>, paddr
                 assert forall|idx: int|
                     #![trigger s.regions.slot_owners[idx]]
                     0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
-                        && s.regions.slot_owners[idx].ref_count()
-                        != REF_COUNT_UNUSED
+                        && s.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
                         && s.regions.slot_owners[idx].ref_count()
                         != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
                     || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
@@ -2893,9 +2882,10 @@ proof fn lemma_step_frame_drop<'rcu>(tracked s: &mut VmStore<'rcu>, fid: FrameId
         #![trigger s.regions.slot_owners[idx]]
         0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
             && s.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
-            && s.regions.slot_owners[idx].ref_count()
-            != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
-        || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
+            && s.regions.slot_owners[idx].ref_count() != REF_COUNT_UNIQUE implies handle_count(
+        s.frames,
+        idx,
+    ) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
         s.segments,
         index_to_frame(idx),
     ) > 0 by {
@@ -3023,9 +3013,8 @@ proof fn lemma_step_segment_from_unused_accounting<'rcu>(
         forall|paddr: Paddr|
             #![trigger frame_to_index(paddr)]
             (range.start <= paddr < range.end && paddr % PAGE_SIZE == 0)
-                ==> old_store.regions.slot_owners[frame_to_index(
-                paddr,
-            )].ref_count() == REF_COUNT_UNUSED,
+                ==> old_store.regions.slot_owners[frame_to_index(paddr)].ref_count()
+                == REF_COUNT_UNUSED,
     ensures
         s_after.accounting_inv(),
 {
@@ -3034,8 +3023,7 @@ proof fn lemma_step_segment_from_unused_accounting<'rcu>(
     let old_segments = old_store.segments;
     assert forall|idx: int|
         #![trigger s_after.regions.slot_owners[idx]]
-        0 <= idx < max_meta_slots()
-            && s_after.regions.slot_owners[idx].ref_count()
+        0 <= idx < max_meta_slots() && s_after.regions.slot_owners[idx].ref_count()
             == REF_COUNT_UNUSED implies handle_count(s_after.frames, idx) == 0
         && s_after.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
         s_after.segments,
@@ -3113,8 +3101,7 @@ proof fn lemma_step_segment_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, ran
         && range.end <= MAX_PADDR && (forall|paddr: Paddr|
         #![trigger frame_to_index(paddr)]
         (range.start <= paddr < range.end && paddr % PAGE_SIZE == 0)
-            ==> s.regions.slot_owners[frame_to_index(paddr)].ref_count()
-            == REF_COUNT_UNUSED) {
+            ==> s.regions.slot_owners[frame_to_index(paddr)].ref_count() == REF_COUNT_UNUSED) {
         let ghost s_before = *s;
         let ghost old_regions = s.regions;
         let ghost old_frames = s.frames;
@@ -3152,9 +3139,8 @@ proof fn lemma_accounting_inv_intro<'rcu>(store: VmStore<'rcu>)
     requires
         forall|idx: int|
             #![trigger store.regions.slot_owners[idx]]
-            0 <= idx < max_meta_slots()
-                && store.regions.slot_owners[idx].ref_count() == REF_COUNT_UNUSED
-                ==> handle_count(store.frames, idx) == 0
+            0 <= idx < max_meta_slots() && store.regions.slot_owners[idx].ref_count()
+                == REF_COUNT_UNUSED ==> handle_count(store.frames, idx) == 0
                 && store.regions.slot_owners[idx].paths_in_pt.is_empty() && segment_cover_count(
                 store.segments,
                 index_to_frame(idx),
@@ -3163,9 +3149,10 @@ proof fn lemma_accounting_inv_intro<'rcu>(store: VmStore<'rcu>)
             #![trigger store.regions.slot_owners[idx]]
             0 <= idx < max_meta_slots() && store.regions.slot_owners[idx].usage is Frame
                 && store.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
-                && store.regions.slot_owners[idx].ref_count() != REF_COUNT_UNIQUE
-                ==> handle_count(store.frames, idx) > 0
-                || store.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
+                && store.regions.slot_owners[idx].ref_count() != REF_COUNT_UNIQUE ==> handle_count(
+                store.frames,
+                idx,
+            ) > 0 || store.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
                 store.segments,
                 index_to_frame(idx),
             ) > 0,
@@ -3217,11 +3204,8 @@ proof fn lemma_drop_segment_with_store_inv<'rcu>(
                 &&& so_new.paths_in_pt == so_old.paths_in_pt
                 &&& so_new.slot_vaddr == so_old.slot_vaddr
                 &&& so_new.in_list_perm == so_old.in_list_perm
-                &&& so_old.ref_count() == 1
-                    ==> so_new.ref_count() == REF_COUNT_UNUSED
-                &&& so_old.ref_count() > 1
-                    ==> so_new.ref_count() == (
-                so_old.ref_count() - 1) as u64
+                &&& so_old.ref_count() == 1 ==> so_new.ref_count() == REF_COUNT_UNUSED
+                &&& so_old.ref_count() > 1 ==> so_new.ref_count() == (so_old.ref_count() - 1) as u64
             },
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
@@ -3284,6 +3268,7 @@ proof fn lemma_drop_segment_with_store_inv<'rcu>(
 /// releases the segment's forgotten reference at each covered frame.
 /// Frames whose `rc` reaches 1 transition to UNUSED.
 #[verifier::spinoff_prover]
+#[verifier::rlimit(50)]
 proof fn lemma_step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: SegmentId)
     requires
         old(s).inv(),
@@ -3385,9 +3370,10 @@ proof fn lemma_step_segment_drop<'rcu>(tracked s: &mut VmStore<'rcu>, sid: Segme
         #![trigger s.regions.slot_owners[idx]]
         0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
             && s.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
-            && s.regions.slot_owners[idx].ref_count()
-            != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
-        || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
+            && s.regions.slot_owners[idx].ref_count() != REF_COUNT_UNIQUE implies handle_count(
+        s.frames,
+        idx,
+    ) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
         s.segments,
         index_to_frame(idx),
     ) > 0 by {
@@ -3679,9 +3665,10 @@ proof fn lemma_step_segment_split<'rcu>(
         #![trigger s.regions.slot_owners[idx]]
         0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
             && s.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
-            && s.regions.slot_owners[idx].ref_count()
-            != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
-        || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
+            && s.regions.slot_owners[idx].ref_count() != REF_COUNT_UNIQUE implies handle_count(
+        s.frames,
+        idx,
+    ) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
         s.segments,
         index_to_frame(idx),
     ) > 0 by {
@@ -3929,9 +3916,10 @@ proof fn lemma_step_segment_next<'rcu>(tracked s: &mut VmStore<'rcu>, sid: Segme
         #![trigger s.regions.slot_owners[idx]]
         0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
             && s.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
-            && s.regions.slot_owners[idx].ref_count()
-            != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
-        || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
+            && s.regions.slot_owners[idx].ref_count() != REF_COUNT_UNIQUE implies handle_count(
+        s.frames,
+        idx,
+    ) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
         s.segments,
         index_to_frame(idx),
     ) > 0 by {
@@ -4022,8 +4010,7 @@ proof fn lemma_step_segment_clone_range<'rcu>(
             #![trigger frame_to_index(paddr)]
             (sub_range.start <= paddr < sub_range.end && paddr % PAGE_SIZE == 0) ==> old(
                 s,
-            ).regions.slot_owners[frame_to_index(paddr)].ref_count() + 1
-                <= REF_COUNT_MAX,
+            ).regions.slot_owners[frame_to_index(paddr)].ref_count() + 1 <= REF_COUNT_MAX,
     ensures
         final(s).inv(),
 {
@@ -4207,9 +4194,10 @@ proof fn lemma_step_segment_clone_range<'rcu>(
         #![trigger s.regions.slot_owners[idx]]
         0 <= idx < max_meta_slots() && s.regions.slot_owners[idx].usage is Frame
             && s.regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
-            && s.regions.slot_owners[idx].ref_count()
-            != REF_COUNT_UNIQUE implies handle_count(s.frames, idx) > 0
-        || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
+            && s.regions.slot_owners[idx].ref_count() != REF_COUNT_UNIQUE implies handle_count(
+        s.frames,
+        idx,
+    ) > 0 || s.regions.slot_owners[idx].paths_in_pt.len() > 0 || segment_cover_count(
         s.segments,
         index_to_frame(idx),
     ) > 0 by {
@@ -4302,9 +4290,8 @@ proof fn lemma_step_segment_clone<'rcu>(tracked s: &mut VmStore<'rcu>, sid: Segm
         forall|paddr: Paddr|
             #![trigger frame_to_index(paddr)]
             (old(s).segments[sid].range.start <= paddr < old(s).segments[sid].range.end && paddr
-                % PAGE_SIZE == 0) ==> old(s).regions.slot_owners[frame_to_index(
-                paddr,
-            )].ref_count() + 1 <= REF_COUNT_MAX,
+                % PAGE_SIZE == 0) ==> old(s).regions.slot_owners[frame_to_index(paddr)].ref_count()
+                + 1 <= REF_COUNT_MAX,
     ensures
         final(s).inv(),
 {
@@ -4338,8 +4325,7 @@ proof fn lemma_step_segment_slice<'rcu>(
             #![trigger frame_to_index(paddr)]
             (sub_range.start <= paddr < sub_range.end && paddr % PAGE_SIZE == 0) ==> old(
                 s,
-            ).regions.slot_owners[frame_to_index(paddr)].ref_count() + 1
-                <= REF_COUNT_MAX,
+            ).regions.slot_owners[frame_to_index(paddr)].ref_count() + 1 <= REF_COUNT_MAX,
     ensures
         final(s).inv(),
 {
@@ -4357,8 +4343,7 @@ proof fn lemma_step_unique_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, padd
     // frame slot; only the success branch mutates the store.
     if valid_frame_paddr(paddr) && s.regions.slots.contains_key(frame_to_index(paddr))
         && s.regions.slot_owners[frame_to_index(paddr)].usage is Unused
-        && s.regions.slot_owners[frame_to_index(paddr)].ref_count()
-        == REF_COUNT_UNUSED {
+        && s.regions.slot_owners[frame_to_index(paddr)].ref_count() == REF_COUNT_UNUSED {
         let ghost old_regions = s.regions;
         let ghost old_frames = s.frames;
         let ghost old_segments = s.segments;
@@ -4437,8 +4422,7 @@ proof fn lemma_step_unique_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, padd
             } else {
                 assert(old_unique.dom().contains(u));
                 assert(s.unique_frames[u] == old_unique[u]);
-                assert(old_regions.slot_owners[u_idx].ref_count()
-                    == REF_COUNT_UNIQUE);
+                assert(old_regions.slot_owners[u_idx].ref_count() == REF_COUNT_UNIQUE);
                 assert(u_idx != idx);
                 assert(s.regions.slot_owners[u_idx] == old_regions.slot_owners[u_idx]);
             }
@@ -4461,15 +4445,13 @@ proof fn lemma_step_unique_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, padd
                 assert(old_unique.dom().contains(u2));
                 assert(s.unique_frames[u2].paddr == paddr);
                 assert(frame_to_index(s.unique_frames[u2].paddr) == idx);
-                assert(old_regions.slot_owners[idx].ref_count()
-                    == REF_COUNT_UNIQUE);
+                assert(old_regions.slot_owners[idx].ref_count() == REF_COUNT_UNIQUE);
                 assert(false);
             } else if u2 == uid && u1 != uid {
                 assert(old_unique.dom().contains(u1));
                 assert(s.unique_frames[u1].paddr == paddr);
                 assert(frame_to_index(s.unique_frames[u1].paddr) == idx);
-                assert(old_regions.slot_owners[idx].ref_count()
-                    == REF_COUNT_UNIQUE);
+                assert(old_regions.slot_owners[idx].ref_count() == REF_COUNT_UNIQUE);
                 assert(false);
             } else if u1 != uid && u2 != uid {
                 assert(old_unique.dom().contains(u1));
@@ -4498,9 +4480,10 @@ proof fn lemma_step_unique_from_unused<'rcu>(tracked s: &mut VmStore<'rcu>, padd
             #![trigger s.regions.slot_owners[i]]
             0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage is Frame
                 && s.regions.slot_owners[i].ref_count() != REF_COUNT_UNUSED
-                && s.regions.slot_owners[i].ref_count()
-                != REF_COUNT_UNIQUE implies handle_count(s.frames, i) > 0
-            || s.regions.slot_owners[i].paths_in_pt.len() > 0 || segment_cover_count(
+                && s.regions.slot_owners[i].ref_count() != REF_COUNT_UNIQUE implies handle_count(
+            s.frames,
+            i,
+        ) > 0 || s.regions.slot_owners[i].paths_in_pt.len() > 0 || segment_cover_count(
             s.segments,
             index_to_frame(i),
         ) > 0 by {
@@ -4602,8 +4585,7 @@ proof fn lemma_step_unique_drop<'rcu>(tracked s: &mut VmStore<'rcu>, uid: Unique
 
     // --- structural: in_list == 0 everywhere ---
     assert forall|i: int|
-        0 <= i
-            < max_meta_slots() implies #[trigger] s.regions.slot_owners[i].in_list_perm.value()
+        0 <= i < max_meta_slots() implies #[trigger] s.regions.slot_owners[i].in_list_perm.value()
         == 0 by {
         if i != idx {
             assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
@@ -4692,9 +4674,10 @@ proof fn lemma_step_unique_drop<'rcu>(tracked s: &mut VmStore<'rcu>, uid: Unique
         #![trigger s.regions.slot_owners[i]]
         0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage is Frame
             && s.regions.slot_owners[i].ref_count() != REF_COUNT_UNUSED
-            && s.regions.slot_owners[i].ref_count()
-            != REF_COUNT_UNIQUE implies handle_count(s.frames, i) > 0
-        || s.regions.slot_owners[i].paths_in_pt.len() > 0 || segment_cover_count(
+            && s.regions.slot_owners[i].ref_count() != REF_COUNT_UNIQUE implies handle_count(
+        s.frames,
+        i,
+    ) > 0 || s.regions.slot_owners[i].paths_in_pt.len() > 0 || segment_cover_count(
         s.segments,
         index_to_frame(i),
     ) > 0 by {
@@ -4795,8 +4778,7 @@ proof fn lemma_step_from_unique<'rcu>(tracked s: &mut VmStore<'rcu>, uid: Unique
 
     // --- structural: in_list == 0 everywhere ---
     assert forall|i: int|
-        0 <= i
-            < max_meta_slots() implies #[trigger] s.regions.slot_owners[i].in_list_perm.value()
+        0 <= i < max_meta_slots() implies #[trigger] s.regions.slot_owners[i].in_list_perm.value()
         == 0 by {
         if i != idx {
             assert(s.regions.slot_owners[i] == old_regions.slot_owners[i]);
@@ -4884,9 +4866,10 @@ proof fn lemma_step_from_unique<'rcu>(tracked s: &mut VmStore<'rcu>, uid: Unique
         #![trigger s.regions.slot_owners[i]]
         0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage is Frame
             && s.regions.slot_owners[i].ref_count() != REF_COUNT_UNUSED
-            && s.regions.slot_owners[i].ref_count()
-            != REF_COUNT_UNIQUE implies handle_count(s.frames, i) > 0
-        || s.regions.slot_owners[i].paths_in_pt.len() > 0 || segment_cover_count(
+            && s.regions.slot_owners[i].ref_count() != REF_COUNT_UNIQUE implies handle_count(
+        s.frames,
+        i,
+    ) > 0 || s.regions.slot_owners[i].paths_in_pt.len() > 0 || segment_cover_count(
         s.segments,
         index_to_frame(i),
     ) > 0 by {
@@ -5039,8 +5022,7 @@ proof fn lemma_step_try_from_shared<'rcu>(tracked s: &mut VmStore<'rcu>, fid: Fr
                 assert(old_unique.dom().contains(u));
                 assert(s.unique_frames[u] == old_unique[u]);
                 // old entry's slot was UNIQUE (≠ idx, which was rc==1).
-                assert(old_regions.slot_owners[u_idx].ref_count()
-                    == REF_COUNT_UNIQUE);
+                assert(old_regions.slot_owners[u_idx].ref_count() == REF_COUNT_UNIQUE);
                 assert(u_idx != idx);
                 assert(s.regions.slot_owners[u_idx] == old_regions.slot_owners[u_idx]);
             }
@@ -5061,15 +5043,13 @@ proof fn lemma_step_try_from_shared<'rcu>(tracked s: &mut VmStore<'rcu>, fid: Fr
                 assert(old_unique.dom().contains(u2));
                 assert(s.unique_frames[u2].paddr == paddr);
                 assert(frame_to_index(s.unique_frames[u2].paddr) == idx);
-                assert(old_regions.slot_owners[idx].ref_count()
-                    == REF_COUNT_UNIQUE);
+                assert(old_regions.slot_owners[idx].ref_count() == REF_COUNT_UNIQUE);
                 assert(false);
             } else if u2 == uid && u1 != uid {
                 assert(old_unique.dom().contains(u1));
                 assert(s.unique_frames[u1].paddr == paddr);
                 assert(frame_to_index(s.unique_frames[u1].paddr) == idx);
-                assert(old_regions.slot_owners[idx].ref_count()
-                    == REF_COUNT_UNIQUE);
+                assert(old_regions.slot_owners[idx].ref_count() == REF_COUNT_UNIQUE);
                 assert(false);
             } else if u1 != uid && u2 != uid {
                 assert(old_unique.dom().contains(u1));
@@ -5099,9 +5079,10 @@ proof fn lemma_step_try_from_shared<'rcu>(tracked s: &mut VmStore<'rcu>, fid: Fr
             #![trigger s.regions.slot_owners[i]]
             0 <= i < max_meta_slots() && s.regions.slot_owners[i].usage is Frame
                 && s.regions.slot_owners[i].ref_count() != REF_COUNT_UNUSED
-                && s.regions.slot_owners[i].ref_count()
-                != REF_COUNT_UNIQUE implies handle_count(s.frames, i) > 0
-            || s.regions.slot_owners[i].paths_in_pt.len() > 0 || segment_cover_count(
+                && s.regions.slot_owners[i].ref_count() != REF_COUNT_UNIQUE implies handle_count(
+            s.frames,
+            i,
+        ) > 0 || s.regions.slot_owners[i].paths_in_pt.len() > 0 || segment_cover_count(
             s.segments,
             index_to_frame(i),
         ) > 0 by {

--- a/ostd/specs/mm/embedding/segment.rs
+++ b/ostd/specs/mm/embedding/segment.rs
@@ -90,7 +90,7 @@ pub axiom fn segment_from_unused_embedded(
             #![trigger frame_to_index(paddr)]
             (range.start <= paddr < range.end && paddr % PAGE_SIZE == 0)
                 ==> old(regions).slot_owners[frame_to_index(paddr)]
-                        .inner_perms.ref_count.value() == REF_COUNT_UNUSED,
+                        .ref_count() == REF_COUNT_UNUSED,
         forall|paddr: Paddr|
             #![trigger frame_to_index(paddr)]
             (range.start <= paddr < range.end && paddr % PAGE_SIZE == 0)
@@ -108,10 +108,10 @@ pub axiom fn segment_from_unused_embedded(
                     let idx = frame_to_index(paddr);
                     let so = final(regions).slot_owners[idx];
                     &&& so.usage is Frame
-                    &&& so.inner_perms.ref_count.value() == 1
+                    &&& so.ref_count() == 1
                     &&& so.paths_in_pt.is_empty()
-                    &&& so.inner_perms.in_list.value() == 0
-                    &&& so.inner_perms.storage.is_init()
+                    &&& so.in_list_perm.value() == 0
+                    &&& so.storage_perm().is_init()
                 },
         // Slots OUTSIDE the range are fully preserved.
         res is Some ==> forall|i: int|
@@ -171,14 +171,14 @@ pub proof fn lemma_segment_drop_embedded(
             (range.start <= paddr < range.end && paddr % PAGE_SIZE == 0)
                 ==> {
                     let so = old(regions).slot_owners[frame_to_index(paddr)];
-                    &&& so.inner_perms.ref_count.value() >= 1
-                    &&& so.inner_perms.ref_count.value()
+                    &&& so.ref_count() >= 1
+                    &&& so.ref_count()
                             <= REF_COUNT_MAX
                     &&& so.usage is Frame
                     // At rc==1 (sole reference being dropped), no PTE
                     // points to this frame — required for the
                     // teardown's `drop_last_in_place_safety_cond`.
-                    &&& so.inner_perms.ref_count.value() == 1
+                    &&& so.ref_count() == 1
                         ==> so.paths_in_pt.is_empty()
                 },
     ensures
@@ -196,12 +196,12 @@ pub proof fn lemma_segment_drop_embedded(
                     &&& so_new.usage == so_old.usage
                     &&& so_new.paths_in_pt == so_old.paths_in_pt
                     &&& so_new.slot_vaddr == so_old.slot_vaddr
-                    &&& so_new.inner_perms.in_list == so_old.inner_perms.in_list
-                    &&& so_old.inner_perms.ref_count.value() == 1
-                        ==> so_new.inner_perms.ref_count.value() == REF_COUNT_UNUSED
-                    &&& so_old.inner_perms.ref_count.value() > 1
-                        ==> so_new.inner_perms.ref_count.value()
-                                == (so_old.inner_perms.ref_count.value() - 1) as u64
+                    &&& so_new.in_list_perm == so_old.in_list_perm
+                    &&& so_old.ref_count() == 1
+                        ==> so_new.ref_count() == REF_COUNT_UNUSED
+                    &&& so_old.ref_count() > 1
+                        ==> so_new.ref_count()
+                                == (so_old.ref_count() - 1) as u64
                 },
         // Slots OUTSIDE the range are fully preserved.
         forall|i: int|
@@ -259,9 +259,9 @@ pub proof fn segment_next_embedded(
         valid_frame_paddr(paddr),
         old(regions).contains(frame_to_index(paddr)),
         old(regions).slot_owners[frame_to_index(paddr)]
-                .inner_perms.ref_count.value() >= 1,
+                .ref_count() >= 1,
         old(regions).slot_owners[frame_to_index(paddr)]
-                .inner_perms.ref_count.value()
+                .ref_count()
             <= REF_COUNT_MAX,
         old(regions).slot_owners[frame_to_index(paddr)].usage
             is Frame,
@@ -273,13 +273,13 @@ pub proof fn segment_next_embedded(
             let idx = frame_to_index(paddr);
             let so_old = old(regions).slot_owners[idx];
             let so_new = final(regions).slot_owners[idx];
-            &&& so_new.inner_perms.ref_count == so_old.inner_perms.ref_count
+            &&& so_new.ref_count_perm == so_old.ref_count_perm
             &&& so_new.usage == so_old.usage
             &&& so_new.slot_vaddr == so_old.slot_vaddr
             &&& so_new.paths_in_pt == so_old.paths_in_pt
-            &&& so_new.inner_perms.in_list == so_old.inner_perms.in_list
-            &&& so_new.inner_perms.storage == so_old.inner_perms.storage
-            &&& so_new.inner_perms.vtable_ptr == so_old.inner_perms.vtable_ptr
+            &&& so_new.in_list_perm == so_old.in_list_perm
+            &&& so_new.storage_perm() == so_old.storage_perm()
+            &&& so_new.vtable_ptr_perm() == so_old.vtable_ptr_perm()
         },
         // All other slots fully preserved.
         forall|i: int| #![trigger final(regions).slot_owners[i]]
@@ -311,7 +311,7 @@ pub(super) proof fn from_unused_step(
             #![trigger frame_to_index(paddr)]
             (range.start <= paddr < range.end && paddr % PAGE_SIZE == 0)
                 ==> old(regions).slot_owners[frame_to_index(paddr)]
-                        .inner_perms.ref_count.value() == REF_COUNT_UNUSED,
+                        .ref_count() == REF_COUNT_UNUSED,
         forall|paddr: Paddr|
             #![trigger frame_to_index(paddr)]
             (range.start <= paddr < range.end && paddr % PAGE_SIZE == 0)
@@ -327,7 +327,7 @@ pub(super) proof fn from_unused_step(
                     let idx = frame_to_index(paddr);
                     let so = final(regions).slot_owners[idx];
                     &&& so.usage is Frame
-                    &&& so.inner_perms.ref_count.value() == 1
+                    &&& so.ref_count() == 1
                     &&& so.paths_in_pt.is_empty()
                 },
         res is Some ==> forall|i: int|
@@ -371,11 +371,11 @@ pub(super) proof fn drop_step(
             (entry.range.start <= paddr < entry.range.end
                 && paddr % PAGE_SIZE == 0) ==> {
                 let so = old(regions).slot_owners[frame_to_index(paddr)];
-                &&& so.inner_perms.ref_count.value() >= 1
-                &&& so.inner_perms.ref_count.value()
+                &&& so.ref_count() >= 1
+                &&& so.ref_count()
                         <= REF_COUNT_MAX
                 &&& so.usage is Frame
-                &&& so.inner_perms.ref_count.value() == 1
+                &&& so.ref_count() == 1
                     ==> so.paths_in_pt.is_empty()
             },
     ensures
@@ -391,12 +391,12 @@ pub(super) proof fn drop_step(
                 &&& so_new.usage == so_old.usage
                 &&& so_new.paths_in_pt == so_old.paths_in_pt
                 &&& so_new.slot_vaddr == so_old.slot_vaddr
-                &&& so_new.inner_perms.in_list == so_old.inner_perms.in_list
-                &&& so_old.inner_perms.ref_count.value() == 1
-                    ==> so_new.inner_perms.ref_count.value() == REF_COUNT_UNUSED
-                &&& so_old.inner_perms.ref_count.value() > 1
-                    ==> so_new.inner_perms.ref_count.value()
-                            == (so_old.inner_perms.ref_count.value() - 1) as u64
+                &&& so_new.in_list_perm == so_old.in_list_perm
+                &&& so_old.ref_count() == 1
+                    ==> so_new.ref_count() == REF_COUNT_UNUSED
+                &&& so_old.ref_count() > 1
+                    ==> so_new.ref_count()
+                            == (so_old.ref_count() - 1) as u64
             },
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
@@ -434,8 +434,8 @@ pub axiom fn segment_clone_embedded(
                 ==> {
                     let so = old(regions).slot_owners[frame_to_index(paddr)];
                     &&& so.usage is Frame
-                    &&& so.inner_perms.ref_count.value() >= 1
-                    &&& so.inner_perms.ref_count.value() + 1 <= REF_COUNT_MAX
+                    &&& so.ref_count() >= 1
+                    &&& so.ref_count() + 1 <= REF_COUNT_MAX
                 },
     ensures
         final(regions).inv(),
@@ -448,14 +448,14 @@ pub axiom fn segment_clone_embedded(
                     let idx = frame_to_index(paddr);
                     let so_old = old(regions).slot_owners[idx];
                     let so_new = final(regions).slot_owners[idx];
-                    &&& so_new.inner_perms.ref_count.value()
-                            == (so_old.inner_perms.ref_count.value() + 1) as u64
+                    &&& so_new.ref_count()
+                            == (so_old.ref_count() + 1) as u64
                     &&& so_new.usage == so_old.usage
                     &&& so_new.slot_vaddr == so_old.slot_vaddr
                     &&& so_new.paths_in_pt == so_old.paths_in_pt
-                    &&& so_new.inner_perms.in_list == so_old.inner_perms.in_list
-                    &&& so_new.inner_perms.storage == so_old.inner_perms.storage
-                    &&& so_new.inner_perms.vtable_ptr == so_old.inner_perms.vtable_ptr
+                    &&& so_new.in_list_perm == so_old.in_list_perm
+                    &&& so_new.storage_perm() == so_old.storage_perm()
+                    &&& so_new.vtable_ptr_perm() == so_old.vtable_ptr_perm()
                 },
         // Slots OUTSIDE the range are fully preserved.
         forall|i: int|

--- a/ostd/specs/mm/embedding/unique.rs
+++ b/ostd/specs/mm/embedding/unique.rs
@@ -86,7 +86,7 @@ pub axiom fn unique_from_unused_embedded(tracked regions: &mut MetaRegionOwners,
         valid_frame_paddr(paddr),
         old(regions).contains(frame_to_index(paddr)),
         old(regions).slot_owners[frame_to_index(paddr)].usage is Unused,
-        old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
+        old(regions).slot_owners[frame_to_index(paddr)].ref_count()
             == REF_COUNT_UNUSED,
     ensures
         final(regions).inv(),
@@ -98,9 +98,9 @@ pub axiom fn unique_from_unused_embedded(tracked regions: &mut MetaRegionOwners,
             let so_old = old(regions).slot_owners[idx];
             let so_new = final(regions).slot_owners[idx];
             &&& so_new.usage is Frame
-            &&& so_new.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
-            &&& so_new.inner_perms.in_list.value() == 0
-            &&& so_new.inner_perms.storage.is_init()
+            &&& so_new.ref_count() == REF_COUNT_UNIQUE
+            &&& so_new.in_list_perm.value() == 0
+            &&& so_new.storage_perm().is_init()
             &&& so_new.paths_in_pt == so_old.paths_in_pt
             &&& so_new.slot_vaddr == so_old.slot_vaddr
         },
@@ -129,10 +129,10 @@ pub axiom fn unique_drop_embedded(tracked regions: &mut MetaRegionOwners, paddr:
     requires
         old(regions).inv(),
         old(regions).contains(frame_to_index(paddr)),
-        old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
+        old(regions).slot_owners[frame_to_index(paddr)].ref_count()
             == REF_COUNT_UNIQUE,
-        old(regions).slot_owners[frame_to_index(paddr)].inner_perms.in_list.value() == 0,
-        old(regions).slot_owners[frame_to_index(paddr)].inner_perms.storage.is_init(),
+        old(regions).slot_owners[frame_to_index(paddr)].in_list_perm.value() == 0,
+        old(regions).slot_owners[frame_to_index(paddr)].storage_perm().is_init(),
         old(regions).slot_owners[frame_to_index(paddr)].paths_in_pt.is_empty(),
     ensures
         final(regions).inv(),
@@ -143,10 +143,10 @@ pub axiom fn unique_drop_embedded(tracked regions: &mut MetaRegionOwners, paddr:
             let idx = frame_to_index(paddr);
             let so_old = old(regions).slot_owners[idx];
             let so_new = final(regions).slot_owners[idx];
-            &&& so_new.inner_perms.ref_count.value() == REF_COUNT_UNUSED
+            &&& so_new.ref_count() == REF_COUNT_UNUSED
             &&& so_new.usage == so_old.usage
             &&& so_new.paths_in_pt == so_old.paths_in_pt
-            &&& so_new.inner_perms.in_list == so_old.inner_perms.in_list
+            &&& so_new.in_list_perm == so_old.in_list_perm
             &&& so_new.slot_vaddr == so_old.slot_vaddr
         },
         // All other slots fully preserved.
@@ -171,7 +171,7 @@ pub axiom fn from_unique_embedded(tracked regions: &mut MetaRegionOwners, paddr:
     requires
         old(regions).inv(),
         old(regions).contains(frame_to_index(paddr)),
-        old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
+        old(regions).slot_owners[frame_to_index(paddr)].ref_count()
             == REF_COUNT_UNIQUE,
     ensures
         final(regions).inv(),
@@ -180,11 +180,11 @@ pub axiom fn from_unique_embedded(tracked regions: &mut MetaRegionOwners, paddr:
             let idx = frame_to_index(paddr);
             let so_old = old(regions).slot_owners[idx];
             let so_new = final(regions).slot_owners[idx];
-            &&& so_new.inner_perms.ref_count.value() == 1
+            &&& so_new.ref_count() == 1
             &&& so_new.usage == so_old.usage
             &&& so_new.paths_in_pt == so_old.paths_in_pt
-            &&& so_new.inner_perms.in_list == so_old.inner_perms.in_list
-            &&& so_new.inner_perms.storage == so_old.inner_perms.storage
+            &&& so_new.in_list_perm == so_old.in_list_perm
+            &&& so_new.storage_perm() == so_old.storage_perm()
             &&& so_new.slot_vaddr == so_old.slot_vaddr
         },
         forall|i: int|
@@ -207,7 +207,7 @@ pub axiom fn try_from_shared_embedded(tracked regions: &mut MetaRegionOwners, pa
     requires
         old(regions).inv(),
         old(regions).contains(frame_to_index(paddr)),
-        old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() == 1,
+        old(regions).slot_owners[frame_to_index(paddr)].ref_count() == 1,
         old(regions).slot_owners[frame_to_index(paddr)].usage is Frame,
         old(regions).slot_owners[frame_to_index(paddr)].paths_in_pt.is_empty(),
     ensures
@@ -217,11 +217,11 @@ pub axiom fn try_from_shared_embedded(tracked regions: &mut MetaRegionOwners, pa
             let idx = frame_to_index(paddr);
             let so_old = old(regions).slot_owners[idx];
             let so_new = final(regions).slot_owners[idx];
-            &&& so_new.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+            &&& so_new.ref_count() == REF_COUNT_UNIQUE
             &&& so_new.usage == so_old.usage
             &&& so_new.paths_in_pt == so_old.paths_in_pt
-            &&& so_new.inner_perms.in_list == so_old.inner_perms.in_list
-            &&& so_new.inner_perms.storage == so_old.inner_perms.storage
+            &&& so_new.in_list_perm == so_old.in_list_perm
+            &&& so_new.storage_perm() == so_old.storage_perm()
             &&& so_new.slot_vaddr == so_old.slot_vaddr
         },
         forall|i: int|

--- a/ostd/specs/mm/embedding/vm_space.rs
+++ b/ostd/specs/mm/embedding/vm_space.rs
@@ -56,13 +56,13 @@ pub axiom fn vm_space_new_embedded<'a>(tracked regions: &mut MetaRegionOwners) -
         old(regions).contains(vm_space_root_idx(res)),
         final(regions).slots == old(regions).slots.remove(vm_space_root_idx(res)),
         final(regions).slot_owners[vm_space_root_idx(res)].usage is PageTable,
-        final(regions).slot_owners[vm_space_root_idx(res)].inner_perms.ref_count.value()
+        final(regions).slot_owners[vm_space_root_idx(res)].ref_count()
             != REF_COUNT_UNUSED,
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
-            final(regions).slot_owners[i].inner_perms.in_list == old(
+            final(regions).slot_owners[i].in_list_perm == old(
                 regions,
-            ).slot_owners[i].inner_perms.in_list,
+            ).slot_owners[i].in_list_perm,
         // Stage 5.3: `VmSpace::new` / `cursor` only allocate fresh PT
         // nodes — every *changed* slot was UNUSED before and becomes a
         // non-UNUSED PT node (`usage == PageTable`). `accounting_inv`
@@ -71,8 +71,8 @@ pub axiom fn vm_space_new_embedded<'a>(tracked regions: &mut MetaRegionOwners) -
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners[i] != old(regions).slot_owners[i] ==> {
-                &&& old(regions).slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNUSED
-                &&& final(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
+                &&& old(regions).slot_owners[i].ref_count() == REF_COUNT_UNUSED
+                &&& final(regions).slot_owners[i].ref_count() != REF_COUNT_UNUSED
                 &&& final(regions).slot_owners[i].usage is PageTable
             },
         forall|c: CursorOwner<'a, UserPtConfig>|
@@ -106,13 +106,13 @@ pub(super) proof fn new_vm_space_step<'a>(tracked regions: &mut MetaRegionOwners
         old(regions).contains(vm_space_root_idx(res)),
         final(regions).slots == old(regions).slots.remove(vm_space_root_idx(res)),
         final(regions).slot_owners[vm_space_root_idx(res)].usage is PageTable,
-        final(regions).slot_owners[vm_space_root_idx(res)].inner_perms.ref_count.value()
+        final(regions).slot_owners[vm_space_root_idx(res)].ref_count()
             != REF_COUNT_UNUSED,
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
-            final(regions).slot_owners[i].inner_perms.in_list == old(
+            final(regions).slot_owners[i].in_list_perm == old(
                 regions,
-            ).slot_owners[i].inner_perms.in_list,
+            ).slot_owners[i].in_list_perm,
         // Stage 5.3: `VmSpace::new` / `cursor` only allocate fresh PT
         // nodes — every *changed* slot was UNUSED before and becomes a
         // non-UNUSED PT node (`usage == PageTable`). `accounting_inv`
@@ -121,8 +121,8 @@ pub(super) proof fn new_vm_space_step<'a>(tracked regions: &mut MetaRegionOwners
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
             final(regions).slot_owners[i] != old(regions).slot_owners[i] ==> {
-                &&& old(regions).slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNUSED
-                &&& final(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
+                &&& old(regions).slot_owners[i].ref_count() == REF_COUNT_UNUSED
+                &&& final(regions).slot_owners[i].ref_count() != REF_COUNT_UNUSED
                 &&& final(regions).slot_owners[i].usage is PageTable
             },
         forall|c: CursorOwner<'a, UserPtConfig>|

--- a/ostd/specs/mm/embedding/vm_space.rs
+++ b/ostd/specs/mm/embedding/vm_space.rs
@@ -56,13 +56,10 @@ pub axiom fn vm_space_new_embedded<'a>(tracked regions: &mut MetaRegionOwners) -
         old(regions).contains(vm_space_root_idx(res)),
         final(regions).slots == old(regions).slots.remove(vm_space_root_idx(res)),
         final(regions).slot_owners[vm_space_root_idx(res)].usage is PageTable,
-        final(regions).slot_owners[vm_space_root_idx(res)].ref_count()
-            != REF_COUNT_UNUSED,
+        final(regions).slot_owners[vm_space_root_idx(res)].ref_count() != REF_COUNT_UNUSED,
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
-            final(regions).slot_owners[i].in_list_perm == old(
-                regions,
-            ).slot_owners[i].in_list_perm,
+            final(regions).slot_owners[i].in_list_perm == old(regions).slot_owners[i].in_list_perm,
         // Stage 5.3: `VmSpace::new` / `cursor` only allocate fresh PT
         // nodes — every *changed* slot was UNUSED before and becomes a
         // non-UNUSED PT node (`usage == PageTable`). `accounting_inv`
@@ -106,13 +103,10 @@ pub(super) proof fn new_vm_space_step<'a>(tracked regions: &mut MetaRegionOwners
         old(regions).contains(vm_space_root_idx(res)),
         final(regions).slots == old(regions).slots.remove(vm_space_root_idx(res)),
         final(regions).slot_owners[vm_space_root_idx(res)].usage is PageTable,
-        final(regions).slot_owners[vm_space_root_idx(res)].ref_count()
-            != REF_COUNT_UNUSED,
+        final(regions).slot_owners[vm_space_root_idx(res)].ref_count() != REF_COUNT_UNUSED,
         forall|i: int|
             #![trigger final(regions).slot_owners[i]]
-            final(regions).slot_owners[i].in_list_perm == old(
-                regions,
-            ).slot_owners[i].in_list_perm,
+            final(regions).slot_owners[i].in_list_perm == old(regions).slot_owners[i].in_list_perm,
         // Stage 5.3: `VmSpace::new` / `cursor` only allocate fresh PT
         // nodes — every *changed* slot was UNUSED before and becomes a
         // non-UNUSED PT node (`usage == PageTable`). `accounting_inv`

--- a/ostd/specs/mm/frame/frame_specs.rs
+++ b/ostd/specs/mm/frame/frame_specs.rs
@@ -43,8 +43,7 @@ impl<'a, M: ?Sized> Frame<M> {
         &&& regions.slot_owners[frame_to_index(paddr)].slot_vaddr == frame_to_meta(paddr)
         &&& valid_frame_paddr(paddr)
         &&& regions.inv()
-        &&& regions.slot_owners[frame_to_index(paddr)].ref_count()
-            != REF_COUNT_UNUSED
+        &&& regions.slot_owners[frame_to_index(paddr)].ref_count() != REF_COUNT_UNUSED
     }
 
     pub open spec fn from_raw_ensures(
@@ -300,10 +299,8 @@ impl<M: ?Sized> TrackDrop for Frame<M> {
         // is in `[1, REF_COUNT_MAX]`, so these cases are exhaustive:
         //  - last reference (== 1): the slot is torn down to UNUSED.
         //  - otherwise (> 1): the refcount is decremented by one.
-        &&& so0.ref_count() == 1 ==> so1.ref_count()
-            == REF_COUNT_UNUSED
-        &&& so0.ref_count() > 1 ==> so1.ref_count() == (
-        so0.ref_count()
+        &&& so0.ref_count() == 1 ==> so1.ref_count() == REF_COUNT_UNUSED
+        &&& so0.ref_count() > 1 ==> so1.ref_count() == (so0.ref_count()
             - 1) as u64
         // Linear-drop pilot: `Frame::drop` doesn't redeem segment-level
         // obligations, so the segment ledger is preserved.

--- a/ostd/specs/mm/frame/frame_specs.rs
+++ b/ostd/specs/mm/frame/frame_specs.rs
@@ -43,7 +43,7 @@ impl<'a, M: ?Sized> Frame<M> {
         &&& regions.slot_owners[frame_to_index(paddr)].slot_vaddr == frame_to_meta(paddr)
         &&& valid_frame_paddr(paddr)
         &&& regions.inv()
-        &&& regions.slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
+        &&& regions.slot_owners[frame_to_index(paddr)].ref_count()
             != REF_COUNT_UNUSED
     }
 
@@ -85,7 +85,7 @@ impl<'a, M: ?Sized> Frame<M> {
 
     /// **Bookkeeping**: The frame must be in use (not unused).
     pub open spec fn into_raw_pre_not_unused(self, regions: MetaRegionOwners) -> bool {
-        regions.slot_owners[self.index()].inner_perms.ref_count.value() != REF_COUNT_UNUSED
+        regions.slot_owners[self.index()].ref_count() != REF_COUNT_UNUSED
     }
 
     /// **Safety**: Frames other than this one are not affected by the call.
@@ -131,8 +131,8 @@ impl<M: ?Sized> Frame<M> {
         let pre_owner = pre.slot_owners[idx];
         let post_owner = post.slot_owners[idx];
         {
-            &&& pre_owner.inner_perms.ref_count.value() == REF_COUNT_UNUSED
-            &&& MetaSlot::get_from_unused_inner_perms_spec(false, post_owner.inner_perms)
+            &&& pre_owner.ref_count() == REF_COUNT_UNUSED
+            &&& MetaSlot::get_from_unused_owner_spec(false, post_owner)
             &&& post_owner.usage is Frame
             &&& post_owner.slot_vaddr == pre_owner.slot_vaddr
             &&& post_owner.paths_in_pt == pre_owner.paths_in_pt
@@ -173,10 +173,10 @@ impl<M: ?Sized> Frame<M> {
         &&& s.inv()
         &&& s.contains(idx)
         &&& s.slots[idx].pptr() == self.ptr
-        &&& slot_own.inner_perms.ref_count.value() != REF_COUNT_UNUSED
-        &&& slot_own.inner_perms.ref_count.value() != REF_COUNT_UNIQUE
-        &&& slot_own.inner_perms.ref_count.value() > 0
-        &&& slot_own.inner_perms.ref_count.value() <= REF_COUNT_MAX
+        &&& slot_own.ref_count() != REF_COUNT_UNUSED
+        &&& slot_own.ref_count() != REF_COUNT_UNIQUE
+        &&& slot_own.ref_count() > 0
+        &&& slot_own.ref_count() <= REF_COUNT_MAX
     }
 }
 
@@ -267,7 +267,7 @@ impl<M: ?Sized> TrackDrop for Frame<M> {
         // strengthened `MetaSlotOwner::inv` SHARED branch
         // (`0 < rc <= REF_COUNT_MAX`) — they hold universally for any
         // in-use slot, not just at `rc == 1`.
-        &&& slot_own.inner_perms.ref_count.value() == 1 ==> {
+        &&& slot_own.ref_count() == 1 ==> {
             &&& slot_own.paths_in_pt.is_empty()
         }
         &&& s.frame_obligations.count(self.index()) > 0
@@ -300,10 +300,10 @@ impl<M: ?Sized> TrackDrop for Frame<M> {
         // is in `[1, REF_COUNT_MAX]`, so these cases are exhaustive:
         //  - last reference (== 1): the slot is torn down to UNUSED.
         //  - otherwise (> 1): the refcount is decremented by one.
-        &&& so0.inner_perms.ref_count.value() == 1 ==> so1.inner_perms.ref_count.value()
+        &&& so0.ref_count() == 1 ==> so1.ref_count()
             == REF_COUNT_UNUSED
-        &&& so0.inner_perms.ref_count.value() > 1 ==> so1.inner_perms.ref_count.value() == (
-        so0.inner_perms.ref_count.value()
+        &&& so0.ref_count() > 1 ==> so1.ref_count() == (
+        so0.ref_count()
             - 1) as u64
         // Linear-drop pilot: `Frame::drop` doesn't redeem segment-level
         // obligations, so the segment ledger is preserved.

--- a/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
+++ b/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
@@ -284,10 +284,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
 
     pub open spec fn meta_value_at(self, regions: MetaRegionOwners, i: int) -> Link<M> {
         let idx = meta_to_index(self.list[i].paddr);
-        typed_meta_value::<Link<M>>(
-            regions.slot_owners[idx].metadata_perm,
-            self.repr_perms[i],
-        )
+        typed_meta_value::<Link<M>>(regions.slot_owners[idx].metadata_perm, self.repr_perms[i])
     }
 
     /// The per-link invariant expressed directly over the region-owned slot and
@@ -659,10 +656,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
         } else {
             p + 1
         };
-        let fp = typed_meta_value::<Link<M>>(
-            fr.slot_owners[i].metadata_perm,
-            self.repr_perms[np],
-        );
+        let fp = typed_meta_value::<Link<M>>(fr.slot_owners[i].metadata_perm, self.repr_perms[np]);
         &&& fr.contains(i)
         &&& fr.slots[i].addr() == old.list[p].paddr
         &&& fr.slots[i].pptr() == r0.slots[i].pptr()

--- a/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
+++ b/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
@@ -277,7 +277,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
         let idx = meta_to_index(self.list[i].paddr);
         typed_meta_wf::<Link<M>>(
             *regions.slots[idx],
-            regions.slot_owners[idx].storage_perm(),
+            regions.slot_owners[idx].metadata_perm,
             self.repr_perms[i],
         )
     }
@@ -285,7 +285,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
     pub open spec fn meta_value_at(self, regions: MetaRegionOwners, i: int) -> Link<M> {
         let idx = meta_to_index(self.list[i].paddr);
         typed_meta_value::<Link<M>>(
-            regions.slot_owners[idx].storage_perm(),
+            regions.slot_owners[idx].metadata_perm,
             self.repr_perms[i],
         )
     }
@@ -529,7 +529,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
                         p - 1
                     };
                     let fp = typed_meta_value::<Link<M>>(
-                        fr.slot_owners[i].storage_perm(),
+                        fr.slot_owners[i].metadata_perm,
                         new.repr_perms[np],
                     );
                     &&& fr.contains(i)
@@ -540,7 +540,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
                     &&& fr.slot_owners[i].in_list_perm.value() == new.list_id
                     &&& typed_meta_wf::<Link<M>>(
                         *fr.slots[i],
-                        fr.slot_owners[i].storage_perm(),
+                        fr.slot_owners[i].metadata_perm,
                         new.repr_perms[np],
                     )
                     &&& fr.slots[i].addr() % META_SLOT_SIZE == 0
@@ -660,7 +660,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
             p + 1
         };
         let fp = typed_meta_value::<Link<M>>(
-            fr.slot_owners[i].storage_perm(),
+            fr.slot_owners[i].metadata_perm,
             self.repr_perms[np],
         );
         &&& fr.contains(i)

--- a/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
+++ b/ostd/specs/mm/frame/linked_list/linked_list_owners.rs
@@ -277,7 +277,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
         let idx = meta_to_index(self.list[i].paddr);
         typed_meta_wf::<Link<M>>(
             *regions.slots[idx],
-            regions.slot_owners[idx].inner_perms.storage,
+            regions.slot_owners[idx].storage_perm(),
             self.repr_perms[i],
         )
     }
@@ -285,7 +285,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
     pub open spec fn meta_value_at(self, regions: MetaRegionOwners, i: int) -> Link<M> {
         let idx = meta_to_index(self.list[i].paddr);
         typed_meta_value::<Link<M>>(
-            regions.slot_owners[idx].inner_perms.storage,
+            regions.slot_owners[idx].storage_perm(),
             self.repr_perms[i],
         )
     }
@@ -298,9 +298,9 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
         let value = self.meta_value_at(regions, i);
         &&& regions.contains(idx)
         &&& regions.slots[idx].addr() == self.list[i].paddr
-        &&& regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+        &&& regions.slot_owners[idx].ref_count() == REF_COUNT_UNIQUE
         &&& regions.slot_owners[idx].usage is Frame
-        &&& regions.slot_owners[idx].inner_perms.in_list.value() == self.list_id
+        &&& regions.slot_owners[idx].in_list_perm.value() == self.list_id
         &&& self.meta_wf_at(regions, i)
         &&& regions.slots[idx].addr() % META_SLOT_SIZE == 0
         &&& FRAME_METADATA_RANGE.start <= regions.slots[idx].addr() < FRAME_METADATA_RANGE.start
@@ -395,9 +395,9 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
                 let value = self.meta_value_at(regions, i);
                 &&& regions.contains(idx)
                 &&& regions.slots[idx].addr() == self.list[i].paddr
-                &&& regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+                &&& regions.slot_owners[idx].ref_count() == REF_COUNT_UNIQUE
                 &&& regions.slot_owners[idx].usage is Frame
-                &&& regions.slot_owners[idx].inner_perms.in_list.value() == self.list_id
+                &&& regions.slot_owners[idx].in_list_perm.value() == self.list_id
                 &&& self.meta_wf_at(regions, i)
                 &&& regions.slots[idx].addr() % META_SLOT_SIZE == 0
                 &&& FRAME_METADATA_RANGE.start <= regions.slots[idx].addr()
@@ -432,9 +432,9 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
                 &&& regions.contains(idx)
                 &&& self.repr_perms.len() == self.list.len()
                 &&& regions.slots[idx].addr() == self.list[i].paddr
-                &&& regions.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+                &&& regions.slot_owners[idx].ref_count() == REF_COUNT_UNIQUE
                 &&& regions.slot_owners[idx].usage is Frame
-                &&& regions.slot_owners[idx].inner_perms.in_list.value() == self.list_id
+                &&& regions.slot_owners[idx].in_list_perm.value() == self.list_id
                 &&& self.meta_wf_at(regions, i)
                 &&& regions.slots[idx].addr() % META_SLOT_SIZE == 0
                 &&& FRAME_METADATA_RANGE.start <= regions.slots[idx].addr()
@@ -529,18 +529,18 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
                         p - 1
                     };
                     let fp = typed_meta_value::<Link<M>>(
-                        fr.slot_owners[i].inner_perms.storage,
+                        fr.slot_owners[i].storage_perm(),
                         new.repr_perms[np],
                     );
                     &&& fr.contains(i)
                     &&& fr.slots[i].addr() == old.list[p].paddr
                     &&& fr.slots[i].pptr() == r0.slots[i].pptr()
-                    &&& fr.slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+                    &&& fr.slot_owners[i].ref_count() == REF_COUNT_UNIQUE
                     &&& fr.slot_owners[i].usage is Frame
-                    &&& fr.slot_owners[i].inner_perms.in_list.value() == new.list_id
+                    &&& fr.slot_owners[i].in_list_perm.value() == new.list_id
                     &&& typed_meta_wf::<Link<M>>(
                         *fr.slots[i],
-                        fr.slot_owners[i].inner_perms.storage,
+                        fr.slot_owners[i].storage_perm(),
                         new.repr_perms[np],
                     )
                     &&& fr.slots[i].addr() % META_SLOT_SIZE == 0
@@ -660,15 +660,15 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
             p + 1
         };
         let fp = typed_meta_value::<Link<M>>(
-            fr.slot_owners[i].inner_perms.storage,
+            fr.slot_owners[i].storage_perm(),
             self.repr_perms[np],
         );
         &&& fr.contains(i)
         &&& fr.slots[i].addr() == old.list[p].paddr
         &&& fr.slots[i].pptr() == r0.slots[i].pptr()
-        &&& fr.slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+        &&& fr.slot_owners[i].ref_count() == REF_COUNT_UNIQUE
         &&& fr.slot_owners[i].usage is Frame
-        &&& fr.slot_owners[i].inner_perms.in_list.value() == self.list_id
+        &&& fr.slot_owners[i].in_list_perm.value() == self.list_id
         &&& self.meta_wf_at(fr, np)
         &&& fr.slots[i].addr() % META_SLOT_SIZE == 0
         &&& FRAME_METADATA_RANGE.start <= fr.slots[i].addr() < FRAME_METADATA_RANGE.start
@@ -745,9 +745,9 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedListOwner<M> {
                 let fpn = new.meta_value_at(fr, n);
                 &&& fr.contains(ins)
                 &&& fr.slots[ins].addr() == link.paddr
-                &&& fr.slot_owners[ins].inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+                &&& fr.slot_owners[ins].ref_count() == REF_COUNT_UNIQUE
                 &&& fr.slot_owners[ins].usage is Frame
-                &&& fr.slot_owners[ins].inner_perms.in_list.value() == new.list_id
+                &&& fr.slot_owners[ins].in_list_perm.value() == new.list_id
                 &&& new.meta_wf_at(fr, n)
                 &&& fr.slots[ins].addr() % META_SLOT_SIZE == 0
                 &&& FRAME_METADATA_RANGE.start <= fr.slots[ins].addr() < FRAME_METADATA_RANGE.start
@@ -1228,7 +1228,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> UniqueFrameOwner<Link<M>> {
         &&& self.meta_value(regions).prev is None
         &&& self.meta_value(regions).next is None
         &&& self.meta_own.paddr == regions.slots[self.slot_index].addr()
-        &&& regions.slot_owners[self.slot_index].inner_perms.in_list.value() == 0
+        &&& regions.slot_owners[self.slot_index].in_list_perm.value() == 0
     }
 }
 

--- a/ostd/specs/mm/frame/meta_owners.rs
+++ b/ostd/specs/mm/frame/meta_owners.rs
@@ -193,11 +193,11 @@ impl MetaSlotStorage {
     }
 }
 
-pub tracked struct MetadataInnerPerms {
-    pub storage: pcell_maybe_uninit::PointsTo<MetaSlotStorage>,
-    pub ref_count: PermissionU64,
-    pub vtable_ptr: vstd::simple_pptr::PointsTo<usize>,
-    pub in_list: PermissionU64,
+/// Permissions whose initialized contents belong to one installed metadata
+/// value.
+pub tracked struct MetadataPerms {
+    pub storage_perm: pcell_maybe_uninit::PointsTo<MetaSlotStorage>,
+    pub vtable_ptr_perm: vstd::simple_pptr::PointsTo<usize>,
 }
 
 /// Well-formedness of a concrete metadata representation. The permissions for
@@ -247,34 +247,40 @@ pub fn borrow_meta_mut<'a, M: AnyFrameMeta + Repr<MetaSlotStorage>>(
     requires
         old(slot_owner).inv(),
         points_to.value().wf(*old(slot_owner)),
-        typed_meta_wf::<M>(*points_to, old(slot_owner).inner_perms.storage, *old(repr_perm)),
+        typed_meta_wf::<M>(*points_to, old(slot_owner).storage_perm(), *old(repr_perm)),
         ptr.addr() == points_to.addr(),
     ensures
-        *res == typed_meta_value::<M>(old(slot_owner).inner_perms.storage, *old(repr_perm)),
+        *res == typed_meta_value::<M>(old(slot_owner).storage_perm(), *old(repr_perm)),
         final(slot_owner).inv(),
         points_to.value().wf(*final(slot_owner)),
         final(slot_owner).slot_vaddr == old(slot_owner).slot_vaddr,
         final(slot_owner).usage == old(slot_owner).usage,
         final(slot_owner).paths_in_pt == old(slot_owner).paths_in_pt,
-        final(slot_owner).inner_perms.ref_count == old(slot_owner).inner_perms.ref_count,
-        final(slot_owner).inner_perms.vtable_ptr == old(slot_owner).inner_perms.vtable_ptr,
-        final(slot_owner).inner_perms.in_list == old(slot_owner).inner_perms.in_list,
-        typed_meta_wf::<M>(*points_to, final(slot_owner).inner_perms.storage, *final(repr_perm)),
+        final(slot_owner).ref_count_perm == old(slot_owner).ref_count_perm,
+        final(slot_owner).vtable_ptr_perm() == old(slot_owner).vtable_ptr_perm(),
+        final(slot_owner).in_list_perm == old(slot_owner).in_list_perm,
+        typed_meta_wf::<M>(*points_to, final(slot_owner).storage_perm(), *final(repr_perm)),
         *final(res) == typed_meta_value::<M>(
-            final(slot_owner).inner_perms.storage,
+            final(slot_owner).storage_perm(),
             *final(repr_perm),
         ),
 {
     let slot = PPtr::<MetaSlot>::from_addr(ptr.addr()).borrow(Tracked(points_to));
-    let tracked inner_perms = slot_owner.tracked_borrow_mut_inner_perms();
+    let tracked metadata_perms = slot_owner.tracked_borrow_mut_metadata_perms();
     M::from_borrowed_mut(
-        slot.storage.borrow_mut(Tracked(&mut inner_perms.storage)),
+        slot.storage.borrow_mut(Tracked(&mut metadata_perms.storage_perm)),
         Tracked(repr_perm),
     )
 }
 
+/// Permissions that remain under the authority of `MetaRegionOwners`.
+///
+/// `ref_count` and `in_list` exist for the complete lifetime of the
+/// corresponding `MetaSlot` (i.e., `'static`).
 pub tracked struct MetaSlotOwner {
-    pub inner_perms: MetadataInnerPerms,
+    pub metadata_perm: MetadataPerms,
+    pub ref_count_perm: PermissionU64,
+    pub in_list_perm: PermissionU64,
     pub ghost slot_vaddr: Vaddr,
     pub ghost usage: PageUsage,
     /// The set of tree paths at which this slot is referenced. For PT-node
@@ -297,15 +303,15 @@ impl Inv for MetaSlotOwner {
         // `UNUSED` sentinel while still mapped), exactly as the embedding
         // accounting and the huge-page split loop invariant scope out
         // `usage == MMIO`.
-        &&& self.inner_perms.ref_count.value() == REF_COUNT_UNUSED ==> {
-            &&& self.inner_perms.storage.is_uninit()
-            &&& self.inner_perms.vtable_ptr.is_uninit()
-            &&& self.inner_perms.in_list.value() == 0
+        &&& self.ref_count() == REF_COUNT_UNUSED ==> {
+            &&& self.storage_perm().is_uninit()
+            &&& self.vtable_ptr_perm().is_uninit()
+            &&& self.in_list_perm.value() == 0
             &&& (self.usage != PageUsage::MMIO ==> self.paths_in_pt.is_empty())
         }
-        &&& self.inner_perms.ref_count.value() == REF_COUNT_UNIQUE ==> {
-            &&& self.inner_perms.vtable_ptr.is_init()
-            &&& self.inner_perms.storage.is_init()
+        &&& self.ref_count() == REF_COUNT_UNIQUE ==> {
+            &&& self.vtable_ptr_perm().is_init()
+            &&& self.storage_perm().is_init()
             // A UNIQUE non-MMIO slot has no live PTE mapping (same rationale as
             // the UNUSED branch): a mapping would be a reference keeping the
             // count above the unique sentinel. Lets the list-store embedding
@@ -322,14 +328,14 @@ impl Inv for MetaSlotOwner {
         // these are invariants, the embedding's `op_pre[FrameDrop]` can
         // drop its `rc == 1 ⟹ storage.is_init ∧ in_list == 0` residual
         // (it follows from `regions.inv() ⟹ slot_owners[idx].inv()`).
-        &&& 0 < self.inner_perms.ref_count.value() <= REF_COUNT_MAX ==> {
-            &&& self.inner_perms.vtable_ptr.is_init()
-            &&& self.inner_perms.storage.is_init()
-            &&& self.inner_perms.in_list.value() == 0
+        &&& 0 < self.ref_count() <= REF_COUNT_MAX ==> {
+            &&& self.vtable_ptr_perm().is_init()
+            &&& self.storage_perm().is_init()
+            &&& self.in_list_perm.value() == 0
         }
-        &&& REF_COUNT_MAX < self.inner_perms.ref_count.value() < REF_COUNT_UNIQUE ==> { false }
-        &&& self.inner_perms.ref_count.value() == 0 ==> {
-            &&& self.inner_perms.in_list.value() == 0
+        &&& REF_COUNT_MAX < self.ref_count() < REF_COUNT_UNIQUE ==> { false }
+        &&& self.ref_count() == 0 ==> {
+            &&& self.in_list_perm.value() == 0
         }
         &&& FRAME_METADATA_RANGE.start <= self.slot_vaddr < FRAME_METADATA_RANGE.end
         &&& self.slot_vaddr % META_SLOT_SIZE == 0
@@ -365,10 +371,10 @@ impl View for MetaSlotOwner {
     type V = MetaSlotModel;
 
     open spec fn view(&self) -> Self::V {
-        let storage = self.inner_perms.storage.mem_contents();
-        let ref_count = self.inner_perms.ref_count.value();
-        let vtable_ptr = self.inner_perms.vtable_ptr.mem_contents();
-        let in_list = self.inner_perms.in_list.value();
+        let storage = self.storage_perm().mem_contents();
+        let ref_count = self.ref_count_perm.value();
+        let vtable_ptr = self.vtable_ptr_perm().mem_contents();
+        let in_list = self.in_list_perm.value();
         let slot_vaddr = self.slot_vaddr;
         let usage = self.usage;
         let status = match ref_count {
@@ -391,21 +397,39 @@ impl OwnerOf for MetaSlot {
     type Owner = MetaSlotOwner;
 
     open spec fn wf(self, owner: Self::Owner) -> bool {
-        &&& self.storage.id() == owner.inner_perms.storage.id()
-        &&& self.ref_count.id() == owner.inner_perms.ref_count.id()
-        &&& self.vtable_ptr == owner.inner_perms.vtable_ptr.pptr()
-        &&& self.in_list.id() == owner.inner_perms.in_list.id()
+        &&& self.storage.id() == owner.storage_perm().id()
+        &&& self.ref_count.id() == owner.ref_count_perm.id()
+        &&& self.vtable_ptr == owner.vtable_ptr_perm().pptr()
+        &&& self.in_list.id() == owner.in_list_perm.id()
     }
 }
 
 impl MetaSlotOwner {
-    pub proof fn tracked_borrow_mut_inner_perms(tracked &mut self) -> (tracked res:
-        &mut MetadataInnerPerms)
+    pub open spec fn same_permissions(self, other: Self) -> bool {
+        &&& self.metadata_perm == other.metadata_perm
+        &&& self.ref_count_perm == other.ref_count_perm
+        &&& self.in_list_perm == other.in_list_perm
+    }
+
+    pub open spec fn ref_count(self) -> u64 {
+        self.ref_count_perm.value()
+    }
+
+    pub open spec fn storage_perm(self) -> pcell_maybe_uninit::PointsTo<MetaSlotStorage> {
+        self.metadata_perm.storage_perm
+    }
+
+    pub open spec fn vtable_ptr_perm(self) -> vstd::simple_pptr::PointsTo<usize> {
+        self.metadata_perm.vtable_ptr_perm
+    }
+
+    pub proof fn tracked_borrow_mut_metadata_perms(tracked &mut self) -> (tracked res:
+        &mut MetadataPerms)
         ensures
-            *res == old(self).inner_perms,
-            *final(self) == (Self { inner_perms: *final(res), ..*old(self) }),
+            *res == old(self).metadata_perm,
+            *final(self) == (Self { metadata_perm: *final(res), ..*old(self) }),
     {
-        &mut self.inner_perms
+        &mut self.metadata_perm
     }
 }
 

--- a/ostd/specs/mm/frame/meta_owners.rs
+++ b/ostd/specs/mm/frame/meta_owners.rs
@@ -200,42 +200,44 @@ pub tracked struct MetadataPerms {
     pub vtable_ptr_perm: vstd::simple_pptr::PointsTo<usize>,
 }
 
-/// Well-formedness of a concrete metadata representation. The permissions for
-/// the outer slot and its storage remain owned by `MetaRegionOwners`; only the
-/// representation-specific permission is supplied by the concrete metadata
-/// owner.
+/// Well-formedness of a concrete metadata representation. The outer slot
+/// permission remains permanently in `MetaRegionOwners`; the metadata bundle
+/// describes the permissions tied to the currently installed metadata.
 pub open spec fn typed_meta_wf<M: AnyFrameMeta + Repr<MetaSlotStorage>>(
     points_to: vstd::simple_pptr::PointsTo<MetaSlot>,
-    storage: pcell_maybe_uninit::PointsTo<MetaSlotStorage>,
+    metadata_perms: MetadataPerms,
     repr_perm: M::ReprPerm,
 ) -> bool {
     &&& points_to.is_init()
-    &&& storage.is_init()
-    &&& storage.id() == points_to.value().storage.id()
-    &&& M::wf(storage.value(), repr_perm)
+    &&& metadata_perms.storage_perm.is_init()
+    &&& metadata_perms.storage_perm.id() == points_to.value().storage.id()
+    &&& M::wf(metadata_perms.storage_perm.value(), repr_perm)
 }
 
 pub open spec fn typed_meta_value<M: AnyFrameMeta + Repr<MetaSlotStorage>>(
-    storage: pcell_maybe_uninit::PointsTo<MetaSlotStorage>,
+    metadata_perms: MetadataPerms,
     repr_perm: M::ReprPerm,
 ) -> M {
-    M::from_repr_spec(storage.value(), repr_perm)
+    M::from_repr_spec(metadata_perms.storage_perm.value(), repr_perm)
 }
 
 pub fn borrow_meta<'a, M: AnyFrameMeta + Repr<MetaSlotStorage>>(
     ptr: cast_ptr::ReprPtr<MetaSlotStorage, M>,
     Tracked(points_to): Tracked<&'a vstd::simple_pptr::PointsTo<MetaSlot>>,
-    Tracked(storage): Tracked<&'a pcell_maybe_uninit::PointsTo<MetaSlotStorage>>,
+    Tracked(metadata_perms): Tracked<&'a MetadataPerms>,
     Tracked(repr_perm): Tracked<&'a M::ReprPerm>,
 ) -> (res: &'a M)
     requires
-        typed_meta_wf::<M>(*points_to, *storage, *repr_perm),
+        typed_meta_wf::<M>(*points_to, *metadata_perms, *repr_perm),
         ptr.addr() == points_to.addr(),
     ensures
-        *res == typed_meta_value::<M>(*storage, *repr_perm),
+        *res == typed_meta_value::<M>(*metadata_perms, *repr_perm),
 {
     let slot = PPtr::<MetaSlot>::from_addr(ptr.addr()).borrow(Tracked(points_to));
-    M::from_borrowed(slot.storage.borrow(Tracked(storage)), Tracked(repr_perm))
+    M::from_borrowed(
+        slot.storage.borrow(Tracked(&metadata_perms.storage_perm)),
+        Tracked(repr_perm),
+    )
 }
 
 pub fn borrow_meta_mut<'a, M: AnyFrameMeta + Repr<MetaSlotStorage>>(
@@ -247,10 +249,10 @@ pub fn borrow_meta_mut<'a, M: AnyFrameMeta + Repr<MetaSlotStorage>>(
     requires
         old(slot_owner).inv(),
         points_to.value().wf(*old(slot_owner)),
-        typed_meta_wf::<M>(*points_to, old(slot_owner).storage_perm(), *old(repr_perm)),
+        typed_meta_wf::<M>(*points_to, old(slot_owner).metadata_perm, *old(repr_perm)),
         ptr.addr() == points_to.addr(),
     ensures
-        *res == typed_meta_value::<M>(old(slot_owner).storage_perm(), *old(repr_perm)),
+        *res == typed_meta_value::<M>(old(slot_owner).metadata_perm, *old(repr_perm)),
         final(slot_owner).inv(),
         points_to.value().wf(*final(slot_owner)),
         final(slot_owner).slot_vaddr == old(slot_owner).slot_vaddr,
@@ -259,9 +261,9 @@ pub fn borrow_meta_mut<'a, M: AnyFrameMeta + Repr<MetaSlotStorage>>(
         final(slot_owner).ref_count_perm == old(slot_owner).ref_count_perm,
         final(slot_owner).vtable_ptr_perm() == old(slot_owner).vtable_ptr_perm(),
         final(slot_owner).in_list_perm == old(slot_owner).in_list_perm,
-        typed_meta_wf::<M>(*points_to, final(slot_owner).storage_perm(), *final(repr_perm)),
+        typed_meta_wf::<M>(*points_to, final(slot_owner).metadata_perm, *final(repr_perm)),
         *final(res) == typed_meta_value::<M>(
-            final(slot_owner).storage_perm(),
+            final(slot_owner).metadata_perm,
             *final(repr_perm),
         ),
 {

--- a/ostd/specs/mm/frame/meta_owners.rs
+++ b/ostd/specs/mm/frame/meta_owners.rs
@@ -234,10 +234,7 @@ pub fn borrow_meta<'a, M: AnyFrameMeta + Repr<MetaSlotStorage>>(
         *res == typed_meta_value::<M>(*metadata_perms, *repr_perm),
 {
     let slot = PPtr::<MetaSlot>::from_addr(ptr.addr()).borrow(Tracked(points_to));
-    M::from_borrowed(
-        slot.storage.borrow(Tracked(&metadata_perms.storage_perm)),
-        Tracked(repr_perm),
-    )
+    M::from_borrowed(slot.storage.borrow(Tracked(&metadata_perms.storage_perm)), Tracked(repr_perm))
 }
 
 pub fn borrow_meta_mut<'a, M: AnyFrameMeta + Repr<MetaSlotStorage>>(
@@ -262,10 +259,7 @@ pub fn borrow_meta_mut<'a, M: AnyFrameMeta + Repr<MetaSlotStorage>>(
         final(slot_owner).vtable_ptr_perm() == old(slot_owner).vtable_ptr_perm(),
         final(slot_owner).in_list_perm == old(slot_owner).in_list_perm,
         typed_meta_wf::<M>(*points_to, final(slot_owner).metadata_perm, *final(repr_perm)),
-        *final(res) == typed_meta_value::<M>(
-            final(slot_owner).metadata_perm,
-            *final(repr_perm),
-        ),
+        *final(res) == typed_meta_value::<M>(final(slot_owner).metadata_perm, *final(repr_perm)),
 {
     let slot = PPtr::<MetaSlot>::from_addr(ptr.addr()).borrow(Tracked(points_to));
     let tracked metadata_perms = slot_owner.tracked_borrow_mut_metadata_perms();
@@ -374,7 +368,7 @@ impl View for MetaSlotOwner {
 
     open spec fn view(&self) -> Self::V {
         let storage = self.storage_perm().mem_contents();
-        let ref_count = self.ref_count_perm.value();
+        let ref_count = self.ref_count();
         let vtable_ptr = self.vtable_ptr_perm().mem_contents();
         let in_list = self.in_list_perm.value();
         let slot_vaddr = self.slot_vaddr;

--- a/ostd/specs/mm/frame/meta_region_owners.rs
+++ b/ostd/specs/mm/frame/meta_region_owners.rs
@@ -133,7 +133,7 @@ impl MetaRegionOwners {
         recommends
             0 <= i < max_meta_slots(),
     {
-        self.slot_owners[i].inner_perms.ref_count.value()
+        self.slot_owners[i].ref_count()
     }
 
     /// `other` agrees with `self` on every slot owner except the one at index

--- a/ostd/specs/mm/frame/meta_specs.rs
+++ b/ostd/specs/mm/frame/meta_specs.rs
@@ -12,7 +12,6 @@ use crate::specs::{
     arch::*,
     mm::frame::{
         mapping::{frame_to_index, index_to_meta},
-        meta_owners::MetadataInnerPerms,
         meta_region_owners::MetaRegionOwners,
     },
 };
@@ -47,18 +46,15 @@ impl MetaSlot {
 
     }
 
-    pub open spec fn get_from_unused_inner_perms_spec(
-        as_unique: bool,
-        perms: MetadataInnerPerms,
-    ) -> bool {
-        &&& perms.ref_count.value() == (if as_unique {
+    pub open spec fn get_from_unused_owner_spec(as_unique: bool, owner: MetaSlotOwner) -> bool {
+        &&& owner.ref_count() == (if as_unique {
             REF_COUNT_UNIQUE as u64
         } else {
             1u64
         })
-        &&& perms.in_list.value() == 0
-        &&& perms.storage.is_init()
-        &&& perms.vtable_ptr.is_init()
+        &&& owner.in_list_perm.value() == 0
+        &&& owner.storage_perm().is_init()
+        &&& owner.vtable_ptr_perm().is_init()
     }
 
     /// The `slot_owners`/`obligations` transition of claiming an unused slot.
@@ -72,8 +68,8 @@ impl MetaSlot {
         let pre_owner = pre.slot_owners[idx];
         let post_owner = post.slot_owners[idx];
         {
-            &&& pre_owner.inner_perms.ref_count.value() == REF_COUNT_UNUSED
-            &&& MetaSlot::get_from_unused_inner_perms_spec(as_unique, post_owner.inner_perms)
+            &&& pre_owner.ref_count() == REF_COUNT_UNUSED
+            &&& MetaSlot::get_from_unused_owner_spec(as_unique, post_owner)
             &&& post_owner.usage is Frame
             &&& post_owner.slot_vaddr == pre_owner.slot_vaddr
             &&& post_owner.paths_in_pt == pre_owner.paths_in_pt
@@ -96,12 +92,12 @@ impl MetaSlot {
         let idx = frame_to_index(paddr);
         {
             &&& post.slot_owners.dom() =~= pre.slot_owners.dom()
-            &&& MetaSlot::get_from_unused_inner_perms_spec(false, post.slot_owners[idx].inner_perms)
+            &&& MetaSlot::get_from_unused_owner_spec(false, post.slot_owners[idx])
             &&& post.slot_owners[idx].usage is PageTable
             &&& post.slot_owners[idx].slot_vaddr == pre.slot_owners[idx].slot_vaddr
             &&& post.slot_owners[idx].paths_in_pt == pre.slot_owners[idx].paths_in_pt
             &&& forall|i: int| i != idx ==> (#[trigger] post.slot_owners[i] == pre.slot_owners[i])
-            &&& pre.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNUSED
+            &&& pre.slot_owners[idx].ref_count() == REF_COUNT_UNUSED
         }
     }
 
@@ -173,17 +169,17 @@ impl MetaSlot {
         post: MetaRegionOwners,
     ) -> bool {
         let idx = frame_to_index(paddr);
-        let pre_perms = pre.slot_owners[idx].inner_perms.ref_count.value();
+        let pre_perms = pre.slot_owners[idx].ref_count();
         {
-            &&& post.slot_owners[idx].inner_perms.ref_count.value() == pre_perms + 1
-            &&& post.slot_owners[idx].inner_perms.ref_count.id()
-                == pre.slot_owners[idx].inner_perms.ref_count.id()
-            &&& post.slot_owners[idx].inner_perms.storage
-                == pre.slot_owners[idx].inner_perms.storage
-            &&& post.slot_owners[idx].inner_perms.vtable_ptr
-                == pre.slot_owners[idx].inner_perms.vtable_ptr
-            &&& post.slot_owners[idx].inner_perms.in_list
-                == pre.slot_owners[idx].inner_perms.in_list
+            &&& post.slot_owners[idx].ref_count() == pre_perms + 1
+            &&& post.slot_owners[idx].ref_count_perm.id()
+                == pre.slot_owners[idx].ref_count_perm.id()
+            &&& post.slot_owners[idx].storage_perm()
+                == pre.slot_owners[idx].storage_perm()
+            &&& post.slot_owners[idx].vtable_ptr_perm()
+                == pre.slot_owners[idx].vtable_ptr_perm()
+            &&& post.slot_owners[idx].in_list_perm
+                == pre.slot_owners[idx].in_list_perm
             &&& post.slot_owners[idx].slot_vaddr == pre.slot_owners[idx].slot_vaddr
             &&& post.slot_owners[idx].usage == pre.slot_owners[idx].usage
             &&& post.slot_owners[idx].paths_in_pt == pre.slot_owners[idx].paths_in_pt
@@ -192,10 +188,10 @@ impl MetaSlot {
     }
 
     pub open spec fn drop_last_in_place_safety_cond(owner: MetaSlotOwner) -> bool {
-        &&& (owner.inner_perms.ref_count.value() == 0 || owner.inner_perms.ref_count.value()
+        &&& (owner.ref_count() == 0 || owner.ref_count()
             == REF_COUNT_UNIQUE)
-        &&& owner.inner_perms.storage.is_init()
-        &&& owner.inner_perms.in_list.value()
+        &&& owner.storage_perm().is_init()
+        &&& owner.in_list_perm.value()
             == 0
         // The slot is torn down to `REF_COUNT_UNUSED`; the strengthened
         // `MetaSlotOwner::inv` UNUSED branch requires an empty

--- a/ostd/specs/mm/frame/meta_specs.rs
+++ b/ostd/specs/mm/frame/meta_specs.rs
@@ -174,12 +174,9 @@ impl MetaSlot {
             &&& post.slot_owners[idx].ref_count() == pre_perms + 1
             &&& post.slot_owners[idx].ref_count_perm.id()
                 == pre.slot_owners[idx].ref_count_perm.id()
-            &&& post.slot_owners[idx].storage_perm()
-                == pre.slot_owners[idx].storage_perm()
-            &&& post.slot_owners[idx].vtable_ptr_perm()
-                == pre.slot_owners[idx].vtable_ptr_perm()
-            &&& post.slot_owners[idx].in_list_perm
-                == pre.slot_owners[idx].in_list_perm
+            &&& post.slot_owners[idx].storage_perm() == pre.slot_owners[idx].storage_perm()
+            &&& post.slot_owners[idx].vtable_ptr_perm() == pre.slot_owners[idx].vtable_ptr_perm()
+            &&& post.slot_owners[idx].in_list_perm == pre.slot_owners[idx].in_list_perm
             &&& post.slot_owners[idx].slot_vaddr == pre.slot_owners[idx].slot_vaddr
             &&& post.slot_owners[idx].usage == pre.slot_owners[idx].usage
             &&& post.slot_owners[idx].paths_in_pt == pre.slot_owners[idx].paths_in_pt
@@ -188,8 +185,7 @@ impl MetaSlot {
     }
 
     pub open spec fn drop_last_in_place_safety_cond(owner: MetaSlotOwner) -> bool {
-        &&& (owner.ref_count() == 0 || owner.ref_count()
-            == REF_COUNT_UNIQUE)
+        &&& (owner.ref_count() == 0 || owner.ref_count() == REF_COUNT_UNIQUE)
         &&& owner.storage_perm().is_init()
         &&& owner.in_list_perm.value()
             == 0

--- a/ostd/specs/mm/frame/segment.rs
+++ b/ostd/specs/mm/frame/segment.rs
@@ -146,8 +146,7 @@ impl<M: AnyFrameMeta + ?Sized> Segment<M> {
                 // Borrow-protocol transition: `raw_count` is dormant.
                 &&& regions.slot_owners[idx].slot_vaddr == index_to_meta(idx)
                 &&& regions.slot_owners[idx].ref_count() > 0
-                &&& regions.slot_owners[idx].ref_count()
-                    <= crate::mm::frame::meta::REF_COUNT_MAX
+                &&& regions.slot_owners[idx].ref_count() <= crate::mm::frame::meta::REF_COUNT_MAX
                 &&& regions.slot_owners[idx].paths_in_pt.is_empty()
                 &&& regions.slot_owners[idx].usage is Frame
             }),

--- a/ostd/specs/mm/frame/segment.rs
+++ b/ostd/specs/mm/frame/segment.rs
@@ -109,10 +109,10 @@ impl<M: AnyFrameMeta + ?Sized> Segment<M> {
                 &&& regions.frame_obligations.count(idx) >= 1
                 &&& regions.contains(idx)
                 &&& regions.slot_owners[idx].slot_vaddr == index_to_meta(idx)
-                &&& regions.slot_owners[idx].inner_perms.ref_count.value()
+                &&& regions.slot_owners[idx].ref_count()
                     > 0
                 // Segment frames are shared (never `UNIQUE`).
-                &&& regions.slot_owners[idx].inner_perms.ref_count.value()
+                &&& regions.slot_owners[idx].ref_count()
                     <= crate::mm::frame::meta::REF_COUNT_MAX
                 // A segment holds its frames as a unit; they are not
                 // mapped into any page table, so the slot carries no PTE
@@ -145,8 +145,8 @@ impl<M: AnyFrameMeta + ?Sized> Segment<M> {
                 )
                 // Borrow-protocol transition: `raw_count` is dormant.
                 &&& regions.slot_owners[idx].slot_vaddr == index_to_meta(idx)
-                &&& regions.slot_owners[idx].inner_perms.ref_count.value() > 0
-                &&& regions.slot_owners[idx].inner_perms.ref_count.value()
+                &&& regions.slot_owners[idx].ref_count() > 0
+                &&& regions.slot_owners[idx].ref_count()
                     <= crate::mm::frame::meta::REF_COUNT_MAX
                 &&& regions.slot_owners[idx].paths_in_pt.is_empty()
                 &&& regions.slot_owners[idx].usage is Frame

--- a/ostd/specs/mm/frame/unique.rs
+++ b/ostd/specs/mm/frame/unique.rs
@@ -116,14 +116,14 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrameOwner<M> {
     pub open spec fn meta_wf(self, regions: MetaRegionOwners) -> bool {
         typed_meta_wf::<M>(
             *regions.slots[self.slot_index],
-            regions.slot_owners[self.slot_index].storage_perm(),
+            regions.slot_owners[self.slot_index].metadata_perm,
             self.repr_perm->0,
         )
     }
 
     pub open spec fn meta_value(self, regions: MetaRegionOwners) -> M {
         typed_meta_value::<M>(
-            regions.slot_owners[self.slot_index].storage_perm(),
+            regions.slot_owners[self.slot_index].metadata_perm,
             self.repr_perm->0,
         )
     }

--- a/ostd/specs/mm/frame/unique.rs
+++ b/ostd/specs/mm/frame/unique.rs
@@ -106,8 +106,8 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrame<M> {
         &&& self.wf(owner)
         &&& owner.inv()
         &&& s.inv()
-        &&& so.inner_perms.ref_count.value() == REF_COUNT_UNIQUE
-        &&& so.inner_perms.in_list.value() == 0
+        &&& so.ref_count() == REF_COUNT_UNIQUE
+        &&& so.in_list_perm.value() == 0
         &&& so.paths_in_pt.is_empty()
     }
 }
@@ -116,14 +116,14 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrameOwner<M> {
     pub open spec fn meta_wf(self, regions: MetaRegionOwners) -> bool {
         typed_meta_wf::<M>(
             *regions.slots[self.slot_index],
-            regions.slot_owners[self.slot_index].inner_perms.storage,
+            regions.slot_owners[self.slot_index].storage_perm(),
             self.repr_perm->0,
         )
     }
 
     pub open spec fn meta_value(self, regions: MetaRegionOwners) -> M {
         typed_meta_value::<M>(
-            regions.slot_owners[self.slot_index].inner_perms.storage,
+            regions.slot_owners[self.slot_index].storage_perm(),
             self.repr_perm->0,
         )
     }
@@ -148,7 +148,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrameOwner<M> {
         &&& regions.slots[self.slot_index].addr() == index_to_meta(self.slot_index)
         &&& self.meta_value(regions).wf(self.meta_own)
         &&& regions.slot_owners[self.slot_index].slot_vaddr == index_to_meta(self.slot_index)
-        &&& regions.slot_owners[self.slot_index].inner_perms.ref_count.value()
+        &&& regions.slot_owners[self.slot_index].ref_count()
             == REF_COUNT_UNIQUE
         // Data-frame node-repark discriminator (our change): a unique frame's
         // slot is tracked with `Frame` usage, distinguishing it from page-table
@@ -216,7 +216,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> TrackDrop for UniqueFram
 
     open spec fn tracked_redeem_requires(self, s: Self::State) -> bool {
         &&& s.contains(self.index())
-        &&& s.slot_owners[meta_to_index(self.ptr.addr())].inner_perms.ref_count.value()
+        &&& s.slot_owners[meta_to_index(self.ptr.addr())].ref_count()
             != REF_COUNT_UNUSED
         &&& s.inv()
     }
@@ -227,7 +227,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> TrackDrop for UniqueFram
         s1: Self::State,
         obl: Self::Obligation,
     ) -> bool {
-        &&& s1.slot_owners[self.index()].inner_perms == s0.slot_owners[self.index()].inner_perms
+        &&& s1.slot_owners[self.index()].same_permissions(s0.slot_owners[self.index()])
         &&& s1.slot_owners[self.index()].slot_vaddr == s0.slot_owners[self.index()].slot_vaddr
         &&& s1.slot_owners[self.index()].usage == s0.slot_owners[self.index()].usage
         &&& s1.slot_owners[self.index()].paths_in_pt == s0.slot_owners[self.index()].paths_in_pt

--- a/ostd/specs/mm/frame/unique.rs
+++ b/ostd/specs/mm/frame/unique.rs
@@ -122,10 +122,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrameOwner<M> {
     }
 
     pub open spec fn meta_value(self, regions: MetaRegionOwners) -> M {
-        typed_meta_value::<M>(
-            regions.slot_owners[self.slot_index].metadata_perm,
-            self.repr_perm->0,
-        )
+        typed_meta_value::<M>(regions.slot_owners[self.slot_index].metadata_perm, self.repr_perm->0)
     }
 
     pub open spec fn perm_inv(self, perm: vstd::simple_pptr::PointsTo<MetaSlot>) -> bool {
@@ -216,8 +213,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> TrackDrop for UniqueFram
 
     open spec fn tracked_redeem_requires(self, s: Self::State) -> bool {
         &&& s.contains(self.index())
-        &&& s.slot_owners[meta_to_index(self.ptr.addr())].ref_count()
-            != REF_COUNT_UNUSED
+        &&& s.slot_owners[meta_to_index(self.ptr.addr())].ref_count() != REF_COUNT_UNUSED
         &&& s.inv()
     }
 

--- a/ostd/specs/mm/page_table/cursor/cursor_fn_specs.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_fn_specs.rs
@@ -188,16 +188,13 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 0 < j < page_size(level) / PAGE_SIZE ==> {
                     let sub_idx = frame_to_index((pa + j * PAGE_SIZE) as usize);
                     &&& regions.contains(sub_idx)
-                    &&& C::tracked(item)
-                        ==> regions.slot_owners[sub_idx].ref_count()
+                    &&& C::tracked(item) ==> regions.slot_owners[sub_idx].ref_count()
                         != REF_COUNT_UNUSED
-                    &&& C::tracked(item)
-                        ==> regions.slot_owners[sub_idx].ref_count()
+                    &&& C::tracked(item) ==> regions.slot_owners[sub_idx].ref_count()
                         > 0
                     // SHARED upper bound for tracked sub-pages — carries `rc <= MAX`
                     // into the mapped huge frame's `frame_sub_pages_valid`.
-                    &&& C::tracked(item)
-                        ==> regions.slot_owners[sub_idx].ref_count()
+                    &&& C::tracked(item) ==> regions.slot_owners[sub_idx].ref_count()
                         <= REF_COUNT_MAX
                 }
         }

--- a/ostd/specs/mm/page_table/cursor/cursor_fn_specs.rs
+++ b/ostd/specs/mm/page_table/cursor/cursor_fn_specs.rs
@@ -74,7 +74,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
         &&& self.barrier_va.start <= self.va < self.barrier_va.end
         &&& owner@.present()
         &&& !is_mmio_paddr(pa)
-        &&& regions.slot_owners[idx].inner_perms.ref_count.value() >= REF_COUNT_MAX
+        &&& regions.slot_owners[idx].ref_count() >= REF_COUNT_MAX
     }
 
     pub open spec fn query_some_ensures(
@@ -170,16 +170,16 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
         let idx = frame_to_index(pa);
         &&& regions.contains(idx)
         &&& regions.slot_owners[idx].usage !is PageTable
-        &&& regions.slot_owners[idx].inner_perms.ref_count.value()
+        &&& regions.slot_owners[idx].ref_count()
             != REF_COUNT_UNUSED
         // Tracked items hold a refcount; untracked (MMIO) don't.
-        &&& C::tracked(item) ==> regions.slot_owners[idx].inner_perms.ref_count.value()
+        &&& C::tracked(item) ==> regions.slot_owners[idx].ref_count()
             > 0
         // A tracked (mapped) item is a SHARED frame, never the UNIQUE sentinel:
         // `rc <= MAX < REF_COUNT_UNIQUE`. Carries the bound into the mapped
         // slot's `metaregion_sound`, keeping the UNIQUE-branch `paths_in_pt`
         // inv clause vacuous.
-        &&& C::tracked(item) ==> regions.slot_owners[idx].inner_perms.ref_count.value()
+        &&& C::tracked(item) ==> regions.slot_owners[idx].ref_count()
             <= REF_COUNT_MAX
         // Sub-page slot existence for huge frames (unconditional). Rc parts gated on tracked.
         &&& level > 1 ==> {
@@ -189,15 +189,15 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                     let sub_idx = frame_to_index((pa + j * PAGE_SIZE) as usize);
                     &&& regions.contains(sub_idx)
                     &&& C::tracked(item)
-                        ==> regions.slot_owners[sub_idx].inner_perms.ref_count.value()
+                        ==> regions.slot_owners[sub_idx].ref_count()
                         != REF_COUNT_UNUSED
                     &&& C::tracked(item)
-                        ==> regions.slot_owners[sub_idx].inner_perms.ref_count.value()
+                        ==> regions.slot_owners[sub_idx].ref_count()
                         > 0
                     // SHARED upper bound for tracked sub-pages — carries `rc <= MAX`
                     // into the mapped huge frame's `frame_sub_pages_valid`.
                     &&& C::tracked(item)
-                        ==> regions.slot_owners[sub_idx].inner_perms.ref_count.value()
+                        ==> regions.slot_owners[sub_idx].ref_count()
                         <= REF_COUNT_MAX
                 }
         }

--- a/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
@@ -169,8 +169,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             forall|i: int|
                 #![trigger regions1.slot_owners[i]]
                 i != changed_idx ==> regions0.slot_owners[i] == regions1.slot_owners[i],
-            regions1.slot_owners[changed_idx].inner_perms
-                == regions0.slot_owners[changed_idx].inner_perms,
+            regions1.slot_owners[changed_idx].same_permissions(
+                regions0.slot_owners[changed_idx],
+            ),
             regions1.slot_owners[changed_idx].slot_vaddr
                 == regions0.slot_owners[changed_idx].slot_vaddr,
             regions1.slot_owners[changed_idx].usage == regions0.slot_owners[changed_idx].usage,
@@ -403,8 +404,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             forall|i: int|
                 #![trigger regions1.slot_owners[i]]
                 i != changed_idx ==> regions0.slot_owners[i] == regions1.slot_owners[i],
-            regions1.slot_owners[changed_idx].inner_perms
-                == regions0.slot_owners[changed_idx].inner_perms,
+            regions1.slot_owners[changed_idx].same_permissions(
+                regions0.slot_owners[changed_idx],
+            ),
             regions1.slot_owners[changed_idx].slot_vaddr
                 == regions0.slot_owners[changed_idx].slot_vaddr,
             regions1.slot_owners[changed_idx].usage == regions0.slot_owners[changed_idx].usage,
@@ -473,8 +475,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             forall|i: int|
                 #![trigger regions1.slot_owners[i]]
                 i != removed_idx ==> regions0.slot_owners[i] == regions1.slot_owners[i],
-            regions1.slot_owners[removed_idx].inner_perms
-                == regions0.slot_owners[removed_idx].inner_perms,
+            regions1.slot_owners[removed_idx].same_permissions(
+                regions0.slot_owners[removed_idx],
+            ),
             regions1.slot_owners[removed_idx].slot_vaddr
                 == regions0.slot_owners[removed_idx].slot_vaddr,
             regions1.slot_owners[removed_idx].usage == regions0.slot_owners[removed_idx].usage,

--- a/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
+++ b/ostd/specs/mm/page_table/cursor/invariant_preservation_lemmas.rs
@@ -169,9 +169,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             forall|i: int|
                 #![trigger regions1.slot_owners[i]]
                 i != changed_idx ==> regions0.slot_owners[i] == regions1.slot_owners[i],
-            regions1.slot_owners[changed_idx].same_permissions(
-                regions0.slot_owners[changed_idx],
-            ),
+            regions1.slot_owners[changed_idx].same_permissions(regions0.slot_owners[changed_idx]),
             regions1.slot_owners[changed_idx].slot_vaddr
                 == regions0.slot_owners[changed_idx].slot_vaddr,
             regions1.slot_owners[changed_idx].usage == regions0.slot_owners[changed_idx].usage,
@@ -404,9 +402,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             forall|i: int|
                 #![trigger regions1.slot_owners[i]]
                 i != changed_idx ==> regions0.slot_owners[i] == regions1.slot_owners[i],
-            regions1.slot_owners[changed_idx].same_permissions(
-                regions0.slot_owners[changed_idx],
-            ),
+            regions1.slot_owners[changed_idx].same_permissions(regions0.slot_owners[changed_idx]),
             regions1.slot_owners[changed_idx].slot_vaddr
                 == regions0.slot_owners[changed_idx].slot_vaddr,
             regions1.slot_owners[changed_idx].usage == regions0.slot_owners[changed_idx].usage,
@@ -475,9 +471,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             forall|i: int|
                 #![trigger regions1.slot_owners[i]]
                 i != removed_idx ==> regions0.slot_owners[i] == regions1.slot_owners[i],
-            regions1.slot_owners[removed_idx].same_permissions(
-                regions0.slot_owners[removed_idx],
-            ),
+            regions1.slot_owners[removed_idx].same_permissions(regions0.slot_owners[removed_idx]),
             regions1.slot_owners[removed_idx].slot_vaddr
                 == regions0.slot_owners[removed_idx].slot_vaddr,
             regions1.slot_owners[removed_idx].usage == regions0.slot_owners[removed_idx].usage,

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -1114,9 +1114,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             // The recorded entry trackedness matches the item being cloned.
             C::tracked(item) == self.cur_entry_owner().frame_is_tracked(),
             // Saturation aborts (Arc-style) via `inc_ref_count`'s diverging panic.
-            C::tracked(item) ==> (regions.slot_owners[frame_to_index(
-                pa,
-            )].ref_count() < REF_COUNT_MAX || may_panic()),
+            C::tracked(item) ==> (regions.slot_owners[frame_to_index(pa)].ref_count()
+                < REF_COUNT_MAX || may_panic()),
         ensures
             item.clone_requires(regions),
     {
@@ -1145,8 +1144,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             old_regions.slot_owners.contains_key(idx),
             new_regions.slot_owners.contains_key(idx),
             // rc at idx is incremented by 1
-            new_regions.slot_owners[idx].ref_count()
-                == old_regions.slot_owners[idx].ref_count() + 1,
+            new_regions.slot_owners[idx].ref_count() == old_regions.slot_owners[idx].ref_count()
+                + 1,
             // The ref-count permission at idx retains the same tracked identity.
             new_regions.slot_owners[idx].ref_count_perm.id()
                 == old_regions.slot_owners[idx].ref_count_perm.id(),
@@ -1154,8 +1153,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 == old_regions.slot_owners[idx].storage_perm(),
             new_regions.slot_owners[idx].vtable_ptr_perm()
                 == old_regions.slot_owners[idx].vtable_ptr_perm(),
-            new_regions.slot_owners[idx].in_list_perm
-                == old_regions.slot_owners[idx].in_list_perm,
+            new_regions.slot_owners[idx].in_list_perm == old_regions.slot_owners[idx].in_list_perm,
             // Other MetaSlotOwner fields at idx unchanged
             new_regions.slot_owners[idx].paths_in_pt == old_regions.slot_owners[idx].paths_in_pt,
             new_regions.slot_owners[idx].slot_vaddr == old_regions.slot_owners[idx].slot_vaddr,
@@ -2127,16 +2125,13 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             regions0.inv(),
             regions1.slots == regions0.slots,
             regions1.slot_owners.dom() == regions0.slot_owners.dom(),
-            regions1.slot_owners[idx].ref_count()
-                == regions0.slot_owners[idx].ref_count() + 1,
+            regions1.slot_owners[idx].ref_count() == regions0.slot_owners[idx].ref_count() + 1,
             regions1.slot_owners[idx].ref_count_perm.id()
                 == regions0.slot_owners[idx].ref_count_perm.id(),
-            regions1.slot_owners[idx].storage_perm()
-                == regions0.slot_owners[idx].storage_perm(),
+            regions1.slot_owners[idx].storage_perm() == regions0.slot_owners[idx].storage_perm(),
             regions1.slot_owners[idx].vtable_ptr_perm()
                 == regions0.slot_owners[idx].vtable_ptr_perm(),
-            regions1.slot_owners[idx].in_list_perm
-                == regions0.slot_owners[idx].in_list_perm,
+            regions1.slot_owners[idx].in_list_perm == regions0.slot_owners[idx].in_list_perm,
             regions1.slot_owners[idx].paths_in_pt == regions0.slot_owners[idx].paths_in_pt,
             regions1.slot_owners[idx].slot_vaddr == regions0.slot_owners[idx].slot_vaddr,
             regions1.slot_owners[idx].usage == regions0.slot_owners[idx].usage,
@@ -2179,9 +2174,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 regions0.slots.contains_key(k) ==> regions0.slots[k]
                     == #[trigger] regions1.slots[k],
             // All other fields at changed_idx preserved
-            regions1.slot_owners[changed_idx].same_permissions(
-                regions0.slot_owners[changed_idx],
-            ),
+            regions1.slot_owners[changed_idx].same_permissions(regions0.slot_owners[changed_idx]),
             regions1.slot_owners[changed_idx].slot_vaddr
                 == regions0.slot_owners[changed_idx].slot_vaddr,
             regions1.slot_owners[changed_idx].usage == regions0.slot_owners[changed_idx].usage,

--- a/ostd/specs/mm/page_table/cursor/owners.rs
+++ b/ostd/specs/mm/page_table/cursor/owners.rs
@@ -1116,7 +1116,7 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             // Saturation aborts (Arc-style) via `inc_ref_count`'s diverging panic.
             C::tracked(item) ==> (regions.slot_owners[frame_to_index(
                 pa,
-            )].inner_perms.ref_count.value() < REF_COUNT_MAX || may_panic()),
+            )].ref_count() < REF_COUNT_MAX || may_panic()),
         ensures
             item.clone_requires(regions),
     {
@@ -1145,17 +1145,17 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             old_regions.slot_owners.contains_key(idx),
             new_regions.slot_owners.contains_key(idx),
             // rc at idx is incremented by 1
-            new_regions.slot_owners[idx].inner_perms.ref_count.value()
-                == old_regions.slot_owners[idx].inner_perms.ref_count.value() + 1,
-            // All other inner_perms fields at idx are identical (same tracked object)
-            new_regions.slot_owners[idx].inner_perms.ref_count.id()
-                == old_regions.slot_owners[idx].inner_perms.ref_count.id(),
-            new_regions.slot_owners[idx].inner_perms.storage
-                == old_regions.slot_owners[idx].inner_perms.storage,
-            new_regions.slot_owners[idx].inner_perms.vtable_ptr
-                == old_regions.slot_owners[idx].inner_perms.vtable_ptr,
-            new_regions.slot_owners[idx].inner_perms.in_list
-                == old_regions.slot_owners[idx].inner_perms.in_list,
+            new_regions.slot_owners[idx].ref_count()
+                == old_regions.slot_owners[idx].ref_count() + 1,
+            // The ref-count permission at idx retains the same tracked identity.
+            new_regions.slot_owners[idx].ref_count_perm.id()
+                == old_regions.slot_owners[idx].ref_count_perm.id(),
+            new_regions.slot_owners[idx].storage_perm()
+                == old_regions.slot_owners[idx].storage_perm(),
+            new_regions.slot_owners[idx].vtable_ptr_perm()
+                == old_regions.slot_owners[idx].vtable_ptr_perm(),
+            new_regions.slot_owners[idx].in_list_perm
+                == old_regions.slot_owners[idx].in_list_perm,
             // Other MetaSlotOwner fields at idx unchanged
             new_regions.slot_owners[idx].paths_in_pt == old_regions.slot_owners[idx].paths_in_pt,
             new_regions.slot_owners[idx].slot_vaddr == old_regions.slot_owners[idx].slot_vaddr,
@@ -1173,8 +1173,8 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             // in the valid `[1, REF_COUNT_MAX]` range. The `<=` form (vs strict `<`)
             // matches what callers actually have: post-`clone_item`, the new rc is
             // bounded by the slot's `inv()` (which permits `rc == REF_COUNT_MAX`).
-            0 < old_regions.slot_owners[idx].inner_perms.ref_count.value(),
-            old_regions.slot_owners[idx].inner_perms.ref_count.value() + 1 <= REF_COUNT_MAX,
+            0 < old_regions.slot_owners[idx].ref_count(),
+            old_regions.slot_owners[idx].ref_count() + 1 <= REF_COUNT_MAX,
         ensures
             new_regions.inv(),
             self.metaregion_sound(new_regions),
@@ -2127,22 +2127,22 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
             regions0.inv(),
             regions1.slots == regions0.slots,
             regions1.slot_owners.dom() == regions0.slot_owners.dom(),
-            regions1.slot_owners[idx].inner_perms.ref_count.value()
-                == regions0.slot_owners[idx].inner_perms.ref_count.value() + 1,
-            regions1.slot_owners[idx].inner_perms.ref_count.id()
-                == regions0.slot_owners[idx].inner_perms.ref_count.id(),
-            regions1.slot_owners[idx].inner_perms.storage
-                == regions0.slot_owners[idx].inner_perms.storage,
-            regions1.slot_owners[idx].inner_perms.vtable_ptr
-                == regions0.slot_owners[idx].inner_perms.vtable_ptr,
-            regions1.slot_owners[idx].inner_perms.in_list
-                == regions0.slot_owners[idx].inner_perms.in_list,
+            regions1.slot_owners[idx].ref_count()
+                == regions0.slot_owners[idx].ref_count() + 1,
+            regions1.slot_owners[idx].ref_count_perm.id()
+                == regions0.slot_owners[idx].ref_count_perm.id(),
+            regions1.slot_owners[idx].storage_perm()
+                == regions0.slot_owners[idx].storage_perm(),
+            regions1.slot_owners[idx].vtable_ptr_perm()
+                == regions0.slot_owners[idx].vtable_ptr_perm(),
+            regions1.slot_owners[idx].in_list_perm
+                == regions0.slot_owners[idx].in_list_perm,
             regions1.slot_owners[idx].paths_in_pt == regions0.slot_owners[idx].paths_in_pt,
             regions1.slot_owners[idx].slot_vaddr == regions0.slot_owners[idx].slot_vaddr,
             regions1.slot_owners[idx].usage == regions0.slot_owners[idx].usage,
-            regions1.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED,
+            regions1.slot_owners[idx].ref_count() != REF_COUNT_UNUSED,
             // Bumped rc stays in the SHARED range (needed for the node branch).
-            regions1.slot_owners[idx].inner_perms.ref_count.value() <= REF_COUNT_MAX,
+            regions1.slot_owners[idx].ref_count() <= REF_COUNT_MAX,
             forall|i: int|
                 #![trigger regions1.slot_owners[i]]
                 i != idx && regions0.slot_owners.contains_key(i) ==> regions1.slot_owners[i]
@@ -2179,8 +2179,9 @@ impl<'rcu, C: PageTableConfig> CursorOwner<'rcu, C> {
                 regions0.slots.contains_key(k) ==> regions0.slots[k]
                     == #[trigger] regions1.slots[k],
             // All other fields at changed_idx preserved
-            regions1.slot_owners[changed_idx].inner_perms
-                == regions0.slot_owners[changed_idx].inner_perms,
+            regions1.slot_owners[changed_idx].same_permissions(
+                regions0.slot_owners[changed_idx],
+            ),
             regions1.slot_owners[changed_idx].slot_vaddr
                 == regions0.slot_owners[changed_idx].slot_vaddr,
             regions1.slot_owners[changed_idx].usage == regions0.slot_owners[changed_idx].usage,

--- a/ostd/specs/mm/page_table/node/entry.rs
+++ b/ostd/specs/mm/page_table/node/entry.rs
@@ -106,9 +106,8 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             new_child.is_node(),
             regions0.inv(),
             regions0.contains(frame_to_index(new_child.meta_slot_paddr()->0)),
-            regions0.slot_owners[frame_to_index(
-                new_child.meta_slot_paddr()->0,
-            )].ref_count() == REF_COUNT_UNUSED,
+            regions0.slot_owners[frame_to_index(new_child.meta_slot_paddr()->0)].ref_count()
+                == REF_COUNT_UNUSED,
             // Allocator-pool / MMIO disjointness: the freshly-allocated node's
             // paddr is non-MMIO. Rules out an MMIO-frame entry sitting at the
             // same idx as the new node (delivered by `PageTableNode::alloc`).
@@ -160,9 +159,8 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
         &&& old_owner.parent_level == new_owner.parent_level
         &&& new_owner.is_node() ==> {
             &&& regions.contains(frame_to_index(new_owner.meta_slot_paddr()->0))
-            &&& regions.slot_owners[frame_to_index(
-                new_owner.meta_slot_paddr()->0,
-            )].ref_count() != REF_COUNT_UNUSED
+            &&& regions.slot_owners[frame_to_index(new_owner.meta_slot_paddr()->0)].ref_count()
+                != REF_COUNT_UNUSED
         }
     }
 

--- a/ostd/specs/mm/page_table/node/entry.rs
+++ b/ostd/specs/mm/page_table/node/entry.rs
@@ -108,7 +108,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             regions0.contains(frame_to_index(new_child.meta_slot_paddr()->0)),
             regions0.slot_owners[frame_to_index(
                 new_child.meta_slot_paddr()->0,
-            )].inner_perms.ref_count.value() == REF_COUNT_UNUSED,
+            )].ref_count() == REF_COUNT_UNUSED,
             // Allocator-pool / MMIO disjointness: the freshly-allocated node's
             // paddr is non-MMIO. Rules out an MMIO-frame entry sitting at the
             // same idx as the new node (delivered by `PageTableNode::alloc`).
@@ -162,7 +162,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             &&& regions.contains(frame_to_index(new_owner.meta_slot_paddr()->0))
             &&& regions.slot_owners[frame_to_index(
                 new_owner.meta_slot_paddr()->0,
-            )].inner_perms.ref_count.value() != REF_COUNT_UNUSED
+            )].ref_count() != REF_COUNT_UNUSED
         }
     }
 

--- a/ostd/specs/mm/page_table/node/entry_owners.rs
+++ b/ostd/specs/mm/page_table/node/entry_owners.rs
@@ -431,9 +431,9 @@ impl<C: PageTableConfig> EntryOwner<C> {
                 let sub_idx = frame_to_index((pa + j * PAGE_SIZE) as usize);
                 &&& r1.slots.contains_key(sub_idx)
                 &&& r1.slot_owners[sub_idx].usage !is MMIO ==> {
-                    &&& r1.slot_owners[sub_idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-                    &&& r1.slot_owners[sub_idx].inner_perms.ref_count.value() > 0
-                    &&& r1.slot_owners[sub_idx].inner_perms.ref_count.value() <= REF_COUNT_MAX
+                    &&& r1.slot_owners[sub_idx].ref_count() != REF_COUNT_UNUSED
+                    &&& r1.slot_owners[sub_idx].ref_count() > 0
+                    &&& r1.slot_owners[sub_idx].ref_count() <= REF_COUNT_MAX
                 }
             } by {
                 let sub_idx = frame_to_index((pa + j * PAGE_SIZE) as usize);
@@ -486,10 +486,10 @@ impl<C: PageTableConfig> EntryOwner<C> {
                     // sub-pages. MMIO sub-page slots stay in the free pool with
                     // `rc == UNUSED` and `usage == MMIO`.
                     &&& regions.slot_owners[sub_idx].usage !is MMIO ==> {
-                        &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value()
+                        &&& regions.slot_owners[sub_idx].ref_count()
                             != REF_COUNT_UNUSED
-                        &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value() > 0
-                        &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value()
+                        &&& regions.slot_owners[sub_idx].ref_count() > 0
+                        &&& regions.slot_owners[sub_idx].ref_count()
                             <= REF_COUNT_MAX
                     }
                 }
@@ -499,8 +499,8 @@ impl<C: PageTableConfig> EntryOwner<C> {
     pub open spec fn metaregion_sound(self, regions: MetaRegionOwners) -> bool {
         if self.is_node() {
             let idx = frame_to_index(self.meta_slot_paddr()->0);
-            &&& regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-            &&& 0 < regions.slot_owners[idx].inner_perms.ref_count.value() <= REF_COUNT_MAX
+            &&& regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
+            &&& 0 < regions.slot_owners[idx].ref_count() <= REF_COUNT_MAX
             &&& regions.slot_owners[idx].slot_vaddr == self.node().meta_vaddr()
             &&& regions.slots[idx].value().wf(regions.slot_owners[idx])
             &&& regions.slot_owners[idx].paths_in_pt == set![self.path]
@@ -517,14 +517,14 @@ impl<C: PageTableConfig> EntryOwner<C> {
             // `rc > 0`. The slot's `usage == MMIO` is pinned by the paddr's
             // range membership via `axiom_mmio_usage_iff_mmio_paddr`.
             &&& regions.slot_owners[idx].usage !is MMIO ==> {
-                &&& regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-                &&& regions.slot_owners[idx].inner_perms.ref_count.value()
+                &&& regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
+                &&& regions.slot_owners[idx].ref_count()
                     > 0
                 // A mapped (tracked) frame is SHARED, never the UNIQUE sentinel
                 // (`rc <= MAX < REF_COUNT_UNIQUE`). Lets the UNIQUE-branch
                 // `paths_in_pt`-empty inv clause hold vacuously for mapped
                 // frames whose `paths_in_pt` is non-empty.
-                &&& regions.slot_owners[idx].inner_perms.ref_count.value() <= REF_COUNT_MAX
+                &&& regions.slot_owners[idx].ref_count() <= REF_COUNT_MAX
             }
             &&& regions.slot_owners[idx].paths_in_pt.contains(self.path)
             &&& self.frame_sub_pages_valid(regions)
@@ -546,7 +546,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
             entry.is_node(),
             entry.metaregion_sound(regions),
             regions.slots.contains_key(free_idx),
-            regions.slot_owners[free_idx].inner_perms.ref_count.value() == REF_COUNT_UNUSED,
+            regions.slot_owners[free_idx].ref_count() == REF_COUNT_UNUSED,
         ensures
             frame_to_index(entry.meta_slot_paddr()->0) != free_idx,
     {
@@ -617,10 +617,10 @@ impl<C: PageTableConfig> EntryOwner<C> {
                         let sub_idx = #[trigger] frame_to_index((pa + j * PAGE_SIZE) as usize);
                         sub_idx != changed_idx || r1.slot_owners[sub_idx].usage is MMIO || (
                         r1.slots.contains_key(sub_idx)
-                            && r1.slot_owners[sub_idx].inner_perms.ref_count.value()
+                            && r1.slot_owners[sub_idx].ref_count()
                             != REF_COUNT_UNUSED
-                            && r1.slot_owners[sub_idx].inner_perms.ref_count.value() > 0
-                            && r1.slot_owners[sub_idx].inner_perms.ref_count.value()
+                            && r1.slot_owners[sub_idx].ref_count() > 0
+                            && r1.slot_owners[sub_idx].ref_count()
                             <= REF_COUNT_MAX)
                     }
             },
@@ -648,7 +648,7 @@ impl<C: PageTableConfig> EntryOwner<C> {
                 #![trigger r1.slot_owners[i]]
                 i != changed_idx ==> r0.slot_owners[i] == r1.slot_owners[i],
             // At changed_idx, only paths_in_pt differs.
-            r1.slot_owners[changed_idx].inner_perms == r0.slot_owners[changed_idx].inner_perms,
+            r1.slot_owners[changed_idx].same_permissions(r0.slot_owners[changed_idx]),
             r1.slot_owners[changed_idx].slot_vaddr == r0.slot_owners[changed_idx].slot_vaddr,
             r1.slot_owners[changed_idx].usage == r0.slot_owners[changed_idx].usage,
             // For nodes at changed_idx: the new paths_in_pt must match this entry's path.
@@ -677,8 +677,8 @@ impl<C: PageTableConfig> EntryOwner<C> {
     {
         if self.meta_slot_paddr() is Some {
             let eidx = frame_to_index(self.meta_slot_paddr().unwrap());
-            // Bridge `rc > 0` from r0 to r1: at `eidx == changed_idx` inner_perms
-            // are identical; elsewhere the entire slot_owner is identical.
+            // Bridge `rc > 0` from r0 to r1: at `eidx == changed_idx` the
+            // permissions are preserved; elsewhere the entire slot owner is identical.
             if self.is_frame() {
                 // Sub-page validity for huge frames: slot existence (unconditional)
                 // plus `rc` bookkeeping when tracked.
@@ -692,10 +692,10 @@ impl<C: PageTableConfig> EntryOwner<C> {
                         let sub_idx = frame_to_index((pa + j * PAGE_SIZE) as usize);
                         &&& r1.slots.contains_key(sub_idx)
                         &&& r1.slot_owners[sub_idx].usage !is MMIO ==> {
-                            &&& r1.slot_owners[sub_idx].inner_perms.ref_count.value()
+                            &&& r1.slot_owners[sub_idx].ref_count()
                                 != REF_COUNT_UNUSED
-                            &&& r1.slot_owners[sub_idx].inner_perms.ref_count.value() > 0
-                            &&& r1.slot_owners[sub_idx].inner_perms.ref_count.value()
+                            &&& r1.slot_owners[sub_idx].ref_count() > 0
+                            &&& r1.slot_owners[sub_idx].ref_count()
                                 <= REF_COUNT_MAX
                         }
                     } by {
@@ -735,19 +735,19 @@ impl<C: PageTableConfig> EntryOwner<C> {
             ({
                 let idx = frame_to_index(self.meta_slot_paddr()->0);
                 &&& r1.slot_owners.contains_key(idx)
-                &&& r1.slot_owners[idx].inner_perms.ref_count.id()
-                    == r0.slot_owners[idx].inner_perms.ref_count.id()
-                &&& r1.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-                &&& r1.slot_owners[idx].inner_perms.ref_count.value()
+                &&& r1.slot_owners[idx].ref_count_perm.id()
+                    == r0.slot_owners[idx].ref_count_perm.id()
+                &&& r1.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
+                &&& r1.slot_owners[idx].ref_count()
                     > 0
                 // Needed to re-establish the node branch's SHARED range (`<= MAX`).
-                &&& r1.slot_owners[idx].inner_perms.ref_count.value() <= REF_COUNT_MAX
-                &&& r1.slot_owners[idx].inner_perms.storage
-                    == r0.slot_owners[idx].inner_perms.storage
-                &&& r1.slot_owners[idx].inner_perms.vtable_ptr
-                    == r0.slot_owners[idx].inner_perms.vtable_ptr
-                &&& r1.slot_owners[idx].inner_perms.in_list
-                    == r0.slot_owners[idx].inner_perms.in_list
+                &&& r1.slot_owners[idx].ref_count() <= REF_COUNT_MAX
+                &&& r1.slot_owners[idx].storage_perm()
+                    == r0.slot_owners[idx].storage_perm()
+                &&& r1.slot_owners[idx].vtable_ptr_perm()
+                    == r0.slot_owners[idx].vtable_ptr_perm()
+                &&& r1.slot_owners[idx].in_list_perm
+                    == r0.slot_owners[idx].in_list_perm
                 &&& r1.slot_owners[idx].slot_vaddr == r0.slot_owners[idx].slot_vaddr
                 &&& r1.slot_owners[idx].paths_in_pt
                     == r0.slot_owners[idx].paths_in_pt
@@ -773,8 +773,8 @@ impl<C: PageTableConfig> EntryOwner<C> {
                 let sub_idx = frame_to_index((pa + j * PAGE_SIZE) as usize);
                 &&& r1.slots.contains_key(sub_idx)
                 &&& r1.slot_owners[sub_idx].usage !is MMIO ==> {
-                    &&& r1.slot_owners[sub_idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
-                    &&& r1.slot_owners[sub_idx].inner_perms.ref_count.value() > 0
+                    &&& r1.slot_owners[sub_idx].ref_count() != REF_COUNT_UNUSED
+                    &&& r1.slot_owners[sub_idx].ref_count() > 0
                 }
             } by {
                 let sub_idx = frame_to_index((pa + j * PAGE_SIZE) as usize);

--- a/ostd/specs/mm/page_table/node/entry_owners.rs
+++ b/ostd/specs/mm/page_table/node/entry_owners.rs
@@ -486,11 +486,9 @@ impl<C: PageTableConfig> EntryOwner<C> {
                     // sub-pages. MMIO sub-page slots stay in the free pool with
                     // `rc == UNUSED` and `usage == MMIO`.
                     &&& regions.slot_owners[sub_idx].usage !is MMIO ==> {
-                        &&& regions.slot_owners[sub_idx].ref_count()
-                            != REF_COUNT_UNUSED
+                        &&& regions.slot_owners[sub_idx].ref_count() != REF_COUNT_UNUSED
                         &&& regions.slot_owners[sub_idx].ref_count() > 0
-                        &&& regions.slot_owners[sub_idx].ref_count()
-                            <= REF_COUNT_MAX
+                        &&& regions.slot_owners[sub_idx].ref_count() <= REF_COUNT_MAX
                     }
                 }
         }
@@ -616,12 +614,9 @@ impl<C: PageTableConfig> EntryOwner<C> {
                     0 < j < nr_pages ==> {
                         let sub_idx = #[trigger] frame_to_index((pa + j * PAGE_SIZE) as usize);
                         sub_idx != changed_idx || r1.slot_owners[sub_idx].usage is MMIO || (
-                        r1.slots.contains_key(sub_idx)
-                            && r1.slot_owners[sub_idx].ref_count()
-                            != REF_COUNT_UNUSED
-                            && r1.slot_owners[sub_idx].ref_count() > 0
-                            && r1.slot_owners[sub_idx].ref_count()
-                            <= REF_COUNT_MAX)
+                        r1.slots.contains_key(sub_idx) && r1.slot_owners[sub_idx].ref_count()
+                            != REF_COUNT_UNUSED && r1.slot_owners[sub_idx].ref_count() > 0
+                            && r1.slot_owners[sub_idx].ref_count() <= REF_COUNT_MAX)
                     }
             },
         ensures
@@ -692,11 +687,9 @@ impl<C: PageTableConfig> EntryOwner<C> {
                         let sub_idx = frame_to_index((pa + j * PAGE_SIZE) as usize);
                         &&& r1.slots.contains_key(sub_idx)
                         &&& r1.slot_owners[sub_idx].usage !is MMIO ==> {
-                            &&& r1.slot_owners[sub_idx].ref_count()
-                                != REF_COUNT_UNUSED
+                            &&& r1.slot_owners[sub_idx].ref_count() != REF_COUNT_UNUSED
                             &&& r1.slot_owners[sub_idx].ref_count() > 0
-                            &&& r1.slot_owners[sub_idx].ref_count()
-                                <= REF_COUNT_MAX
+                            &&& r1.slot_owners[sub_idx].ref_count() <= REF_COUNT_MAX
                         }
                     } by {
                         let sub_idx = frame_to_index((pa + j * PAGE_SIZE) as usize);
@@ -742,12 +735,9 @@ impl<C: PageTableConfig> EntryOwner<C> {
                     > 0
                 // Needed to re-establish the node branch's SHARED range (`<= MAX`).
                 &&& r1.slot_owners[idx].ref_count() <= REF_COUNT_MAX
-                &&& r1.slot_owners[idx].storage_perm()
-                    == r0.slot_owners[idx].storage_perm()
-                &&& r1.slot_owners[idx].vtable_ptr_perm()
-                    == r0.slot_owners[idx].vtable_ptr_perm()
-                &&& r1.slot_owners[idx].in_list_perm
-                    == r0.slot_owners[idx].in_list_perm
+                &&& r1.slot_owners[idx].storage_perm() == r0.slot_owners[idx].storage_perm()
+                &&& r1.slot_owners[idx].vtable_ptr_perm() == r0.slot_owners[idx].vtable_ptr_perm()
+                &&& r1.slot_owners[idx].in_list_perm == r0.slot_owners[idx].in_list_perm
                 &&& r1.slot_owners[idx].slot_vaddr == r0.slot_owners[idx].slot_vaddr
                 &&& r1.slot_owners[idx].paths_in_pt
                     == r0.slot_owners[idx].paths_in_pt

--- a/ostd/specs/mm/page_table/node/owners.rs
+++ b/ostd/specs/mm/page_table/node/owners.rs
@@ -261,14 +261,14 @@ impl<C: PageTableConfig> NodeOwner<C> {
     pub open spec fn meta_wf(self, regions: MetaRegionOwners) -> bool {
         typed_meta_wf::<PageTablePageMeta<C>>(
             *regions.slots[self.slot_index],
-            regions.slot_owners[self.slot_index].storage_perm(),
+            regions.slot_owners[self.slot_index].metadata_perm,
             (),
         )
     }
 
     pub open spec fn meta_value(self, regions: MetaRegionOwners) -> PageTablePageMeta<C> {
         typed_meta_value::<PageTablePageMeta<C>>(
-            regions.slot_owners[self.slot_index].storage_perm(),
+            regions.slot_owners[self.slot_index].metadata_perm,
             (),
         )
     }

--- a/ostd/specs/mm/page_table/node/owners.rs
+++ b/ostd/specs/mm/page_table/node/owners.rs
@@ -261,14 +261,14 @@ impl<C: PageTableConfig> NodeOwner<C> {
     pub open spec fn meta_wf(self, regions: MetaRegionOwners) -> bool {
         typed_meta_wf::<PageTablePageMeta<C>>(
             *regions.slots[self.slot_index],
-            regions.slot_owners[self.slot_index].inner_perms.storage,
+            regions.slot_owners[self.slot_index].storage_perm(),
             (),
         )
     }
 
     pub open spec fn meta_value(self, regions: MetaRegionOwners) -> PageTablePageMeta<C> {
         typed_meta_value::<PageTablePageMeta<C>>(
-            regions.slot_owners[self.slot_index].inner_perms.storage,
+            regions.slot_owners[self.slot_index].storage_perm(),
             (),
         )
     }
@@ -386,7 +386,7 @@ impl<C: PageTableConfig> PageTableNode<C> {
         &&& self.wf(
             owner,
         )
-        //        &&& owner.meta_perm.wf(&owner.meta_perm.inner_perms)
+        //        &&& owner.meta_perm.wf(owner.meta_perm.storage_perm())
         //        &&& owner.meta_perm.addr() == self.ptr.addr()
         //        &&& owner.meta_perm.addr() == self.ptr.addr()
 

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -1546,11 +1546,9 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                                     (pa + j * PAGE_SIZE) as usize,
                                 );
                                 sub_idx != changed_idx || (r1.slots.contains_key(sub_idx)
-                                    && r1.slot_owners[sub_idx].ref_count()
-                                    != REF_COUNT_UNUSED
+                                    && r1.slot_owners[sub_idx].ref_count() != REF_COUNT_UNUSED
                                     && r1.slot_owners[sub_idx].ref_count() > 0
-                                    && r1.slot_owners[sub_idx].ref_count()
-                                    <= REF_COUNT_MAX)
+                                    && r1.slot_owners[sub_idx].ref_count() <= REF_COUNT_MAX)
                             }
                     },
             ),
@@ -1600,11 +1598,9 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                                     (pa + j * PAGE_SIZE) as usize,
                                 );
                                 sub_idx != changed_idx || (r1.slots.contains_key(sub_idx)
-                                    && r1.slot_owners[sub_idx].ref_count()
-                                    != REF_COUNT_UNUSED
+                                    && r1.slot_owners[sub_idx].ref_count() != REF_COUNT_UNUSED
                                     && r1.slot_owners[sub_idx].ref_count() > 0
-                                    && r1.slot_owners[sub_idx].ref_count()
-                                    <= REF_COUNT_MAX)
+                                    && r1.slot_owners[sub_idx].ref_count() <= REF_COUNT_MAX)
                             }
                     },
             ),

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -1546,10 +1546,10 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                                     (pa + j * PAGE_SIZE) as usize,
                                 );
                                 sub_idx != changed_idx || (r1.slots.contains_key(sub_idx)
-                                    && r1.slot_owners[sub_idx].inner_perms.ref_count.value()
+                                    && r1.slot_owners[sub_idx].ref_count()
                                     != REF_COUNT_UNUSED
-                                    && r1.slot_owners[sub_idx].inner_perms.ref_count.value() > 0
-                                    && r1.slot_owners[sub_idx].inner_perms.ref_count.value()
+                                    && r1.slot_owners[sub_idx].ref_count() > 0
+                                    && r1.slot_owners[sub_idx].ref_count()
                                     <= REF_COUNT_MAX)
                             }
                     },
@@ -1600,10 +1600,10 @@ impl<C: PageTableConfig> PageTableOwner<C> {
                                     (pa + j * PAGE_SIZE) as usize,
                                 );
                                 sub_idx != changed_idx || (r1.slots.contains_key(sub_idx)
-                                    && r1.slot_owners[sub_idx].inner_perms.ref_count.value()
+                                    && r1.slot_owners[sub_idx].ref_count()
                                     != REF_COUNT_UNUSED
-                                    && r1.slot_owners[sub_idx].inner_perms.ref_count.value() > 0
-                                    && r1.slot_owners[sub_idx].inner_perms.ref_count.value()
+                                    && r1.slot_owners[sub_idx].ref_count() > 0
+                                    && r1.slot_owners[sub_idx].ref_count()
                                     <= REF_COUNT_MAX)
                             }
                     },

--- a/ostd/specs/mm/page_table/owners.rs
+++ b/ostd/specs/mm/page_table/owners.rs
@@ -1271,6 +1271,7 @@ impl<C: PageTableConfig> PageTableOwner<C> {
     /// `parent_level < NR_LEVELS` constraint plus the arithmetic identity
     /// `page_size(k) ∈ {4K, 2M, 1G}` for `k ∈ {1, 2, 3}`, and VA alignment
     /// + no-overflow via `lemma_vaddr_path_alignment_and_bound`.
+    #[verifier::rlimit(200)]
     pub proof fn view_rec_mapping_inv(self, path: TreePath<NR_ENTRIES>)
         requires
             self.pt_inv(),
@@ -1353,6 +1354,11 @@ impl<C: PageTableConfig> PageTableOwner<C> {
             assert(0x1_0000_0000_0000int + 0xffffint * 0x1_0000_0000_0000int
                 == 0x1_0000_0000_0000_0000int) by (compute_only);
             vstd_extra::arithmetic::lemma_mod_0_add(m.va_range.start, ps, ps);
+            assert forall|m2: Mapping| #[trigger]
+                self.view_rec(path).contains(m2) implies m2.inv() by {
+                assert(self.view_rec(path).contains(m2) <==> m2 == m);
+                assert(m.inv());
+            };
         } else if self.0.value().is_node() && path.len() < INC_LEVELS - 1 {
             assert forall|m: Mapping| #[trigger]
                 self.view_rec(path).contains(m) implies m.inv() by {

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -694,7 +694,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                 let link = borrow_meta(
                     current,
                     Tracked(points_to),
-                    Tracked(&slot_owner.metadata_perm.storage_perm),
+                    Tracked(&slot_owner.metadata_perm),
                     Tracked(repr_perm),
                 );
                 link.next
@@ -753,7 +753,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                 let link = borrow_meta(
                     current,
                     Tracked(points_to),
-                    Tracked(&slot_owner.metadata_perm.storage_perm),
+                    Tracked(&slot_owner.metadata_perm),
                     Tracked(repr_perm),
                 );
                 link.prev
@@ -1235,7 +1235,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
             let opt_prev_link: Option<ReprPtr<MetaSlotStorage, Link<M>>> = borrow_meta(
                 current,
                 Tracked(points_to),
-                Tracked(&slot_owner.metadata_perm.storage_perm),
+                Tracked(&slot_owner.metadata_perm),
                 Tracked(repr_perm),
             ).prev;
 

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -110,7 +110,7 @@ verus! {
 /// ## Invariant
 /// The linked list uniquely owns the raw frames that it contains, so they cannot be used by other
 /// data structures. The frame metadata field `in_list` is equal to `list_id` for all links in the list.
-/// The per-link well-formedness against the region (pptr/inner_perms wiring,
+/// The per-link well-formedness against the region (pointer/permission wiring,
 /// `next`/`prev` pointer chain) is captured by
 /// [`LinkedListOwner::relate_region`] (opaque, with per-position
 /// [`LinkedListOwner::relate_region_at`]). The cursor exposes this via
@@ -166,7 +166,7 @@ proof fn lemma_insert_before_slot_distinct<M: AnyFrameMeta + Repr<MetaSlotSmall>
         owner0.relate_region(regions0),
         regions0.inv(),
         regions0.contains(frame_idx),
-        regions0.slot_owners[frame_idx].inner_perms.in_list.value() == 0,
+        regions0.slot_owners[frame_idx].in_list_perm.value() == 0,
         0 <= nn <= owner0.list.len() as int,
     ensures
         forall|p: int|
@@ -184,7 +184,7 @@ proof fn lemma_insert_before_slot_distinct<M: AnyFrameMeta + Repr<MetaSlotSmall>
         if frame_idx == meta_to_index(owner0.list[p].paddr) {
             assert(regions0.slot_owners[meta_to_index(
                 owner0.list[p].paddr,
-            )].inner_perms.in_list.value() == owner0.list_id);
+            )].in_list_perm.value() == owner0.list_id);
         }
     }
 }
@@ -463,9 +463,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
 
         let tracked mut slot_own = regions.slot_owners.tracked_borrow_mut(idx);
 
-        let tracked mut inner_perms = slot_own.tracked_borrow_mut_inner_perms();
-
-        slot.in_list.load(Tracked(&mut inner_perms.in_list)) == #[verus_spec(with Tracked(owner))]
+        slot.in_list.load(Tracked(&mut slot_own.in_list_perm)) == #[verus_spec(with Tracked(owner))]
         self.lazy_get_id()
     }
 
@@ -521,9 +519,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> LinkedList<M> {
         };
 
         let tracked mut slot_own = regions.slot_owners.tracked_borrow_mut(idx);
-        let tracked mut inner_perms = slot_own.tracked_borrow_mut_inner_perms();
-
-        let contains = slot.in_list.load(Tracked(&mut inner_perms.in_list))
+        let contains = slot.in_list.load(Tracked(&mut slot_own.in_list_perm))
             == #[verus_spec(with Tracked(&owner))]
         self.lazy_get_id();
 
@@ -698,7 +694,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                 let link = borrow_meta(
                     current,
                     Tracked(points_to),
-                    Tracked(&slot_owner.inner_perms.storage),
+                    Tracked(&slot_owner.metadata_perm.storage_perm),
                     Tracked(repr_perm),
                 );
                 link.next
@@ -757,7 +753,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                 let link = borrow_meta(
                     current,
                     Tracked(points_to),
-                    Tracked(&slot_owner.inner_perms.storage),
+                    Tracked(&slot_owner.metadata_perm.storage_perm),
                     Tracked(repr_perm),
                 );
                 link.prev
@@ -896,11 +892,11 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                 let paddr = old(self).current->0.addr();
                 let idx = meta_to_index(paddr);
                 &&& final(regions).slots.dom() == old(regions).slots.dom()
-                &&& final(regions).slot_owners[idx].inner_perms.ref_count.value()
+                &&& final(regions).slot_owners[idx].ref_count()
                     == REF_COUNT_UNIQUE
-                &&& final(regions).slot_owners[idx].inner_perms.in_list.value() == 0
-                &&& final(regions).slot_owners[idx].inner_perms.storage.is_init()
-                &&& final(regions).slot_owners[idx].inner_perms.vtable_ptr.is_init()
+                &&& final(regions).slot_owners[idx].in_list_perm.value() == 0
+                &&& final(regions).slot_owners[idx].storage_perm().is_init()
+                &&& final(regions).slot_owners[idx].vtable_ptr_perm().is_init()
                 &&& final(regions).slot_owners[idx].slot_vaddr == index_to_meta(idx)
                 &&& final(regions).slot_owners[idx].paths_in_pt == old(
                     regions,
@@ -1057,10 +1053,9 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
 
         let tracked frame_outer = regions.slots.tracked_borrow(idx);
         let tracked mut frame_so = regions.slot_owners.tracked_borrow_mut(idx);
-        let tracked mut fip = frame_so.tracked_borrow_mut_inner_perms();
         #[verus_spec(with Tracked(&frame_outer))]
         let slot = frame.slot();
-        slot.in_list.store(Tracked(&mut fip.in_list), 0);
+        slot.in_list.store(Tracked(&mut frame_so.in_list_perm), 0);
         proof {
             assert(regions.inv());
             assert(regions.slots.dom() == regions0.slots.dom());
@@ -1091,9 +1086,9 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                 &&& regions.contains(i)
                 &&& regions.slots[i].addr() == oldl.list[p].paddr
                 &&& regions.slots[i].pptr() == regions0.slots[i].pptr()
-                &&& regions.slot_owners[i].inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+                &&& regions.slot_owners[i].ref_count() == REF_COUNT_UNIQUE
                 &&& regions.slot_owners[i].usage is Frame
-                &&& regions.slot_owners[i].inner_perms.in_list.value() == owner.list_own.list_id
+                &&& regions.slot_owners[i].in_list_perm.value() == owner.list_own.list_id
                 &&& owner.list_own.meta_wf_at(*regions, np)
                 &&& regions.slots[i].addr() % META_SLOT_SIZE == 0
                 &&& FRAME_METADATA_RANGE.start <= regions.slots[i].addr()
@@ -1240,7 +1235,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
             let opt_prev_link: Option<ReprPtr<MetaSlotStorage, Link<M>>> = borrow_meta(
                 current,
                 Tracked(points_to),
-                Tracked(&slot_owner.inner_perms.storage),
+                Tracked(&slot_owner.metadata_perm.storage_perm),
                 Tracked(repr_perm),
             ).prev;
 
@@ -1336,10 +1331,9 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
         }
         let tracked frame_outer = regions.slots.tracked_borrow_mut(frame_own.slot_index);
         let tracked mut frame_so = regions.slot_owners.tracked_borrow_mut(frame_own.slot_index);
-        let tracked mut fip = frame_so.tracked_borrow_mut_inner_perms();
         #[verus_spec(with Tracked(frame_outer))]
         let slot = frame.slot();
-        slot.in_list.store(Tracked(&mut fip.in_list), list_id);
+        slot.in_list.store(Tracked(&mut frame_so.in_list_perm), list_id);
         proof {
             assert(regions.inv()) by {
                 reveal(<MetaRegionOwners as Inv>::inv);
@@ -1472,7 +1466,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> TrackDrop for LinkedList<M> {
             #![trigger s.0.list[i]]
             0 <= i < s.0.list.len() ==> {
                 let idx = meta_to_index(s.0.list[i].paddr);
-                s.1.slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNIQUE
+                s.1.slot_owners[idx].ref_count() == REF_COUNT_UNIQUE
             }
         &&& forall|i: int|
             #![trigger s.0.list[i]]
@@ -1621,7 +1615,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> Drop for LinkedList<M> {
                         &&& original_regions.contains(idx)
                         &&& original_regions.frame_obligations.count(idx) == 0
                         &&& original_regions.slot_owners[idx].paths_in_pt.is_empty()
-                        &&& original_regions.slot_owners[idx].inner_perms.ref_count.value()
+                        &&& original_regions.slot_owners[idx].ref_count()
                             == REF_COUNT_UNIQUE
                     },
             ensures

--- a/ostd/src/mm/frame/linked_list.rs
+++ b/ostd/src/mm/frame/linked_list.rs
@@ -182,9 +182,8 @@ proof fn lemma_insert_before_slot_distinct<M: AnyFrameMeta + Repr<MetaSlotSmall>
     ) by {
         owner0.relate_region_at_facts(regions0, p);
         if frame_idx == meta_to_index(owner0.list[p].paddr) {
-            assert(regions0.slot_owners[meta_to_index(
-                owner0.list[p].paddr,
-            )].in_list_perm.value() == owner0.list_id);
+            assert(regions0.slot_owners[meta_to_index(owner0.list[p].paddr)].in_list_perm.value()
+                == owner0.list_id);
         }
     }
 }
@@ -892,8 +891,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotSmall>> CursorMut<'a, M> {
                 let paddr = old(self).current->0.addr();
                 let idx = meta_to_index(paddr);
                 &&& final(regions).slots.dom() == old(regions).slots.dom()
-                &&& final(regions).slot_owners[idx].ref_count()
-                    == REF_COUNT_UNIQUE
+                &&& final(regions).slot_owners[idx].ref_count() == REF_COUNT_UNIQUE
                 &&& final(regions).slot_owners[idx].in_list_perm.value() == 0
                 &&& final(regions).slot_owners[idx].storage_perm().is_init()
                 &&& final(regions).slot_owners[idx].vtable_ptr_perm().is_init()
@@ -1615,8 +1613,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotSmall>> Drop for LinkedList<M> {
                         &&& original_regions.contains(idx)
                         &&& original_regions.frame_obligations.count(idx) == 0
                         &&& original_regions.slot_owners[idx].paths_in_pt.is_empty()
-                        &&& original_regions.slot_owners[idx].ref_count()
-                            == REF_COUNT_UNIQUE
+                        &&& original_regions.slot_owners[idx].ref_count() == REF_COUNT_UNIQUE
                     },
             ensures
                 k == n,

--- a/ostd/src/mm/frame/meta.rs
+++ b/ostd/src/mm/frame/meta.rs
@@ -392,11 +392,11 @@ impl MetaSlot {
                 &&& final(regions).inv()
                 &&& Self::get_from_unused_spec(paddr, as_unique_ptr, *old(regions), *final(regions))
                 &&& <M as Repr<MetaSlotStorage>>::wf(
-                    final(regions).slot_owners[frame_to_index(paddr)].inner_perms.storage.value(),
+                    final(regions).slot_owners[frame_to_index(paddr)].storage_perm().value(),
                     *final(repr_perm),
                 )
                 &&& M::from_repr_spec(
-                    final(regions).slot_owners[frame_to_index(paddr)].inner_perms.storage.value(),
+                    final(regions).slot_owners[frame_to_index(paddr)].storage_perm().value(),
                     *final(repr_perm),
                 ) == metadata
             },
@@ -431,7 +431,7 @@ impl MetaSlot {
         // `Acquire` pairs with the `Release` in `drop_last_in_place` and ensures the metadata
         // initialization won't be reordered before this memory compare-and-exchange.
         let last_ref_cnt = slot.ref_count.compare_exchange(
-            Tracked(&mut slot_own.inner_perms.ref_count),
+            Tracked(&mut slot_own.ref_count_perm),
             REF_COUNT_UNUSED,
             0,
         ).map_err(
@@ -448,8 +448,8 @@ impl MetaSlot {
                 // CAS failure leaves `ref_count` unchanged (value + id), so the
                 // re-parked slot is exactly the original — region state intact.
                 vstd_extra::auxiliary::axiom_permission_u64_ext_eq(
-                    regions.slot_owners[idx].inner_perms.ref_count,
-                    old(regions).slot_owners[idx].inner_perms.ref_count,
+                    regions.slot_owners[idx].ref_count_perm,
+                    old(regions).slot_owners[idx].ref_count_perm,
                 );
             }
 
@@ -460,9 +460,9 @@ impl MetaSlot {
 
         unsafe {
             #[verus_spec(with
-                Tracked(&mut slot_own.inner_perms.storage),
+                Tracked(&mut slot_own.metadata_perm.storage_perm),
                 Tracked(repr_perm),
-                Tracked(&mut slot_own.inner_perms.vtable_ptr)
+                Tracked(&mut slot_own.metadata_perm.vtable_ptr_perm)
             )]
             slot.write_meta(metadata)
         };
@@ -470,11 +470,11 @@ impl MetaSlot {
         if as_unique_ptr {
             // No one can create a `Frame` instance directly from the page
             // address, so `Relaxed` is fine here.
-            slot.ref_count.store(Tracked(&mut slot_own.inner_perms.ref_count), REF_COUNT_UNIQUE);
+            slot.ref_count.store(Tracked(&mut slot_own.ref_count_perm), REF_COUNT_UNIQUE);
         } else {
             // `Release` is used to ensure that the metadata initialization
             // won't be reordered after this memory store.
-            slot.ref_count.store(Tracked(&mut slot_own.inner_perms.ref_count), 1);
+            slot.ref_count.store(Tracked(&mut slot_own.ref_count_perm), 1);
         }
 
         proof {
@@ -535,14 +535,14 @@ impl MetaSlot {
         {
             proof {
                 vstd_extra::auxiliary::axiom_permission_u64_ext_eq(
-                    regions.slot_owners[idx].inner_perms.ref_count,
-                    old(regions).slot_owners[idx].inner_perms.ref_count,
+                    regions.slot_owners[idx].ref_count_perm,
+                    old(regions).slot_owners[idx].ref_count_perm,
                 );
             }
 
             let tracked slot_own = regions.slot_owners.tracked_borrow_mut(idx);
 
-            match slot.ref_count.load(Tracked(&mut slot_own.inner_perms.ref_count)) {
+            match slot.ref_count.load(Tracked(&mut slot_own.ref_count_perm)) {
                 REF_COUNT_UNUSED => return Err(GetFrameError::Unused),
                 REF_COUNT_UNIQUE => return Err(GetFrameError::Unique),
                 0 => return Err(GetFrameError::Busy),
@@ -558,7 +558,7 @@ impl MetaSlot {
                     // It ensures that the written metadata will be visible to us.
 
                     if slot.ref_count.compare_exchange_weak(
-                        Tracked(&mut slot_own.inner_perms.ref_count),
+                        Tracked(&mut slot_own.ref_count_perm),
                         last_ref_cnt,
                         last_ref_cnt + 1,
                     ).is_ok() {
@@ -566,8 +566,8 @@ impl MetaSlot {
                     }
                     proof {
                         vstd_extra::auxiliary::axiom_permission_u64_ext_eq(
-                            slot_own.inner_perms.ref_count,
-                            old(regions).slot_owners[idx].inner_perms.ref_count,
+                            slot_own.ref_count_perm,
+                            old(regions).slot_owners[idx].ref_count_perm,
                         );
                     }
 
@@ -764,17 +764,17 @@ impl MetaSlot {
             Tracked(owner): Tracked<&mut MetaSlotOwner>,
         requires
             old(owner).inv(),
-            self.ref_count.id() == old(owner).inner_perms.ref_count.id(),
+            self.ref_count.id() == old(owner).ref_count_perm.id(),
             Self::drop_last_in_place_safety_cond(*old(owner)),
         ensures
             final(owner).inv(),
-            final(owner).inner_perms.ref_count.value() == REF_COUNT_UNUSED,
-            final(owner).inner_perms.ref_count.id() == old(owner).inner_perms.ref_count.id(),
-            final(owner).inner_perms.storage.id() == old(owner).inner_perms.storage.id(),
-            final(owner).inner_perms.storage.is_uninit(),
-            final(owner).inner_perms.vtable_ptr.is_uninit(),
-            final(owner).inner_perms.vtable_ptr.pptr() == old(owner).inner_perms.vtable_ptr.pptr(),
-            final(owner).inner_perms.in_list == old(owner).inner_perms.in_list,
+            final(owner).ref_count() == REF_COUNT_UNUSED,
+            final(owner).ref_count_perm.id() == old(owner).ref_count_perm.id(),
+            final(owner).storage_perm().id() == old(owner).storage_perm().id(),
+            final(owner).storage_perm().is_uninit(),
+            final(owner).vtable_ptr_perm().is_uninit(),
+            final(owner).vtable_ptr_perm().pptr() == old(owner).vtable_ptr_perm().pptr(),
+            final(owner).in_list_perm == old(owner).in_list_perm,
             final(owner).slot_vaddr == old(owner).slot_vaddr,
             final(owner).usage == old(owner).usage,
             final(owner).paths_in_pt == old(owner).paths_in_pt,
@@ -790,7 +790,7 @@ impl MetaSlot {
 
         // `Release` pairs with the `Acquire` in `Frame::from_unused` and ensures
         // `drop_meta_in_place` won't be reordered after this memory store.
-        self.ref_count.store(Tracked(&mut owner.inner_perms.ref_count), REF_COUNT_UNUSED);
+        self.ref_count.store(Tracked(&mut owner.ref_count_perm), REF_COUNT_UNUSED);
     }
 
     /// Drops the metadata of a slot in place.
@@ -815,16 +815,16 @@ impl MetaSlot {
         with
             Tracked(slot_own): Tracked<&mut MetaSlotOwner>,
         requires
-            old(slot_own).inner_perms.ref_count.value() == 0 || old(slot_own).inner_perms.ref_count.value() == REF_COUNT_UNIQUE,
-            old(slot_own).inner_perms.storage.is_init(),
-            old(slot_own).inner_perms.in_list.value() == 0,
+            old(slot_own).ref_count() == 0 || old(slot_own).ref_count() == REF_COUNT_UNIQUE,
+            old(slot_own).storage_perm().is_init(),
+            old(slot_own).in_list_perm.value() == 0,
         ensures
-            final(slot_own).inner_perms.ref_count == old(slot_own).inner_perms.ref_count,
-            final(slot_own).inner_perms.storage.is_uninit(),
-            final(slot_own).inner_perms.storage.id() == old(slot_own).inner_perms.storage.id(),
-            final(slot_own).inner_perms.in_list == old(slot_own).inner_perms.in_list,
-            final(slot_own).inner_perms.vtable_ptr.is_uninit(),
-            final(slot_own).inner_perms.vtable_ptr.pptr() == old(slot_own).inner_perms.vtable_ptr.pptr(),
+            final(slot_own).ref_count_perm == old(slot_own).ref_count_perm,
+            final(slot_own).storage_perm().is_uninit(),
+            final(slot_own).storage_perm().id() == old(slot_own).storage_perm().id(),
+            final(slot_own).in_list_perm == old(slot_own).in_list_perm,
+            final(slot_own).vtable_ptr_perm().is_uninit(),
+            final(slot_own).vtable_ptr_perm().pptr() == old(slot_own).vtable_ptr_perm().pptr(),
             final(slot_own).slot_vaddr == old(slot_own).slot_vaddr,
             final(slot_own).usage == old(slot_own).usage,
             final(slot_own).paths_in_pt == old(slot_own).paths_in_pt,

--- a/ostd/src/mm/frame/mod.rs
+++ b/ostd/src/mm/frame/mod.rs
@@ -416,11 +416,11 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + ?Sized> Frame<M> {
             points_to.is_init(),
             points_to.value().wf(*slot_own),
         returns
-            slot_own.inner_perms.ref_count.value(),
+            slot_own.ref_count(),
     )]
     pub fn reference_count(&self) -> u64 {
         let refcnt = (#[verus_spec(with Tracked(points_to))]
-        self.slot()).ref_count.load(Tracked(&slot_own.inner_perms.ref_count));
+        self.slot()).ref_count.load(Tracked(&slot_own.ref_count_perm));
         refcnt
     }
 
@@ -485,7 +485,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + ?Sized> Frame<M> {
         requires
             self.inv(),
             old(regions).inv(),
-            old(regions).slot_owners[self.index()].inner_perms.ref_count.value() != REF_COUNT_UNUSED,
+            old(regions).slot_owners[self.index()].ref_count() != REF_COUNT_UNUSED,
             old(regions).slot_owners[self.index()].usage !is PageTable,
             old(regions).frame_obligations.count(self.index()) > 0,
         ensures
@@ -571,7 +571,7 @@ impl<M> Frame<M> {
             // down). The `unsafe` keyword still gates whether the produced
             // Frame corresponds to a real prior `into_raw`; this condition
             // only ensures the slot isn't a dead/unused one.
-            old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
+            old(regions).slot_owners[frame_to_index(paddr)].ref_count()
                 != REF_COUNT_UNUSED,
         ensures
             Self::from_raw_ensures(*old(regions), *final(regions), paddr, r),
@@ -608,11 +608,11 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage>> RCClone for Frame<M> {
         let idx = self.index();
         &&& self.inv()
         &&& perm.inv()
-        &&& perm.slot_owners[idx].inner_perms.ref_count.value() > 0
-        &&& perm.slot_owners[idx].inner_perms.ref_count.value()
+        &&& perm.slot_owners[idx].ref_count() > 0
+        &&& perm.slot_owners[idx].ref_count()
             != REF_COUNT_UNUSED
         // Saturation aborts (Arc-style) via `inc_ref_count`'s diverging panic.
-        &&& perm.slot_owners[idx].inner_perms.ref_count.value() >= REF_COUNT_MAX ==> may_panic()
+        &&& perm.slot_owners[idx].ref_count() >= REF_COUNT_MAX ==> may_panic()
         &&& valid_frame_paddr(self.paddr())
     }
 
@@ -625,17 +625,17 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage>> RCClone for Frame<M> {
         let idx = self.index();
         &&& new_perm.inv()
         // ref_count incremented
-        &&& new_perm.slot_owners[idx].inner_perms.ref_count.value()
-            == old_perm.slot_owners[idx].inner_perms.ref_count.value() + 1
-        &&& new_perm.slot_owners[idx].inner_perms.ref_count.id()
-            == old_perm.slot_owners[idx].inner_perms.ref_count.id()
+        &&& new_perm.slot_owners[idx].ref_count()
+            == old_perm.slot_owners[idx].ref_count() + 1
+        &&& new_perm.slot_owners[idx].ref_count_perm.id()
+            == old_perm.slot_owners[idx].ref_count_perm.id()
         // All other fields at idx unchanged
-        &&& new_perm.slot_owners[idx].inner_perms.storage
-            == old_perm.slot_owners[idx].inner_perms.storage
-        &&& new_perm.slot_owners[idx].inner_perms.vtable_ptr
-            == old_perm.slot_owners[idx].inner_perms.vtable_ptr
-        &&& new_perm.slot_owners[idx].inner_perms.in_list
-            == old_perm.slot_owners[idx].inner_perms.in_list
+        &&& new_perm.slot_owners[idx].storage_perm()
+            == old_perm.slot_owners[idx].storage_perm()
+        &&& new_perm.slot_owners[idx].vtable_ptr_perm()
+            == old_perm.slot_owners[idx].vtable_ptr_perm()
+        &&& new_perm.slot_owners[idx].in_list_perm
+            == old_perm.slot_owners[idx].in_list_perm
         &&& new_perm.slot_owners[idx].paths_in_pt == old_perm.slot_owners[idx].paths_in_pt
         &&& new_perm.slot_owners[idx].slot_vaddr == old_perm.slot_owners[idx].slot_vaddr
         &&& new_perm.slot_owners[idx].usage
@@ -695,7 +695,7 @@ impl<M: ?Sized> Drop for Frame<M> {
         let ghost so0 = slot_own;
 
         let last_ref_cnt = slot.ref_count.fetch_sub(
-            Tracked(&mut slot_own.inner_perms.ref_count),
+            Tracked(&mut slot_own.ref_count_perm),
             1,
         );
 
@@ -846,28 +846,28 @@ impl TryFrom<Frame<dyn AnyFrameMeta>> for UFrame {
         // The caller holds a reference, so rc > 0, and the slot must be live
         // (not the UNUSED sentinel). Saturation is caught at runtime by
         // `inc_ref_count`'s Arc-style abort.
-        old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() > 0,
-        old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
+        old(regions).slot_owners[frame_to_index(paddr)].ref_count() > 0,
+        old(regions).slot_owners[frame_to_index(paddr)].ref_count()
             != REF_COUNT_UNUSED,
-        old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value()
+        old(regions).slot_owners[frame_to_index(paddr)].ref_count()
             >= REF_COUNT_MAX ==> may_panic(),
     ensures
         final(regions).inv(),
-        final(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() == old(
+        final(regions).slot_owners[frame_to_index(paddr)].ref_count() == old(
             regions,
-        ).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() + 1,
-        final(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.id() == old(
+        ).slot_owners[frame_to_index(paddr)].ref_count() + 1,
+        final(regions).slot_owners[frame_to_index(paddr)].ref_count_perm.id() == old(
             regions,
-        ).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.id(),
-        final(regions).slot_owners[frame_to_index(paddr)].inner_perms.storage == old(
+        ).slot_owners[frame_to_index(paddr)].ref_count_perm.id(),
+        final(regions).slot_owners[frame_to_index(paddr)].storage_perm() == old(
             regions,
-        ).slot_owners[frame_to_index(paddr)].inner_perms.storage,
-        final(regions).slot_owners[frame_to_index(paddr)].inner_perms.vtable_ptr == old(
+        ).slot_owners[frame_to_index(paddr)].storage_perm(),
+        final(regions).slot_owners[frame_to_index(paddr)].vtable_ptr_perm() == old(
             regions,
-        ).slot_owners[frame_to_index(paddr)].inner_perms.vtable_ptr,
-        final(regions).slot_owners[frame_to_index(paddr)].inner_perms.in_list == old(
+        ).slot_owners[frame_to_index(paddr)].vtable_ptr_perm(),
+        final(regions).slot_owners[frame_to_index(paddr)].in_list_perm == old(
             regions,
-        ).slot_owners[frame_to_index(paddr)].inner_perms.in_list,
+        ).slot_owners[frame_to_index(paddr)].in_list_perm,
         final(regions).slot_owners[frame_to_index(paddr)].paths_in_pt == old(
             regions,
         ).slot_owners[frame_to_index(paddr)].paths_in_pt,
@@ -890,7 +890,6 @@ impl TryFrom<Frame<dyn AnyFrameMeta>> for UFrame {
 pub(in crate::mm) unsafe fn inc_frame_ref_count(paddr: Paddr) {
     let tracked mut slot_own = regions.slot_owners.tracked_remove(frame_to_index(paddr));
     let tracked perm = regions.slots.tracked_borrow(frame_to_index(paddr));
-    let tracked inner_perms = slot_own.tracked_borrow_mut_inner_perms();
 
     let vaddr: Vaddr = frame_to_meta(paddr);
     // SAFETY: `vaddr` points to a valid `MetaSlot` that will never be mutably borrowed, so taking
@@ -898,7 +897,7 @@ pub(in crate::mm) unsafe fn inc_frame_ref_count(paddr: Paddr) {
     let slot = PPtr::<MetaSlot>::from_addr(vaddr);
 
     unsafe {
-        #[verus_spec(with Tracked(&mut inner_perms.ref_count))]
+        #[verus_spec(with Tracked(&mut slot_own.ref_count_perm))]
         slot.borrow(Tracked(perm)).inc_ref_count()
     };
 
@@ -906,14 +905,14 @@ pub(in crate::mm) unsafe fn inc_frame_ref_count(paddr: Paddr) {
         let idx = frame_to_index(paddr);
 
         // inc_ref_count preserves permission id
-        assert(inner_perms.ref_count.id() == old(
+        assert(slot_own.ref_count_perm.id() == old(
             regions,
-        ).slot_owners[idx].inner_perms.ref_count.id());
+        ).slot_owners[idx].ref_count_perm.id());
 
         // slot_own.inv() holds: rc in (0, REF_COUNT_MAX), vtable_ptr init, slot_vaddr ok
         assert(slot_own.inv());
 
-        // wf: the slot's cell ids still match the (updated) inner_perms ids
+        // wf: the slot's cell ids still match the updated owner permissions.
         assert(regions.slots[idx].value().wf(slot_own));
 
         regions.slot_owners.tracked_insert(idx, slot_own);

--- a/ostd/src/mm/frame/mod.rs
+++ b/ostd/src/mm/frame/mod.rs
@@ -625,17 +625,14 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage>> RCClone for Frame<M> {
         let idx = self.index();
         &&& new_perm.inv()
         // ref_count incremented
-        &&& new_perm.slot_owners[idx].ref_count()
-            == old_perm.slot_owners[idx].ref_count() + 1
+        &&& new_perm.slot_owners[idx].ref_count() == old_perm.slot_owners[idx].ref_count() + 1
         &&& new_perm.slot_owners[idx].ref_count_perm.id()
             == old_perm.slot_owners[idx].ref_count_perm.id()
         // All other fields at idx unchanged
-        &&& new_perm.slot_owners[idx].storage_perm()
-            == old_perm.slot_owners[idx].storage_perm()
+        &&& new_perm.slot_owners[idx].storage_perm() == old_perm.slot_owners[idx].storage_perm()
         &&& new_perm.slot_owners[idx].vtable_ptr_perm()
             == old_perm.slot_owners[idx].vtable_ptr_perm()
-        &&& new_perm.slot_owners[idx].in_list_perm
-            == old_perm.slot_owners[idx].in_list_perm
+        &&& new_perm.slot_owners[idx].in_list_perm == old_perm.slot_owners[idx].in_list_perm
         &&& new_perm.slot_owners[idx].paths_in_pt == old_perm.slot_owners[idx].paths_in_pt
         &&& new_perm.slot_owners[idx].slot_vaddr == old_perm.slot_owners[idx].slot_vaddr
         &&& new_perm.slot_owners[idx].usage
@@ -694,10 +691,7 @@ impl<M: ?Sized> Drop for Frame<M> {
         // `drop_ensures` (refcount transition + identity preservation).
         let ghost so0 = slot_own;
 
-        let last_ref_cnt = slot.ref_count.fetch_sub(
-            Tracked(&mut slot_own.ref_count_perm),
-            1,
-        );
+        let last_ref_cnt = slot.ref_count.fetch_sub(Tracked(&mut slot_own.ref_count_perm), 1);
 
         if last_ref_cnt == 1 {
             // A fence is needed here with the same reasons stated in the implementation of
@@ -905,9 +899,7 @@ pub(in crate::mm) unsafe fn inc_frame_ref_count(paddr: Paddr) {
         let idx = frame_to_index(paddr);
 
         // inc_ref_count preserves permission id
-        assert(slot_own.ref_count_perm.id() == old(
-            regions,
-        ).slot_owners[idx].ref_count_perm.id());
+        assert(slot_own.ref_count_perm.id() == old(regions).slot_owners[idx].ref_count_perm.id());
 
         // slot_own.inv() holds: rc in (0, REF_COUNT_MAX), vtable_ptr init, slot_vaddr ok
         assert(slot_own.inv());

--- a/ostd/src/mm/frame/mod.rs
+++ b/ostd/src/mm/frame/mod.rs
@@ -258,13 +258,13 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Frame<M> {
     #[verus_spec(
         with
             Tracked(points_to): Tracked<&'a vstd::simple_pptr::PointsTo<MetaSlot>>,
-            Tracked(storage): Tracked<&'a vstd::cell::pcell_maybe_uninit::PointsTo<MetaSlotStorage>>,
+            Tracked(metadata_perms): Tracked<&'a MetadataPerms>,
             Tracked(repr_perm): Tracked<&'a M::ReprPerm>,
         requires
             self.ptr == points_to.pptr(),
-            typed_meta_wf::<M>(*points_to, *storage, *repr_perm),
+            typed_meta_wf::<M>(*points_to, *metadata_perms, *repr_perm),
         returns
-            typed_meta_value::<M>(*storage, *repr_perm),
+            typed_meta_value::<M>(*metadata_perms, *repr_perm),
     )]
     pub fn meta<'a>(&'a self) -> &'a M {
         // SAFETY: The type is tracked by the typed storage permission.
@@ -272,7 +272,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Frame<M> {
         borrow_meta(
             ReprPtr::<MetaSlotStorage, M>::from_pptr(PPtr::from_addr(self.ptr.addr())),
             Tracked(points_to),
-            Tracked(storage),
+            Tracked(metadata_perms),
             Tracked(repr_perm),
         )
     }

--- a/ostd/src/mm/frame/segment.rs
+++ b/ostd/src/mm/frame/segment.rs
@@ -106,8 +106,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> RCClone for Segment<M> {
                 &&& perm.contains(idx)
                 &&& valid_frame_paddr(pa)
                 &&& perm.slot_owners[idx].ref_count() > 0
-                &&& perm.slot_owners[idx].ref_count() + 1
-                    < super::meta::REF_COUNT_MAX
+                &&& perm.slot_owners[idx].ref_count() + 1 < super::meta::REF_COUNT_MAX
                 &&& !MetaSlot::inc_ref_count_panic_cond(perm.slot_owners[idx].ref_count_perm)
             }
     }
@@ -149,8 +148,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> RCClone for Segment<M> {
                         &&& perm.contains(idx)
                         &&& valid_frame_paddr(pa)
                         &&& perm.slot_owners[idx].ref_count() > 0
-                        &&& perm.slot_owners[idx].ref_count() + 1
-                            < super::meta::REF_COUNT_MAX
+                        &&& perm.slot_owners[idx].ref_count() + 1 < super::meta::REF_COUNT_MAX
                         &&& !MetaSlot::inc_ref_count_panic_cond(
                             perm.slot_owners[idx].ref_count_perm,
                         )
@@ -452,8 +450,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                 &&& regions.contains(idx)
                 &&& regions.slot_owners[idx].slot_vaddr == index_to_meta(idx)
                 &&& regions.slot_owners[idx].ref_count() > 0
-                &&& regions.slot_owners[idx].ref_count()
-                    <= crate::mm::frame::meta::REF_COUNT_MAX
+                &&& regions.slot_owners[idx].ref_count() <= crate::mm::frame::meta::REF_COUNT_MAX
                 &&& regions.slot_owners[idx].paths_in_pt.is_empty()
                 &&& regions.slot_owners[idx].usage is Frame
             } by {
@@ -615,8 +612,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                 &&& regions.contains(idx)
                 &&& regions.slot_owners[idx].slot_vaddr == index_to_meta(idx)
                 &&& regions.slot_owners[idx].ref_count() > 0
-                &&& regions.slot_owners[idx].ref_count()
-                    <= crate::mm::frame::meta::REF_COUNT_MAX
+                &&& regions.slot_owners[idx].ref_count() <= crate::mm::frame::meta::REF_COUNT_MAX
                 &&& regions.slot_owners[idx].paths_in_pt.is_empty()
                 &&& regions.slot_owners[idx].usage is Frame
             } by {
@@ -630,8 +626,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                 &&& regions.contains(idx)
                 &&& regions.slot_owners[idx].slot_vaddr == index_to_meta(idx)
                 &&& regions.slot_owners[idx].ref_count() > 0
-                &&& regions.slot_owners[idx].ref_count()
-                    <= crate::mm::frame::meta::REF_COUNT_MAX
+                &&& regions.slot_owners[idx].ref_count() <= crate::mm::frame::meta::REF_COUNT_MAX
                 &&& regions.slot_owners[idx].paths_in_pt.is_empty()
                 &&& regions.slot_owners[idx].usage is Frame
             } by {

--- a/ostd/src/mm/frame/segment.rs
+++ b/ostd/src/mm/frame/segment.rs
@@ -105,10 +105,10 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> RCClone for Segment<M> {
                 let idx = frame_to_index(pa);
                 &&& perm.contains(idx)
                 &&& valid_frame_paddr(pa)
-                &&& perm.slot_owners[idx].inner_perms.ref_count.value() > 0
-                &&& perm.slot_owners[idx].inner_perms.ref_count.value() + 1
+                &&& perm.slot_owners[idx].ref_count() > 0
+                &&& perm.slot_owners[idx].ref_count() + 1
                     < super::meta::REF_COUNT_MAX
-                &&& !MetaSlot::inc_ref_count_panic_cond(perm.slot_owners[idx].inner_perms.ref_count)
+                &&& !MetaSlot::inc_ref_count_panic_cond(perm.slot_owners[idx].ref_count_perm)
             }
     }
 
@@ -148,11 +148,11 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> RCClone for Segment<M> {
                         let idx = frame_to_index(pa);
                         &&& perm.contains(idx)
                         &&& valid_frame_paddr(pa)
-                        &&& perm.slot_owners[idx].inner_perms.ref_count.value() > 0
-                        &&& perm.slot_owners[idx].inner_perms.ref_count.value() + 1
+                        &&& perm.slot_owners[idx].ref_count() > 0
+                        &&& perm.slot_owners[idx].ref_count() + 1
                             < super::meta::REF_COUNT_MAX
                         &&& !MetaSlot::inc_ref_count_panic_cond(
-                            perm.slot_owners[idx].inner_perms.ref_count,
+                            perm.slot_owners[idx].ref_count_perm,
                         )
                     },
             decreases self.range.end - paddr,
@@ -291,8 +291,8 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                         let idx = frame_to_index(addrs[j]);
                         &&& regions.contains(idx)
                         &&& regions.slot_owners[idx].slot_vaddr == index_to_meta(idx)
-                        &&& regions.slot_owners[idx].inner_perms.ref_count.value() > 0
-                        &&& regions.slot_owners[idx].inner_perms.ref_count.value()
+                        &&& regions.slot_owners[idx].ref_count() > 0
+                        &&& regions.slot_owners[idx].ref_count()
                             <= crate::mm::frame::meta::REF_COUNT_MAX
                         &&& regions.slot_owners[idx].paths_in_pt.is_empty()
                         &&& regions.slot_owners[idx].usage is Frame
@@ -339,8 +339,8 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                                     let idx = frame_to_index(addrs[j]);
                                     &&& regions.contains(idx)
                                     &&& regions.slot_owners[idx].slot_vaddr == index_to_meta(idx)
-                                    &&& regions.slot_owners[idx].inner_perms.ref_count.value() > 0
-                                    &&& regions.slot_owners[idx].inner_perms.ref_count.value()
+                                    &&& regions.slot_owners[idx].ref_count() > 0
+                                    &&& regions.slot_owners[idx].ref_count()
                                         <= crate::mm::frame::meta::REF_COUNT_MAX
                                     &&& regions.slot_owners[idx].paths_in_pt.is_empty()
                                     &&& regions.slot_owners[idx].usage is Frame
@@ -451,8 +451,8 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                 &&& regions.frame_obligations.count(idx) >= 1
                 &&& regions.contains(idx)
                 &&& regions.slot_owners[idx].slot_vaddr == index_to_meta(idx)
-                &&& regions.slot_owners[idx].inner_perms.ref_count.value() > 0
-                &&& regions.slot_owners[idx].inner_perms.ref_count.value()
+                &&& regions.slot_owners[idx].ref_count() > 0
+                &&& regions.slot_owners[idx].ref_count()
                     <= crate::mm::frame::meta::REF_COUNT_MAX
                 &&& regions.slot_owners[idx].paths_in_pt.is_empty()
                 &&& regions.slot_owners[idx].usage is Frame
@@ -614,8 +614,8 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                 &&& regions.frame_obligations.count(idx) >= 1
                 &&& regions.contains(idx)
                 &&& regions.slot_owners[idx].slot_vaddr == index_to_meta(idx)
-                &&& regions.slot_owners[idx].inner_perms.ref_count.value() > 0
-                &&& regions.slot_owners[idx].inner_perms.ref_count.value()
+                &&& regions.slot_owners[idx].ref_count() > 0
+                &&& regions.slot_owners[idx].ref_count()
                     <= crate::mm::frame::meta::REF_COUNT_MAX
                 &&& regions.slot_owners[idx].paths_in_pt.is_empty()
                 &&& regions.slot_owners[idx].usage is Frame
@@ -629,8 +629,8 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                 &&& regions.frame_obligations.count(idx) >= 1
                 &&& regions.contains(idx)
                 &&& regions.slot_owners[idx].slot_vaddr == index_to_meta(idx)
-                &&& regions.slot_owners[idx].inner_perms.ref_count.value() > 0
-                &&& regions.slot_owners[idx].inner_perms.ref_count.value()
+                &&& regions.slot_owners[idx].ref_count() > 0
+                &&& regions.slot_owners[idx].ref_count()
                     <= crate::mm::frame::meta::REF_COUNT_MAX
                 &&& regions.slot_owners[idx].paths_in_pt.is_empty()
                 &&& regions.slot_owners[idx].usage is Frame
@@ -686,7 +686,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
             (range.start as int) / (PAGE_SIZE as int) <= j < (range.end as int) / (PAGE_SIZE as int)
                 && regions.slot_owners[frame_to_index(
                 (self.start_paddr() + j * PAGE_SIZE) as usize,
-            )].inner_perms.ref_count.value() >= REF_COUNT_MAX
+            )].ref_count() >= REF_COUNT_MAX
     }
 
     // [FIXED] BUG FOUND BY FV: potential overflow. https://github.com/asterinas/asterinas/pull/3587
@@ -769,7 +769,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Segment<M> {
                         regions,
                     ).slot_owners[frame_to_index(
                         (self.range.start + j * PAGE_SIZE) as usize,
-                    )].inner_perms.ref_count.value() < REF_COUNT_MAX,
+                    )].ref_count() < REF_COUNT_MAX,
             decreases addr_len - i,
         {
             if paddr >= end {
@@ -1082,8 +1082,8 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> SegmentIterator<'a, 
                     &&& (**regions_ref).frame_obligations.count(idx) >= 1
                     &&& (**regions_ref).contains(idx)
                     &&& (**regions_ref).slot_owners[idx].slot_vaddr == index_to_meta(idx)
-                    &&& (**regions_ref).slot_owners[idx].inner_perms.ref_count.value() > 0
-                    &&& (**regions_ref).slot_owners[idx].inner_perms.ref_count.value()
+                    &&& (**regions_ref).slot_owners[idx].ref_count() > 0
+                    &&& (**regions_ref).slot_owners[idx].ref_count()
                         <= crate::mm::frame::meta::REF_COUNT_MAX
                     &&& (**regions_ref).slot_owners[idx].paths_in_pt.is_empty()
                     &&& (**regions_ref).slot_owners[idx].usage is Frame
@@ -1229,9 +1229,9 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage>> Segment<M> {
                 #![trigger frame_to_index((self.range.start + i * PAGE_SIZE) as usize)]
                 0 <= i < crate::specs::mm::frame::segment::seg_nframes(self.range) ==> {
                     let idx = frame_to_index((self.range.start + i * PAGE_SIZE) as usize);
-                    old(regions).slot_owners[idx].inner_perms.ref_count.value() == 1 ==> {
-                        &&& old(regions).slot_owners[idx].inner_perms.storage.is_init()
-                        &&& old(regions).slot_owners[idx].inner_perms.in_list.value() == 0
+                    old(regions).slot_owners[idx].ref_count() == 1 ==> {
+                        &&& old(regions).slot_owners[idx].storage_perm().is_init()
+                        &&& old(regions).slot_owners[idx].in_list_perm.value() == 0
                     }
                 },
         ensures
@@ -1245,9 +1245,9 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage>> Segment<M> {
 
         assert forall|i: int| #![trigger frame_idx_at(self.range.start, i)] 0 <= i < n implies {
             let idx = frame_idx_at(self.range.start, i);
-            old(regions).slot_owners[idx].inner_perms.ref_count.value() == 1 ==> {
-                &&& old(regions).slot_owners[idx].inner_perms.storage.is_init()
-                &&& old(regions).slot_owners[idx].inner_perms.in_list.value() == 0
+            old(regions).slot_owners[idx].ref_count() == 1 ==> {
+                &&& old(regions).slot_owners[idx].storage_perm().is_init()
+                &&& old(regions).slot_owners[idx].in_list_perm.value() == 0
             }
         } by {};
 
@@ -1303,9 +1303,9 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage>> Segment<M> {
                     #![trigger frame_to_index((self.range.start + i * PAGE_SIZE) as usize)]
                     0 <= i < n ==> {
                         let idx = frame_to_index((self.range.start + i * PAGE_SIZE) as usize);
-                        old(regions).slot_owners[idx].inner_perms.ref_count.value() == 1 ==> {
-                            &&& old(regions).slot_owners[idx].inner_perms.storage.is_init()
-                            &&& old(regions).slot_owners[idx].inner_perms.in_list.value() == 0
+                        old(regions).slot_owners[idx].ref_count() == 1 ==> {
+                            &&& old(regions).slot_owners[idx].storage_perm().is_init()
+                            &&& old(regions).slot_owners[idx].in_list_perm.value() == 0
                         }
                     },
             decreases n - k,
@@ -1391,11 +1391,11 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage>> Segment<M> {
                         let idx = frame_to_index(pa);
                         &&& perm.contains(idx)
                         &&& valid_frame_paddr(pa)
-                        &&& perm.slot_owners[idx].inner_perms.ref_count.value() > 0
-                        &&& perm.slot_owners[idx].inner_perms.ref_count.value() + 1
+                        &&& perm.slot_owners[idx].ref_count() > 0
+                        &&& perm.slot_owners[idx].ref_count() + 1
                             < super::meta::REF_COUNT_MAX
                         &&& !MetaSlot::inc_ref_count_panic_cond(
-                            perm.slot_owners[idx].inner_perms.ref_count,
+                            perm.slot_owners[idx].ref_count_perm,
                         )
                     },
             decreases self.range.end - paddr,

--- a/ostd/src/mm/frame/unique.rs
+++ b/ostd/src/mm/frame/unique.rs
@@ -156,7 +156,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrame<M> {
             self.wf(owner),
             owner.inv(),
             owner.global_inv(*old(regions)),
-            old(regions).slot_owners[self.index()].inner_perms.in_list.value() == 0,
+            old(regions).slot_owners[self.index()].in_list_perm.value() == 0,
             old(regions).inv(),
             <M1 as OwnerOf>::wf(metadata, meta_own_in),
         ensures
@@ -193,19 +193,19 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrame<M> {
             slot.drop_meta_in_place()
         };
 
-        let tracked mut inner_perms = slot_own.tracked_borrow_mut_inner_perms();
+        let tracked mut metadata_perms = slot_own.tracked_borrow_mut_metadata_perms();
 
         proof {
-            assert(inner_perms.storage.id() == perm_ref.value().storage.id());
+            assert(metadata_perms.storage_perm.id() == perm_ref.value().storage.id());
         }
 
         let slot = self.ptr.borrow(Tracked(perm_ref));
 
         unsafe {
             #[verus_spec(with
-                Tracked(&mut inner_perms.storage),
+                Tracked(&mut metadata_perms.storage_perm),
                 Tracked(&mut repr_perm),
-                Tracked(&mut inner_perms.vtable_ptr)
+                Tracked(&mut metadata_perms.vtable_ptr_perm)
             )]
             slot.write_meta(metadata)
         };
@@ -253,7 +253,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrame<M> {
         borrow_meta(
             ReprPtr::<MetaSlotStorage, M>::from_pptr(PPtr::from_addr(self.ptr.addr())),
             Tracked(points_to),
-            Tracked(&slot_owner.inner_perms.storage),
+            Tracked(&slot_owner.metadata_perm.storage_perm),
             Tracked(owner.tracked_borrow_repr_perm()),
         )
     }
@@ -297,10 +297,10 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrame<M> {
                 == old(regions).slot_owners[old(owner).slot_index].slot_vaddr,
             final(regions).slot_owners[final(owner).slot_index].usage
                 == old(regions).slot_owners[old(owner).slot_index].usage,
-            final(regions).slot_owners[final(owner).slot_index].inner_perms.ref_count
-                == old(regions).slot_owners[old(owner).slot_index].inner_perms.ref_count,
-            final(regions).slot_owners[final(owner).slot_index].inner_perms.in_list
-                == old(regions).slot_owners[old(owner).slot_index].inner_perms.in_list,
+            final(regions).slot_owners[final(owner).slot_index].ref_count_perm
+                == old(regions).slot_owners[old(owner).slot_index].ref_count_perm,
+            final(regions).slot_owners[final(owner).slot_index].in_list_perm
+                == old(regions).slot_owners[old(owner).slot_index].in_list_perm,
             final(regions).slot_owners[final(owner).slot_index].paths_in_pt
                 == old(regions).slot_owners[old(owner).slot_index].paths_in_pt,
             final(regions).frame_obligations == old(regions).frame_obligations,
@@ -421,7 +421,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> 
 
         #[verus_spec(with Tracked(perm_ref))]
         let slot = self.slot();
-        slot.ref_count.store(Tracked(&mut slot_own.inner_perms.ref_count), 0);
+        slot.ref_count.store(Tracked(&mut slot_own.ref_count_perm), 0);
 
         // SAFETY: We are the sole owner and the reference count is 0.
         // The slot is initialized.
@@ -464,7 +464,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> 
             self.wf(*owner),
             owner.inv(),
             old(regions).inv(),
-            old(regions).slot_owners[self.index()].inner_perms.ref_count.value() != REF_COUNT_UNUSED,
+            old(regions).slot_owners[self.index()].ref_count() != REF_COUNT_UNUSED,
         ensures
             Self::into_raw_ensures(self, *old(regions), *final(regions), r),
             final(regions).inv(),
@@ -500,7 +500,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> 
             valid_frame_paddr(paddr),
             old(regions).inv(),
             old(regions).contains(frame_to_index(paddr)),
-            old(regions).slot_owners[frame_to_index(paddr)].inner_perms.ref_count.value() == REF_COUNT_UNIQUE,
+            old(regions).slot_owners[frame_to_index(paddr)].ref_count() == REF_COUNT_UNIQUE,
         ensures
             res.0.ptr.addr() == frame_to_meta(paddr),
             res.0.wf(res.1@),
@@ -591,8 +591,8 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf + ?Sized> UniqueFrame<M> 
             // `rc == REF_COUNT_UNIQUE`) gives the storage/vtable init.
             assert(regions.slot_owners.contains_key(idx));
             assert(regions.slot_owners[idx].slot_vaddr == index_to_meta(idx));
-            assert(regions.slot_owners[idx].inner_perms.storage.is_init());
-            assert(regions.slot_owners[idx].inner_perms.vtable_ptr.is_init());
+            assert(regions.slot_owners[idx].storage_perm().is_init());
+            assert(regions.slot_owners[idx].vtable_ptr_perm().is_init());
 
             // Running `Drop` discharges the value's pending-Drop obligation.
             let tracked redeem_tok = vstd_extra::drop_tracking::DropObligation::tracked_mint(idx);
@@ -650,11 +650,10 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> Frame<M> {
         }
         let tracked mut slot_own = regions.slot_owners.tracked_remove(idx);
         let tracked slot_perm = regions.slots.tracked_borrow(idx);
-        let tracked mut inner_perms = slot_own.tracked_borrow_mut_inner_perms();
 
         #[verus_spec(with Tracked(&slot_perm))]
         let slot = unique.slot();
-        slot.ref_count.store(Tracked(&mut inner_perms.ref_count), 1);
+        slot.ref_count.store(Tracked(&mut slot_own.ref_count_perm), 1);
 
         proof {
             regions.slot_owners.tracked_insert(idx, slot_own);
@@ -690,12 +689,11 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrame<M> {
         }
         let tracked mut slot_own = regions.slot_owners.tracked_borrow_mut(idx);
         let tracked slot_perm = regions.slots.tracked_borrow(idx);
-        let tracked inner_perms = slot_own.tracked_borrow_mut_inner_perms();
 
         #[verus_spec(with Tracked(&slot_perm))]
         let slot = frame.slot();
         let res = slot.ref_count.compare_exchange(
-            Tracked(&mut inner_perms.ref_count),
+            Tracked(&mut slot_own.ref_count_perm),
             1,
             REF_COUNT_UNIQUE,
         );

--- a/ostd/src/mm/frame/unique.rs
+++ b/ostd/src/mm/frame/unique.rs
@@ -253,7 +253,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> UniqueFrame<M> {
         borrow_meta(
             ReprPtr::<MetaSlotStorage, M>::from_pptr(PPtr::from_addr(self.ptr.addr())),
             Tracked(points_to),
-            Tracked(&slot_owner.metadata_perm.storage_perm),
+            Tracked(&slot_owner.metadata_perm),
             Tracked(owner.tracked_borrow_repr_perm()),
         )
     }

--- a/ostd/src/mm/kspace/kvirt_area.rs
+++ b/ostd/src/mm/kspace/kvirt_area.rs
@@ -350,8 +350,8 @@ impl KVirtArea {
         let pa = v.query_mapping().pa_range.start;
         let idx = frame_to_index(pa);
         ||| !(self.range.start <= addr < self.range.end)
-        ||| (v.present() && !is_mmio_paddr(pa)
-            && regions.slot_owners[idx].ref_count() >= REF_COUNT_MAX)
+        ||| (v.present() && !is_mmio_paddr(pa) && regions.slot_owners[idx].ref_count()
+            >= REF_COUNT_MAX)
     }
 
     pub fn start(&self) -> Vaddr
@@ -882,8 +882,7 @@ impl KVirtArea {
                         pa_range.start <= pa < pa_range.end && pa % PAGE_SIZE == 0 ==> {
                             let idx = crate::specs::mm::frame::mapping::frame_to_index(pa);
                             &&& regions.contains(idx)
-                            &&& regions.slot_owners[idx].ref_count()
-                                != REF_COUNT_UNUSED
+                            &&& regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
                         },
             {
                 let pos: Ghost<int> = Ghost(it.index() as int);

--- a/ostd/src/mm/kspace/kvirt_area.rs
+++ b/ostd/src/mm/kspace/kvirt_area.rs
@@ -351,7 +351,7 @@ impl KVirtArea {
         let idx = frame_to_index(pa);
         ||| !(self.range.start <= addr < self.range.end)
         ||| (v.present() && !is_mmio_paddr(pa)
-            && regions.slot_owners[idx].inner_perms.ref_count.value() >= REF_COUNT_MAX)
+            && regions.slot_owners[idx].ref_count() >= REF_COUNT_MAX)
     }
 
     pub fn start(&self) -> Vaddr
@@ -732,7 +732,7 @@ impl KVirtArea {
             pa_range.start <= pa < pa_range.end && pa % PAGE_SIZE == 0 ==> {
                 let idx = crate::specs::mm::frame::mapping::frame_to_index(pa);
                 &&& regions.contains(idx)
-                &&& regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
+                &&& regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
             }
     }
 
@@ -832,7 +832,7 @@ impl KVirtArea {
                     pa_range.start <= pa < pa_range.end && pa % PAGE_SIZE == 0 implies {
                     let idx = crate::specs::mm::frame::mapping::frame_to_index(pa);
                     &&& regions.contains(idx)
-                    &&& regions.slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
+                    &&& regions.slot_owners[idx].ref_count() != REF_COUNT_UNUSED
                 } by {
                     let idx = crate::specs::mm::frame::mapping::frame_to_index(pa);
                     assert(regions.contains(idx));
@@ -882,7 +882,7 @@ impl KVirtArea {
                         pa_range.start <= pa < pa_range.end && pa % PAGE_SIZE == 0 ==> {
                             let idx = crate::specs::mm::frame::mapping::frame_to_index(pa);
                             &&& regions.contains(idx)
-                            &&& regions.slot_owners[idx].inner_perms.ref_count.value()
+                            &&& regions.slot_owners[idx].ref_count()
                                 != REF_COUNT_UNUSED
                         },
             {

--- a/ostd/src/mm/page_table/cursor/locking.rs
+++ b/ostd/src/mm/page_table/cursor/locking.rs
@@ -415,7 +415,7 @@ fn try_traverse_and_lock_subtree_root<'rcu, C: PageTableConfig, A: InAtomicMode>
         let tracked meta_slot_owner = regions.slot_owners.tracked_borrow(node_owner.slot_index);
         #[verus_spec(with
             Tracked(meta_points_to),
-            Tracked(&meta_slot_owner.metadata_perm.storage_perm),
+            Tracked(&meta_slot_owner.metadata_perm),
             Tracked(&()),
             Ghost(node_owner.meta_own.stray.id())
         )]
@@ -497,7 +497,7 @@ fn try_traverse_and_lock_subtree_root<'rcu, C: PageTableConfig, A: InAtomicMode>
     let tracked meta_slot_owner = regions.slot_owners.tracked_borrow(node_owner.slot_index);
     #[verus_spec(with
         Tracked(meta_points_to),
-        Tracked(&meta_slot_owner.metadata_perm.storage_perm),
+        Tracked(&meta_slot_owner.metadata_perm),
         Tracked(&()),
         Ghost(node_owner.meta_own.stray.id())
     )]

--- a/ostd/src/mm/page_table/cursor/locking.rs
+++ b/ostd/src/mm/page_table/cursor/locking.rs
@@ -223,13 +223,12 @@ pub fn lock_range<'rcu, C: PageTableConfig, A: InAtomicMode>(
             == pt_own.0.value().path);
         assume((forall|i: int|
             #![trigger old(regions).slot_owners[i]]
-            old(regions).contains(i) && old(regions).slot_owners[i].ref_count()
-                != REF_COUNT_UNUSED ==> old(regions).slot_owners[i].ref_count()
-                + 1 < REF_COUNT_MAX) ==> (forall|i: int|
+            old(regions).contains(i) && old(regions).slot_owners[i].ref_count() != REF_COUNT_UNUSED
+                ==> old(regions).slot_owners[i].ref_count() + 1 < REF_COUNT_MAX) ==> (forall|i: int|
+
             #![trigger regions.slot_owners[i]]
-            regions.contains(i) && regions.slot_owners[i].ref_count()
-                != REF_COUNT_UNUSED ==> regions.slot_owners[i].ref_count() + 1
-                < REF_COUNT_MAX));
+            regions.contains(i) && regions.slot_owners[i].ref_count() != REF_COUNT_UNUSED
+                ==> regions.slot_owners[i].ref_count() + 1 < REF_COUNT_MAX));
     }
     res
 }

--- a/ostd/src/mm/page_table/cursor/locking.rs
+++ b/ostd/src/mm/page_table/cursor/locking.rs
@@ -69,21 +69,21 @@ pub assume_specification<Idx: Clone>[ Range::<Idx>::clone ](range: &Range<Idx>) 
         // safe bounds during a single lock_range call.
         (forall |i: int| #![trigger old(regions).slot_owners[i]]
             old(regions).contains(i)
-            && old(regions).slot_owners[i].inner_perms.ref_count.value()
+            && old(regions).slot_owners[i].ref_count()
                 != REF_COUNT_UNUSED
-            ==> old(regions).slot_owners[i].inner_perms.ref_count.value() + 1
+            ==> old(regions).slot_owners[i].ref_count() + 1
                 < REF_COUNT_MAX)
         ==>
         (forall |i: int| #![trigger final(regions).slot_owners[i]]
             final(regions).contains(i)
-            && final(regions).slot_owners[i].inner_perms.ref_count.value()
+            && final(regions).slot_owners[i].ref_count()
                 != REF_COUNT_UNUSED
-            ==> final(regions).slot_owners[i].inner_perms.ref_count.value() + 1
+            ==> final(regions).slot_owners[i].ref_count() + 1
                 < REF_COUNT_MAX),
         // Locking only allocates page-table nodes from UNUSED slots, so any
         // slot that was already in use keeps its paths_in_pt intact.
         forall|idx: int| #![trigger final(regions).slot_owners[idx].paths_in_pt]
-            old(regions).slot_owners[idx].inner_perms.ref_count.value()
+            old(regions).slot_owners[idx].ref_count()
                 != REF_COUNT_UNUSED
             ==> final(regions).slot_owners[idx].paths_in_pt
                     == old(regions).slot_owners[idx].paths_in_pt,
@@ -93,25 +93,25 @@ pub assume_specification<Idx: Clone>[ Range::<Idx>::clone ](range: &Range<Idx>) 
         // `dfs_acquire_lock`'s `slot_owners ==` preservation.
         forall|idx: int| #![trigger final(regions).slot_owners[idx]]
             old(regions).contains(idx)
-            && old(regions).slot_owners[idx].inner_perms.ref_count.value()
+            && old(regions).slot_owners[idx].ref_count()
                 != REF_COUNT_UNUSED
-            ==> final(regions).slot_owners[idx].inner_perms.ref_count.value()
-                    == old(regions).slot_owners[idx].inner_perms.ref_count.value()
+            ==> final(regions).slot_owners[idx].ref_count()
+                    == old(regions).slot_owners[idx].ref_count()
                 && final(regions).slot_owners[idx].usage
                     == old(regions).slot_owners[idx].usage,
         // Saturated-slot bridge (bidirectional): a slot is at
         // `>= REF_COUNT_MAX` before iff after, with the same value.
         // Composes helpers' clauses (see their ensures).
-        forall|idx: int| #![trigger final(regions).slot_owners[idx].inner_perms.ref_count.value()]
-            final(regions).slot_owners[idx].inner_perms.ref_count.value()
+        forall|idx: int| #![trigger final(regions).slot_owners[idx].ref_count()]
+            final(regions).slot_owners[idx].ref_count()
                 >= REF_COUNT_MAX
-            ==> old(regions).slot_owners[idx].inner_perms.ref_count.value()
-                    == final(regions).slot_owners[idx].inner_perms.ref_count.value(),
-        forall|idx: int| #![trigger old(regions).slot_owners[idx].inner_perms.ref_count.value()]
-            old(regions).slot_owners[idx].inner_perms.ref_count.value()
+            ==> old(regions).slot_owners[idx].ref_count()
+                    == final(regions).slot_owners[idx].ref_count(),
+        forall|idx: int| #![trigger old(regions).slot_owners[idx].ref_count()]
+            old(regions).slot_owners[idx].ref_count()
                 >= REF_COUNT_MAX
-            ==> final(regions).slot_owners[idx].inner_perms.ref_count.value()
-                    == old(regions).slot_owners[idx].inner_perms.ref_count.value(),
+            ==> final(regions).slot_owners[idx].ref_count()
+                    == old(regions).slot_owners[idx].ref_count(),
         // Frames that were item_not_mapped before remain so after locking.
         forall|item: C::Item| #![trigger CursorMut::<C, A>::item_not_mapped(item, *old(regions))]
             CursorMut::<C, A>::item_not_mapped(item, *old(regions)) ==>
@@ -223,12 +223,12 @@ pub fn lock_range<'rcu, C: PageTableConfig, A: InAtomicMode>(
             == pt_own.0.value().path);
         assume((forall|i: int|
             #![trigger old(regions).slot_owners[i]]
-            old(regions).contains(i) && old(regions).slot_owners[i].inner_perms.ref_count.value()
-                != REF_COUNT_UNUSED ==> old(regions).slot_owners[i].inner_perms.ref_count.value()
+            old(regions).contains(i) && old(regions).slot_owners[i].ref_count()
+                != REF_COUNT_UNUSED ==> old(regions).slot_owners[i].ref_count()
                 + 1 < REF_COUNT_MAX) ==> (forall|i: int|
             #![trigger regions.slot_owners[i]]
-            regions.contains(i) && regions.slot_owners[i].inner_perms.ref_count.value()
-                != REF_COUNT_UNUSED ==> regions.slot_owners[i].inner_perms.ref_count.value() + 1
+            regions.contains(i) && regions.slot_owners[i].ref_count()
+                != REF_COUNT_UNUSED ==> regions.slot_owners[i].ref_count() + 1
                 < REF_COUNT_MAX));
     }
     res
@@ -305,7 +305,7 @@ pub fn unlock_range<C: PageTableConfig, A: InAtomicMode>(cursor: &mut Cursor<'_,
         // Locking only allocates fresh page-table nodes from UNUSED slots;
         // it does not mutate any slot that was already in use.
         forall|idx: int| #![trigger final(regions).slot_owners[idx].paths_in_pt]
-            old(regions).slot_owners[idx].inner_perms.ref_count.value()
+            old(regions).slot_owners[idx].ref_count()
                 != REF_COUNT_UNUSED
             ==> final(regions).slot_owners[idx].paths_in_pt
                     == old(regions).slot_owners[idx].paths_in_pt,
@@ -314,10 +314,10 @@ pub fn unlock_range<C: PageTableConfig, A: InAtomicMode>(cursor: &mut Cursor<'_,
         // nodes from UNUSED slots; it never mutates a slot already in use.
         forall|idx: int| #![trigger final(regions).slot_owners[idx]]
             old(regions).contains(idx)
-            && old(regions).slot_owners[idx].inner_perms.ref_count.value()
+            && old(regions).slot_owners[idx].ref_count()
                 != REF_COUNT_UNUSED
-            ==> final(regions).slot_owners[idx].inner_perms.ref_count.value()
-                    == old(regions).slot_owners[idx].inner_perms.ref_count.value()
+            ==> final(regions).slot_owners[idx].ref_count()
+                    == old(regions).slot_owners[idx].ref_count()
                 && final(regions).slot_owners[idx].usage
                     == old(regions).slot_owners[idx].usage,
         // Saturated-slot bridge (bidirectional): a slot is at
@@ -327,16 +327,16 @@ pub fn unlock_range<C: PageTableConfig, A: InAtomicMode>(cursor: &mut Cursor<'_,
         // already-saturated slots. Used by `KVirtArea::query` to bridge
         // the inner `Cursor::query`'s per-specific-slot saturation
         // condition back to the caller's `*old(regions)` snapshot.
-        forall|idx: int| #![trigger final(regions).slot_owners[idx].inner_perms.ref_count.value()]
-            final(regions).slot_owners[idx].inner_perms.ref_count.value()
+        forall|idx: int| #![trigger final(regions).slot_owners[idx].ref_count()]
+            final(regions).slot_owners[idx].ref_count()
                 >= REF_COUNT_MAX
-            ==> old(regions).slot_owners[idx].inner_perms.ref_count.value()
-                    == final(regions).slot_owners[idx].inner_perms.ref_count.value(),
-        forall|idx: int| #![trigger old(regions).slot_owners[idx].inner_perms.ref_count.value()]
-            old(regions).slot_owners[idx].inner_perms.ref_count.value()
+            ==> old(regions).slot_owners[idx].ref_count()
+                    == final(regions).slot_owners[idx].ref_count(),
+        forall|idx: int| #![trigger old(regions).slot_owners[idx].ref_count()]
+            old(regions).slot_owners[idx].ref_count()
                 >= REF_COUNT_MAX
-            ==> final(regions).slot_owners[idx].inner_perms.ref_count.value()
-                    == old(regions).slot_owners[idx].inner_perms.ref_count.value(),
+            ==> final(regions).slot_owners[idx].ref_count()
+                    == old(regions).slot_owners[idx].ref_count(),
         // Therefore any frame that was `item_not_mapped` (its paths_in_pt was
         // empty, hence `ref_count` might be UNUSED-or-non-UNUSED) stays so:
         // the paddr range's slots either had non-UNUSED ref_count (preserved
@@ -415,7 +415,7 @@ fn try_traverse_and_lock_subtree_root<'rcu, C: PageTableConfig, A: InAtomicMode>
         let tracked meta_slot_owner = regions.slot_owners.tracked_borrow(node_owner.slot_index);
         #[verus_spec(with
             Tracked(meta_points_to),
-            Tracked(&meta_slot_owner.inner_perms.storage),
+            Tracked(&meta_slot_owner.metadata_perm.storage_perm),
             Tracked(&()),
             Ghost(node_owner.meta_own.stray.id())
         )]
@@ -497,7 +497,7 @@ fn try_traverse_and_lock_subtree_root<'rcu, C: PageTableConfig, A: InAtomicMode>
     let tracked meta_slot_owner = regions.slot_owners.tracked_borrow(node_owner.slot_index);
     #[verus_spec(with
         Tracked(meta_points_to),
-        Tracked(&meta_slot_owner.inner_perms.storage),
+        Tracked(&meta_slot_owner.metadata_perm.storage_perm),
         Tracked(&()),
         Ghost(node_owner.meta_own.stray.id())
     )]

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -654,8 +654,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                         old(regions).inv_implies_correct_addr(pa);
                         assert(regions.slot_owners.contains_key(idx));
                         assert(owner.cur_entry_owner().inv_base());
-                        if C::tracked(item)
-                            && regions.slot_owners[idx].ref_count()
+                        if C::tracked(item) && regions.slot_owners[idx].ref_count()
                             >= REF_COUNT_MAX {
                             EntryOwner::<C>::axiom_frame_is_tracked_iff_not_mmio(
                                 owner.cur_entry_owner(),
@@ -704,10 +703,10 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                         assert(owner@ == old(owner)@);
                         assert(owner@.query_mapping().pa_range.start == pa);
                         if C::tracked(item) {
-                            assert(old_regions.slot_owners[idx].ref_count()
-                                == old(regions).slot_owners[idx].ref_count());
-                            assert(old(regions).slot_owners[idx].ref_count()
-                                < REF_COUNT_MAX);
+                            assert(old_regions.slot_owners[idx].ref_count() == old(
+                                regions,
+                            ).slot_owners[idx].ref_count());
+                            assert(old(regions).slot_owners[idx].ref_count() < REF_COUNT_MAX);
                         } else {
                             EntryOwner::<C>::axiom_frame_is_tracked_iff_not_mmio(
                                 owner.cur_entry_owner(),
@@ -746,8 +745,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                             let sub_idx = frame_to_index((pa + j * PAGE_SIZE) as usize);
                             &&& regions.contains(sub_idx)
                             &&& regions.slot_owners[sub_idx].usage !is MMIO ==> {
-                                &&& regions.slot_owners[sub_idx].ref_count()
-                                    != REF_COUNT_UNUSED
+                                &&& regions.slot_owners[sub_idx].ref_count() != REF_COUNT_UNUSED
                                 &&& regions.slot_owners[sub_idx].ref_count() > 0
                             }
                         } by {
@@ -2987,9 +2985,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         assert(Self::item_slot_in_regions(item, regions_after_ref));
                     };
                     assert forall|idx: int|
-                        old(regions).slot_owners[idx].ref_count()
-                            != REF_COUNT_UNUSED implies (#[trigger] regions.slot_owners[idx])
-                        == old(regions).slot_owners[idx] by {
+                        old(regions).slot_owners[idx].ref_count() != REF_COUNT_UNUSED implies (
+                    #[trigger] regions.slot_owners[idx]) == old(regions).slot_owners[idx] by {
                         assert(regions0.slot_owners[idx] == old(regions).slot_owners[idx]);
                         assert(regions_after_ref.slot_owners[idx] == regions0.slot_owners[idx]);
                     };
@@ -3359,12 +3356,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 if C::tracked(item) && old(regions).contains(pa_idx2) && old(
                     regions,
                 ).slot_owners[pa_idx2].ref_count() > 0 {
-                    assert(regions_before_new_child.slot_owners[pa_idx2].ref_count()
-                        > 0);
-                    assert(regions_after_new_child.slot_owners[pa_idx2].ref_count()
-                        > 0);
-                    assert(regions_after_replace.slot_owners[pa_idx2].ref_count()
-                        > 0);
+                    assert(regions_before_new_child.slot_owners[pa_idx2].ref_count() > 0);
+                    assert(regions_after_new_child.slot_owners[pa_idx2].ref_count() > 0);
+                    assert(regions_after_replace.slot_owners[pa_idx2].ref_count() > 0);
                 }
             };
 

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -218,17 +218,17 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                 ).slot_owners[i]),
             // The frame's slot: bumped if the item is ref-counted, otherwise unchanged.
             C::tracked(*item) ==> {
-                &&& final(regions).slot_owners[frame_to_index(pa)].inner_perms.ref_count.id()
-                    == old(regions).slot_owners[frame_to_index(pa)].inner_perms.ref_count.id()
-                &&& final(regions).slot_owners[frame_to_index(pa)].inner_perms.storage == old(
+                &&& final(regions).slot_owners[frame_to_index(pa)].ref_count_perm.id()
+                    == old(regions).slot_owners[frame_to_index(pa)].ref_count_perm.id()
+                &&& final(regions).slot_owners[frame_to_index(pa)].storage_perm() == old(
                     regions,
-                ).slot_owners[frame_to_index(pa)].inner_perms.storage
-                &&& final(regions).slot_owners[frame_to_index(pa)].inner_perms.vtable_ptr == old(
+                ).slot_owners[frame_to_index(pa)].storage_perm()
+                &&& final(regions).slot_owners[frame_to_index(pa)].vtable_ptr_perm() == old(
                     regions,
-                ).slot_owners[frame_to_index(pa)].inner_perms.vtable_ptr
-                &&& final(regions).slot_owners[frame_to_index(pa)].inner_perms.in_list == old(
+                ).slot_owners[frame_to_index(pa)].vtable_ptr_perm()
+                &&& final(regions).slot_owners[frame_to_index(pa)].in_list_perm == old(
                     regions,
-                ).slot_owners[frame_to_index(pa)].inner_perms.in_list
+                ).slot_owners[frame_to_index(pa)].in_list_perm
                 &&& final(regions).slot_owners[frame_to_index(pa)].paths_in_pt == old(
                     regions,
                 ).slot_owners[frame_to_index(pa)].paths_in_pt
@@ -238,8 +238,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                 &&& final(regions).slot_owners[frame_to_index(pa)].usage == old(
                     regions,
                 ).slot_owners[frame_to_index(pa)].usage
-                &&& final(regions).slot_owners[frame_to_index(pa)].inner_perms.ref_count.value()
-                    == old(regions).slot_owners[frame_to_index(pa)].inner_perms.ref_count.value()
+                &&& final(regions).slot_owners[frame_to_index(pa)].ref_count()
+                    == old(regions).slot_owners[frame_to_index(pa)].ref_count()
                     + 1
             },
             !C::tracked(*item) ==> final(regions).slot_owners[frame_to_index(pa)] == old(
@@ -302,7 +302,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
             // slots that were non-UNUSED before the call keep their
             // paths_in_pt (new PT allocations come from UNUSED slots).
             forall|idx: int| #![trigger final(regions).slot_owners[idx].paths_in_pt]
-                old(regions).slot_owners[idx].inner_perms.ref_count.value()
+                old(regions).slot_owners[idx].ref_count()
                     != REF_COUNT_UNUSED
                 ==> final(regions).slot_owners[idx].paths_in_pt
                         == old(regions).slot_owners[idx].paths_in_pt,
@@ -310,10 +310,10 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
             // preserved across `Cursor::new` (= `lock_range`).
             forall|idx: int| #![trigger final(regions).slot_owners[idx]]
                 old(regions).contains(idx)
-                && old(regions).slot_owners[idx].inner_perms.ref_count.value()
+                && old(regions).slot_owners[idx].ref_count()
                     != REF_COUNT_UNUSED
-                ==> final(regions).slot_owners[idx].inner_perms.ref_count.value()
-                        == old(regions).slot_owners[idx].inner_perms.ref_count.value()
+                ==> final(regions).slot_owners[idx].ref_count()
+                        == old(regions).slot_owners[idx].ref_count()
                     && final(regions).slot_owners[idx].usage
                         == old(regions).slot_owners[idx].usage,
             // Saturated-slot bridge (bidirectional): a slot is at
@@ -322,32 +322,32 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
             // saturation condition back to the caller's snapshot — both
             // for the `requires P ==> may_panic()` discharge (forward
             // direction) and the `ensures !P` discharge (backward).
-            forall|idx: int| #![trigger final(regions).slot_owners[idx].inner_perms.ref_count.value()]
-                final(regions).slot_owners[idx].inner_perms.ref_count.value()
+            forall|idx: int| #![trigger final(regions).slot_owners[idx].ref_count()]
+                final(regions).slot_owners[idx].ref_count()
                     >= REF_COUNT_MAX
-                ==> old(regions).slot_owners[idx].inner_perms.ref_count.value()
-                        == final(regions).slot_owners[idx].inner_perms.ref_count.value(),
-            forall|idx: int| #![trigger old(regions).slot_owners[idx].inner_perms.ref_count.value()]
-                old(regions).slot_owners[idx].inner_perms.ref_count.value()
+                ==> old(regions).slot_owners[idx].ref_count()
+                        == final(regions).slot_owners[idx].ref_count(),
+            forall|idx: int| #![trigger old(regions).slot_owners[idx].ref_count()]
+                old(regions).slot_owners[idx].ref_count()
                     >= REF_COUNT_MAX
-                ==> final(regions).slot_owners[idx].inner_perms.ref_count.value()
-                        == old(regions).slot_owners[idx].inner_perms.ref_count.value(),
+                ==> final(regions).slot_owners[idx].ref_count()
+                        == old(regions).slot_owners[idx].ref_count(),
             forall|item: C::Item| #![trigger CursorMut::<C, A>::item_not_mapped(item, *old(regions))]
                 CursorMut::<C, A>::item_not_mapped(item, *old(regions)) ==>
                 CursorMut::<C, A>::item_not_mapped(item, *final(regions)),
             // Non-saturation preservation.
             (forall |i: int| #![trigger old(regions).slot_owners[i]]
                 old(regions).contains(i)
-                && old(regions).slot_owners[i].inner_perms.ref_count.value()
+                && old(regions).slot_owners[i].ref_count()
                     != REF_COUNT_UNUSED
-                ==> old(regions).slot_owners[i].inner_perms.ref_count.value() + 1
+                ==> old(regions).slot_owners[i].ref_count() + 1
                     < REF_COUNT_MAX)
             ==>
             (forall |i: int| #![trigger final(regions).slot_owners[i]]
                 final(regions).contains(i)
-                && final(regions).slot_owners[i].inner_perms.ref_count.value()
+                && final(regions).slot_owners[i].ref_count()
                     != REF_COUNT_UNUSED
-                ==> final(regions).slot_owners[i].inner_perms.ref_count.value() + 1
+                ==> final(regions).slot_owners[i].ref_count() + 1
                     < REF_COUNT_MAX),
     )]
     pub fn new(pt: &'rcu PageTable<C>, guard: &'rcu A, va: &Range<Vaddr>) -> Result<
@@ -493,9 +493,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                 forall|i: int|
                     #![trigger regions.slot_owners[i]]
                     old(regions).contains(i)
-                        ==> regions.slot_owners[i].inner_perms.ref_count.value() == old(
+                        ==> regions.slot_owners[i].ref_count() == old(
                         regions,
-                    ).slot_owners[i].inner_perms.ref_count.value(),
+                    ).slot_owners[i].ref_count(),
                 regions.slot_owners.dom() == old(regions).slot_owners.dom(),
                 forall|idx: int|
                     #![trigger regions.slot_owners[idx]]
@@ -507,25 +507,25 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                             regions,
                         ).slot_owners[idx].slot_vaddr
                         &&& regions.slot_owners[idx].usage == old(regions).slot_owners[idx].usage
-                        &&& regions.slot_owners[idx].inner_perms.ref_count.id() == old(
+                        &&& regions.slot_owners[idx].ref_count_perm.id() == old(
                             regions,
-                        ).slot_owners[idx].inner_perms.ref_count.id()
-                        &&& regions.slot_owners[idx].inner_perms.ref_count.value() >= old(
+                        ).slot_owners[idx].ref_count_perm.id()
+                        &&& regions.slot_owners[idx].ref_count() >= old(
                             regions,
-                        ).slot_owners[idx].inner_perms.ref_count.value()
-                        &&& regions.slot_owners[idx].inner_perms.ref_count.value()
+                        ).slot_owners[idx].ref_count()
+                        &&& regions.slot_owners[idx].ref_count()
                             != REF_COUNT_UNUSED || old(
                             regions,
-                        ).slot_owners[idx].inner_perms.ref_count.value() == REF_COUNT_UNUSED
-                        &&& regions.slot_owners[idx].inner_perms.storage == old(
+                        ).slot_owners[idx].ref_count() == REF_COUNT_UNUSED
+                        &&& regions.slot_owners[idx].storage_perm() == old(
                             regions,
-                        ).slot_owners[idx].inner_perms.storage
-                        &&& regions.slot_owners[idx].inner_perms.vtable_ptr.pptr() == old(
+                        ).slot_owners[idx].storage_perm()
+                        &&& regions.slot_owners[idx].vtable_ptr_perm().pptr() == old(
                             regions,
-                        ).slot_owners[idx].inner_perms.vtable_ptr.pptr()
-                        &&& regions.slot_owners[idx].inner_perms.in_list.id() == old(
+                        ).slot_owners[idx].vtable_ptr_perm().pptr()
+                        &&& regions.slot_owners[idx].in_list_perm.id() == old(
                             regions,
-                        ).slot_owners[idx].inner_perms.in_list.id()
+                        ).slot_owners[idx].in_list_perm.id()
                     },
                 forall|k: int|
                     old(regions).slots.contains_key(k) ==> #[trigger] regions.slots.contains_key(k),
@@ -655,7 +655,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                         assert(regions.slot_owners.contains_key(idx));
                         assert(owner.cur_entry_owner().inv_base());
                         if C::tracked(item)
-                            && regions.slot_owners[idx].inner_perms.ref_count.value()
+                            && regions.slot_owners[idx].ref_count()
                             >= REF_COUNT_MAX {
                             EntryOwner::<C>::axiom_frame_is_tracked_iff_not_mmio(
                                 owner.cur_entry_owner(),
@@ -704,9 +704,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                         assert(owner@ == old(owner)@);
                         assert(owner@.query_mapping().pa_range.start == pa);
                         if C::tracked(item) {
-                            assert(old_regions.slot_owners[idx].inner_perms.ref_count.value()
-                                == old(regions).slot_owners[idx].inner_perms.ref_count.value());
-                            assert(old(regions).slot_owners[idx].inner_perms.ref_count.value()
+                            assert(old_regions.slot_owners[idx].ref_count()
+                                == old(regions).slot_owners[idx].ref_count());
+                            assert(old(regions).slot_owners[idx].ref_count()
                                 < REF_COUNT_MAX);
                         } else {
                             EntryOwner::<C>::axiom_frame_is_tracked_iff_not_mmio(
@@ -746,9 +746,9 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> Cursor<'rcu, C, A> {
                             let sub_idx = frame_to_index((pa + j * PAGE_SIZE) as usize);
                             &&& regions.contains(sub_idx)
                             &&& regions.slot_owners[sub_idx].usage !is MMIO ==> {
-                                &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value()
+                                &&& regions.slot_owners[sub_idx].ref_count()
                                     != REF_COUNT_UNUSED
-                                &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value() > 0
+                                &&& regions.slot_owners[sub_idx].ref_count() > 0
                             }
                         } by {
                             let sub_idx = frame_to_index((pa + j * PAGE_SIZE) as usize);
@@ -2270,16 +2270,16 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             // PT-node allocations come from UNUSED slots, so any slot that
             // was already in use keeps its paths_in_pt.
             forall |idx: int| #![trigger final(regions).slot_owners[idx].paths_in_pt]
-                old(regions).slot_owners[idx].inner_perms.ref_count.value()
+                old(regions).slot_owners[idx].ref_count()
                     != REF_COUNT_UNUSED
                 ==> final(regions).slot_owners[idx].paths_in_pt
                         == old(regions).slot_owners[idx].paths_in_pt,
             forall|idx: int| #![trigger final(regions).slot_owners[idx]]
                 old(regions).contains(idx)
-                && old(regions).slot_owners[idx].inner_perms.ref_count.value()
+                && old(regions).slot_owners[idx].ref_count()
                     != REF_COUNT_UNUSED
-                ==> final(regions).slot_owners[idx].inner_perms.ref_count.value()
-                        == old(regions).slot_owners[idx].inner_perms.ref_count.value()
+                ==> final(regions).slot_owners[idx].ref_count()
+                        == old(regions).slot_owners[idx].ref_count()
                     && final(regions).slot_owners[idx].usage
                         == old(regions).slot_owners[idx].usage,
     )]
@@ -2556,7 +2556,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 Self::item_slot_in_regions(item, *final(regions)),
             (level <= old(self).0.level && old(owner).cur_entry_owner().is_absent()) ==> final(owner).cur_entry_owner().is_absent(),
             forall|idx: int|
-                old(regions).slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED ==>
+                old(regions).slot_owners[idx].ref_count() != REF_COUNT_UNUSED ==>
                 (#[trigger] final(regions).slot_owners[idx]) == old(regions).slot_owners[idx],
             // `regions.slots` is monotonic — PT-node allocation removes-and-re-inserts
             // each slot it touches, so all old keys are preserved.
@@ -2604,7 +2604,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                 self.0.level < level ==> self.0.level >= owner0.level,
                 self.0.level < level ==> owner@ == owner0@,
                 forall|idx: int|
-                    old(regions).slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED
+                    old(regions).slot_owners[idx].ref_count() != REF_COUNT_UNUSED
                         ==> (#[trigger] regions.slot_owners[idx]) == old(regions).slot_owners[idx],
                 forall|idx: int|
                     #![trigger regions.slots.contains_key(idx)]
@@ -2838,7 +2838,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                                 assert(eo.metaregion_sound(regions_after_ref));
                                 let eo_idx = frame_to_index(eo.meta_slot_paddr().unwrap());
                                 assert(eo_idx == eo.node().slot_index);
-                                assert(regions_after_ref.slot_owners[eo_idx].inner_perms.ref_count.value()
+                                assert(regions_after_ref.slot_owners[eo_idx].ref_count()
                                     != REF_COUNT_UNUSED);
                                 assert(eo_idx != new_pt_idx);
                                 assert(regions.slot_owners[eo_idx]
@@ -2987,7 +2987,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                         assert(Self::item_slot_in_regions(item, regions_after_ref));
                     };
                     assert forall|idx: int|
-                        old(regions).slot_owners[idx].inner_perms.ref_count.value()
+                        old(regions).slot_owners[idx].ref_count()
                             != REF_COUNT_UNUSED implies (#[trigger] regions.slot_owners[idx])
                         == old(regions).slot_owners[idx] by {
                         assert(regions0.slot_owners[idx] == old(regions).slot_owners[idx]);
@@ -3076,49 +3076,49 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             forall|idx: int| #![trigger final(regions).slot_owners[idx].paths_in_pt]
                 old(regions).contains(idx) &&
                 idx != frame_to_index(C::item_into_raw(item).0) &&
-                old(regions).slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED ==>
+                old(regions).slot_owners[idx].ref_count() != REF_COUNT_UNUSED ==>
                 final(regions).slot_owners[idx].paths_in_pt == old(regions).slot_owners[idx].paths_in_pt,
             // For non-UNUSED indices, ref_count stays non-UNUSED across the map.
             // (map_loop only allocates new PT nodes from previously-UNUSED slots, so
             // any slot already in use stays in use; replace_cur_entry replaces the
             // current entry without dropping refcounts of unrelated slots.)
-            forall|idx: int| #![trigger final(regions).slot_owners[idx].inner_perms.ref_count.value()]
+            forall|idx: int| #![trigger final(regions).slot_owners[idx].ref_count()]
                 old(regions).contains(idx) &&
-                old(regions).slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED ==>
-                final(regions).slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED,
+                old(regions).slot_owners[idx].ref_count() != REF_COUNT_UNUSED ==>
+                final(regions).slot_owners[idx].ref_count() != REF_COUNT_UNUSED,
             // ref_count is preserved exactly at non-mapped, non-UNUSED indices.
             // map_loop preserves slot_owners fully at non-UNUSED slots, new_child
             // only mutates the new mapped frame's slot, and replace_cur_entry
             // preserves ref_count for all slots (per its own postcondition at
             // [mod.rs:3380]). Lets callers re-derive `item_slot_in_regions`
             // for unrelated paddrs.
-            forall|idx: int| #![trigger final(regions).slot_owners[idx].inner_perms.ref_count.value()]
+            forall|idx: int| #![trigger final(regions).slot_owners[idx].ref_count()]
                 old(regions).contains(idx) &&
                 idx != frame_to_index(C::item_into_raw(item).0) &&
-                old(regions).slot_owners[idx].inner_perms.ref_count.value() != REF_COUNT_UNUSED ==>
-                final(regions).slot_owners[idx].inner_perms.ref_count.value()
-                    == old(regions).slot_owners[idx].inner_perms.ref_count.value(),
+                old(regions).slot_owners[idx].ref_count() != REF_COUNT_UNUSED ==>
+                final(regions).slot_owners[idx].ref_count()
+                    == old(regions).slot_owners[idx].ref_count(),
             // At the mapped index, ref_count > 0 is preserved (incremented if
             // already > 0). Together with `slots.contains_key` monotonicity,
             // gives `item_slot_in_regions(item, *final(regions))` post-map.
             (C::tracked(item)
                 && old(regions).contains(frame_to_index(C::item_into_raw(item).0))
                 && old(regions).slot_owners[
-                    frame_to_index(C::item_into_raw(item).0)].inner_perms.ref_count.value() > 0)
+                    frame_to_index(C::item_into_raw(item).0)].ref_count() > 0)
                 ==>
                 final(regions).slot_owners[
-                    frame_to_index(C::item_into_raw(item).0)].inner_perms.ref_count.value() > 0,
+                    frame_to_index(C::item_into_raw(item).0)].ref_count() > 0,
             // At the mapped index, the SHARED upper bound is preserved: on the
             // non-panic path the clone's saturation guard keeps `rc <= MAX`.
             // Lets callers re-derive `item_slot_in_regions`'s `rc <= MAX` for the
             // mapped frame (covers duplicate frames in a map sequence).
             (C::tracked(item)
                 && old(regions).slot_owners[
-                    frame_to_index(C::item_into_raw(item).0)].inner_perms.ref_count.value()
+                    frame_to_index(C::item_into_raw(item).0)].ref_count()
                     <= REF_COUNT_MAX)
                 ==>
                 final(regions).slot_owners[
-                    frame_to_index(C::item_into_raw(item).0)].inner_perms.ref_count.value()
+                    frame_to_index(C::item_into_raw(item).0)].ref_count()
                     <= REF_COUNT_MAX,
             // `regions.slots` is monotonic — slot existence is preserved through map.
             forall|idx: int| #![trigger final(regions).contains(idx)]
@@ -3346,24 +3346,24 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             assert forall|idx: int|
                 old(regions).contains(idx) && idx != pa_idx2 && old(
                     regions,
-                ).slot_owners[idx].inner_perms.ref_count.value()
+                ).slot_owners[idx].ref_count()
                     != REF_COUNT_UNUSED implies #[trigger] regions.slot_owners[idx].paths_in_pt
                 == old(regions).slot_owners[idx].paths_in_pt by {
                 assert(regions_after_new_child.slot_owners == regions_before_new_child.slot_owners);
             };
             assert(C::tracked(item) && old(regions).contains(pa_idx2) && old(
                 regions,
-            ).slot_owners[pa_idx2].inner_perms.ref_count.value() > 0 ==> {
-                &&& regions.slot_owners[pa_idx2].inner_perms.ref_count.value() > 0
+            ).slot_owners[pa_idx2].ref_count() > 0 ==> {
+                &&& regions.slot_owners[pa_idx2].ref_count() > 0
             }) by {
                 if C::tracked(item) && old(regions).contains(pa_idx2) && old(
                     regions,
-                ).slot_owners[pa_idx2].inner_perms.ref_count.value() > 0 {
-                    assert(regions_before_new_child.slot_owners[pa_idx2].inner_perms.ref_count.value()
+                ).slot_owners[pa_idx2].ref_count() > 0 {
+                    assert(regions_before_new_child.slot_owners[pa_idx2].ref_count()
                         > 0);
-                    assert(regions_after_new_child.slot_owners[pa_idx2].inner_perms.ref_count.value()
+                    assert(regions_after_new_child.slot_owners[pa_idx2].ref_count()
                         > 0);
-                    assert(regions_after_replace.slot_owners[pa_idx2].inner_perms.ref_count.value()
+                    assert(regions_after_replace.slot_owners[pa_idx2].ref_count()
                         > 0);
                 }
             };
@@ -3967,10 +3967,10 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             // ref_count by spec); `dfs_mark_stray_and_unlock` doesn't take regions at
             // all, so the StrayPageTable branch can't perturb refcounts either.
             forall|idx: int|
-                #![trigger final(regions).slot_owners[idx].inner_perms.ref_count.value()]
-                final(regions).slot_owners[idx].inner_perms.ref_count.value() == old(
+                #![trigger final(regions).slot_owners[idx].ref_count()]
+                final(regions).slot_owners[idx].ref_count() == old(
                     regions,
-                ).slot_owners[idx].inner_perms.ref_count.value(),
+                ).slot_owners[idx].ref_count(),
             // When `res is None` (⇔ pre-replace cur_entry was absent), `Entry::replace`
             // fully preserves `regions.slots`.
             res is None ==> final(regions).slots == old(regions).slots,

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -3126,6 +3126,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
     #[verifier::spinoff_prover]
     #[verifier::rlimit(200)]
     pub unsafe fn map(&mut self, item: C::Item) -> (res: Result<(), PageTableFrag<C>>) {
+        hide(MetaSlotOwner::storage_perm);
+        hide(MetaSlotOwner::vtable_ptr_perm);
         let ghost self0 = *self;
         let ghost owner0 = *owner;
 
@@ -3224,6 +3226,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             );
 
             assert(new_owner.value().metaregion_sound(*regions)) by {
+                reveal(MetaSlotOwner::storage_perm);
+                reveal(MetaSlotOwner::vtable_ptr_perm);
                 broadcast use crate::specs::mm::frame::meta_owners::axiom_mmio_usage_iff_mmio_paddr;
 
                 assert(Self::item_slot_in_regions(item, regions_before_new_child));
@@ -3261,6 +3265,8 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
                     &&& regions.slots[i].value().wf(regions.slot_owners[i])
                     &&& regions.slot_owners[i].slot_vaddr == regions.slots[i].addr()
                 } by {
+                    reveal(MetaSlotOwner::storage_perm);
+                    reveal(MetaSlotOwner::vtable_ptr_perm);
                     assert(regions_before_new_child.slots.contains_key(i));
                     if i == pa_idx_install {
                         assert(regions_before_new_child.slot_owners[pa_idx_install].inv());

--- a/ostd/src/mm/page_table/cursor/mod.rs
+++ b/ostd/src/mm/page_table/cursor/mod.rs
@@ -3532,7 +3532,7 @@ impl<'rcu, C: PageTableConfig, A: InAtomicMode> CursorMut<'rcu, C, A> {
             },
     )]
     #[verifier::spinoff_prover]
-    #[verifier::rlimit(50)]
+    #[verifier::rlimit(600)]
     pub unsafe fn take_next(&mut self, len: usize) -> (r: Option<PageTableFrag<C>>) {
         // This proof touches several cursor snapshots. Keep their quantified invariants
         // opaque by default, then reveal only the concrete facts needed below. Leaving

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -369,16 +369,16 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
                     == old_regions.slot_owners[i]),
             // The frame's slot: bumped if the item is ref-counted, otherwise unchanged.
             Self::tracked(item) ==> {
-                &&& new_regions.slot_owners[frame_to_index(pa)].inner_perms.ref_count.value()
-                    == old_regions.slot_owners[frame_to_index(pa)].inner_perms.ref_count.value() + 1
-                &&& new_regions.slot_owners[frame_to_index(pa)].inner_perms.ref_count.id()
-                    == old_regions.slot_owners[frame_to_index(pa)].inner_perms.ref_count.id()
-                &&& new_regions.slot_owners[frame_to_index(pa)].inner_perms.storage
-                    == old_regions.slot_owners[frame_to_index(pa)].inner_perms.storage
-                &&& new_regions.slot_owners[frame_to_index(pa)].inner_perms.vtable_ptr
-                    == old_regions.slot_owners[frame_to_index(pa)].inner_perms.vtable_ptr
-                &&& new_regions.slot_owners[frame_to_index(pa)].inner_perms.in_list
-                    == old_regions.slot_owners[frame_to_index(pa)].inner_perms.in_list
+                &&& new_regions.slot_owners[frame_to_index(pa)].ref_count()
+                    == old_regions.slot_owners[frame_to_index(pa)].ref_count() + 1
+                &&& new_regions.slot_owners[frame_to_index(pa)].ref_count_perm.id()
+                    == old_regions.slot_owners[frame_to_index(pa)].ref_count_perm.id()
+                &&& new_regions.slot_owners[frame_to_index(pa)].storage_perm()
+                    == old_regions.slot_owners[frame_to_index(pa)].storage_perm()
+                &&& new_regions.slot_owners[frame_to_index(pa)].vtable_ptr_perm()
+                    == old_regions.slot_owners[frame_to_index(pa)].vtable_ptr_perm()
+                &&& new_regions.slot_owners[frame_to_index(pa)].in_list_perm
+                    == old_regions.slot_owners[frame_to_index(pa)].in_list_perm
                 &&& new_regions.slot_owners[frame_to_index(pa)].paths_in_pt
                     == old_regions.slot_owners[frame_to_index(pa)].paths_in_pt
                 &&& new_regions.slot_owners[frame_to_index(pa)].slot_vaddr
@@ -415,15 +415,15 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
             regions.contains(frame_to_index(pa)),
             Self::tracked(item) ==> regions.slot_owners[frame_to_index(
                 pa,
-            )].inner_perms.ref_count.value() > 0,
+            )].ref_count() > 0,
             // `rc != UNUSED` is needed only for tracked frames (untracked clone is a no-op).
             Self::tracked(item) ==> regions.slot_owners[frame_to_index(
                 pa,
-            )].inner_perms.ref_count.value() != REF_COUNT_UNUSED,
+            )].ref_count() != REF_COUNT_UNUSED,
             // Saturation aborts (Arc-style) via `inc_ref_count`'s diverging panic.
             Self::tracked(item) ==> (regions.slot_owners[frame_to_index(
                 pa,
-            )].inner_perms.ref_count.value() < REF_COUNT_MAX || may_panic()),
+            )].ref_count() < REF_COUNT_MAX || may_panic()),
         ensures
             item.clone_requires(regions),
     ;
@@ -1098,11 +1098,11 @@ impl PageTable<KernelPtConfig> {
                                     (pa + j * PAGE_SIZE) as usize,
                                 );
                                 sub_idx != new_idx || (regions.contains(sub_idx)
-                                    && regions.slot_owners[sub_idx].inner_perms.ref_count.value()
+                                    && regions.slot_owners[sub_idx].ref_count()
                                     != REF_COUNT_UNUSED
-                                    && regions.slot_owners[sub_idx].inner_perms.ref_count.value()
+                                    && regions.slot_owners[sub_idx].ref_count()
                                     > 0
-                                    && regions.slot_owners[sub_idx].inner_perms.ref_count.value()
+                                    && regions.slot_owners[sub_idx].ref_count()
                                     <= REF_COUNT_MAX)
                             }
                     },
@@ -1446,16 +1446,16 @@ impl<C: PageTableConfig> PageTable<C> {
             // PT-node allocations come from UNUSED slots, so any slot that
             // was already in use keeps its paths_in_pt.
             forall |idx: int| #![trigger final(regions).slot_owners[idx].paths_in_pt]
-                old(regions).slot_owners[idx].inner_perms.ref_count.value()
+                old(regions).slot_owners[idx].ref_count()
                     != REF_COUNT_UNUSED
                 ==> final(regions).slot_owners[idx].paths_in_pt
                         == old(regions).slot_owners[idx].paths_in_pt,
             forall|idx: int| #![trigger final(regions).slot_owners[idx]]
                 old(regions).contains(idx)
-                && old(regions).slot_owners[idx].inner_perms.ref_count.value()
+                && old(regions).slot_owners[idx].ref_count()
                     != REF_COUNT_UNUSED
-                ==> final(regions).slot_owners[idx].inner_perms.ref_count.value()
-                        == old(regions).slot_owners[idx].inner_perms.ref_count.value()
+                ==> final(regions).slot_owners[idx].ref_count()
+                        == old(regions).slot_owners[idx].ref_count()
                     && final(regions).slot_owners[idx].usage
                         == old(regions).slot_owners[idx].usage,
     )]
@@ -1497,38 +1497,38 @@ impl<C: PageTableConfig> PageTable<C> {
             },
             !Cursor::<C, G>::cursor_new_success_conditions(*va) ==> r is Err,
             forall|idx: int| #![trigger final(regions).slot_owners[idx].paths_in_pt]
-                old(regions).slot_owners[idx].inner_perms.ref_count.value()
+                old(regions).slot_owners[idx].ref_count()
                     != REF_COUNT_UNUSED
                 ==> final(regions).slot_owners[idx].paths_in_pt
                         == old(regions).slot_owners[idx].paths_in_pt,
             // Non-saturation preservation.
             (forall |i: int| #![trigger old(regions).slot_owners[i]]
                 old(regions).contains(i)
-                && old(regions).slot_owners[i].inner_perms.ref_count.value()
+                && old(regions).slot_owners[i].ref_count()
                     != REF_COUNT_UNUSED
-                ==> old(regions).slot_owners[i].inner_perms.ref_count.value() + 1
+                ==> old(regions).slot_owners[i].ref_count() + 1
                     < REF_COUNT_MAX)
             ==>
             (forall |i: int| #![trigger final(regions).slot_owners[i]]
                 final(regions).contains(i)
-                && final(regions).slot_owners[i].inner_perms.ref_count.value()
+                && final(regions).slot_owners[i].ref_count()
                     != REF_COUNT_UNUSED
-                ==> final(regions).slot_owners[i].inner_perms.ref_count.value() + 1
+                ==> final(regions).slot_owners[i].ref_count() + 1
                     < REF_COUNT_MAX),
             // Saturated-slot bridge (relayed from `Cursor::new`):
             // a slot at `>= REF_COUNT_MAX` before iff after, with the same
             // value. Used by `KVirtArea::query` to bridge inner-cursor
             // saturation back to the caller's snapshot.
-            forall|idx: int| #![trigger final(regions).slot_owners[idx].inner_perms.ref_count.value()]
-                final(regions).slot_owners[idx].inner_perms.ref_count.value()
+            forall|idx: int| #![trigger final(regions).slot_owners[idx].ref_count()]
+                final(regions).slot_owners[idx].ref_count()
                     >= REF_COUNT_MAX
-                ==> old(regions).slot_owners[idx].inner_perms.ref_count.value()
-                        == final(regions).slot_owners[idx].inner_perms.ref_count.value(),
-            forall|idx: int| #![trigger old(regions).slot_owners[idx].inner_perms.ref_count.value()]
-                old(regions).slot_owners[idx].inner_perms.ref_count.value()
+                ==> old(regions).slot_owners[idx].ref_count()
+                        == final(regions).slot_owners[idx].ref_count(),
+            forall|idx: int| #![trigger old(regions).slot_owners[idx].ref_count()]
+                old(regions).slot_owners[idx].ref_count()
                     >= REF_COUNT_MAX
-                ==> final(regions).slot_owners[idx].inner_perms.ref_count.value()
-                        == old(regions).slot_owners[idx].inner_perms.ref_count.value(),
+                ==> final(regions).slot_owners[idx].ref_count()
+                        == old(regions).slot_owners[idx].ref_count(),
     )]
     pub fn cursor<'rcu, G: InAtomicMode>(&'rcu self, guard: &'rcu G, va: &Range<Vaddr>) -> Result<
         (Cursor<'rcu, C, G>, Tracked<CursorOwner<'rcu, C>>),

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -413,17 +413,13 @@ pub unsafe trait PageTableConfig: Clone + Debug + Send + Sync + 'static {
             Self::raw_item_well_formed(pa, level, prop),
             valid_frame_paddr(pa),
             regions.contains(frame_to_index(pa)),
-            Self::tracked(item) ==> regions.slot_owners[frame_to_index(
-                pa,
-            )].ref_count() > 0,
+            Self::tracked(item) ==> regions.slot_owners[frame_to_index(pa)].ref_count() > 0,
             // `rc != UNUSED` is needed only for tracked frames (untracked clone is a no-op).
-            Self::tracked(item) ==> regions.slot_owners[frame_to_index(
-                pa,
-            )].ref_count() != REF_COUNT_UNUSED,
+            Self::tracked(item) ==> regions.slot_owners[frame_to_index(pa)].ref_count()
+                != REF_COUNT_UNUSED,
             // Saturation aborts (Arc-style) via `inc_ref_count`'s diverging panic.
-            Self::tracked(item) ==> (regions.slot_owners[frame_to_index(
-                pa,
-            )].ref_count() < REF_COUNT_MAX || may_panic()),
+            Self::tracked(item) ==> (regions.slot_owners[frame_to_index(pa)].ref_count()
+                < REF_COUNT_MAX || may_panic()),
         ensures
             item.clone_requires(regions),
     ;
@@ -1098,12 +1094,9 @@ impl PageTable<KernelPtConfig> {
                                     (pa + j * PAGE_SIZE) as usize,
                                 );
                                 sub_idx != new_idx || (regions.contains(sub_idx)
-                                    && regions.slot_owners[sub_idx].ref_count()
-                                    != REF_COUNT_UNUSED
-                                    && regions.slot_owners[sub_idx].ref_count()
-                                    > 0
-                                    && regions.slot_owners[sub_idx].ref_count()
-                                    <= REF_COUNT_MAX)
+                                    && regions.slot_owners[sub_idx].ref_count() != REF_COUNT_UNUSED
+                                    && regions.slot_owners[sub_idx].ref_count() > 0
+                                    && regions.slot_owners[sub_idx].ref_count() <= REF_COUNT_MAX)
                             }
                     },
             );

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -327,18 +327,18 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             // ref_count is preserved per-slot. `into_pte_regions_spec` and
             // `from_pte_regions_spec` only ever rewrite `raw_count` (and the
             // ghost `paths_in_pt` is touched by the surrounding body, never
-            // `inner_perms`); both use the `..old_slot` struct-update form
-            // so `inner_perms.ref_count` is preserved across the rewrite.
+            // the permissions); both use the `..old_slot` struct-update form,
+            // so `ref_count` is preserved across the rewrite.
             forall|idx: int|
-                #![trigger final(regions).slot_owners[idx].inner_perms.ref_count.value()]
-                final(regions).slot_owners[idx].inner_perms.ref_count.value() == old(
+                #![trigger final(regions).slot_owners[idx].ref_count()]
+                final(regions).slot_owners[idx].ref_count() == old(
                     regions,
-                ).slot_owners[idx].inner_perms.ref_count.value(),
+                ).slot_owners[idx].ref_count(),
             forall|idx: int|
-                #![trigger final(regions).slot_owners[idx].inner_perms]
-                final(regions).slot_owners[idx].inner_perms == old(
-                    regions,
-                ).slot_owners[idx].inner_perms,
+                #![trigger final(regions).slot_owners[idx]]
+                final(regions).slot_owners[idx].same_permissions(
+                    old(regions).slot_owners[idx],
+                ),
             final(regions).slots == old(regions).slots,
             // When both old and new are not nodes: from_pte/into_pte are identity.
             (!old(owner).is_node() && !final(new_owner).is_node()) ==> {
@@ -401,7 +401,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             );
             #[verus_spec(with
                 Tracked(meta_points_to),
-                Tracked(&meta_slot_owner.inner_perms.storage),
+                Tracked(&meta_slot_owner.metadata_perm.storage_perm),
                 Ghost(parent_owner.meta_own.nr_children.id())
             )]
             let nr_children = self.node.nr_children_mut();
@@ -417,7 +417,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             );
             #[verus_spec(with
                 Tracked(meta_points_to),
-                Tracked(&meta_slot_owner.inner_perms.storage),
+                Tracked(&meta_slot_owner.metadata_perm.storage_perm),
                 Ghost(parent_owner.meta_own.nr_children.id())
             )]
             let nr_children = self.node.nr_children_mut();
@@ -572,10 +572,10 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                     ==> final(regions).slots[i] == old(regions).slots[i]
                 // The new PT node's ref_count is not UNUSED (was set to 1 by get_from_unused).
                 &&& final(regions).slot_owners[frame_to_index(final(owner).value().meta_slot_paddr()->0)]
-                    .inner_perms.ref_count.value() != REF_COUNT_UNUSED
+                    .ref_count() != REF_COUNT_UNUSED
                 // The allocated slot had ref_count == UNUSED before allocation (from get_from_unused).
                 &&& old(regions).slot_owners[frame_to_index(final(owner).value().meta_slot_paddr().unwrap())]
-                    .inner_perms.ref_count.value() == REF_COUNT_UNUSED
+                    .ref_count() == REF_COUNT_UNUSED
                 // Allocator pool is disjoint from MMIO ranges (from `PageTableNode::alloc`).
                 &&& !crate::specs::mm::frame::meta_owners::is_mmio_paddr(
                     final(owner).value().meta_slot_paddr().unwrap())
@@ -672,7 +672,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             );
             #[verus_spec(with
                 Tracked(meta_points_to),
-                Tracked(&meta_slot_owner.inner_perms.storage),
+                Tracked(&meta_slot_owner.metadata_perm.storage_perm),
                 Ghost(parent_owner.meta_own.nr_children.id())
             )]
             let nr_children = self.node.nr_children_mut();
@@ -803,7 +803,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                             + j * PAGE_SIZE) as usize);
                     &&& old(regions).slots.contains_key(sub_idx)
                     &&& old(regions).slot_owners[sub_idx].usage !is MMIO ==>
-                        old(regions).slot_owners[sub_idx].inner_perms.ref_count.value()
+                        old(regions).slot_owners[sub_idx].ref_count()
                             != REF_COUNT_UNUSED
                 },
         ensures
@@ -858,10 +858,10 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                     ==> (#[trigger] final(regions).slots.contains_key(i))
                 // The new PT node's ref_count is not UNUSED.
                 &&& final(regions).slot_owners[meta_to_index(final(owner).value().node().meta_vaddr())]
-                    .inner_perms.ref_count.value() != REF_COUNT_UNUSED
+                    .ref_count() != REF_COUNT_UNUSED
                 // The allocated slot had ref_count == UNUSED before allocation.
                 &&& old(regions).slot_owners[meta_to_index(final(owner).value().node().meta_vaddr())]
-                    .inner_perms.ref_count.value() == REF_COUNT_UNUSED
+                    .ref_count() == REF_COUNT_UNUSED
             },
             // Parent's other PTEs are preserved: only the entry at self.idx
             // is overwritten (with the new PT pointer). Lets callers re-derive
@@ -976,10 +976,10 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                     != crate::specs::mm::frame::meta_owners::PageUsage::PageTable
                 &&& regions.slot_owners[sub_idx].usage
                     != crate::specs::mm::frame::meta_owners::PageUsage::MMIO ==> {
-                    &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value()
+                    &&& regions.slot_owners[sub_idx].ref_count()
                         != REF_COUNT_UNUSED
-                    &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value() > 0
-                    &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value() <= REF_COUNT_MAX
+                    &&& regions.slot_owners[sub_idx].ref_count() > 0
+                    &&& regions.slot_owners[sub_idx].ref_count() <= REF_COUNT_MAX
                 }
             } by {
                 let sub_idx = frame_to_index((pa + j * PAGE_SIZE) as usize);
@@ -1064,10 +1064,10 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                         &&& regions.slots.contains_key(sub_idx)
                         &&& regions.slot_owners[sub_idx].usage !is PageTable
                         &&& regions.slot_owners[sub_idx].usage !is MMIO ==> {
-                            &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value()
+                            &&& regions.slot_owners[sub_idx].ref_count()
                                 != REF_COUNT_UNUSED
-                            &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value() > 0
-                            &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value()
+                            &&& regions.slot_owners[sub_idx].ref_count() > 0
+                            &&& regions.slot_owners[sub_idx].ref_count()
                                 <= REF_COUNT_MAX
                         }
                     },
@@ -1075,10 +1075,10 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 regions.slots.contains_key(frame_to_index(pa)),
                 regions.slot_owners[frame_to_index(pa)].usage !is PageTable,
                 regions.slot_owners[frame_to_index(pa)].usage !is MMIO ==> {
-                    &&& regions.slot_owners[frame_to_index(pa)].inner_perms.ref_count.value()
+                    &&& regions.slot_owners[frame_to_index(pa)].ref_count()
                         != REF_COUNT_UNUSED
-                    &&& regions.slot_owners[frame_to_index(pa)].inner_perms.ref_count.value() > 0
-                    &&& regions.slot_owners[frame_to_index(pa)].inner_perms.ref_count.value()
+                    &&& regions.slot_owners[frame_to_index(pa)].ref_count() > 0
+                    &&& regions.slot_owners[frame_to_index(pa)].ref_count()
                         <= REF_COUNT_MAX
                 },
                 new_page.ptr.addr() == new_owner_meta_addr,
@@ -1089,10 +1089,10 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 // `into_pte`'s `Child::invariants` holds after the loop.
                 regions.slot_owners[meta_to_index(
                     new_owner_meta_addr,
-                )].inner_perms.ref_count.value() != REF_COUNT_UNUSED,
+                )].ref_count() != REF_COUNT_UNUSED,
                 0 < regions.slot_owners[meta_to_index(
                     new_owner_meta_addr,
-                )].inner_perms.ref_count.value() <= REF_COUNT_MAX,
+                )].ref_count() <= REF_COUNT_MAX,
                 regions.slot_owners[meta_to_index(new_owner_meta_addr)].paths_in_pt
                     == set![new_owner_path],
         {
@@ -1150,10 +1150,10 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                         let sub_idx = frame_to_index((small_pa + j_prime * PAGE_SIZE) as usize);
                         &&& regions.slots.contains_key(sub_idx)
                         &&& regions.slot_owners[sub_idx].usage !is MMIO ==> {
-                            &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value()
+                            &&& regions.slot_owners[sub_idx].ref_count()
                                 != REF_COUNT_UNUSED
-                            &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value() > 0
-                            &&& regions.slot_owners[sub_idx].inner_perms.ref_count.value()
+                            &&& regions.slot_owners[sub_idx].ref_count() > 0
+                            &&& regions.slot_owners[sub_idx].ref_count()
                                 <= REF_COUNT_MAX
                         }
                     } by {
@@ -1320,7 +1320,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 };
                 assert(new_owner.inv());
 
-                // `replace` of a frame child preserves every slot's `inner_perms`
+                // `replace` of a frame child preserves every slot's permissions
                 // (unconditional) and `paths_in_pt` (non-node child), so the new
                 // node's own-slot rc + paths_in_pt are unchanged — re-establish
                 // the loop invariant's node-slot clauses for the next iteration.
@@ -1541,7 +1541,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
                 &&& old(regions).slots.contains_key(frame_to_index(old(new_owner).meta_slot_paddr()->0))
                 &&& old(regions).slot_owners[frame_to_index(
                     old(new_owner).meta_slot_paddr()->0,
-                )].inner_perms.ref_count.value() != REF_COUNT_UNUSED
+                )].ref_count() != REF_COUNT_UNUSED
             },
             old(parent_owner).metaregion_sound_node(*old(regions)),
             new_child matches Child::PageTable(node) ==> old(regions).frame_obligations.count(
@@ -1592,15 +1592,15 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
             forall|k: int|
                 old(regions).slots.contains_key(k) ==> #[trigger] final(regions).slots.contains_key(k),
             forall|slot: int|
-                #![trigger final(regions).slot_owners[slot].inner_perms.ref_count.value()]
-                final(regions).slot_owners[slot].inner_perms.ref_count.value() == old(
+                #![trigger final(regions).slot_owners[slot].ref_count()]
+                final(regions).slot_owners[slot].ref_count() == old(
                     regions,
-                ).slot_owners[slot].inner_perms.ref_count.value(),
+                ).slot_owners[slot].ref_count(),
             forall|slot: int|
-                #![trigger final(regions).slot_owners[slot].inner_perms]
-                final(regions).slot_owners[slot].inner_perms == old(
-                    regions,
-                ).slot_owners[slot].inner_perms,
+                #![trigger final(regions).slot_owners[slot]]
+                final(regions).slot_owners[slot].same_permissions(
+                    old(regions).slot_owners[slot],
+                ),
             final(regions).slots == old(regions).slots,
             (!old(owner).is_node() && !final(new_owner).is_node()) ==> {
                 &&& final(regions).slots == old(regions).slots
@@ -1656,7 +1656,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
             );
             #[verus_spec(with
                 Tracked(meta_points_to),
-                Tracked(&meta_slot_owner.inner_perms.storage),
+                Tracked(&meta_slot_owner.metadata_perm.storage_perm),
                 Ghost(parent_owner.meta_own.nr_children.id())
             )]
             let nr_children = self.nr_children_mut();
@@ -1672,7 +1672,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
             );
             #[verus_spec(with
                 Tracked(meta_points_to),
-                Tracked(&meta_slot_owner.inner_perms.storage),
+                Tracked(&meta_slot_owner.metadata_perm.storage_perm),
                 Ghost(parent_owner.meta_own.nr_children.id())
             )]
             let nr_children = self.nr_children_mut();
@@ -1800,9 +1800,9 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
                     && old(regions).slots.contains_key(i)
                 ==> final(regions).slots[i] == old(regions).slots[i],
             final(regions).slot_owners[frame_to_index(final(owner).value().meta_slot_paddr()->0)]
-                .inner_perms.ref_count.value() != REF_COUNT_UNUSED,
+                .ref_count() != REF_COUNT_UNUSED,
             old(regions).slot_owners[frame_to_index(final(owner).value().meta_slot_paddr().unwrap())]
-                .inner_perms.ref_count.value() == REF_COUNT_UNUSED,
+                .ref_count() == REF_COUNT_UNUSED,
             !crate::specs::mm::frame::meta_owners::is_mmio_paddr(
                 final(owner).value().meta_slot_paddr().unwrap()),
             final(regions).inv(),
@@ -1909,7 +1909,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
         let tracked meta_slot_owner = regions.slot_owners.tracked_borrow(parent_owner.slot_index);
         #[verus_spec(with
             Tracked(meta_points_to),
-            Tracked(&meta_slot_owner.inner_perms.storage),
+            Tracked(&meta_slot_owner.metadata_perm.storage_perm),
             Ghost(parent_owner.meta_own.nr_children.id())
         )]
         let nr_children = self.nr_children_mut();
@@ -2045,7 +2045,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
         let tracked meta_slot_owner = regions.slot_owners.tracked_borrow(parent_owner.slot_index);
         #[verus_spec(with
             Tracked(meta_points_to),
-            Tracked(&meta_slot_owner.inner_perms.storage),
+            Tracked(&meta_slot_owner.metadata_perm.storage_perm),
             Ghost(parent_owner.meta_own.nr_children.id())
         )]
         let nr_children = self.nr_children_mut();

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -976,8 +976,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                     != crate::specs::mm::frame::meta_owners::PageUsage::PageTable
                 &&& regions.slot_owners[sub_idx].usage
                     != crate::specs::mm::frame::meta_owners::PageUsage::MMIO ==> {
-                    &&& regions.slot_owners[sub_idx].ref_count()
-                        != REF_COUNT_UNUSED
+                    &&& regions.slot_owners[sub_idx].ref_count() != REF_COUNT_UNUSED
                     &&& regions.slot_owners[sub_idx].ref_count() > 0
                     &&& regions.slot_owners[sub_idx].ref_count() <= REF_COUNT_MAX
                 }
@@ -1064,22 +1063,18 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                         &&& regions.slots.contains_key(sub_idx)
                         &&& regions.slot_owners[sub_idx].usage !is PageTable
                         &&& regions.slot_owners[sub_idx].usage !is MMIO ==> {
-                            &&& regions.slot_owners[sub_idx].ref_count()
-                                != REF_COUNT_UNUSED
+                            &&& regions.slot_owners[sub_idx].ref_count() != REF_COUNT_UNUSED
                             &&& regions.slot_owners[sub_idx].ref_count() > 0
-                            &&& regions.slot_owners[sub_idx].ref_count()
-                                <= REF_COUNT_MAX
+                            &&& regions.slot_owners[sub_idx].ref_count() <= REF_COUNT_MAX
                         }
                     },
                 // j = 0: the huge frame's own slot.
                 regions.slots.contains_key(frame_to_index(pa)),
                 regions.slot_owners[frame_to_index(pa)].usage !is PageTable,
                 regions.slot_owners[frame_to_index(pa)].usage !is MMIO ==> {
-                    &&& regions.slot_owners[frame_to_index(pa)].ref_count()
-                        != REF_COUNT_UNUSED
+                    &&& regions.slot_owners[frame_to_index(pa)].ref_count() != REF_COUNT_UNUSED
                     &&& regions.slot_owners[frame_to_index(pa)].ref_count() > 0
-                    &&& regions.slot_owners[frame_to_index(pa)].ref_count()
-                        <= REF_COUNT_MAX
+                    &&& regions.slot_owners[frame_to_index(pa)].ref_count() <= REF_COUNT_MAX
                 },
                 new_page.ptr.addr() == new_owner_meta_addr,
                 new_owner.value().node().metaregion_sound_node(*regions),
@@ -1087,12 +1082,10 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                 // `metaregion_sound` conjuncts not derivable from
                 // `metaregion_sound_node` (slot_vaddr/wf derive). Carried so
                 // `into_pte`'s `Child::invariants` holds after the loop.
-                regions.slot_owners[meta_to_index(
-                    new_owner_meta_addr,
-                )].ref_count() != REF_COUNT_UNUSED,
-                0 < regions.slot_owners[meta_to_index(
-                    new_owner_meta_addr,
-                )].ref_count() <= REF_COUNT_MAX,
+                regions.slot_owners[meta_to_index(new_owner_meta_addr)].ref_count()
+                    != REF_COUNT_UNUSED,
+                0 < regions.slot_owners[meta_to_index(new_owner_meta_addr)].ref_count()
+                    <= REF_COUNT_MAX,
                 regions.slot_owners[meta_to_index(new_owner_meta_addr)].paths_in_pt
                     == set![new_owner_path],
         {
@@ -1150,11 +1143,9 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
                         let sub_idx = frame_to_index((small_pa + j_prime * PAGE_SIZE) as usize);
                         &&& regions.slots.contains_key(sub_idx)
                         &&& regions.slot_owners[sub_idx].usage !is MMIO ==> {
-                            &&& regions.slot_owners[sub_idx].ref_count()
-                                != REF_COUNT_UNUSED
+                            &&& regions.slot_owners[sub_idx].ref_count() != REF_COUNT_UNUSED
                             &&& regions.slot_owners[sub_idx].ref_count() > 0
-                            &&& regions.slot_owners[sub_idx].ref_count()
-                                <= REF_COUNT_MAX
+                            &&& regions.slot_owners[sub_idx].ref_count() <= REF_COUNT_MAX
                         }
                     } by {
                         let sub_pages_per_subframe = page_size((level - 1) as PagingLevel)

--- a/ostd/src/mm/page_table/node/entry.rs
+++ b/ostd/src/mm/page_table/node/entry.rs
@@ -401,7 +401,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             );
             #[verus_spec(with
                 Tracked(meta_points_to),
-                Tracked(&meta_slot_owner.metadata_perm.storage_perm),
+                Tracked(&meta_slot_owner.metadata_perm),
                 Ghost(parent_owner.meta_own.nr_children.id())
             )]
             let nr_children = self.node.nr_children_mut();
@@ -417,7 +417,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             );
             #[verus_spec(with
                 Tracked(meta_points_to),
-                Tracked(&meta_slot_owner.metadata_perm.storage_perm),
+                Tracked(&meta_slot_owner.metadata_perm),
                 Ghost(parent_owner.meta_own.nr_children.id())
             )]
             let nr_children = self.node.nr_children_mut();
@@ -672,7 +672,7 @@ impl<'a, 'rcu, C: PageTableConfig> Entry<'a, 'rcu, C> {
             );
             #[verus_spec(with
                 Tracked(meta_points_to),
-                Tracked(&meta_slot_owner.metadata_perm.storage_perm),
+                Tracked(&meta_slot_owner.metadata_perm),
                 Ghost(parent_owner.meta_own.nr_children.id())
             )]
             let nr_children = self.node.nr_children_mut();
@@ -1656,7 +1656,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
             );
             #[verus_spec(with
                 Tracked(meta_points_to),
-                Tracked(&meta_slot_owner.metadata_perm.storage_perm),
+                Tracked(&meta_slot_owner.metadata_perm),
                 Ghost(parent_owner.meta_own.nr_children.id())
             )]
             let nr_children = self.nr_children_mut();
@@ -1672,7 +1672,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
             );
             #[verus_spec(with
                 Tracked(meta_points_to),
-                Tracked(&meta_slot_owner.metadata_perm.storage_perm),
+                Tracked(&meta_slot_owner.metadata_perm),
                 Ghost(parent_owner.meta_own.nr_children.id())
             )]
             let nr_children = self.nr_children_mut();
@@ -1909,7 +1909,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
         let tracked meta_slot_owner = regions.slot_owners.tracked_borrow(parent_owner.slot_index);
         #[verus_spec(with
             Tracked(meta_points_to),
-            Tracked(&meta_slot_owner.metadata_perm.storage_perm),
+            Tracked(&meta_slot_owner.metadata_perm),
             Ghost(parent_owner.meta_own.nr_children.id())
         )]
         let nr_children = self.nr_children_mut();
@@ -2045,7 +2045,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
         let tracked meta_slot_owner = regions.slot_owners.tracked_borrow(parent_owner.slot_index);
         #[verus_spec(with
             Tracked(meta_points_to),
-            Tracked(&meta_slot_owner.metadata_perm.storage_perm),
+            Tracked(&meta_slot_owner.metadata_perm),
             Ghost(parent_owner.meta_own.nr_children.id())
         )]
         let nr_children = self.nr_children_mut();

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -509,7 +509,7 @@ impl<C: PageTableConfig> PageTableNode<C> {
         let tracked slot_owner = regions.slot_owners.tracked_borrow(owner.slot_index);
         #[verus_spec(with
             Tracked(points_to),
-            Tracked(&slot_owner.inner_perms.storage),
+            Tracked(&slot_owner.metadata_perm.storage_perm),
             Tracked(&())
         )]
         let meta = self.meta();
@@ -546,7 +546,7 @@ impl<C: PageTableConfig> PageTableNode<C> {
                 meta_to_frame(owner@.value().node().meta_vaddr())),
             owner@.value().metaregion_sound(*final(regions)),
             forall|i: int|
-                #[trigger] old(regions).slot_owners[i].inner_perms.ref_count.value() != REF_COUNT_UNUSED
+                #[trigger] old(regions).slot_owners[i].ref_count() != REF_COUNT_UNUSED
                 ==> i != meta_to_index(owner@.value().node().meta_vaddr()),
             owner@.value().match_pte(C::E::new_pt_spec(meta_to_frame(owner@.value().node().meta_vaddr())), level as PagingLevel),
             final(parent_owner).meta_own == old(parent_owner).meta_own,
@@ -773,7 +773,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
         let tracked slot_owner = regions.slot_owners.tracked_borrow(owner.slot_index);
         #[verus_spec(with
             Tracked(points_to),
-            Tracked(&slot_owner.inner_perms.storage),
+            Tracked(&slot_owner.metadata_perm.storage_perm),
             Tracked(&())
         )]
         let meta = self.meta();
@@ -1120,12 +1120,10 @@ impl<C: PageTableConfig> PageTablePageMeta<C> {
                     paddr,
                 )
                 // Borrow-protocol transition: `raw_count` is dormant.
-                &&& so.inner_perms.ref_count.value() > 0
-                &&& so.inner_perms.ref_count.value() != REF_COUNT_UNUSED
-                &&& so.inner_perms.ref_count.value() <= REF_COUNT_MAX
-                &&& so.inner_perms.ref_count.value() == 1 ==> {
-                    &&& so.inner_perms.storage.is_init()
-                    &&& so.inner_perms.in_list.value() == 0
+                &&& 0 < so.ref_count() <= REF_COUNT_MAX
+                &&& so.ref_count() == 1 ==> {
+                    &&& so.storage_perm().is_init()
+                    &&& so.in_list_perm.value() == 0
                     &&& so.paths_in_pt.is_empty()
                 }
                 // Borrow-protocol redesign: in steady state between

--- a/ostd/src/mm/page_table/node/mod.rs
+++ b/ostd/src/mm/page_table/node/mod.rs
@@ -58,7 +58,9 @@ use crate::mm::{Paddr, Vaddr};
 use crate::specs::mm::{
     frame::{
         mapping::{frame_to_index, lemma_frame_to_index_injective, meta_to_index},
-        meta_owners::{MetaSlotOwner, MetaSlotStorage, typed_meta_value, typed_meta_wf},
+        meta_owners::{
+            MetaSlotOwner, MetaSlotStorage, MetadataPerms, typed_meta_value, typed_meta_wf,
+        },
         meta_region_owners::MetaRegionOwners,
     },
     page_table::node::owners::*,
@@ -509,7 +511,7 @@ impl<C: PageTableConfig> PageTableNode<C> {
         let tracked slot_owner = regions.slot_owners.tracked_borrow(owner.slot_index);
         #[verus_spec(with
             Tracked(points_to),
-            Tracked(&slot_owner.metadata_perm.storage_perm),
+            Tracked(&slot_owner.metadata_perm),
             Tracked(&())
         )]
         let meta = self.meta();
@@ -773,7 +775,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
         let tracked slot_owner = regions.slot_owners.tracked_borrow(owner.slot_index);
         #[verus_spec(with
             Tracked(points_to),
-            Tracked(&slot_owner.metadata_perm.storage_perm),
+            Tracked(&slot_owner.metadata_perm),
             Tracked(&())
         )]
         let meta = self.meta();
@@ -785,13 +787,13 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
     #[verus_spec(res =>
         with
             Tracked(points_to): Tracked<&'a vstd::simple_pptr::PointsTo<MetaSlot>>,
-            Tracked(storage): Tracked<&'a pcell_maybe_uninit::PointsTo<MetaSlotStorage>>,
+            Tracked(metadata_perms): Tracked<&'a MetadataPerms>,
             Tracked(repr_perm): Tracked<&'a ()>,
             Ghost(stray_id): Ghost<vstd::cell::CellId>,
         requires
             old(self).inner.inner@.ptr.addr() == points_to.addr(),
-            typed_meta_wf::<PageTablePageMeta<C>>(*points_to, *storage, *repr_perm),
-            typed_meta_value::<PageTablePageMeta<C>>(*storage, *repr_perm).stray.id()
+            typed_meta_wf::<PageTablePageMeta<C>>(*points_to, *metadata_perms, *repr_perm),
+            typed_meta_value::<PageTablePageMeta<C>>(*metadata_perms, *repr_perm).stray.id()
                 == stray_id,
         ensures
             res.id() == stray_id,
@@ -801,7 +803,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
         // SAFETY: The lock is held so we have an exclusive access.
         #[verus_spec(with
             Tracked(points_to),
-            Tracked(storage),
+            Tracked(metadata_perms),
             Tracked(repr_perm)
         )]
         let meta = self.meta();
@@ -902,12 +904,12 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
     #[verus_spec(res =>
         with
             Tracked(points_to): Tracked<&'a vstd::simple_pptr::PointsTo<MetaSlot>>,
-            Tracked(storage): Tracked<&'a pcell_maybe_uninit::PointsTo<MetaSlotStorage>>,
+            Tracked(metadata_perms): Tracked<&'a MetadataPerms>,
             Ghost(nr_children_id): Ghost<vstd::cell::CellId>,
         requires
             old(self).inner.inner@.ptr.addr() == points_to.addr(),
-            typed_meta_wf::<PageTablePageMeta<C>>(*points_to, *storage, ()),
-            typed_meta_value::<PageTablePageMeta<C>>(*storage, ()).nr_children.id()
+            typed_meta_wf::<PageTablePageMeta<C>>(*points_to, *metadata_perms, ()),
+            typed_meta_value::<PageTablePageMeta<C>>(*metadata_perms, ()).nr_children.id()
                 == nr_children_id,
         ensures
             res.id() == nr_children_id,
@@ -917,7 +919,7 @@ impl<'rcu, C: PageTableConfig> PageTableGuard<'rcu, C> {
         // SAFETY: The lock is held so we have an exclusive access.
         #[verus_spec(with
             Tracked(points_to),
-            Tracked(storage),
+            Tracked(metadata_perms),
             Tracked(&())
         )]
         let meta = self.meta();


### PR DESCRIPTION
This PR makes some preparations for #675. 

`MetadataInnerPerms` currently stores all permissions, but these four fields actually have two kinds of lifetimes:
- `MetaSlotStorage` and `vtable_ptr` can be allocated and reused according to the reference count.
- `in_list` and `ref_count` always live when the kernel is alive (i.e., 'static).

This PR moves `PointsTo<MetaSlotStorage>` and `vtable_ptr` into a separate `MetadataPerms` struct:
```
pub tracked struct MetadataPerms {
    pub storage: pcell_maybe_uninit::PointsTo<MetaSlotStorage>,
    pub vtable_ptr: simple_pptr::PointsTo<usize>,
}
```
`in_list` and `ref_count` are moved into `MetaSlotOwner`. `MetadataInnerPerms` is removed.

This PR only move things around and does not modify any actual permissions.