### PR TITLE
 chore: usize as fraction count

### DIFF
--- a/ostd/src/sync/rcu/mod.rs
+++ b/ostd/src/sync/rcu/mod.rs
@@ -52,7 +52,7 @@ broadcast use vstd_extra::external::nonnull::group_nonull_axioms;
 // `CountResource`; the final RCU proof should discharge the admission assumption
 // with an unbounded ghost registry or a CPU/epoch-based sharding model.
 
-const RCU_READER_SLOTS: u64 = 1u64 << 60;
+const RCU_READER_SLOTS: usize = 1usize << 60;
 
 type RcuReadPool<P> = CountResource<<P as NonNullPtr>::Permission, RCU_READER_SLOTS>;
 

--- a/ostd/src/sync/rwlock.rs
+++ b/ostd/src/sync/rwlock.rs
@@ -27,21 +27,6 @@ use super::{
 
 verus! {
 
-const MAX_READER_U64: u64 = MAX_READER as u64;
-
-spec const V_MAX_READ_RETRACT_FRACS_SPEC: u64 = (MAX_READER_MASK + 1) as u64;
-
-#[verifier::when_used_as_spec(V_MAX_READ_RETRACT_FRACS_SPEC)]
-exec const V_MAX_READ_RETRACT_FRACS: u64
-    ensures
-        V_MAX_READ_RETRACT_FRACS == V_MAX_READ_RETRACT_FRACS_SPEC,
-        V_MAX_READ_RETRACT_FRACS == MAX_READER_MASK + 1,
-        V_MAX_READ_RETRACT_FRACS < u64::MAX,
-{
-    assert(MAX_READER_MASK + 1 < u64::MAX) by (compute_only);
-    (MAX_READER_MASK + 1) as u64
-}
-
 /// The token reserved in the lock when the write permission is given out.
 type NoPerm<T> = EmptyCount<PointsTo<T>>;
 
@@ -60,15 +45,15 @@ tracked struct RwPerms<T> {
     /// The permission to retract a `READER` count. Its total quantity tracks the gap between
     /// the number of `try_read` increments recorded in the lock atomic and the number of active
     /// `RwLockReadGuard`s (created and ongoing creation that will succeed) represented by `read_guard_token`.
-    /// It can be splited up to `V_MAX_READ_RETRACT_FRACS:= 2 * MAX_READER` pieces,
-    /// which allows at most `2*MAX_READER - 1` `try_read` attempts that will fail to acquire the lock.
-    read_retract_token: TokenResource<V_MAX_READ_RETRACT_FRACS>,
+    /// It can be splited up to `MAX_READER_MASK` pieces,
+    /// which allows at most `MAX_READER_MASK - 1` `try_read` attempts that will fail to acquire the lock.
+    read_retract_token: TokenResource<MAX_READER_MASK>,
     /// The permission to retract the set of `UPGRADEABLE_READER` bit.
     upread_retract_token: Option<UniqueToken>,
     /// Tracks whether there is a live `RwLockUpgradeableGuard`, also stores half of the permission for read access.
     upreader_guard_token: Option<OneLeftOwner<HalfPerm<T>, NoPerm<T>, 3>>,
     /// Tracks the remaining read permissions, or an empty state while a writer owns the resource.
-    read_guard_token: CountResource<ReadPerm<T>, MAX_READER_U64>,
+    read_guard_token: CountResource<ReadPerm<T>, MAX_READER>,
 }
 
 ghost struct RwId {
@@ -209,12 +194,12 @@ closed spec fn wf(self) -> bool {
         let active_read_guards: int = if g.read_guard_token.is_resource_vacant() {
             0
         } else {
-            MAX_READER_U64 - g.read_guard_token.frac()
+            MAX_READER - g.read_guard_token.frac()
         };
         // The first `try_upread` that fails, which has not returned yet.
         let pending_failed_upread_attempt: bool = g.upread_retract_token is None;
         // The number of `try_read` attempts that will fail.
-        let failed_reader_attempts: int = V_MAX_READ_RETRACT_FRACS - g.read_retract_token.frac();
+        let failed_reader_attempts: int = MAX_READER_MASK - g.read_retract_token.frac();
 
         &&& if g.core_token.is_left() {
             let resource = g.read_guard_token.resource();
@@ -360,11 +345,11 @@ impl<T, G> RwLock<T, G> {
         let tracked read_half_cell_perm = frac_perm.split(1int);
         let ghost frac_id = frac_perm.id();
         let tracked mut core_token = SumResource::alloc_left(frac_perm);
-        let tracked read_retract_token = TokenResource::<V_MAX_READ_RETRACT_FRACS>::alloc(());
+        let tracked read_retract_token = TokenResource::<MAX_READER_MASK>::alloc(());
         let tracked upread_retract_token = UniqueToken::alloc(());
         let tracked upreader_guard_token = core_token.split_one_left_owner();
         let tracked left_token = core_token.split_one_left_knowledge();
-        let tracked read_guard_token = CountResource::<ReadPerm<T>, MAX_READER_U64>::alloc(
+        let tracked read_guard_token = CountResource::<ReadPerm<T>, MAX_READER>::alloc(
             (read_half_cell_perm, left_token),
         );
         let ghost ghost_id = RwId {
@@ -456,8 +441,8 @@ impl<T  /*: ?Sized*/ , G: SpinGuardian> RwLock<T, G> {
     #[verus_spec]
     pub fn try_read(&self) -> Option<RwLockReadGuard<'_, T, G>> {
         proof_decl!{
-            let tracked mut read_token: Option<Count<ReadPerm<T>,MAX_READER_U64>> = None;
-            let tracked mut retract_read_token: Option<Token<V_MAX_READ_RETRACT_FRACS>> = None;
+            let tracked mut read_token: Option<Count<ReadPerm<T>,MAX_READER>> = None;
+            let tracked mut retract_read_token: Option<Token<MAX_READER_MASK>> = None;
         }
         proof!{
             use_type_invariant(self);
@@ -701,7 +686,7 @@ unsafe impl<T: Sync, G: SpinGuardian> Sync for RwLockUpgradeableGuard<'_, T, G> 
 pub struct RwLockReadGuard<'a, T  /*: ?Sized*/ , G: SpinGuardian> {
     guard: G::ReadGuard,
     inner: &'a RwLock<T, G>,
-    tracked_token: Tracked<Count<ReadPerm<T>, MAX_READER_U64>>,
+    tracked_token: Tracked<Count<ReadPerm<T>, MAX_READER>>,
 }
 
 /*

--- a/ostd/src/sync/rwmutex.rs
+++ b/ostd/src/sync/rwmutex.rs
@@ -19,21 +19,6 @@ use super::WaitQueue;
 
 verus! {
 
-const MAX_READER_U64: u64 = MAX_READER as u64;
-
-spec const V_MAX_READ_RETRACT_FRACS_SPEC: u64 = (MAX_READER_MASK + 1) as u64;
-
-#[verifier::when_used_as_spec(V_MAX_READ_RETRACT_FRACS_SPEC)]
-exec const V_MAX_READ_RETRACT_FRACS: u64
-    ensures
-        V_MAX_READ_RETRACT_FRACS == V_MAX_READ_RETRACT_FRACS_SPEC,
-        V_MAX_READ_RETRACT_FRACS == MAX_READER_MASK + 1,
-        V_MAX_READ_RETRACT_FRACS < u64::MAX,
-{
-    assert(MAX_READER_MASK + 1 < u64::MAX) by (compute_only);
-    (MAX_READER_MASK + 1) as u64
-}
-
 type NoPerm<T> = EmptyCount<PointsTo<T>>;
 
 type HalfPerm<T> = Count<PointsTo<T>>;
@@ -42,10 +27,10 @@ type ReadPerm<T> = (HalfPerm<T>, OneLeftKnowledge<HalfPerm<T>, NoPerm<T>, 3>);
 
 tracked struct RwPerms<T> {
     core_token: SumResource<HalfPerm<T>, NoPerm<T>, 3>,
-    read_retract_token: TokenResource<V_MAX_READ_RETRACT_FRACS>,
+    read_retract_token: TokenResource<MAX_READER_MASK>,
     upread_retract_token: Option<UniqueToken>,
     upreader_guard_token: Option<OneLeftOwner<HalfPerm<T>, NoPerm<T>, 3>>,
-    read_guard_token: CountResource<ReadPerm<T>, MAX_READER_U64>,
+    read_guard_token: CountResource<ReadPerm<T>, MAX_READER>,
 }
 
 ghost struct RwId {
@@ -162,10 +147,10 @@ closed spec fn wf(self) -> bool {
         let active_read_guards: int = if g.read_guard_token.is_resource_vacant() {
             0
         } else {
-            MAX_READER_U64 - g.read_guard_token.frac()
+            MAX_READER - g.read_guard_token.frac()
         };
         let pending_failed_upread_attempt: bool = g.upread_retract_token is None;
-        let failed_reader_attempts: int = V_MAX_READ_RETRACT_FRACS - g.read_retract_token.frac();
+        let failed_reader_attempts: int = MAX_READER_MASK - g.read_retract_token.frac();
 
         &&& if g.core_token.is_left() {
             let resource = g.read_guard_token.resource();
@@ -291,11 +276,11 @@ impl<T> RwMutex<T> {
         let tracked read_half_cell_perm = frac_perm.split(1int);
         let ghost frac_id = frac_perm.id();
         let tracked mut core_token = SumResource::alloc_left(frac_perm);
-        let tracked read_retract_token = TokenResource::<V_MAX_READ_RETRACT_FRACS>::alloc(());
+        let tracked read_retract_token = TokenResource::<MAX_READER_MASK>::alloc(());
         let tracked upread_retract_token = UniqueToken::alloc(());
         let tracked upreader_guard_token = core_token.split_one_left_owner();
         let tracked left_token = core_token.split_one_left_knowledge();
-        let tracked read_guard_token = CountResource::<ReadPerm<T>, MAX_READER_U64>::alloc(
+        let tracked read_guard_token = CountResource::<ReadPerm<T>, MAX_READER>::alloc(
             (read_half_cell_perm, left_token),
         );
         let ghost ghost_id = RwId {
@@ -368,8 +353,8 @@ impl<T  /*: ?Sized*/ > RwMutex<T> {
     #[verus_spec]
     pub fn try_read(&self) -> Option<RwMutexReadGuard<'_, T>> {
         proof_decl! {
-            let tracked mut read_token: Option<Count<ReadPerm<T>, MAX_READER_U64>> = None;
-            let tracked mut retract_read_token: Option<Token<V_MAX_READ_RETRACT_FRACS>> = None;
+            let tracked mut read_token: Option<Count<ReadPerm<T>, MAX_READER>> = None;
+            let tracked mut retract_read_token: Option<Token<MAX_READER_MASK>> = None;
         }
         proof! {
             use_type_invariant(self);
@@ -582,7 +567,7 @@ unsafe impl<T:   /*: ?Sized +*/ Sync> Sync for RwMutexUpgradeableGuard<'_, T> {
 #[must_use]
 pub struct RwMutexReadGuard<'a, T  /*: ?Sized*/ > {
     inner: &'a RwMutex<T>,
-    tracked_token: Tracked<Count<ReadPerm<T>, MAX_READER_U64>>,
+    tracked_token: Tracked<Count<ReadPerm<T>, MAX_READER>>,
 }
 
 impl<'a, T> RwMutexReadGuard<'a, T> {

--- a/verified_libs/vstd_extra/src/resource/ghost_resource/count_auth.rs
+++ b/verified_libs/vstd_extra/src/resource/ghost_resource/count_auth.rs
@@ -8,13 +8,13 @@ use vstd::resource::storage_protocol::*;
 verus! {
 
 /// A protocol monoid that tracks a resource value, its fraction, and **the authority**.
-ghost enum FractionalCarrierOpt<T, const TOTAL: u64> {
+ghost enum FractionalCarrierOpt<T, const TOTAL: usize> {
     Value { v: Option<T>, n: int, auth: bool },
     Empty,
     Invalid,
 }
 
-impl<T, const TOTAL: u64> Protocol<(), T> for FractionalCarrierOpt<T, TOTAL> {
+impl<T, const TOTAL: usize> Protocol<(), T> for FractionalCarrierOpt<T, TOTAL> {
     closed spec fn op(self, other: Self) -> Self {
         match self {
             FractionalCarrierOpt::Invalid => FractionalCarrierOpt::Invalid,
@@ -64,15 +64,15 @@ impl<T, const TOTAL: u64> Protocol<(), T> for FractionalCarrierOpt<T, TOTAL> {
     }
 }
 
-pub tracked struct Count<T, const TOTAL: u64 = 2> {
+pub tracked struct Count<T, const TOTAL: usize = 2> {
     r: StorageResource<(), T, FractionalCarrierOpt<T, TOTAL>>,
 }
 
-pub tracked struct EmptyCount<T, const TOTAL: u64 = 2> {
+pub tracked struct EmptyCount<T, const TOTAL: usize = 2> {
     r: StorageResource<(), T, FractionalCarrierOpt<T, TOTAL>>,
 }
 
-impl<T, const TOTAL: u64> Count<T, TOTAL> {
+impl<T, const TOTAL: usize> Count<T, TOTAL> {
     #[verifier::type_invariant]
     spec fn inv(self) -> bool {
         &&& self.r.value() matches FractionalCarrierOpt::Value { v: Some(_), .. }
@@ -299,7 +299,7 @@ impl<T, const TOTAL: u64> Count<T, TOTAL> {
     }
 }
 
-impl<T, const TOTAL: u64> EmptyCount<T, TOTAL> {
+impl<T, const TOTAL: usize> EmptyCount<T, TOTAL> {
     #[verifier::type_invariant]
     spec fn inv(self) -> bool {
         &&& self.r.value() matches FractionalCarrierOpt::Value { v: None, n, auth: true }
@@ -360,11 +360,11 @@ impl<T, const TOTAL: u64> EmptyCount<T, TOTAL> {
 ///
 /// The authority and every dispatched [`Count`] use the same [`Loc`]. The
 /// authority remains present and records the resource when the pool's fraction reaches zero.
-pub tracked struct CountResource<T, const TOTAL: u64> {
+pub tracked struct CountResource<T, const TOTAL: usize> {
     tracked r: StorageResource<(), T, FractionalCarrierOpt<T, TOTAL>>,
 }
 
-impl<T, const TOTAL: u64> CountResource<T, TOTAL> {
+impl<T, const TOTAL: usize> CountResource<T, TOTAL> {
     #[verifier::type_invariant]
     pub closed spec fn type_inv(self) -> bool {
         &&& TOTAL > 0

--- a/verified_libs/vstd_extra/src/resource/ghost_resource/count_auth.rs
+++ b/verified_libs/vstd_extra/src/resource/ghost_resource/count_auth.rs
@@ -1,4 +1,4 @@
-//! Authoritative and integer-based counting storage resources.
+//! Integer-based counting storage resources with authority.
 use vstd::imap::*;
 use vstd::modes::tracked_swap;
 use vstd::prelude::*;
@@ -94,7 +94,7 @@ impl<T, const TOTAL: u64> Count<T, TOTAL> {
         self.r.value()->n
     }
 
-    /// Whether this token carries the unique authority for the taking/updating the resource.
+    /// Whether this token carries the unique authority for taking/updating the resource.
     pub closed spec fn has_authority(self) -> bool {
         self.r.value()->auth
     }
@@ -576,6 +576,9 @@ impl<T, const TOTAL: u64> CountResource<T, TOTAL> {
         use_type_invariant(self);
     }
 
+    /// A `CountResource` and a `Count` with the same id agree on the value.
+    ///
+    /// Unlike `Count::agree`, this works even when the resource is empty (all fractions split out).
     pub proof fn validate_with_frac(tracked &self, tracked frac: &Count<T, TOTAL>)
         requires
             self.id() == frac.id(),

--- a/verified_libs/vstd_extra/src/resource/ghost_resource/count_ghost.rs
+++ b/verified_libs/vstd_extra/src/resource/ghost_resource/count_ghost.rs
@@ -10,19 +10,19 @@ use vstd::resource::pcm::{PCM, Resource};
 verus! {
 
 /// A PCM that tracks a resource value, its fraction, and **the authority**.
-ghost enum FractionalCarrier<T, const TOTAL: u64> {
+ghost enum FractionalCarrier<T, const TOTAL: usize> {
     Value { v: T, n: int, auth: bool },
     Empty,
     Invalid,
 }
 
-impl<T, const TOTAL: u64> FractionalCarrier<T, TOTAL> {
+impl<T, const TOTAL: usize> FractionalCarrier<T, TOTAL> {
     spec fn new(v: T) -> Self {
         FractionalCarrier::Value { v, n: TOTAL as int, auth: true }
     }
 }
 
-impl<T, const TOTAL: u64> ResourceAlgebra for FractionalCarrier<T, TOTAL> {
+impl<T, const TOTAL: usize> ResourceAlgebra for FractionalCarrier<T, TOTAL> {
     closed spec fn valid(self) -> bool {
         match self {
             FractionalCarrier::Invalid => false,
@@ -63,7 +63,7 @@ impl<T, const TOTAL: u64> ResourceAlgebra for FractionalCarrier<T, TOTAL> {
     }
 }
 
-impl<T, const TOTAL: u64> PCM for FractionalCarrier<T, TOTAL> {
+impl<T, const TOTAL: usize> PCM for FractionalCarrier<T, TOTAL> {
     closed spec fn unit() -> Self {
         FractionalCarrier::Empty
     }
@@ -75,11 +75,11 @@ impl<T, const TOTAL: u64> PCM for FractionalCarrier<T, TOTAL> {
     }
 }
 
-pub tracked struct CountGhost<T, const TOTAL: u64 = 2> {
+pub tracked struct CountGhost<T, const TOTAL: usize = 2> {
     r: Resource<FractionalCarrier<T, TOTAL>>,
 }
 
-impl<T, const TOTAL: u64> CountGhost<T, TOTAL> {
+impl<T, const TOTAL: usize> CountGhost<T, TOTAL> {
     #[verifier::type_invariant]
     spec fn inv(self) -> bool {
         &&& self.r.value() is Value
@@ -257,11 +257,11 @@ impl<T, const TOTAL: u64> CountGhost<T, TOTAL> {
 /// A struct that stores and dispatches `CountGhost<T>`.
 /// Unlike `CountGhost`, it provides an `empty` state: after all fractions have been split out,
 /// it still remembers the resource value inside the carrier, mirroring `CountResource`.
-pub tracked struct CountGhostResource<T, const TOTAL: u64> {
+pub tracked struct CountGhostResource<T, const TOTAL: usize> {
     tracked r: Resource<FractionalCarrier<T, TOTAL>>,
 }
 
-impl<T, const TOTAL: u64> CountGhostResource<T, TOTAL> {
+impl<T, const TOTAL: usize> CountGhostResource<T, TOTAL> {
     #[verifier::type_invariant]
     pub closed spec fn type_inv(self) -> bool {
         &&& TOTAL > 0
@@ -445,8 +445,8 @@ impl<T, const TOTAL: u64> CountGhostResource<T, TOTAL> {
     }
 }
 
-pub type TokenResource<const TOTAL: u64> = CountGhostResource<(), TOTAL>;
+pub type TokenResource<const TOTAL: usize> = CountGhostResource<(), TOTAL>;
 
-pub type Token<const TOTAL: u64> = CountGhost<(), TOTAL>;
+pub type Token<const TOTAL: usize> = CountGhost<(), TOTAL>;
 
 } // verus!

--- a/verified_libs/vstd_extra/src/resource/ghost_resource/count_ghost.rs
+++ b/verified_libs/vstd_extra/src/resource/ghost_resource/count_ghost.rs
@@ -1,4 +1,4 @@
-//! Integer-based counting ghost resources.
+//! Integer-based counting ghost resources with authority.
 use crate::sum::*;
 use vstd::map::*;
 use vstd::modes::tracked_swap;
@@ -9,16 +9,16 @@ use vstd::resource::pcm::{PCM, Resource};
 
 verus! {
 
-// Integer-based counting ghost tokens which duplicate the retired int-based fractional resources.
+/// A PCM that tracks a resource value, its fraction, and **the authority**.
 ghost enum FractionalCarrier<T, const TOTAL: u64> {
-    Value { v: T, n: int },
+    Value { v: T, n: int, auth: bool },
     Empty,
     Invalid,
 }
 
 impl<T, const TOTAL: u64> FractionalCarrier<T, TOTAL> {
     spec fn new(v: T) -> Self {
-        FractionalCarrier::Value { v, n: TOTAL as int }
+        FractionalCarrier::Value { v, n: TOTAL as int, auth: true }
     }
 }
 
@@ -27,7 +27,7 @@ impl<T, const TOTAL: u64> ResourceAlgebra for FractionalCarrier<T, TOTAL> {
         match self {
             FractionalCarrier::Invalid => false,
             FractionalCarrier::Empty => true,
-            FractionalCarrier::Value { v: _, n } => 0 < n <= TOTAL,
+            FractionalCarrier::Value { v: _, n, auth } => (0 < n <= TOTAL) || (n == 0 && auth),
         }
     }
 
@@ -35,16 +35,18 @@ impl<T, const TOTAL: u64> ResourceAlgebra for FractionalCarrier<T, TOTAL> {
         match a {
             FractionalCarrier::Invalid => FractionalCarrier::Invalid,
             FractionalCarrier::Empty => b,
-            FractionalCarrier::Value { v: sv, n: sn } => match b {
+            FractionalCarrier::Value { v: sv, n: sn, auth: sa } => match b {
                 FractionalCarrier::Invalid => FractionalCarrier::Invalid,
                 FractionalCarrier::Empty => a,
-                FractionalCarrier::Value { v: ov, n: on } => {
+                FractionalCarrier::Value { v: ov, n: on, auth: oa } => {
                     if sv != ov {
                         FractionalCarrier::Invalid
-                    } else if sn <= 0 || on <= 0 {
+                    } else if sa && oa {
+                        FractionalCarrier::Invalid
+                    } else if sn < 0 || on < 0 || (!sa && sn == 0) || (!oa && on == 0) {
                         FractionalCarrier::Invalid
                     } else {
-                        FractionalCarrier::Value { v: sv, n: sn + on }
+                        FractionalCarrier::Value { v: sv, n: sn + on, auth: sa || oa }
                     }
                 },
             },
@@ -80,19 +82,28 @@ pub tracked struct CountGhost<T, const TOTAL: u64 = 2> {
 impl<T, const TOTAL: u64> CountGhost<T, TOTAL> {
     #[verifier::type_invariant]
     spec fn inv(self) -> bool {
-        self.r.value() is Value
+        &&& self.r.value() is Value
+        &&& self.r.value()->n > 0
     }
 
+    /// Returns the unique identifier.
     pub closed spec fn id(self) -> Loc {
         self.r.loc()
     }
 
+    /// Returns the stored resource value.
     pub closed spec fn view(self) -> T {
         self.r.value()->v
     }
 
+    /// Returns the fraction of the resource.
     pub closed spec fn frac(self) -> int {
         self.r.value()->n
+    }
+
+    /// Whether this token carries the authority for updating the resource value.
+    pub closed spec fn has_authority(self) -> bool {
+        self.r.value()->auth
     }
 
     pub open spec fn valid(self, id: Loc, frac: int) -> bool {
@@ -100,18 +111,21 @@ impl<T, const TOTAL: u64> CountGhost<T, TOTAL> {
         &&& self.frac() == frac
     }
 
-    pub proof fn new(v: T) -> (tracked result: Self)
+    /// Allocates a new `CountGhost` with the full fraction, the given value, and the authority.
+    pub proof fn alloc(v: T) -> (tracked result: Self)
         requires
             TOTAL > 0,
         ensures
             result.frac() == TOTAL,
             result@ == v,
+            result.has_authority(),
     {
         let f = FractionalCarrier::<T, TOTAL>::new(v);
         let tracked r = Resource::alloc(f);
         Self { r }
     }
 
+    /// Two `CountGhost`s with the same id must have the same resource value.
     pub proof fn agree(tracked self: &Self, tracked other: &Self)
         requires
             self.id() == other.id(),
@@ -124,16 +138,8 @@ impl<T, const TOTAL: u64> CountGhost<T, TOTAL> {
         joined.validate()
     }
 
-    pub proof fn take(tracked &mut self) -> (tracked result: Self)
-        ensures
-            result == *old(self),
-    {
-        self.bounded();
-        let tracked mut mself = Self::dummy();
-        tracked_swap(self, &mut mself);
-        mself
-    }
-
+    /// Splits another fraction `n` from this `CountGhost`, returning a new `CountGhost` with
+    /// that fraction.
     pub proof fn split(tracked &mut self, n: int) -> (tracked result: Self)
         requires
             0 < n < old(self).frac(),
@@ -144,19 +150,26 @@ impl<T, const TOTAL: u64> CountGhost<T, TOTAL> {
             result@ == old(self)@,
             final(self).frac() + result.frac() == old(self).frac(),
             result.frac() == n,
+            !result.has_authority(),
+            final(self).has_authority() == old(self).has_authority(),
     {
         self.bounded();
         let tracked mut mself = Self::dummy();
         tracked_swap(self, &mut mself);
         use_type_invariant(&mself);
         let tracked (r1, r2) = mself.r.split(
-            FractionalCarrier::Value { v: mself.r.value()->v, n: mself.r.value()->n - n },
-            FractionalCarrier::Value { v: mself.r.value()->v, n },
+            FractionalCarrier::Value {
+                v: mself.r.value()->v,
+                n: mself.r.value()->n - n,
+                auth: mself.r.value()->auth,
+            },
+            FractionalCarrier::Value { v: mself.r.value()->v, n, auth: false },
         );
         self.r = r1;
         Self { r: r2 }
     }
 
+    /// Combines a `CountGhost`.
     pub proof fn combine(tracked &mut self, tracked other: Self)
         requires
             old(self).id() == other.id(),
@@ -165,6 +178,7 @@ impl<T, const TOTAL: u64> CountGhost<T, TOTAL> {
             final(self)@ == old(self)@,
             final(self)@ == other@,
             final(self).frac() == old(self).frac() + other.frac(),
+            final(self).has_authority() == (old(self).has_authority() || other.has_authority()),
     {
         self.bounded();
         let tracked mut mself = Self::dummy();
@@ -176,27 +190,33 @@ impl<T, const TOTAL: u64> CountGhost<T, TOTAL> {
         *self = Self { r: r.join(other.r) };
     }
 
+    /// Updates the value stored in this `CountGhost`.
+    /// The token must be the authority and hold the full fraction.
     pub proof fn update(tracked &mut self, v: T)
         requires
+            old(self).has_authority(),
             old(self).frac() == TOTAL,
         ensures
             final(self).id() == old(self).id(),
             final(self)@ == v,
             final(self).frac() == old(self).frac(),
+            final(self).has_authority(),
     {
         self.bounded();
         let tracked mut mself = Self::dummy();
         tracked_swap(self, &mut mself);
         use_type_invariant(&mself);
         let tracked r = mself.r;
-        let f = FractionalCarrier::<T, TOTAL>::Value { v, n: TOTAL as int };
+        let f = FractionalCarrier::<T, TOTAL>::Value { v, n: TOTAL as int, auth: true };
         *self = Self { r: r.update(f) };
     }
 
+    /// Updates the value stored in both `CountGhost`s.
     pub proof fn update_with(tracked &mut self, tracked other: &mut Self, v: T)
         requires
             old(self).id() == old(other).id(),
             old(self).frac() + old(other).frac() == TOTAL,
+            old(self).has_authority() || old(other).has_authority(),
         ensures
             final(self).id() == old(self).id(),
             final(other).id() == old(other).id(),
@@ -217,6 +237,7 @@ impl<T, const TOTAL: u64> CountGhost<T, TOTAL> {
         tracked_swap(other, &mut xother);
     }
 
+    /// The fraction of the resource must be positive and at most `TOTAL`.
     pub proof fn bounded(tracked &self)
         ensures
             0 < self.frac() <= TOTAL,
@@ -229,34 +250,30 @@ impl<T, const TOTAL: u64> CountGhost<T, TOTAL> {
         requires
             TOTAL > 0,
     {
-        Self::new(arbitrary())
+        Self::alloc(arbitrary())
     }
 }
 
 /// A struct that stores and dispatches `CountGhost<T>`.
-/// Unlike `CountGhost`, it provides an `empty` state.
-/// It also remembers the value even it is empty.
+/// Unlike `CountGhost`, it provides an `empty` state: after all fractions have been split out,
+/// it still remembers the resource value inside the carrier, mirroring `CountResource`.
 pub tracked struct CountGhostResource<T, const TOTAL: u64> {
-    tracked r: Option<CountGhost<T, TOTAL>>,
-    ghost snapshot: T,
-    ghost id: Loc,
+    tracked r: Resource<FractionalCarrier<T, TOTAL>>,
 }
 
 impl<T, const TOTAL: u64> CountGhostResource<T, TOTAL> {
     #[verifier::type_invariant]
-    closed spec fn type_inv(self) -> bool {
+    pub closed spec fn type_inv(self) -> bool {
         &&& TOTAL > 0
         &&& 0 <= self.frac() <= TOTAL
-        &&& self.r is Some ==> {
-            &&& self.id == self.r->0.id()
-            &&& self.view() == self.r->0@
-        }
+        &&& self.r.value() matches FractionalCarrier::Value { auth: true, .. }
     }
 
     /// Type invariant.
     pub open spec fn wf(self) -> bool {
         &&& TOTAL > 0
         &&& 0 <= self.frac() <= TOTAL
+        &&& self.type_inv()
     }
 
     /// Whether this `CountGhostResource` is empty, i.e., has no fraction.
@@ -274,28 +291,19 @@ impl<T, const TOTAL: u64> CountGhostResource<T, TOTAL> {
         self.frac() == TOTAL
     }
 
-    /// Returns the `CountGhost<T,TOTAL>` stored in this `CountGhostResource`.
-    pub closed spec fn storage(self) -> CountGhost<T, TOTAL> {
-        self.r->0
-    }
-
     /// Returns the value of type `T` stored in this `CountGhostResource`.
     pub closed spec fn view(self) -> T {
-        self.snapshot
+        self.r.value()->v
     }
 
     /// The fractions stored in this `CountGhostResource`.
     pub closed spec fn frac(self) -> int {
-        if self.r is None {
-            0int
-        } else {
-            self.storage().frac()
-        }
+        self.r.value()->n
     }
 
     /// Returns the unique identifier.
     pub closed spec fn id(self) -> Loc {
-        self.id
+        self.r.loc()
     }
 
     /// Create an arbitrary `CountGhostResource`. Useful as a placeholder.
@@ -303,7 +311,9 @@ impl<T, const TOTAL: u64> CountGhostResource<T, TOTAL> {
         requires
             TOTAL > 0,
     {
-        Self { r: None, snapshot: arbitrary(), id: arbitrary() }
+        let f = FractionalCarrier::<T, TOTAL>::Value { v: arbitrary(), n: 0, auth: true };
+        let tracked r = Resource::alloc(f);
+        Self { r }
     }
 
     /// Allocates a new `CountGhostResource` with the full fraction and the given value.
@@ -316,8 +326,9 @@ impl<T, const TOTAL: u64> CountGhostResource<T, TOTAL> {
             res@ == value,
             res.wf(),
     {
-        let tracked r = CountGhost::new(value);
-        Self { r: Some(r), snapshot: value, id: r.id() }
+        let f = FractionalCarrier::<T, TOTAL>::Value { v: value, n: TOTAL as int, auth: true };
+        let tracked r = Resource::alloc(f);
+        Self { r }
     }
 
     /// Splits a `CountGhost` with fraction 1.
@@ -331,19 +342,12 @@ impl<T, const TOTAL: u64> CountGhostResource<T, TOTAL> {
             res.frac() == 1,
             res.id() == final(self).id(),
             res@ == final(self)@,
+            !res.has_authority(),
             old(self).frac() == 1 ==> final(self).is_empty(),
             final(self).wf(),
     {
         use_type_invariant(&*self);
-        if self.frac() == 1 {
-            self.r.tracked_take()
-        } else {
-            self.r.tracked_borrow().bounded();
-            let tracked mut r = self.r.tracked_take();
-            let tracked res = r.split(1);
-            self.r = Some(r);
-            res
-        }
+        self.split(1)
     }
 
     /// Splits a `CountGhost` with the given fraction.
@@ -357,45 +361,45 @@ impl<T, const TOTAL: u64> CountGhostResource<T, TOTAL> {
             res.frac() == n,
             res.id() == final(self).id(),
             res@ == final(self)@,
+            !res.has_authority(),
             old(self).frac() == n ==> final(self).is_empty(),
             final(self).wf(),
     {
         use_type_invariant(&*self);
-        self.r.tracked_borrow().bounded();
-        if self.frac() == n {
-            self.r.tracked_take()
-        } else {
-            let tracked mut r = self.r.tracked_take();
-            let tracked res = r.split(n);
-            self.r = Some(r);
-            res
-        }
+        self.r.validate();
+        let tracked mut dummy = Self::arbitrary();
+        tracked_swap(self, &mut dummy);
+        let tracked Self { r } = dummy;
+        let p1 = FractionalCarrier::Value { v: r.value()->v, n: r.value()->n - n, auth: true };
+        let p2 = FractionalCarrier::Value { v: r.value()->v, n, auth: false };
+        let tracked (authority, fraction) = r.split(p1, p2);
+        self.r = authority;
+        CountGhost { r: fraction }
     }
 
     /// Combines a `CountGhost`.
     pub proof fn combine(tracked &mut self, tracked other: CountGhost<T, TOTAL>)
         requires
             old(self).id() == other.id(),
-            other@ == old(self)@,
         ensures
             old(self).frac() + other.frac() > TOTAL ==> false,
             old(self).frac() + other.frac() <= TOTAL ==> {
                 &&& final(self).id() == old(self).id()
                 &&& final(self)@ == old(self)@
+                &&& final(self)@ == other@
                 &&& final(self).frac() == old(self).frac() + other.frac()
                 &&& final(self).wf()
             },
     {
-        if self.is_empty() {
-            other.bounded();
-            self.r = Some(other);
-        } else {
-            use_type_invariant(&*self);
-            let tracked mut r = self.r.tracked_take();
-            r.combine(other);
-            r.bounded();
-            self.r = Some(r);
-        }
+        use_type_invariant(&*self);
+        use_type_invariant(&other);
+        let tracked mut dummy = Self::arbitrary();
+        tracked_swap(self, &mut dummy);
+        let tracked Self { r } = dummy;
+        let tracked mut r1 = r;
+        r1.validate_2(&other.r);
+        self.r = r1.join(other.r);
+        self.r.validate();
     }
 
     /// `CountGhostResource` satisfies the type invariant.
@@ -404,6 +408,21 @@ impl<T, const TOTAL: u64> CountGhostResource<T, TOTAL> {
             self.wf(),
     {
         use_type_invariant(self);
+    }
+
+    /// A `CountGhostResource` and a `CountGhost` with the same id agree on the value.
+    ///
+    /// Unlike `CountGhost::agree`, this works even when the resource is empty (all fractions split out).
+    pub proof fn validate_with_frac(tracked &self, tracked frac: &CountGhost<T, TOTAL>)
+        requires
+            self.id() == frac.id(),
+        ensures
+            self@ == frac@,
+    {
+        use_type_invariant(self);
+        use_type_invariant(frac);
+        let tracked joined = self.r.join_shared(&frac.r);
+        joined.validate();
     }
 
     /// Updates the value stored in this `CountGhostResource`.
@@ -418,10 +437,11 @@ impl<T, const TOTAL: u64> CountGhostResource<T, TOTAL> {
             final(self).wf(),
     {
         use_type_invariant(&*self);
-        let tracked mut r = self.r.tracked_take();
-        r.update(value);
-        self.snapshot = value;
-        self.r = Some(r);
+        let tracked mut dummy = Self::arbitrary();
+        tracked_swap(self, &mut dummy);
+        let tracked Self { r } = dummy;
+        let f = FractionalCarrier::<T, TOTAL>::Value { v: value, n: TOTAL as int, auth: true };
+        self.r = r.update(f);
     }
 }
 


### PR DESCRIPTION
I find it easier to use `usize` than the awkward `u64`.