### PR TITLE
fix: assert error in macOS due to Verus update

### DIFF
--- a/ostd/specs/mm/page_table/mod.rs
+++ b/ostd/specs/mm/page_table/mod.rs
@@ -1632,6 +1632,7 @@ impl AbstractVaddr {
                     + aligned.rec_compute_vaddr(4)) as Vaddr);
             };
             assert(aligned.rec_compute_vaddr(2) == self.index[3] * 0x80_0000_0000usize) by {
+                assert(aligned.index[2] == 0);
                 assert(aligned.rec_compute_vaddr(2) == (aligned.index[2] * page_size(3)
                     + aligned.rec_compute_vaddr(3)) as Vaddr);
             };


### PR DESCRIPTION
So this error is introduced since the CI only test the Linux platform when Verus update. @rikosellic 
Strange SMT, strange Verus