### PR TITLE
Fix IRC11 toolchain after Rust 1.98 upgrade

### DIFF
--- a/.github/workflows/ci-irc11.yml
+++ b/.github/workflows/ci-irc11.yml
@@ -49,7 +49,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       VERUS_REPOSITORY: https://github.com/asterinas/verus.git
-      VERUS_BASE_COMMIT: bb61343fc97e4b3a97b1029f385ffb6bbb291da2
+      VERUS_BASE_COMMIT: bf70c19fc4aea17fb38aeee6b0686d13ec400d7a
       VERUS_IRC11_PATCH: tools/patches/verus-irc11.patch
       VERUS_COMPAT_PATCH: tools/patches/verus-irc11-vstd.patch
 
@@ -83,7 +83,7 @@ jobs:
             ~/.rustup/toolchains
             ~/.rustup/update-hashes
             ~/.rustup/tmp
-          key: ${{ runner.os }}-irc11-rust-${{ env.RUST_VERSION }}
+          key: ${{ runner.os }}-irc11-rust-${{ env.RUST_VERSION }}-${{ env.VERUS_BASE_COMMIT }}
 
       - name: Cache IRC11 Cargo dependencies
         uses: actions/cache@v6
@@ -112,14 +112,30 @@ jobs:
             git -C tools/verus checkout --detach FETCH_HEAD
             git -C tools/verus apply "$GITHUB_WORKSPACE/$VERUS_IRC11_PATCH"
             git -C tools/verus apply "$GITHUB_WORKSPACE/$VERUS_COMPAT_PATCH"
-            bash tools/bootstrap-verus-irc11.sh
-          else
-            echo "Using cached IRC11 Verus"
           fi
 
           test "$(git -C tools/verus rev-parse HEAD)" = "$VERUS_BASE_COMMIT"
           git -C tools/verus apply --reverse --check "$GITHUB_WORKSPACE/$VERUS_COMPAT_PATCH"
           git -C tools/verus diff --check
+
+          # A cached Verus still needs the Rust toolchain it was built with.
+          # Use the pinned checkout's version for both bootstrap and Cargo verification.
+          IRC11_RUST_VERSION=$(sed -nE 's/^channel = "([^"]+)"/\1/p' tools/verus/rust-toolchain.toml)
+          if [[ -z "$IRC11_RUST_VERSION" ]]; then
+            echo "Failed to extract the pinned IRC11 Rust version" >&2
+            exit 1
+          fi
+          rustup toolchain install "$IRC11_RUST_VERSION" --profile minimal \
+            --component rustc-dev,llvm-tools,rustfmt --target x86_64-unknown-none
+          export RUSTUP_TOOLCHAIN="$IRC11_RUST_VERSION"
+          echo "RUSTUP_TOOLCHAIN=$RUSTUP_TOOLCHAIN" >> "$GITHUB_ENV"
+
+          if [[ "${{ steps.cache-verus.outputs.cache-hit }}" != "true" ]]; then
+            bash tools/bootstrap-verus-irc11.sh
+          else
+            echo "Using cached IRC11 Verus"
+          fi
+
           test -x tools/verus/source/target-verus/release/cargo-verus
           test -x tools/verus/source/target-verus/release/verus
           test -f tools/verus/source/target-verus/release/vstd.vir
@@ -134,7 +150,7 @@ jobs:
 
       - name: Verify IRC11 adapters and OSTD bridge
         run: |
