### PR TITLE
chore: rename `Frame::paddr` to `Frame::start_paddr_spec`

### DIFF
--- a/ostd/specs/mm/frame/frame_specs.rs
+++ b/ostd/specs/mm/frame/frame_specs.rs
@@ -56,7 +56,7 @@ impl<'a, M: ?Sized> Frame<M> {
         &&& forall|i: int|
             i != frame_to_index(paddr) ==> new_regions.contains(i) == old_regions.contains(i)
         &&& r.ptr.addr() == frame_to_meta(paddr)
-        &&& r.paddr() == paddr
+        &&& r.start_paddr_spec() == paddr
         &&& r.inv()
         // Borrow-protocol: `from_raw` mints exactly one entry in
         // `frame_obligations` at the recovered slot's index. The returned
@@ -95,12 +95,12 @@ impl<M: ?Sized> Inv for Frame<M> {
 }
 
 impl<M: ?Sized> Frame<M> {
-    pub open spec fn paddr(self) -> Paddr {
-        meta_to_frame(self.ptr.addr())
+    pub open spec fn index(self) -> int {
+        frame_to_index(self.start_paddr_spec())
     }
 
-    pub open spec fn index(self) -> int {
-        frame_to_index(self.paddr())
+    pub open spec fn start_paddr_spec(self) -> Paddr {
+        meta_to_frame(self.ptr.addr())
     }
 
     pub open spec fn from_unused_spec(

--- a/ostd/src/mm/frame/mod.rs
+++ b/ostd/src/mm/frame/mod.rs
@@ -177,8 +177,8 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + ?Sized> Frame<M> {
     )]
     pub fn eq(&self, other: &Self) -> bool {
         proof {
-            regions.lemma_contains_valid_frame_paddr(self.paddr());
-            regions.lemma_contains_valid_frame_paddr(other.paddr());
+            regions.lemma_contains_valid_frame_paddr(self.start_paddr_spec());
+            regions.lemma_contains_valid_frame_paddr(other.start_paddr_spec());
         }
         let tracked self_perm = regions.slots.tracked_borrow(self.index());
         let tracked other_perm = regions.slots.tracked_borrow(other.index());
@@ -348,7 +348,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + ?Sized> Frame<M> {
         perm.is_init(),
         self.inv(),
     returns
-        meta_to_frame(self.ptr.addr()),
+        self.start_paddr_spec(),
     )]
     pub fn start_paddr(&self) -> Paddr {
         #[verus_spec(with Tracked(perm))]
@@ -443,7 +443,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + ?Sized> Frame<M> {
     )]
     pub fn borrow<'a>(&self) -> FrameRef<'a, M> {
         proof {
-            regions.lemma_contains_valid_frame_paddr(self.paddr());
+            regions.lemma_contains_valid_frame_paddr(self.start_paddr_spec());
         }
         let tracked slot_perm = regions.slots.tracked_borrow(self.index());
 
@@ -488,7 +488,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + ?Sized> Frame<M> {
             old(regions).frame_obligations.count(self.index()) > 0,
         ensures
             final(regions).inv(),
-            r == self.paddr(),
+            r == self.start_paddr_spec(),
             final(regions).slot_owners[self.index()].usage
                 == old(regions).slot_owners[self.index()].usage,
             self.into_raw_post_noninterference(*old(regions), *final(regions)),
@@ -499,7 +499,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage> + ?Sized> Frame<M> {
         broadcast use group_page_meta;
 
         proof {
-            regions.lemma_contains_valid_frame_paddr(self.paddr());
+            regions.lemma_contains_valid_frame_paddr(self.start_paddr_spec());
         }
 
         let tracked perm = regions.slots.tracked_borrow(self.index());
@@ -598,16 +598,15 @@ impl<M> Frame<M> {
 
 #[verus_verify]
 impl<M: AnyFrameMeta + Repr<MetaSlotStorage>> RCClone for Frame<M> {
-    open spec fn clone_requires(self, perm: MetaRegionOwners) -> bool {
-        let idx = self.index();
+    open spec fn clone_requires(self, regions: MetaRegionOwners) -> bool {
+        let paddr = self.start_paddr_spec();
+        let ref_count = regions.slot_owner(paddr).ref_count();
         &&& self.inv()
-        &&& perm.inv()
-        &&& perm.slot_owners[idx].ref_count() > 0
-        &&& perm.slot_owners[idx].ref_count()
-            != REF_COUNT_UNUSED
-        // Saturation aborts (Arc-style) via `inc_ref_count`'s diverging panic.
-        &&& perm.slot_owners[idx].ref_count() >= REF_COUNT_MAX ==> may_panic()
-        &&& valid_frame_paddr(self.paddr())
+        &&& regions.inv()
+        &&& ref_count > 0
+        &&& ref_count != REF_COUNT_UNUSED
+        &&& ref_count >= REF_COUNT_MAX ==> may_panic()
+        &&& valid_frame_paddr(self.start_paddr_spec())
     }
 
     open spec fn clone_ensures(
@@ -641,7 +640,7 @@ impl<M: AnyFrameMeta + Repr<MetaSlotStorage>> RCClone for Frame<M> {
 
     fn clone(&self, Tracked(perm): Tracked<&mut MetaRegionOwners>) -> Self {
         proof {
-            perm.lemma_contains_valid_frame_paddr(self.paddr());
+            perm.lemma_contains_valid_frame_paddr(self.start_paddr_spec());
         }
 
         let paddr = meta_to_frame(self.ptr.addr());

--- a/ostd/src/mm/frame/segment.rs
+++ b/ostd/src/mm/frame/segment.rs
@@ -1016,7 +1016,7 @@ impl<'a, M: AnyFrameMeta + Repr<MetaSlotStorage> + OwnerOf> SegmentIterator<'a, 
                 Some(item) => {
                     &&& final(range).start == old(range).start + PAGE_SIZE
                     &&& final(range).end == old(range).end
-                    &&& item.0.paddr() == old(range).start
+                    &&& item.0.start_paddr_spec() == old(range).start
                     &&& old(remaining).seq() == seq![item] + final(remaining).seq()
                 },
             },

--- a/ostd/src/mm/page_table/mod.rs
+++ b/ostd/src/mm/page_table/mod.rs
@@ -1054,11 +1054,7 @@ impl PageTable<KernelPtConfig> {
             assert(!regions_after_kroot_borrow.contains(new_idx));
             assert forall|k: int|
                 regions_after_kroot_borrow.contains(k) implies regions_after_kroot_borrow.slots[k]
-                == #[trigger] regions.slots[k] by {
-                if k != new_idx {
-                    // borrow preserves slots[k] at k != self.index() == new_idx
-                }
-            };
+                == #[trigger] regions.slots[k] by {};
             assert(kernel_owner.metaregion_sound(regions_before_alloc));
 
             kernel_owner.0.lemma_subtree_satisfies_implies(

--- a/ostd/src/mm/vm_space.rs
+++ b/ostd/src/mm/vm_space.rs
@@ -1631,7 +1631,7 @@ unsafe impl PageTableConfig for UserPtConfig {
     type Item = MappedItem;
 
     open spec fn item_into_raw_spec(item: Self::Item) -> (Paddr, PagingLevel, PageProperty) {
-        (item.frame.paddr(), 1, item.prop)
+        (item.frame.start_paddr_spec(), 1, item.prop)
     }
 
     #[verifier::external_body]


### PR DESCRIPTION
This change aligns the name with executable code.