-          # The pinned IRC11 and mainline Verus toolchains use different
+          # The pinned IRC11 and mainline Verus toolchains can use different
           # package versions. Keep the repository lockfile aligned with
           # mainline while allowing Cargo to resolve the IRC11 versions here.
           IRC11_LOCKFILE_BACKUP="$RUNNER_TEMP/Cargo.lock.mainline"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,11 +595,11 @@ dependencies = [
 
 [[package]]
 name = "verus_builtin"
-version = "0.0.0-2026-08-30-0159"
+version = "0.0.0-2026-09-06-0133"
 
 [[package]]
 name = "verus_builtin_macros"
-version = "0.0.0-2026-08-30-0159"
+version = "0.0.0-2026-09-06-0133"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "verus_prettyplease"
-version = "0.0.0-2026-08-09-0044"
+version = "0.0.0-2026-09-06-0133"
 dependencies = [
  "proc-macro2",
  "verus_syn",
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "verus_state_machines_macros"
-version = "0.0.0-2026-08-02-0125"
+version = "0.0.0-2026-09-06-0133"
 dependencies = [
  "indexmap",
  "proc-macro2",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "verus_syn"
-version = "0.0.0-2026-08-02-0125"
+version = "0.0.0-2026-09-06-0133"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -651,7 +651,7 @@ checksum = "af8ca9a5d4debca0633e697c88269395493cebf2e10db21ca2dbde37c1356452"
 
 [[package]]
 name = "vstd"
-version = "0.0.0-2026-08-30-0159"
+version = "0.0.0-2026-09-06-0133"
 dependencies = [
  "verus_builtin",
  "verus_builtin_macros",

--- a/tools/bootstrap-verus-irc11.sh
+++ b/tools/bootstrap-verus-irc11.sh
@@ -20,7 +20,10 @@ if [[ ! -x "$source_dir/z3" ]]; then
     )
 fi
 
-cargo build --release --manifest-path "$vargo_manifest"
+(
+    cd "$verus_dir"
+    cargo build --release --manifest-path "$vargo_manifest"
+)
 
 # The IRC11 patch predates weak-memory in Vargo's build fingerprint, so force
 # vstd to rebuild whenever this bootstrap path is invoked.
@@ -32,8 +35,8 @@ rm -f "$source_dir/target-verus/release/.vstd-fingerprint"
     "$vargo_bin" build --release -p verusdoc
 )
 
-# This Verus revision places standalone package builds in Cargo's default
-# target directory, while the current dv searches beside the Verus binary.
+# Vargo places standalone package builds in its Cargo target directory,
+# while dv searches beside the Verus binary.
 cp "$source_dir/target/release/verusdoc" "$source_dir/target-verus/release/verusdoc"
 
 test -x "$source_dir/target-verus/release/verus"

--- a/tools/patches/verus-irc11.patch
+++ b/tools/patches/verus-irc11.patch
@@ -1,8 +1,8 @@
 diff --git a/source/rust_verify_test/tests/core_special_setup.rs b/source/rust_verify_test/tests/core_special_setup.rs
-index d9f26d56..7dcb1fbf 100644
+index e38d186a..03f9d387 100644
 --- a/source/rust_verify_test/tests/core_special_setup.rs
 +++ b/source/rust_verify_test/tests/core_special_setup.rs
-@@ -28,6 +28,7 @@ test_verify_one_file_with_options! {
+@@ -32,6 +32,7 @@ test_verify_one_file_with_options! {
              verus_keep_ghost,
              feature(fn_traits),
          )]
@@ -11,7 +11,7 @@ index d9f26d56..7dcb1fbf 100644
  
          #[verifier::external]
 diff --git a/source/vstd/atomic.rs b/source/vstd/atomic.rs
-index bcc34e13..8bb30533 100644
+index fbf657aa..cc51b5e9 100644
 --- a/source/vstd/atomic.rs
 +++ b/source/vstd/atomic.rs
 @@ -1,56 +1,67 @@
@@ -125,7 +125,7 @@ index bcc34e13..8bb30533 100644
  
          #[verifier::external_body] /* vattr */
          pub struct $at_ident {
-@@ -92,12 +102,12 @@ macro_rules! atomic_types {
+@@ -92,12 +103,12 @@ macro_rules! atomic_types {
          }
  
          }
@@ -143,7 +143,7 @@ index bcc34e13..8bb30533 100644
  
          #[verifier::accept_recursive_types(T)]
          #[verifier::external_body] /* vattr */
-@@ -142,12 +152,12 @@ macro_rules! atomic_types_generic {
+@@ -142,12 +153,12 @@ macro_rules! atomic_types_generic {
          }
  
          }
@@ -160,7 +160,7 @@ index bcc34e13..8bb30533 100644
      ($at_ident: ty, $p_ident: ty, $p_data_ident: ty, $rust_ty: ty, $value_ty: ty, [ $($addr:tt)* ]) => {
          verus_impl!{
  
-@@ -268,7 +278,7 @@ macro_rules! atomic_common_methods {
+@@ -268,7 +279,7 @@ macro_rules! atomic_common_methods {
      };
  }
  
@@ -169,7 +169,7 @@ index bcc34e13..8bb30533 100644
      ($at_ident:ident, $p_ident:ident, $rust_ty: ty, $value_ty: ty, $modname:ident) => {
          verus_impl!{
  
-@@ -436,9 +446,9 @@ macro_rules! atomic_integer_methods {
+@@ -436,9 +447,9 @@ macro_rules! atomic_integer_methods {
      };
  }
  
@@ -182,7 +182,7 @@ index bcc34e13..8bb30533 100644
  
          #[inline(always)]
          #[verifier::external_body] /* vattr */
-@@ -505,8 +515,8 @@ macro_rules! atomic_bool_methods {
+@@ -505,8 +516,8 @@ macro_rules! atomic_bool_methods {
          }
  
          }
@@ -192,8 +192,8 @@ index bcc34e13..8bb30533 100644
 +    }
  
  macro_rules! ptr_atomic_methods {
-     ($at_ty: ty, $rust_ty: ty, $value_ty: ty) => {
-@@ -593,90 +603,163 @@ ptr_atomic_methods!(PAtomicIsize, AtomicIsize, isize);
+     ($at_ty: ty, $rust_ty: ty, $value_ty: ty, $width: literal) => {
+@@ -617,90 +628,163 @@ ptr_atomic_methods!(PAtomicIsize, AtomicIsize, isize, "ptr");
  
  make_bool_atomic!(PAtomicBool, PermissionBool, PermissionDataBool, AtomicBool, bool);
  
@@ -438,7 +438,7 @@ index bcc34e13..8bb30533 100644
  }
  
  impl<X, Y, Pred> core::fmt::Debug for AtomicUpdate<X, Y, Pred> {
-@@ -1125,65 +1208,4 @@ pub use {
+@@ -1149,65 +1233,4 @@ pub use {
      try_open_atomic_update_in_proof,
  };
  
@@ -2963,18 +2963,18 @@ index 00000000..bfb1c293
 +
 +} // verus!
 diff --git a/source/vstd/vstd.rs b/source/vstd/vstd.rs
-index 24ef737c..900e9a6c 100644
+index eb06f180..41016a35 100644
 --- a/source/vstd/vstd.rs
 +++ b/source/vstd/vstd.rs
-@@ -22,6 +22,7 @@
- #![cfg_attr(verus_keep_ghost, feature(slice_index_methods))]
- #![cfg_attr(all(feature = "alloc", verus_keep_ghost), feature(liballoc_internals))]
- #![cfg_attr(verus_keep_ghost, feature(nonzero_internals))]
+@@ -26,6 +26,7 @@
+ #![cfg_attr(verus_keep_ghost, feature(fmt_internals))]
+ #![cfg_attr(verus_keep_ghost, feature(fmt_arguments_from_str))]
+ #![cfg_attr(verus_keep_ghost, feature(panic_internals))]
 +#![cfg_attr(verus_keep_ghost, feature(auto_traits))]
  
  #[cfg(feature = "alloc")]
  extern crate alloc;
-@@ -30,6 +31,7 @@ pub mod arithmetic;
+@@ -34,6 +35,7 @@ pub mod arithmetic;
  pub mod array;
  pub mod atomic;
  pub mod atomic_ghost;
@@ -2982,7 +2982,7 @@ index 24ef737c..900e9a6c 100644
  pub mod bits;
  pub mod bytes;
  pub mod calc_macro;
-@@ -81,6 +83,7 @@ pub mod state_machine_internal;
+@@ -85,6 +87,7 @@ pub mod state_machine_internal;
  pub mod string;
  #[cfg(feature = "std")]
  pub mod thread;


### PR DESCRIPTION
Should fix the incompatibility.